### PR TITLE
feat(overseer): design spike + scaffolding for an embedded operator/observer co-process (#2419)

### DIFF
--- a/docs/design/overseer.md
+++ b/docs/design/overseer.md
@@ -1,0 +1,396 @@
+---
+title: "Overseer — an embedded operator/observer co-process (design spike)"
+description: >
+  Design spike (#2419) for embedding an autonomous "amplihack Copilot" operator/observer
+  co-process into the Simard daemon. All Rust, maximal reuse of Simard's existing subsystems
+  plus the amplihack recipe runner. Covers the role, the co-process-vs-CognitiveThread
+  decision, the observer's own meta-OODA loop, the capability/action set mapped to existing
+  modules, the guardrails (autonomy boundary, anti-recursion, budget/concurrency,
+  conflict-avoidance), persisted state, the explicit boundary against Simard's own OODA, and a
+  phased roadmap. Design + scaffolding only — no daemon runtime behavior change.
+last_updated: 2026-07-03
+review_schedule: as-needed
+owner: simard
+doc_type: design
+status: draft
+related:
+  - ../concepts/operational-autonomy-model.md
+  - ../reference/cognitive-thread-scheduling.md
+  - ../howto/add-a-new-cognitive-thread.md
+  - ../reference/status-snapshot-api.md
+  - ../concepts/unified-telemetry-and-status.md
+  - ../reference/stewardship-api.md
+  - ../reference/self-deploy-api.md
+  - ../reference/cross-repo-merge-authority.md
+---
+
+# Overseer — an embedded operator/observer co-process (design spike)
+
+!!! note "Status — design + scaffolding only (#2419)"
+    This is a **design spike**. It ships a design document, a Rust type/trait
+    **sketch** (`src/overseer/`, additive and `#![allow(dead_code)]`), and prompt
+    scaffolding (`prompt_assets/simard/overseer/`). It changes **no daemon runtime
+    behavior**: nothing constructs or schedules an `Overseer`, and nothing is wired
+    into `main` or the daemon loop. The goal is to fix the architecture, the reuse
+    map, and the guardrails so a later milestone can wire it behind an env flag
+    without redesigning.
+
+## Problem statement
+
+Over many sessions, a human + Copilot pair has acted as Simard's **operator**: not
+writing Simard's feature code, but watching **how** Simard runs, spotting process
+problems, and driving fixes and cross-cutting initiatives. Concretely that operator
+has:
+
+- **Monitored telemetry/health** — distillation parse-failure rate (≈62% at times),
+  reasoner/brain `decide_ladder_exhausted`, graceful self-relaunch/restart churn
+  (≈hourly), engineer spawn rate, LLM cost vs daily budget, cognitive-memory growth,
+  gym-skip status.
+- **Detected and diagnosed problems** — launch-banner pollution causing parse
+  failures, goal-board multi-writer persistence race, stale-completion goals
+  re-litigated forever, restart churn, weak distillation.
+- **Driven fixes OUTSIDE Simard's loop** — launching amplihack recipe workstreams
+  (`smart-orchestrator` → `default-workflow`), then **verifying** the resulting PRs
+  (CI green + constraint checks: no `Bridge`, no stray `print!`, additive /
+  non-breaking, PRD preserved), **resolving** merge conflicts, **merging**, and
+  **deploying** the new binary, updating a deployed-commit marker.
+- **Sequenced parallel workstreams** to avoid conflicts (feature recipes first;
+  mechanical sweeps like rename / `print!`-purge one-at-a-time on shared OODA-core
+  files).
+- **Transferred goals** to Simard via the meeting REPL; ran **quality audits** in
+  loops (crusty-old-engineer-gated); set up a recurring monthly self-audit.
+- **Produced periodic status reports** (uptime, resources, tokens/cost, active
+  workstreams, completed work by repo → PR, memory/brain stats, telemetry
+  anomalies, goals, self-improvement PRs).
+- **Curated naming/architecture** and filed **deduplicated** GitHub issues for
+  recurring failures (stewardship mode).
+
+That role is currently **human-in-the-loop**. This spike designs how to embed it as
+an autonomous **co-process inside the daemon**, all in Rust, reusing Simard's
+already-shipped machinery and the amplihack recipe runner. The operator role is
+mechanical enough — observe a typed snapshot, classify, launch a known recipe,
+verify against a checklist, merge/deploy through gated authorities — that it can be
+encoded faithfully without inventing new execution machinery.
+
+## The name: **Overseer**
+
+We recommend one faculty name: **`Overseer`** (module `overseer`, type `Overseer`).
+
+| Candidate | Verdict | Reason (grounded in source) |
+|-----------|---------|-----------------------------|
+| **Operator** | ✗ reject | Collides with **seven** existing modules — `operator_cli`, `operator_commands`, and `operator_commands_{dashboard,engineer,gym,meeting,ooda,review,terminal}` — which are the **human operator's manual CLI surface** (`simard goal`, `merge-pr`, `self-deploy`, `meeting`, …). Naming the autonomous faculty `operator` creates a three-way `operator` / `operator_cli` / `operator_commands` ambiguity. The Overseer *automates* that operator role, so it needs a distinct name. |
+| **Copilot** | ✗ reject | Collides with `base_type_copilot`, `copilot_status_probe`, `copilot_task_submit`, and the `AMPLIHACK_AGENT_BINARY=copilot` agent binary. "amplihack Copilot" names the *pairing*, not a good type. |
+| **Curator** | ✗ reject | Collides with `goal_curation` and implies a narrow (goal-only) scope. |
+| **Sentinel** | ✗ reject | Connotes passive watching; the faculty also **acts** (launches, merges, deploys). |
+| **Overseer** | ✓ **choose** | Collision-free in the codebase; connotes active meta-level supervision (an overseer *directs* work, not just watches). |
+
+No type or module contains the word **`Bridge`** (operator preference; enforced as a
+review rule for new code — see [pr-verify checklist](#pr-verify-checklist)).
+
+## Architecture
+
+### Decision: sibling co-process, not a `CognitiveThread`
+
+The Overseer is a **sibling co-process** that shares the daemon's durable store and
+telemetry — **not** a `CognitiveThread` hosted by the `Mind`. An optional *read-only
+sensor* may be packaged as a thread for M1 (below), but the **acting** Overseer is a
+co-process.
+
+This is grounded in the shipped cognitive-thread contract
+([reference](../reference/cognitive-thread-scheduling.md),
+[howto](../howto/add-a-new-cognitive-thread.md)):
+
+1. **Threads are least-authority.** A `CognitiveThread` receives a `ThreadContext`
+   with exactly `{ state_root, repo_root, memory, runtime, shutdown, now_epoch,
+   dry_run }` and is explicitly forbidden **"no code path to `self_deploy` /
+   `self_relaunch` / redeploy"**. The Overseer's job **requires** guarded deploy
+   authority and PR-merge authority — the opposite of a thread's mandate.
+2. **Threads are small, bounded, best-effort chores.** They tick synchronously under
+   a per-tick budget (`SIMARD_MIND_MAX_NONCRITICAL_PER_TICK`), are capped to
+   `Priority::Low`/`Normal` (Critical is OODA-only), and are backed off on failure.
+   The Overseer launches **long-running** recipe/merge/deploy work that must not be
+   starved by, or steal budget from, the OODA cycle.
+3. **Clean boundary / anti-recursion.** A thread runs *inside* the same scheduler as
+   OODA. The Overseer must sit at the **meta level** — observing and improving
+   Simard's own process — and must never be scheduled by, or schedule, Simard's
+   OODA. Making it a co-process makes that separation structural, not conventional.
+
+```mermaid
+flowchart TB
+  subgraph daemon["simard daemon process"]
+    subgraph loop["daemon loop — src/operator_commands_ooda/daemon/mod.rs"]
+      ooda["OODA inline cycle\n(external repos + own features)"]
+      mind["Mind.run_due()\nbackground CognitiveThreads\n(off by default)"]
+    end
+    store[("shared durable store\n~/.simard: cognitive/, goal-board,\ntelemetry/metrics_snapshot.json,\ncosts/ledger.jsonl")]
+    overseer["Overseer co-process\n(meta-OODA; guarded capabilities)\n— M2+ sibling task —"]
+  end
+  ooda -->|writes| store
+  mind -->|writes| store
+  overseer -.->|reads snapshot / board / ledger| store
+  overseer -.->|launches recipes, verifies+merges PRs,\nfiles issues, transfers goals, deploys| ext["amplihack recipe runner\n+ gh + self_deploy"]
+```
+
+### How it shares store and telemetry
+
+The Overseer's Observe step is **read-only** over the same durable sources the
+daemon already flushes — it never reads daemon RAM, so it is process-agnostic:
+
+- **Primary input:** `crate::status::assemble(&AssembleOptions)`
+  (`src/status/provider.rs:58`) → `crate::status::StatusSnapshot`
+  (`src/status/mod.rs`) — the exact value `simard status` renders on all three
+  surfaces ([StatusSnapshot API](../reference/status-snapshot-api.md),
+  [unified telemetry](../concepts/unified-telemetry-and-status.md)). Backed by
+  `~/.simard/telemetry/metrics_snapshot.json`, `costs/ledger.jsonl`, `/proc`, and
+  `systemctl`.
+- **Goal board:** `crate::goal_curation::load_goal_board` for dedup/conflict checks,
+  under the flock write-lock `BoardWriteLock` (#2514,
+  `src/goal_curation/operations.rs:190`) when it proposes.
+- **Cost:** `crate::cost_tracking` (`daily_summary`) + `SIMARD_DAILY_BUDGET_USD`.
+
+### Embedding seam (described, not wired)
+
+The daemon loop lives in `src/operator_commands_ooda/daemon/mod.rs`. Each iteration
+it runs the authoritative OODA cycle inline, then ticks the `Mind`
+(`mind.run_due(&mut ctx)`, ~L959–984; the `Mind` is wired ~L517–562, additive and
+**off by default** via `SIMARD_COGNITIVE_THREADS_ENABLED`). Two future wiring
+options — **neither implemented in this spike**:
+
+- **M1 read-only sensor:** register an `impl CognitiveThread` next to
+  `MaintenanceThread` / `EngineerLogAnalysisThread`. It only Observes → emits signals
+  → files deduped issues → renders a report. It fits the least-authority
+  `ThreadContext` because it takes **no** high-risk action.
+- **M2+ acting Overseer:** spawn a sibling supervised task alongside the loop, holding
+  the guarded capability handles. This is the co-process proper.
+
+## The observer's meta-OODA loop
+
+The Overseer runs its **own** OODA, distinct from Simard's repo-facing OODA and
+modeled on the same Observe/Orient/Decide/Act pattern (`src/ooda_loop/cycle.rs`) with
+deterministic floors under prompt-driven reasoners (mirroring `OodaOrientBrain` /
+`OodaDecideBrain`). One turn is `Overseer::run_cycle` in the Rust sketch.
+
+```mermaid
+flowchart LR
+  O["Observe\nStatusSnapshot + logs +\nPR/CI/goal state"] --> R["Orient\nclassify + prioritize +\nDEDUP vs in-flight"]
+  R --> D["Decide\nchoose one Intervention\nper Problem"]
+  D --> A["Act\ngate → dispatch via\nreused capability"]
+  A -.report/telemetry.-> O
+```
+
+| Phase | What it does | Reuses |
+|-------|--------------|--------|
+| **Observe** | Assemble a typed `ObservedState` from `StatusSnapshot` + recent PR/CI/goal state; derive `Signal`s (`signal::signals_from`). | `status::assemble`; `cost_tracking`; PR reads via `PrGhClient` (`merge_authority.rs`). |
+| **Orient** | Classify signals into `Problem`s, assign `Priority`, compute a coarse `dedup_key`, and **drop any problem an in-flight engineer already owns**. | `goal_curation::load_goal_board` (in-flight refs); dedup semantics mirror `stewardship::failure_signature`. |
+| **Decide** | Choose exactly one `Intervention` per `Problem` (prompt-driven with a deterministic floor). | prompt `problem_to_brief.md`; routing floor mirrors `OodaDecideBrain`. |
+| **Act** | Apply guardrails, then dispatch the intervention through the reused capability. `run_cycle` **plans**; execution is the M2+ Act seam (`Overseer::act`). | the capability map below. |
+
+## Capability / action set → existing Simard modules
+
+Every `Intervention` maps onto a capability trait (`src/overseer/capabilities.rs`),
+and every capability is satisfied by an **existing** Simard function — the Overseer
+is an orchestrator over shipped code, not a reimplementation.
+
+| `Intervention` | Capability trait | Existing Simard reuse (file:line) |
+|----------------|------------------|-----------------------------------|
+| `LaunchRecipe{brief}` | `RecipeLauncher` | `amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml -c task_description=…` (`src/bin/simard_engineer_loop_recipe.rs:51`, `src/bin/simard_self_improve_recipe.rs:50`); `recipe-runner-rs` + `AMPLIHACK_AGENT_BINARY` (`src/stewardship/recipe_merge_judge.rs:191`); concurrency via `agent_supervisor::spawn_subordinate` (`src/agent_supervisor/lifecycle/spawn.rs:27`); output parse `recipe_output::extract` (`src/recipe_output/extract.rs`). |
+| `VerifyAndMergePr{repo,pr}` | `PrOps::verify` + `PrOps::merge` | gates `evaluate_objective_gates` (`src/stewardship/merge_authority.rs:495`); merge `merge_pr_if_merge_ready` (`:564`); review `review_pipeline::{review_diff,should_commit}` (`src/review_pipeline.rs:128,147`). |
+| `ResolveConflict{repo,pr}` | `PrOps::resolve_conflict` | `git_guardrails::check_git_safety` (`src/git_guardrails.rs:41`) around the union-merge / `--no-verify` push. |
+| `Deploy{commit}` | `Deployer` | `self_deploy::orchestrator::SelfDeployOrchestrator::run` (`src/self_deploy/orchestrator.rs:229`); `self_relaunch::{build_canary,verify_canary,all_gates_passed,default_gates,handover}` (`src/self_relaunch/*`); marker `env!("SIMARD_GIT_HASH")` via `self_deploy::health`. |
+| `FileIssue{run}` | `IssueFiler` | `stewardship::process_orchestrator_run` (`src/stewardship/mod.rs:51`); dedup `stewardship::{failure_signature,find_existing}` (`src/stewardship/dedup.rs`); backlog `goal_curation::enqueue_stewardship_issue`. |
+| `TransferGoal{goal}` | `MeetingHost` | `meeting_repl::run_meeting_repl` (`src/meeting_repl/repl.rs:211`); `meeting_facilitator` handoff (`MeetingHandoff`, `write_meeting_handoff`); `meetings::PersistedMeetingGoalUpdate`. |
+| `Report` | `StatusReader` | `status::assemble` rendered via `status::render` / `status::json`. |
+| `RunAudit{scope}` | `Auditor` | `self_quality_audit::run_self_quality_audit` (`src/self_quality_audit.rs`); recipe `prompt_assets/simard/recipes/monthly-self-quality-audit.yaml`. |
+| `Escalate{reason}` | (guardrail) | surface to the operator; no auto-execution. |
+| (curation) | `GoalCurator` | `goal_curation::{load_goal_board,promote_to_active,save_goal_board}`; `BoardWriteLock` (#2514, `operations.rs:190`); `MAX_ACTIVE_GOALS`. |
+
+### Signal / Problem model
+
+`Signal`s are cheap, additive indicators; `Problem`s are classified, prioritized,
+deduplicated. Every signal cites the `StatusSnapshot` field it comes from:
+
+| `Signal` | Snapshot source |
+|----------|-----------------|
+| `DistillFailureRate{pct}` | `telemetry.distill_fail_pct` |
+| `RestartChurn{restarts}` | `telemetry.restart_churn` / `daemon.n_restarts` |
+| `LadderExhausted{count}` | `memory.decide_ladder_exhausted` |
+| `BudgetPressure{spent,budget}` | `llm.ledger_today.cost_usd` vs `llm.daily_budget_usd` |
+| `EngineerSpawnRate{live}` | `resources.live_engineers` |
+| `MemoryGrowth{nodes_total}` | `memory.nodes_total` |
+| `GymSkipped` | `gym.skip_gym` |
+| `CiFailureCluster{repo,failing}` | PR `statusCheckRollup` (`merge_authority`) |
+| `PrReadyToMerge{repo,pr}` | `evaluate_objective_gates` OK |
+| `StaleGoal{goal_id}` | goal board + failure counts |
+| `Anomaly{detail}` | `telemetry.anomalies[]` |
+
+## Guardrails (first-class)
+
+Guardrails are a design centerpiece, not an afterthought. They **layer on top of**
+Simard's always-on floors (`git_guardrails`, `ado_acl_guard`) — never replacing them.
+
+### Autonomy boundary
+
+Per the [operational autonomy model](../concepts/operational-autonomy-model.md):
+**most operations run autonomously** ("for most operations she should not need
+outside-party validation"), while a small **HIGH-RISK** set surfaces to the operator.
+Autonomy removes the *human-wait*, never a *quality/safety gate*.
+
+`guardrails::classify(&Intervention) -> RiskClass`:
+
+- **Routine (autonomous):** `LaunchRecipe`, `VerifyAndMergePr`, `FileIssue`,
+  `TransferGoal`, `Report`, `RunAudit`, `GoalCurator` proposals. Objective gates
+  (CI-green, base allowlist, merge-judge) stay intact.
+- **HIGH-RISK (gated → `Escalate` unless opted in):** `Deploy` (self-mutating binary
+  swap), `ResolveConflict` (can involve force-adjacent / `--no-verify` pushes),
+  `Escalate`. These map to the autonomy model's five gated operations (force-push /
+  history rewrite, repo/branch deletion, public/breaking API change,
+  security/credential change, writes to protected `~/src` repos), enforced by
+  `git_guardrails` + `ado_acl_guard`. `AutonomyGate.allow_high_risk` defaults `false`.
+
+### Anti-recursion (never loop on itself; never entangle with OODA)
+
+Two layers:
+
+1. **Structural.** The Overseer is a co-process, **not** a `CognitiveThread`, so
+   Simard's OODA scheduler never runs it and it never runs OODA. The two loops
+   cannot drive each other.
+2. **Identity (`guardrails::RecursionGuard`).** The Overseer stamps its own work
+   (author login, `overseer/` branch prefix, `overseer:` goal-source tag) and
+   **refuses to act on its own artifacts** — it never verifies/merges/deploys its own
+   PRs, sweeps its own branches, or re-opens goals it filed. Combined with Orient's
+   dedup against in-flight work, this prevents both self-loops and fighting Simard's
+   engineers.
+
+### Budget + concurrency caps
+
+- **Budget (`guardrails::BudgetGate`).** Before any cost-bearing intervention
+  (`LaunchRecipe`, `RunAudit`), check today's spend vs `SIMARD_DAILY_BUDGET_USD`
+  (default 500, the same knob OODA uses) via `cost_tracking::daily_summary`. Over
+  budget → hold + report, never launch.
+- **Concurrency.** A per-cycle launch cap (`max_launches_per_cycle`) bounds how many
+  workstreams one cycle starts, on top of the launcher's own AIMD engineer cap
+  (`agent_supervisor` / `SIMARD_MAX_CONCURRENT_ACTIONS`). The Overseer never raises
+  real parallelism beyond the AIMD ceiling.
+
+### Conflict-avoidance sequencing
+
+`guardrails::ConflictSequencer` admits at most one active workstream per
+`sequence_group`. Feature recipes (unsequenced) may run in parallel; **mechanical
+sweeps** that touch shared OODA-core files (renames, `print!`-purges) declare a
+group (e.g. `ooda-core`) and run **one-at-a-time**, exactly the operator's manual
+discipline. This prevents the Overseer's own workstreams from colliding on shared
+files.
+
+### pr-verify checklist
+
+`PrOps::verify` runs a checklist before any merge. Items 1–2 and 7 reuse existing
+code; items 3–6 are **new additive diff-scans** this design introduces (they do not
+exist yet):
+
+| # | Check | Status |
+|---|-------|--------|
+| 1 | CI green (all required checks SUCCESS/NEUTRAL/SKIPPED) | reuse `evaluate_objective_gates` |
+| 2 | Mergeable + base-branch allowlist | reuse `evaluate_objective_gates` |
+| 3 | No `Bridge` naming in added lines | **new** diff-scan |
+| 4 | No stray `print!`/`println!`/`eprintln!` in added `src/**` | **new** diff-scan |
+| 5 | Additive / non-breaking (no removed `pub` items) | **new** diff-scan |
+| 6 | PRD (`Specs/ProductArchitecture.md`) preserved | **new** check |
+| 7 | No Bug/Security finding ≥ High | reuse `review_pipeline::should_commit` |
+
+See `prompt_assets/simard/overseer/pr_verify.md` and `deploy_gate.md`.
+
+## Persisted state
+
+The Overseer is **deliberately DB-free**, matching the cognitive-thread rule
+("do not add a schema, migration, or table"). It persists only small, file-backed
+markers under the shared state root (`~/.simard/overseer/`):
+
+| State | Shape | Why |
+|-------|-------|-----|
+| Last-cycle marker | epoch file (reuse `self_quality_audit::{read_last_run,write_last_run}`) | durable cadence across restarts |
+| Active workstreams | `{ dedup_key → WorkstreamHandle }` (JSON) | dedup + poll launched recipes to their PRs |
+| Active sweep groups | list of `sequence_group` | conflict sequencing across cycles |
+| Deployed-commit marker | reuse the existing `self_deploy` marker (`env!("SIMARD_GIT_HASH")` + drift check) | do not duplicate deploy bookkeeping |
+
+Durable *findings* are **GitHub issues or code**, never committed snapshot docs
+(stewardship rule). Everything else lives in telemetry and the `StatusSnapshot`.
+
+## Explicit boundary vs Simard's own OODA
+
+| | **Simard's OODA** (`ooda_loop`) | **Overseer meta-OODA** (`overseer`) |
+|---|---|---|
+| Scope | External repos she stewards + her own feature work | Simard's **own** health/process + cross-cutting initiatives |
+| Runs as | Inline daemon cycle + `Mind` threads | **Sibling co-process** (M2+) |
+| Observe input | Repo/goal/git/gym/memory state | `StatusSnapshot` + PR/CI/goal state |
+| Acts by | Spawning engineers on goals (`AdvanceGoal`, …) | Launching recipes on **process** problems; verify/merge/deploy; file issues; transfer goals |
+| Scheduling | The OODA scheduler | Its own loop — never scheduled by, and never schedules, OODA |
+| Self-reference | Advances the goal board | **Refuses its own artifacts**; dedups against OODA's in-flight work |
+
+The Overseer works **above** Simard's OODA. When it finds a *process* problem it
+either files a deduped issue, launches a fix workstream, or **transfers a goal** to
+Simard via a meeting — it does not reach into the OODA loop's state.
+
+## Rust sketch
+
+The type/trait sketch lives in `src/overseer/` (additive, `#![allow(dead_code)]`,
+clippy-clean, unit-tested; **not** wired into `main`):
+
+| File | Contents |
+|------|----------|
+| `capabilities.rs` | `OverseerError`; `ObservedState` (Observe input, field-by-field cited); the eight capability traits (`StatusReader`, `RecipeLauncher`, `PrOps`, `Deployer`, `MeetingHost`, `IssueFiler`, `GoalCurator`, `Auditor`), each doc-annotated with the exact reused function; supporting briefs. |
+| `signal.rs` | `Signal`, `Problem`, `ProblemKind`, `Priority`; pure `signals_from`. |
+| `intervention.rs` | `Intervention` (the nine variants above) + `PlannedIntervention`. |
+| `guardrails.rs` | `RiskClass` + `classify`; `AutonomyGate`; `RecursionGuard` + `Subject`; `BudgetGate`; `ConflictSequencer`. |
+| `mod.rs` | `Overseer` co-process type + `Capabilities`; `run_cycle` (meta-OODA); `orient` / `decide` / `classify_signal`; `act` (M2+ execution seam); tests. |
+
+The trait method signatures reference self-contained newtypes (so the sketch
+compiles independently of upstream signature drift); the **doc comments carry the
+precise reuse contract** naming each existing function/file. An optional read-only
+`impl CognitiveThread` sensor (M1) is described above; the acting Overseer is the
+co-process.
+
+## Phased roadmap
+
+Each phase is independently shippable, additive, and gated behind an env flag
+(`SIMARD_OVERSEER_*`, default off).
+
+| Milestone | Scope | Reuse | Test strategy | Exit criteria |
+|-----------|-------|-------|---------------|---------------|
+| **M1 — read-only observer** | Observe + Orient + `Report` + `FileIssue` only. Optional packaging as an `impl CognitiveThread` sensor. No launches, no merges, no deploy. | `status::assemble`; `stewardship::process_orchestrator_run` (deduped issues); `cost_tracking`. | Unit: `signals_from` thresholds; `orient` dedup vs in-flight; issue-filer idempotency with a fake `GhClient` (no network). | Runs behind flag; emits a report + files deduped issues; provably takes no write action beyond issue-filing. |
+| **M2 — autonomous fix-launching + PR verify/merge** | `LaunchRecipe` (smart-orchestrator), poll → PR, `VerifyAndMergePr` for green/merge-ready PRs (routine autonomy). | `spawn_subordinate` / recipe runner; `merge_pr_if_merge_ready`; `evaluate_objective_gates`; `review_pipeline`; NEW pr-verify diff-scans (Bridge / `print!` / additive / PRD). | Unit: budget gate holds launches; per-cycle launch cap; pr-verify checklist pass/fail on fixture diffs; merge only when `ready`. Integration: fake recipe runner + fake `PrGhClient`. | Launches a fix for a seeded process problem and merges the resulting green PR through the gated authority, in a fixture. |
+| **M3 — guarded deploy + goal transfer** | `Deploy` (HIGH-RISK, opt-in) via canary gates + marker update; `ResolveConflict`; `TransferGoal` via meeting REPL. | `SelfDeployOrchestrator` + `self_relaunch` gates + marker; `git_guardrails`; `run_meeting_repl` + handoff. | Unit: deploy gate refuses no-op/rollback/red-canary/crash-loop; HIGH-RISK gated off by default; recursion guard refuses own PRs. Integration: fake deployer/canary; meeting handoff round-trip. | With opt-in, advances the deployed-commit marker only on a green canary; otherwise escalates. Never touches `~/.simard/worktrees`. |
+| **M4 — audits + self-tuning** | `RunAudit` loops (crusty-old-engineer-gated) on demand; recurring self-audit; threshold self-tuning of `SIMARD_OVERSEER_*` knobs. | `self_quality_audit::run_self_quality_audit`; `monthly-self-quality-audit.yaml`; telemetry history. | Unit: audit scope routing; tuning stays within clamped floors; no unbounded growth. | Runs a bounded audit loop and adjusts thresholds within floors, all observable in telemetry. |
+
+## Test strategy (cross-cutting)
+
+- **Pure + injected-clock unit tests**, no sleeps, no network (the shipped
+  cognitive-thread discipline): thresholds, dedup, gating, sequencing, recursion.
+- **Injected capability fakes** for every trait (the sketch's tests already do this
+  for all eight) so behavior is asserted with zero side effects.
+- **Idempotency** on `FileIssue`/`LaunchRecipe` (a second cycle finds the existing
+  issue/workstream and does not duplicate) — mirrors `stewardship` dedup tests.
+- **Failure isolation**: a failing capability degrades one intervention, never the
+  cycle (Observe failure aborts the cycle cleanly; board-read failure degrades to
+  "no dedup", never a crash).
+
+## Non-goals (this spike)
+
+- No daemon runtime behavior change; nothing wired into `main` or the daemon loop.
+- No always-on process; no redeploy; no writes to the live `~/.simard/worktrees`.
+- No new database/schema; no new always-on metrics endpoint.
+- The `Bridge`/`print!`/additive/PRD diff-scans are **specified**, not implemented.
+
+## Related reading
+
+- [Operational autonomy model](../concepts/operational-autonomy-model.md) — the
+  autonomy boundary and HIGH-RISK gating this design inherits.
+- [Cognitive-thread scheduling](../reference/cognitive-thread-scheduling.md) and
+  [Add a new cognitive thread](../howto/add-a-new-cognitive-thread.md) — the
+  least-authority thread contract that justifies co-process over thread.
+- [StatusSnapshot API](../reference/status-snapshot-api.md) and
+  [Unified telemetry and status](../concepts/unified-telemetry-and-status.md) — the
+  Observe input.
+- [Stewardship API](../reference/stewardship-api.md) — deduped issue filing.
+- [Self-Deploy API](../reference/self-deploy-api.md) and
+  [Cross-repo merge authority](../reference/cross-repo-merge-authority.md) — the
+  guarded deploy and merge actions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,8 @@ nav:
     - Brain Introspection + Memory Hygiene: architecture/brain-introspection.md
     - Monthly Self-Quality-Audit: architecture/monthly-self-quality-audit.md
     - Implementation Plan: architecture/implementation-plan.md
+  - Design:
+    - "Overseer — operator/observer co-process (spike)": design/overseer.md
   - Concepts:
     - Operational Autonomy Model: concepts/operational-autonomy-model.md
     - Adaptive Scaling: concepts/adaptive-scaling.md

--- a/prompt_assets/simard/overseer/README.md
+++ b/prompt_assets/simard/overseer/README.md
@@ -1,0 +1,59 @@
+# Overseer prompt/recipe scaffolding (#2419)
+
+> **Status: design scaffolding — NOT wired live.** These prompt templates are part
+> of the Overseer operator/observer design spike. No recipe or code path loads
+> them yet. They pin down the intended prompt surface so a later milestone can
+> wire them behind an env flag without redesigning. See
+> [`docs/design/overseer.md`](../../../docs/design/overseer.md).
+
+## What is here
+
+| File | Meta-OODA phase | Input → output |
+|------|-----------------|----------------|
+| [`observe.md`](./observe.md) | Observe + Orient | `StatusSnapshot` + signals + in-flight → prioritized `Problem`s (deduped) |
+| [`problem_to_brief.md`](./problem_to_brief.md) | Decide | one `Problem` → a `smart-orchestrator` `task_description` |
+| [`pr_verify.md`](./pr_verify.md) | Act (verify) | PR body + CI + diff → merge-ready verdict + checklist |
+| [`deploy_gate.md`](./deploy_gate.md) | Act (deploy, HIGH-RISK) | target/deployed commit + canary → deploy/propose/hold |
+
+## Reuse the existing recipes — do not reinvent
+
+The Overseer **drives fixes through the recipes Simard already uses**. The prompts
+above only *decide what to launch and whether to merge/deploy*; the actual work is
+done by existing recipes and code:
+
+- **`smart-orchestrator` → `default-workflow`.** The Overseer launches fixes the
+  exact way engineers do, via the recipe runner:
+
+  ```bash
+  amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml \
+    -c task_description="<from problem_to_brief.md>" \
+    -c repo_path=.
+  ```
+
+  This is the same entrypoint used at `prompt_assets/simard/engineer_system.md`
+  and invoked from `src/bin/simard_engineer_loop_recipe.rs`. `smart-orchestrator`
+  classifies the task and routes Development work through `default-workflow` (the
+  22-step DEFAULT_WORKFLOW). The Overseer never hand-rolls a workflow.
+
+- **`recipe-runner-rs` + `AMPLIHACK_AGENT_BINARY`.** For structured single-shot
+  brain calls (e.g. rendering `observe.md`/`pr_verify.md` to JSON) the Overseer
+  reuses the subprocess pattern in `src/stewardship/recipe_merge_judge.rs` and
+  parses output with `src/recipe_output/extract.rs`.
+
+- **Quality-audit recipe.** `RunAudit` reuses the existing
+  [`monthly-self-quality-audit.yaml`](../recipes/monthly-self-quality-audit.yaml)
+  recipe and `crate::self_quality_audit::run_self_quality_audit` — the same
+  crusty-old-engineer-gated audit loop, invoked on demand instead of only monthly.
+
+- **Merge / deploy / issues / goals / meetings.** These map to existing code, not
+  prompts: `stewardship::merge_pr_if_merge_ready`, `self_deploy` + `self_relaunch`,
+  `stewardship::process_orchestrator_run`, `goal_curation`, and
+  `meeting_repl::run_meeting_repl`. See the reuse map in the design doc.
+
+## Placeholders
+
+Prompt bodies use `{placeholder}` variables (matching the house style of the other
+`prompt_assets/simard/*.md` prompts) that a recipe would substitute via
+`-c key=value`. Values are always sanitized (`sanitization::sanitize_terminal_text`)
+before substitution; untrusted content never appears in a metric name or an
+`@mention`/`#ref` position.

--- a/prompt_assets/simard/overseer/deploy_gate.md
+++ b/prompt_assets/simard/overseer/deploy_gate.md
@@ -1,0 +1,69 @@
+# Overseer — Deploy gate (HIGH-RISK)
+
+> **Status: design scaffolding (#2419), not wired live.** Part of the Overseer
+> design spike. See `docs/design/overseer.md`.
+
+## ROLE
+
+You are the **deploy gate** of Simard's Overseer. Deploying a new binary of the
+live daemon is the Overseer's single self-mutating, **HIGH-RISK** action. Under
+the [operational autonomy model](../../../docs/concepts/operational-autonomy-model.md),
+HIGH-RISK operations are **not auto-executed by default** — they surface to the
+operator for sign-off. This gate produces the go/no-go verdict; the actual
+build+verify+handover is `Deployer::deploy`
+(`crate::self_deploy::orchestrator::SelfDeployOrchestrator::run` +
+`crate::self_relaunch::{build_canary, verify_canary, all_gates_passed, handover}`).
+
+You never bypass the canary gates. You decide whether a deploy should be
+**proposed** at all, and whether the operator opt-in
+(`allow_high_risk = true` / the deploy env opt-in) is present.
+
+## CONTEXT
+
+```json
+{
+  "target_commit": "{target_commit}",
+  "deployed_commit": "{deployed_commit}",
+  "high_risk_autonomy_enabled": {high_risk_autonomy_enabled},
+  "merged_prs_since_deploy": {merged_prs_since_deploy},
+  "canary_gate_results": {canary_gate_results},
+  "budget_ok": {budget_ok}
+}
+```
+
+## GATE
+
+| # | Condition | Requirement |
+|---|-----------|-------------|
+| 1 | **Advances the deployed commit** | `target_commit != deployed_commit` and is an ancestor-descendant advance (never a rollback disguised as a deploy). |
+| 2 | **Something to ship** | `merged_prs_since_deploy > 0` — do not churn a redeploy for no change (the operator observed ~hourly restart churn; avoid contributing to it). |
+| 3 | **Canary gates pass** | `all_gates_passed(canary_gate_results)` — Smoke + UnitTest + GymBaseline + health, per `self_relaunch::default_gates`. Never deploy on a red canary. |
+| 4 | **Not crash-looping** | The current instance is not already in restart churn (deploying into churn compounds it). |
+| 5 | **Autonomy / sign-off** | If `high_risk_autonomy_enabled` is false, the verdict is **propose-and-wait**: emit `escalate`, do not auto-deploy. |
+
+## OUTPUT
+
+```json
+{
+  "verdict": "deploy | propose | hold",
+  "target_commit": "{target_commit}",
+  "gates": [
+    { "name": "advances_commit", "passed": true },
+    { "name": "has_changes_to_ship", "passed": true },
+    { "name": "canary_green", "passed": true },
+    { "name": "not_crash_looping", "passed": true },
+    { "name": "autonomy_or_signoff", "passed": false }
+  ],
+  "rationale": "one-paragraph justification citing the numbers",
+  "deployed_commit_marker_update": "on success, record target_commit as the new deployed marker"
+}
+```
+
+- `verdict = "deploy"` **only** when every gate passes *and* HIGH-RISK autonomy is
+  enabled. On success, the Overseer updates the deployed-commit marker
+  (`env!("SIMARD_GIT_HASH")` on the new binary; the drift check in
+  `self_deploy::drift` confirms the advance).
+- `verdict = "propose"` when everything is green **except** the autonomy/sign-off
+  gate — surface to the operator, do not deploy.
+- `verdict = "hold"` when any hard gate (1–4) fails — never deploy; relaunch a fix
+  or wait.

--- a/prompt_assets/simard/overseer/observe.md
+++ b/prompt_assets/simard/overseer/observe.md
@@ -1,0 +1,84 @@
+# Overseer — Observe → prioritized Problems
+
+> **Status: design scaffolding (#2419), not wired live.** This prompt template is
+> part of the Overseer operator/observer design spike. It is not yet loaded by any
+> recipe or code path. See `docs/design/overseer.md`.
+
+## ROLE
+
+You are the **Observe/Orient** brain of Simard's Overseer — an autonomous
+operator that watches HOW Simard performs and drives improvements **outside**
+Simard's own OODA loop. You are given one `StatusSnapshot` (the same value
+`simard status` renders, from `crate::status::assemble`) plus recent PR/CI/goal
+state and the goal board's in-flight work. Your job is to distill this into a
+small, **deduplicated, prioritized** list of `Problem`s the Overseer should act
+on. You do **not** choose fixes here — that is the `problem_to_brief` step.
+
+Be conservative and specific. Prefer a short list of well-evidenced problems over
+a long speculative one. A signal that is already being handled by an in-flight
+engineer is **not** a problem — drop it.
+
+## CONTEXT
+
+```json
+{
+  "status_snapshot": {status_snapshot},
+  "in_flight": {in_flight},
+  "recent_prs": {recent_prs},
+  "recent_ci": {recent_ci}
+}
+```
+
+Read these snapshot fields (all from `crate::status::StatusSnapshot`; a section
+may be `unavailable`/`absent` — treat missing as "unknown", never as `0`):
+
+| Field | Source section | Signal it feeds |
+|-------|----------------|-----------------|
+| `telemetry.distill_fail_pct` | TelemetrySignals | `DistillFailureRate` |
+| `telemetry.restart_churn` / `daemon.n_restarts` | TelemetrySignals / Daemon | `RestartChurn` |
+| `memory.decide_ladder_exhausted` | MemoryBrain | `LadderExhausted` |
+| `llm.ledger_today.cost_usd` vs `llm.daily_budget_usd` | LlmUsage | `BudgetPressure` |
+| `resources.live_engineers` | Resources | `EngineerSpawnRate` |
+| `memory.nodes_total` | MemoryBrain | `MemoryGrowth` |
+| `gym.skip_gym` | Gym | `GymSkipped` |
+| `telemetry.anomalies[]` | TelemetrySignals | `Anomaly` |
+| `recent_ci` clusters | (PR statusCheckRollup) | `CiFailureCluster` |
+| `recent_prs` (green + mergeable) | (objective gates) | `PrReadyToMerge` |
+
+## DEDUP RULE (do not fight Simard's own OODA)
+
+Each `in_flight` item carries `refs[]` — the dedup keys of work an engineer is
+already doing. If a candidate problem's `dedup_key` appears in any in-flight
+`refs`, **omit it**. Simard's OODA governs the external repos and her own feature
+work; you operate at the meta level and must never duplicate her in-flight work.
+
+## OUTPUT
+
+Return a single JSON object. `problems` is ordered most-important first.
+
+```json
+{
+  "problems": [
+    {
+      "kind": "process_health | resource_pressure | delivery_ready | quality_regression | goal_hygiene | cross_cutting",
+      "priority": "critical | high | normal | low",
+      "dedup_key": "stable-key-for-this-problem",
+      "summary": "one sentence, concrete, with the number that triggered it",
+      "evidence": ["the signal name(s) and value(s) that support this"]
+    }
+  ],
+  "dropped_as_in_flight": ["dedup_key ..."],
+  "notes": "optional: anything ambiguous or degraded in the snapshot"
+}
+```
+
+Guidance:
+
+- **priority.** `critical` only for active harm (crash-looping, corruption).
+  `high` for parse-failure spikes, restart churn, budget pressure, CI clusters.
+  `normal`/`low` for hygiene and slow-growth signals.
+- **dedup_key.** Stable and coarse (e.g. `process:distill_fail`,
+  `quality:ci:<repo>`, `delivery:pr:<repo>#<n>`), so the same problem across
+  cycles collapses to one.
+- **evidence.** Always cite the concrete number. "distillation parse-failure rate
+  62%" — not "distillation seems unhealthy".

--- a/prompt_assets/simard/overseer/pr_verify.md
+++ b/prompt_assets/simard/overseer/pr_verify.md
@@ -1,0 +1,68 @@
+# Overseer — PR-verify checklist
+
+> **Status: design scaffolding (#2419), not wired live.** Part of the Overseer
+> design spike. See `docs/design/overseer.md`.
+
+## ROLE
+
+You are the **PR-verify** gate of Simard's Overseer. Before the Overseer merges a
+PR produced by one of its launched workstreams, you check it against the
+constraint list the human operator has always enforced by hand. You return a
+structured verdict. You do **not** merge — the Overseer's `PrOps::merge`
+(`crate::stewardship::merge_pr_if_merge_ready`) does that, and only if you return
+`ready: true`.
+
+This gate **layers on top of** Simard's existing objective gates
+(`evaluate_objective_gates`: CI-green + mergeable + base-branch allowlist) and the
+merge-judge — it never replaces them.
+
+## CONTEXT
+
+```json
+{
+  "repo": "{repo}",
+  "pr_number": {pr_number},
+  "pr_body": {pr_body},
+  "status_check_rollup": {status_check_rollup},
+  "diff": {diff}
+}
+```
+
+## CHECKLIST
+
+Evaluate each item. `passed` must be backed by a concrete observation.
+
+| # | Check | How to judge | Backed by |
+|---|-------|--------------|-----------|
+| 1 | **CI green** | Every entry in `status_check_rollup` is `SUCCESS`/`NEUTRAL`/`SKIPPED`. | existing: `evaluate_objective_gates` (`merge_authority.rs:495`) |
+| 2 | **Mergeable / base allowed** | `mergeable == MERGEABLE`; base ∈ allowlist (default `main`). | existing: `evaluate_objective_gates` |
+| 3 | **No `Bridge` naming** | No **added** line introduces a type/module/identifier containing `Bridge`. | NEW additive diff-scan |
+| 4 | **No stray `print!`** | No **added** line adds `print!`/`println!`/`eprint!`/`eprintln!` in `src/**` (structured `tracing`/OTel only). | NEW additive diff-scan |
+| 5 | **Additive / non-breaking** | No **removed** `pub fn`/`pub struct`/`pub enum`/`pub trait` (public surface only grows). | NEW additive diff-scan |
+| 6 | **PRD preserved** | `Specs/ProductArchitecture.md` (the PRD) is not deleted or gutted; product intent intact. | NEW check |
+| 7 | **Review-clean** | No `Bug`/`Security` finding at severity ≥ High. | existing: `review_pipeline::should_commit` |
+
+Items 1–2 and 7 reuse existing code; items 3–6 are **new additive diff-scans**
+this design introduces (they do not yet exist — see the design doc §checklist).
+Scan only **added** lines (diff `+`) for 3–4, **removed** lines (diff `-`) for 5.
+
+## OUTPUT
+
+```json
+{
+  "ready": true,
+  "checks": [
+    { "name": "ci_green", "passed": true, "note": "12/12 required checks SUCCESS" },
+    { "name": "no_bridge_naming", "passed": true, "note": "0 added lines match /Bridge/" },
+    { "name": "no_stray_print", "passed": true, "note": "" },
+    { "name": "additive_non_breaking", "passed": true, "note": "no pub items removed" },
+    { "name": "prd_preserved", "passed": true, "note": "" },
+    { "name": "review_clean", "passed": true, "note": "" }
+  ],
+  "blockers": []
+}
+```
+
+`ready` is `true` **only if every check passes**. On any failure, set
+`ready: false` and list the specific blockers (with file/line where relevant) so
+the Overseer can either relaunch a fix workstream or escalate — never merge.

--- a/prompt_assets/simard/overseer/problem_to_brief.md
+++ b/prompt_assets/simard/overseer/problem_to_brief.md
@@ -1,0 +1,75 @@
+# Overseer — Problem → smart-orchestrator fix brief
+
+> **Status: design scaffolding (#2419), not wired live.** Part of the Overseer
+> design spike. See `docs/design/overseer.md`.
+
+## ROLE
+
+You are the **Decide** brain of Simard's Overseer. You are given one prioritized
+`Problem` (from `observe.md`) and must turn it into a **`task_description`** for a
+`smart-orchestrator` recipe run — the exact same entrypoint engineers use:
+
+```
+amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml \
+  -c task_description="<what you write here>" \
+  -c repo_path=.
+```
+
+`smart-orchestrator` classifies the task and routes it through `default-workflow`
+(the 22-step DEFAULT_WORKFLOW). You are **not** implementing the fix — you are
+writing a crisp, bounded brief so the workflow can. Reuse the existing recipes;
+never invent a new workflow.
+
+## CONTEXT
+
+```json
+{
+  "problem": {problem},
+  "target_repo": "{target_repo}",
+  "constraints": {constraints}
+}
+```
+
+## HOW TO WRITE THE BRIEF
+
+A good `task_description`:
+
+1. **States the observed symptom with its number** ("distillation parse-failure
+   rate is ~62% over the last window") and the **suspected cause** if the evidence
+   points to one (e.g. launch-banner pollution, goal-board multi-writer race,
+   stale-completion re-litigation, restart churn, weak distillation).
+2. **Names the smallest surface** likely responsible — cite modules/files when the
+   problem points at them, so decomposition targets the right code.
+3. **Is additive / non-breaking by default.** Say so explicitly. Preserve the PRD.
+   No `Bridge` naming. No stray `print!`/`println!` in new code (structured
+   `tracing` + OTel only).
+4. **Carries the merge-ready expectation** — CI green, tests, docs/link updates,
+   quality-audit cycles — so the workflow finishes merge-ready, not half-done.
+5. **Declares a sequence group** when the fix is a *mechanical sweep* on shared
+   OODA-core files (renames, `print!` purges). These run one-at-a-time; feature
+   fixes may run in parallel. This prevents the Overseer's workstreams from
+   colliding with each other.
+
+## OUTPUT
+
+```json
+{
+  "recipe": "smart-orchestrator",
+  "task_description": "the full brief, ready to pass verbatim as -c task_description=...",
+  "target_repo": "{target_repo}",
+  "is_mechanical_sweep": true,
+  "sequence_group": "ooda-core | null",
+  "success_criteria": [
+    "CI green on all required checks",
+    "additive / non-breaking; PRD preserved",
+    "no Bridge naming; no stray print! in new code",
+    "..."
+  ]
+}
+```
+
+Keep `task_description` self-contained: an engineer with no other context should
+be able to act on it. If the problem is `resource_pressure` (budget) or otherwise
+**not** a code fix, do **not** fabricate a brief — return
+`{"recipe": null, "escalate": "reason"}` so the Overseer escalates or reports
+instead of launching a pointless workstream.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,10 @@ mod operator_commands_meeting;
 mod operator_commands_ooda;
 mod operator_commands_review;
 mod operator_commands_terminal;
+// Design spike (#2419): additive type/trait sketch for the Overseer
+// operator/observer co-process. NOT wired into `main` or the daemon loop —
+// nothing here is constructed at runtime. See docs/design/overseer.md.
+pub mod overseer;
 mod persistence;
 pub mod prompt_assets;
 pub mod prompt_delivery;

--- a/src/overseer/capabilities.rs
+++ b/src/overseer/capabilities.rs
@@ -1,0 +1,306 @@
+//! Capability traits for the Overseer, each annotated with the EXISTING Simard
+//! module/function that satisfies it. These traits are the seam between the
+//! Overseer's meta-OODA loop and Simard's already-shipped machinery: an
+//! implementation is a thin adapter that calls the cited function, never a
+//! reimplementation.
+//!
+//! Nothing here constructs or runs anything — the module is a design sketch
+//! (`#![allow(dead_code)]` in `mod.rs`). The newtypes below are deliberately
+//! self-contained so the sketch compiles independently of upstream signature
+//! drift; the doc comments carry the precise reuse contract.
+
+use std::fmt;
+
+/// Small, cheap error type shared by every capability. Kept intentionally tiny
+/// so `Result<T, OverseerError>` never trips `clippy::result_large_err`.
+#[derive(Clone, Debug, PartialEq)]
+pub enum OverseerError {
+    /// An underlying Simard capability call failed.
+    Capability { what: &'static str, detail: String },
+    /// A HIGH-RISK intervention was refused by the autonomy gate.
+    Gated {
+        intervention: String,
+        risk: &'static str,
+    },
+    /// A cost-bearing intervention was refused by the budget gate.
+    Budget { spent_usd: f64, budget_usd: f64 },
+    /// An intervention was refused because it targets the Overseer's own work.
+    Recursion { subject: String },
+    /// An intervention was deferred to avoid colliding with in-flight work.
+    Conflict { with: String },
+}
+
+impl fmt::Display for OverseerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Capability { what, detail } => write!(f, "capability {what} failed: {detail}"),
+            Self::Gated { intervention, risk } => {
+                write!(
+                    f,
+                    "{intervention} gated (risk={risk}); escalated to operator"
+                )
+            }
+            Self::Budget {
+                spent_usd,
+                budget_usd,
+            } => {
+                write!(f, "budget gate: spent ${spent_usd:.2} of ${budget_usd:.2}")
+            }
+            Self::Recursion { subject } => write!(f, "anti-recursion: refused own {subject}"),
+            Self::Conflict { with } => write!(f, "conflict-avoidance: deferred (overlaps {with})"),
+        }
+    }
+}
+
+impl std::error::Error for OverseerError {}
+
+// ─────────────────────────── Observe input ────────────────────────────────
+
+/// The subset of `crate::status::StatusSnapshot` the Overseer reads each Observe
+/// pass, flattened into a self-contained value. Every field cites its durable
+/// source so an adapter knows exactly which snapshot section to copy.
+///
+/// **Reuse:** produced by `StatusReader::snapshot`, which wraps
+/// `crate::status::assemble(&AssembleOptions)` (`src/status/provider.rs:58`).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ObservedState {
+    /// `StatusSnapshot.telemetry.distill_fail_pct` (`src/status/mod.rs`).
+    pub distill_fail_pct: Option<f64>,
+    /// `StatusSnapshot.telemetry.restart_churn` + `Daemon.n_restarts`.
+    pub restart_churn: Option<u64>,
+    /// `StatusSnapshot.memory.decide_ladder_exhausted`.
+    pub ladder_exhausted: Option<u64>,
+    /// `StatusSnapshot.llm.ledger_today.cost_usd`.
+    pub spent_today_usd: Option<f64>,
+    /// `StatusSnapshot.llm.daily_budget_usd` (env `SIMARD_DAILY_BUDGET_USD`).
+    pub daily_budget_usd: Option<f64>,
+    /// `StatusSnapshot.resources.live_engineers`.
+    pub live_engineers: Option<u32>,
+    /// `StatusSnapshot.memory.nodes_total`.
+    pub memory_nodes: Option<u64>,
+    /// `StatusSnapshot.gym.skip_gym`.
+    pub gym_skipped: bool,
+    /// `StatusSnapshot.telemetry.anomalies[]` (free-form strings).
+    pub anomalies: Vec<String>,
+    /// Merge-ready PRs observed via `PrOps`/`PrGhClient` (`merge_authority.rs`).
+    pub ready_prs: Vec<PrRef>,
+    /// CI-failure clusters observed across recent runs.
+    pub ci_failures: Vec<CiFailure>,
+}
+
+/// A `(repo, pr)` pair. `repo` is an `owner/name` slug.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PrRef {
+    pub repo: String,
+    pub pr: u32,
+}
+
+/// A cluster of failing checks for one repo over the observation window.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CiFailure {
+    pub repo: String,
+    pub failing: u32,
+}
+
+// ─────────────────────────── Capability briefs ─────────────────────────────
+
+/// Input to `RecipeLauncher::launch`: becomes the `-c task_description=…` context
+/// var of a `smart-orchestrator` run. `sequence_group` lets the conflict
+/// sequencer serialise mechanical sweeps that touch the same shared files.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecipeBrief {
+    pub task_description: String,
+    pub target_repo: String,
+    pub sequence_group: Option<String>,
+}
+
+/// Handle to a launched workstream (a spawned engineer / recipe subprocess).
+///
+/// **Reuse:** `crate::agent_supervisor::SubordinateHandle`
+/// (`src/agent_supervisor/types.rs`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkstreamHandle {
+    pub id: String,
+}
+
+/// Terminal / in-flight state of a launched workstream.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WorkstreamStatus {
+    Running,
+    ProducedPr { repo: String, pr: u32 },
+    Failed { reason: String },
+}
+
+/// Result of the `pr-verify` checklist (see `prompt_assets/simard/overseer/pr_verify.md`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifyReport {
+    pub ready: bool,
+    pub checks: Vec<CheckItem>,
+}
+
+/// One line of the pr-verify checklist.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CheckItem {
+    pub name: String,
+    pub passed: bool,
+    pub note: String,
+}
+
+/// Result of a guarded deploy.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeployReport {
+    pub deployed_commit: String,
+    pub gates_passed: bool,
+}
+
+/// Input to `MeetingHost::transfer_goal` / `GoalCurator::propose`. Mirrors the
+/// fields of `crate::meetings::PersistedMeetingGoalUpdate` and a curated goal.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GoalBrief {
+    pub title: String,
+    pub rationale: String,
+    pub priority: u8,
+    pub target_repo: String,
+}
+
+/// Input to `IssueFiler::file`. Field-for-field a
+/// `crate::stewardship::OrchestratorRunSummary` (`src/stewardship/types.rs`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OrchestratorRunBrief {
+    pub recipe_name: String,
+    pub failed_step: String,
+    pub source_module: String,
+    pub failure_kind: String,
+    pub error_text: String,
+}
+
+/// Outcome of filing a deduplicated issue.
+///
+/// **Reuse:** `crate::stewardship::StewardshipOutcome`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IssueOutcome {
+    FiledNew { url: String },
+    MatchedExisting { url: String },
+}
+
+/// Scope for a quality-audit run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AuditScope {
+    SelfHealth,
+    Repo { slug: String },
+    CrossCutting,
+}
+
+/// Result of a quality-audit run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuditReport {
+    pub scope: AuditScope,
+    pub passed: bool,
+    pub findings: Vec<String>,
+}
+
+/// One in-flight goal/workstream the Overseer must dedup/sequence against.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InFlightItem {
+    pub id: String,
+    pub source: String,
+    pub refs: Vec<String>,
+}
+
+// ─────────────────────────── Capability traits ─────────────────────────────
+
+/// Assemble the Overseer's primary Observe input.
+///
+/// **Reuse:** `crate::status::assemble(&AssembleOptions)` (`src/status/provider.rs:58`)
+/// returning `crate::status::StatusSnapshot` (`src/status/mod.rs`), plus
+/// `crate::cost_tracking::daily_summary` for spend. Read-only; never panics
+/// (degraded sections become `None`).
+pub trait StatusReader {
+    fn snapshot(&self) -> Result<ObservedState, OverseerError>;
+}
+
+/// Launch and poll amplihack recipe workstreams — the Overseer's core "drive a
+/// fix OUTSIDE Simard's loop" action.
+///
+/// **Reuse:** `amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml
+/// -c task_description=<brief>` exactly as engineers do
+/// (`src/bin/simard_engineer_loop_recipe.rs:51`,
+/// `src/bin/simard_self_improve_recipe.rs:50`), and the
+/// `recipe-runner-rs` + `AMPLIHACK_AGENT_BINARY` pattern in
+/// `src/stewardship/recipe_merge_judge.rs:191`. Bound concurrency with
+/// `crate::agent_supervisor::spawn_subordinate`
+/// (`src/agent_supervisor/lifecycle/spawn.rs:27`, AIMD cap). Parse results with
+/// `crate::recipe_output::extract` (`src/recipe_output/extract.rs`).
+pub trait RecipeLauncher {
+    fn launch(&self, brief: &RecipeBrief) -> Result<WorkstreamHandle, OverseerError>;
+    fn poll(&self, handle: &WorkstreamHandle) -> Result<WorkstreamStatus, OverseerError>;
+}
+
+/// Verify, conflict-resolve, and merge pull requests through the gated authority.
+///
+/// **Reuse:** `crate::stewardship::merge_pr_if_merge_ready`
+/// (`src/stewardship/merge_authority.rs:564`) for the merge itself;
+/// `evaluate_objective_gates` (`:495`) for CI-green/mergeable/base-allowlist;
+/// `crate::review_pipeline::{review_diff, should_commit}` for the review gate;
+/// `crate::git_guardrails::check_git_safety` (`src/git_guardrails.rs:41`) around
+/// any conflict-resolution push. The Bridge/`print!`/additive/PRD checklist items
+/// are NEW additive diff-scans (see the design doc §pr-verify checklist).
+pub trait PrOps {
+    fn verify(&self, repo: &str, pr: u32) -> Result<VerifyReport, OverseerError>;
+    fn merge(&self, repo: &str, pr: u32) -> Result<(), OverseerError>;
+    fn resolve_conflict(&self, repo: &str, pr: u32) -> Result<(), OverseerError>;
+}
+
+/// Build, verify, and hand over a new binary — the Overseer's guarded (HIGH-RISK)
+/// deploy action.
+///
+/// **Reuse:** `crate::self_deploy::orchestrator::SelfDeployOrchestrator::run`
+/// (`src/self_deploy/orchestrator.rs:229`);
+/// `crate::self_relaunch::{build_canary, verify_canary, all_gates_passed,
+/// default_gates, handover}`; `crate::safe_update::SafeUpdateOrchestrator`. The
+/// deployed-commit marker is `env!("SIMARD_GIT_HASH")` via
+/// `self_deploy::health` (`src/self_deploy/health.rs`).
+pub trait Deployer {
+    fn deploy(&self, commit: &str) -> Result<DeployReport, OverseerError>;
+    fn deployed_commit(&self) -> Result<String, OverseerError>;
+}
+
+/// Transfer/handoff a goal to Simard via the meeting REPL.
+///
+/// **Reuse:** `crate::meeting_repl::run_meeting_repl`
+/// (`src/meeting_repl/repl.rs:211`); `crate::meeting_facilitator` handoff
+/// (`MeetingHandoff`, `write_meeting_handoff`);
+/// `crate::meetings::PersistedMeetingGoalUpdate`.
+pub trait MeetingHost {
+    fn transfer_goal(&self, goal: &GoalBrief) -> Result<(), OverseerError>;
+}
+
+/// File a deduplicated GitHub issue for a recurring failure (stewardship mode).
+///
+/// **Reuse:** `crate::stewardship::process_orchestrator_run`
+/// (`src/stewardship/mod.rs:51`) with `OrchestratorRunSummary`; dedup via
+/// `crate::stewardship::{failure_signature, find_existing}`
+/// (`src/stewardship/dedup.rs`); backlog enqueue via
+/// `crate::goal_curation::enqueue_stewardship_issue`.
+pub trait IssueFiler {
+    fn file(&self, run: &OrchestratorRunBrief) -> Result<IssueOutcome, OverseerError>;
+}
+
+/// Propose/curate goals and read the board for dedup/conflict checks.
+///
+/// **Reuse:** `crate::goal_curation::{load_goal_board, promote_to_active,
+/// save_goal_board}`; the flock write-lock `BoardWriteLock` (#2514,
+/// `src/goal_curation/operations.rs:190`); `MAX_ACTIVE_GOALS`.
+pub trait GoalCurator {
+    fn propose(&self, goal: &GoalBrief) -> Result<(), OverseerError>;
+    fn in_flight(&self) -> Result<Vec<InFlightItem>, OverseerError>;
+}
+
+/// Run a quality-audit loop (crusty-old-engineer-gated).
+///
+/// **Reuse:** `crate::self_quality_audit::run_self_quality_audit`
+/// (`src/self_quality_audit.rs`) and the quality-audit recipe
+/// `prompt_assets/simard/recipes/monthly-self-quality-audit.yaml`.
+pub trait Auditor {
+    fn run_audit(&self, scope: &AuditScope) -> Result<AuditReport, OverseerError>;
+}

--- a/src/overseer/guardrails.rs
+++ b/src/overseer/guardrails.rs
@@ -1,0 +1,189 @@
+//! First-class guardrails for the Overseer: the autonomy boundary (routine vs
+//! HIGH-RISK), anti-recursion (never act on its own work; never entangle with
+//! Simard's OODA loop), budget caps, and conflict-avoidance sequencing.
+//!
+//! These mirror `docs/concepts/operational-autonomy-model.md` and are enforced
+//! ON TOP of Simard's existing always-on floors
+//! (`crate::git_guardrails`, `crate::ado_acl_guard`) — they never replace them.
+
+use crate::overseer::capabilities::OverseerError;
+use crate::overseer::intervention::Intervention;
+
+/// Risk classification for an intervention. Routine interventions execute
+/// autonomously (per the operator directive "for most operations she should not
+/// need outside-party validation"); HIGH-RISK ones are gated and surface to the
+/// human via `Intervention::Escalate`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RiskClass {
+    Routine,
+    HighRisk,
+}
+
+/// Classify an intervention. HIGH-RISK maps to the five gated operations of the
+/// autonomy model (deploy is the Overseer's one self-mutating action; conflict
+/// resolution can involve force-adjacent pushes; escalation is inherently a
+/// hand-off). Everything else is routine.
+pub fn classify(iv: &Intervention) -> RiskClass {
+    match iv {
+        // Self-mutating binary swap of the live daemon.
+        Intervention::Deploy { .. } => RiskClass::HighRisk,
+        // Conflict resolution can touch shared/protected history; gate it so the
+        // `--no-verify` push path is never taken unattended by default.
+        Intervention::ResolveConflict { .. } => RiskClass::HighRisk,
+        // Escalation is, by definition, a request for human sign-off.
+        Intervention::Escalate { .. } => RiskClass::HighRisk,
+        _ => RiskClass::Routine,
+    }
+}
+
+/// Admits routine interventions; gates HIGH-RISK ones unless the operator has
+/// explicitly opted in (default `false`). A gated intervention is not executed —
+/// it is turned into an `Escalate` in the plan.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct AutonomyGate {
+    pub allow_high_risk: bool,
+}
+
+impl AutonomyGate {
+    pub fn admit(&self, iv: &Intervention) -> Result<(), OverseerError> {
+        match classify(iv) {
+            RiskClass::Routine => Ok(()),
+            RiskClass::HighRisk if self.allow_high_risk => Ok(()),
+            RiskClass::HighRisk => Err(OverseerError::Gated {
+                intervention: iv.label().to_string(),
+                risk: "high",
+            }),
+        }
+    }
+}
+
+/// A subject the Overseer might act on. Used by `RecursionGuard` to refuse the
+/// Overseer's own artifacts.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Subject {
+    Pr {
+        repo: String,
+        pr: u32,
+        author: String,
+    },
+    Commit {
+        sha: String,
+        author: String,
+    },
+    Branch {
+        name: String,
+    },
+    Goal {
+        id: String,
+        source: String,
+    },
+}
+
+/// Anti-recursion identity. The Overseer must never verify/merge/deploy its OWN
+/// PRs/commits, never sweep branches it created, and never re-open goals it
+/// filed. Combined with the architectural fact that the Overseer is a co-process
+/// (NOT a `CognitiveThread`), this guarantees it neither schedules nor is
+/// scheduled by Simard's OODA loop — the two loops never drive each other.
+#[derive(Clone, Debug, Default)]
+pub struct RecursionGuard {
+    /// The GitHub login the Overseer's own workstreams author under.
+    pub author_login: String,
+    /// Branch prefix the Overseer's launched recipes use (e.g. `overseer/`).
+    pub branch_prefix: String,
+    /// Goal-source tag the Overseer stamps on goals it files (e.g. `overseer:`).
+    pub goal_source_tag: String,
+}
+
+impl RecursionGuard {
+    /// True if `subject` is the Overseer's own work and must not be acted on.
+    pub fn is_own(&self, subject: &Subject) -> bool {
+        match subject {
+            Subject::Pr { author, .. } | Subject::Commit { author, .. } => {
+                !self.author_login.is_empty() && author == &self.author_login
+            }
+            Subject::Branch { name } => {
+                !self.branch_prefix.is_empty() && name.starts_with(&self.branch_prefix)
+            }
+            Subject::Goal { source, .. } => {
+                !self.goal_source_tag.is_empty() && source.starts_with(&self.goal_source_tag)
+            }
+        }
+    }
+
+    /// Convenience: refuse acting on own work with a typed error.
+    pub fn admit(&self, subject: &Subject) -> Result<(), OverseerError> {
+        if self.is_own(subject) {
+            Err(OverseerError::Recursion {
+                subject: format!("{subject:?}"),
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Budget cap checked before any cost-bearing intervention (recipe launches,
+/// audits). Reads today's spend vs the daily budget.
+///
+/// **Reuse:** `crate::cost_tracking::daily_summary` for spend;
+/// `SIMARD_DAILY_BUDGET_USD` for the ceiling (the same knob the OODA loop uses).
+#[derive(Clone, Copy, Debug)]
+pub struct BudgetGate {
+    pub daily_budget_usd: f64,
+}
+
+impl Default for BudgetGate {
+    fn default() -> Self {
+        // Mirrors the OODA loop's default daily budget.
+        Self {
+            daily_budget_usd: 500.0,
+        }
+    }
+}
+
+impl BudgetGate {
+    pub fn admit(&self, spent_today_usd: f64) -> Result<(), OverseerError> {
+        if self.daily_budget_usd > 0.0 && spent_today_usd >= self.daily_budget_usd {
+            Err(OverseerError::Budget {
+                spent_usd: spent_today_usd,
+                budget_usd: self.daily_budget_usd,
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Conflict-avoidance sequencing. Feature recipes may run in parallel, but
+/// mechanical sweeps that touch the same shared files (e.g. OODA-core renames,
+/// `print!` purges) must run ONE-AT-A-TIME. The sequencer admits at most one
+/// active sweep per `sequence_group`.
+#[derive(Clone, Debug, Default)]
+pub struct ConflictSequencer {
+    active_groups: Vec<String>,
+}
+
+impl ConflictSequencer {
+    /// Admit a workstream for `group` (None = unsequenced feature work, always
+    /// admitted). A sequenced group is refused while one of its sweeps is active.
+    pub fn admit(&mut self, group: Option<&str>) -> Result<(), OverseerError> {
+        match group {
+            None => Ok(()),
+            Some(g) => {
+                if self.active_groups.iter().any(|a| a == g) {
+                    Err(OverseerError::Conflict {
+                        with: g.to_string(),
+                    })
+                } else {
+                    self.active_groups.push(g.to_string());
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    /// Release a sequence group when its sweep completes.
+    pub fn release(&mut self, group: &str) {
+        self.active_groups.retain(|a| a != group);
+    }
+}

--- a/src/overseer/intervention.rs
+++ b/src/overseer/intervention.rs
@@ -1,0 +1,68 @@
+//! The Overseer's `Intervention` set — one variant per action it can take, each
+//! mapped to an EXISTING Simard capability trait in `capabilities.rs`.
+//! Interventions are proposed by Decide and (in M2+) executed by Act; HIGH-RISK
+//! variants are gated by `guardrails::classify`.
+
+use crate::overseer::capabilities::{AuditScope, GoalBrief, OrchestratorRunBrief, RecipeBrief};
+
+/// A single action the Overseer can take. Each variant names the capability it
+/// dispatches through; see the trait doc comments for the exact reused function.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Intervention {
+    /// Launch an amplihack recipe workstream (smart-orchestrator → default-workflow).
+    /// Capability: `RecipeLauncher`.
+    LaunchRecipe { brief: RecipeBrief },
+    /// Run the pr-verify checklist and merge if merge-ready.
+    /// Capability: `PrOps::verify` + `PrOps::merge`.
+    VerifyAndMergePr { repo: String, pr: u32 },
+    /// Resolve merge conflicts on a PR (union-merge; `--no-verify` push).
+    /// Capability: `PrOps::resolve_conflict` (under `git_guardrails`).
+    ResolveConflict { repo: String, pr: u32 },
+    /// Build+verify+hand over a new binary at `commit`. HIGH-RISK → gated.
+    /// Capability: `Deployer::deploy`.
+    Deploy { commit: String },
+    /// File a deduplicated GitHub issue for a recurring failure.
+    /// Capability: `IssueFiler::file`.
+    FileIssue { run: OrchestratorRunBrief },
+    /// Transfer/handoff a goal to Simard via the meeting REPL.
+    /// Capability: `MeetingHost::transfer_goal`.
+    TransferGoal { goal: GoalBrief },
+    /// Emit a periodic status report (uptime, resources, tokens/cost, workstreams,
+    /// completed work, telemetry anomalies, goals, self-improvement PRs).
+    /// Capability: `StatusReader` (rendered).
+    Report,
+    /// Run a quality-audit loop (crusty-old-engineer-gated).
+    /// Capability: `Auditor::run_audit`.
+    RunAudit { scope: AuditScope },
+    /// Surface a HIGH-RISK or low-confidence decision to the human operator.
+    Escalate { reason: String },
+}
+
+impl Intervention {
+    /// Short, stable label used in gate messages, telemetry, and dedup.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::LaunchRecipe { .. } => "launch_recipe",
+            Self::VerifyAndMergePr { .. } => "verify_and_merge_pr",
+            Self::ResolveConflict { .. } => "resolve_conflict",
+            Self::Deploy { .. } => "deploy",
+            Self::FileIssue { .. } => "file_issue",
+            Self::TransferGoal { .. } => "transfer_goal",
+            Self::Report => "report",
+            Self::RunAudit { .. } => "run_audit",
+            Self::Escalate { .. } => "escalate",
+        }
+    }
+}
+
+/// A planned intervention after gating: the chosen action plus whether the gates
+/// admitted it for autonomous execution and, if not, why. `run_cycle` returns
+/// these; Act (M2+) executes only the admitted ones.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PlannedIntervention {
+    pub intervention: Intervention,
+    pub admitted: bool,
+    /// Human-readable gate note (e.g. "HIGH-RISK: escalated", "budget exceeded",
+    /// "own PR skipped", "deferred: overlaps sweep group ooda-core").
+    pub note: String,
+}

--- a/src/overseer/mod.rs
+++ b/src/overseer/mod.rs
@@ -1,0 +1,696 @@
+//! # Overseer — an autonomous operator/observer co-process (DESIGN SKETCH)
+//!
+//! The `Overseer` embeds the operator/observer role a human+Copilot pair has
+//! performed over many sessions: it watches HOW Simard performs, spots problems,
+//! and drives improvements **outside** Simard's own OODA workstreams. Simard's
+//! OODA governs the external repos she stewards plus her own feature work; the
+//! Overseer works at the **meta level** — improving Simard's own health/process
+//! and driving cross-cutting initiatives.
+//!
+//! ## Status: design + scaffolding only
+//!
+//! This module is a **type/trait sketch**. It is additive, `#![allow(dead_code)]`,
+//! and **not wired into `main`** or the daemon loop — nothing here is constructed
+//! or scheduled at runtime. It exists to pin down the vocabulary (`Signal`,
+//! `Problem`, `Intervention`), the capability seam (`capabilities`), and the
+//! guardrails (`guardrails`), each annotated with the EXISTING Simard function it
+//! reuses. See `docs/design/overseer.md` for the full architecture, the
+//! co-process-vs-`CognitiveThread` decision, and the phased roadmap.
+//!
+//! ## Architecture (summary)
+//!
+//! The Overseer is a **sibling co-process**, not a `CognitiveThread`. A
+//! `CognitiveThread` is given a least-authority `ThreadContext` and is explicitly
+//! forbidden a "code path to self_deploy / self_relaunch / redeploy"
+//! (`docs/howto/add-a-new-cognitive-thread.md`); the Overseer needs guarded
+//! deploy authority and launches long-running recipe/merge work, so it runs as
+//! its own supervised task holding capability handles behind guardrails. A thin,
+//! read-only `impl CognitiveThread` **sensor** (observe → signals → report → file
+//! issue) is a valid M1 packaging and is described in the design doc; the acting
+//! Overseer (M2+) is a co-process.
+//!
+//! ## Meta-OODA loop
+//!
+//! `run_cycle` implements one turn of the Overseer's OWN OODA, distinct from
+//! Simard's repo-facing OODA:
+//!
+//! - **Observe** — `StatusReader::snapshot` (wraps `crate::status::assemble`) plus
+//!   PR/CI/goal state, folded into `ObservedState`, then `signal::signals_from`.
+//! - **Orient** — `orient`: classify + prioritise + **dedup against Simard's
+//!   in-flight work** (`GoalCurator::in_flight`).
+//! - **Decide** — `decide`: choose one `Intervention` per `Problem`.
+//! - **Act** — gate (`guardrails`) then dispatch via the reused capability
+//!   (`act`). `run_cycle` only PLANS; execution of admitted interventions is the
+//!   M2+ seam.
+
+#![allow(dead_code)]
+
+pub mod capabilities;
+pub mod guardrails;
+pub mod intervention;
+pub mod signal;
+
+pub use capabilities::{
+    Auditor, Deployer, GoalCurator, IssueFiler, MeetingHost, ObservedState, OrchestratorRunBrief,
+    OverseerError, PrOps, RecipeBrief, RecipeLauncher, StatusReader,
+};
+pub use guardrails::{
+    AutonomyGate, BudgetGate, ConflictSequencer, RecursionGuard, RiskClass, Subject, classify,
+};
+pub use intervention::{Intervention, PlannedIntervention};
+pub use signal::{Priority, Problem, ProblemKind, Signal, signals_from};
+
+use capabilities::{DeployReport, GoalBrief, InFlightItem, IssueOutcome, WorkstreamHandle};
+
+/// The capability handles the Overseer acts through — one per reused Simard
+/// subsystem. Grouping them keeps the `Overseer` constructor to a single
+/// argument and makes every external dependency explicit and injectable (fakes
+/// in tests, real adapters in the daemon).
+pub struct Capabilities {
+    pub status: Box<dyn StatusReader>,
+    pub recipes: Box<dyn RecipeLauncher>,
+    pub prs: Box<dyn PrOps>,
+    pub deployer: Box<dyn Deployer>,
+    pub meetings: Box<dyn MeetingHost>,
+    pub issues: Box<dyn IssueFiler>,
+    pub goals: Box<dyn GoalCurator>,
+    pub auditor: Box<dyn Auditor>,
+}
+
+/// The Overseer co-process. Holds its capability handles plus its guardrails.
+pub struct Overseer {
+    caps: Capabilities,
+    autonomy: AutonomyGate,
+    recursion: RecursionGuard,
+    budget: BudgetGate,
+    sequencer: ConflictSequencer,
+    /// Cap on how many cost-bearing launches one cycle may plan (concurrency
+    /// bound layered on top of the AIMD engineer cap the launcher already obeys).
+    max_launches_per_cycle: usize,
+}
+
+/// The result of one meta-OODA turn. Side-effect free: it reports what was
+/// observed and what WOULD be done. Act (M2+) executes only the admitted items.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CycleReport {
+    pub observed: ObservedState,
+    pub signals: Vec<Signal>,
+    pub problems: Vec<Problem>,
+    pub plan: Vec<PlannedIntervention>,
+}
+
+/// Outcome of dispatching one intervention through its capability. Returned by
+/// `act` (the M2+ execution seam), exercised here only in tests with fakes.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ActOutcome {
+    Launched(WorkstreamHandle),
+    Merged,
+    ConflictResolved,
+    Deployed(DeployReport),
+    IssueFiled(IssueOutcome),
+    GoalTransferred,
+    Reported,
+    Audited,
+    Escalated,
+}
+
+impl Overseer {
+    /// Construct with default guardrails (HIGH-RISK gated, default daily budget).
+    pub fn new(caps: Capabilities) -> Self {
+        Self {
+            caps,
+            autonomy: AutonomyGate::default(),
+            recursion: RecursionGuard::default(),
+            budget: BudgetGate::default(),
+            sequencer: ConflictSequencer::default(),
+            max_launches_per_cycle: 2,
+        }
+    }
+
+    /// Opt into autonomous HIGH-RISK execution (deploy / conflict-resolution).
+    /// Off by default: those interventions escalate instead.
+    pub fn with_high_risk_autonomy(mut self, allow: bool) -> Self {
+        self.autonomy.allow_high_risk = allow;
+        self
+    }
+
+    /// Set the Overseer's own identity so anti-recursion can refuse its own work.
+    pub fn with_identity(mut self, guard: RecursionGuard) -> Self {
+        self.recursion = guard;
+        self
+    }
+
+    /// Run one meta-OODA turn. Observe → Orient → Decide → plan+gate. Does NOT
+    /// execute side effects; returns the plan for M2+ Act to run.
+    pub fn run_cycle(&mut self) -> Result<CycleReport, OverseerError> {
+        // Observe.
+        let observed = self.caps.status.snapshot()?;
+        let signals = signals_from(&observed);
+
+        // Orient (dedup against Simard's in-flight work; failure to read the
+        // board degrades to "no dedup", never aborts the cycle).
+        let in_flight = self.caps.goals.in_flight().unwrap_or_default();
+        let problems = orient(&signals, &in_flight);
+
+        // Decide + gate.
+        let mut plan = Vec::new();
+        let mut launches = 0usize;
+        for problem in &problems {
+            let iv = decide(problem);
+            let planned = self.gate(&iv, &observed, &mut launches);
+            plan.push(planned);
+        }
+
+        Ok(CycleReport {
+            observed,
+            signals,
+            problems,
+            plan,
+        })
+    }
+
+    /// Apply autonomy, budget, and conflict gates to one intervention, producing
+    /// a `PlannedIntervention` (admitted or held-with-reason).
+    fn gate(
+        &mut self,
+        iv: &Intervention,
+        observed: &ObservedState,
+        launches: &mut usize,
+    ) -> PlannedIntervention {
+        // Autonomy: HIGH-RISK requires opt-in, else it is escalated (held).
+        if let Err(e) = self.autonomy.admit(iv) {
+            return PlannedIntervention {
+                intervention: iv.clone(),
+                admitted: false,
+                note: e.to_string(),
+            };
+        }
+
+        // Budget + concurrency: only for cost-bearing launches/audits.
+        if is_cost_bearing(iv) {
+            if *launches >= self.max_launches_per_cycle {
+                return PlannedIntervention {
+                    intervention: iv.clone(),
+                    admitted: false,
+                    note: "held: per-cycle launch cap reached".to_string(),
+                };
+            }
+            if let Some(spent) = observed.spent_today_usd
+                && let Err(e) = self.budget.admit(spent)
+            {
+                return PlannedIntervention {
+                    intervention: iv.clone(),
+                    admitted: false,
+                    note: e.to_string(),
+                };
+            }
+            // Conflict-avoidance: serialise sweeps sharing a sequence group.
+            if let Intervention::LaunchRecipe { brief } = iv
+                && let Err(e) = self.sequencer.admit(brief.sequence_group.as_deref())
+            {
+                return PlannedIntervention {
+                    intervention: iv.clone(),
+                    admitted: false,
+                    note: e.to_string(),
+                };
+            }
+            *launches += 1;
+        }
+
+        PlannedIntervention {
+            intervention: iv.clone(),
+            admitted: true,
+            note: "admitted".to_string(),
+        }
+    }
+
+    /// Execute one admitted intervention by dispatching to its reused capability.
+    /// This is the M2+ Act seam. Anti-recursion is applied per-subject before any
+    /// PR/deploy action.
+    pub fn act(&mut self, iv: &Intervention) -> Result<ActOutcome, OverseerError> {
+        match iv {
+            Intervention::LaunchRecipe { brief } => {
+                Ok(ActOutcome::Launched(self.caps.recipes.launch(brief)?))
+            }
+            Intervention::VerifyAndMergePr { repo, pr } => {
+                let report = self.caps.prs.verify(repo, *pr)?;
+                if report.ready {
+                    self.caps.prs.merge(repo, *pr)?;
+                    Ok(ActOutcome::Merged)
+                } else {
+                    Ok(ActOutcome::Escalated)
+                }
+            }
+            Intervention::ResolveConflict { repo, pr } => {
+                self.caps.prs.resolve_conflict(repo, *pr)?;
+                Ok(ActOutcome::ConflictResolved)
+            }
+            Intervention::Deploy { commit } => {
+                Ok(ActOutcome::Deployed(self.caps.deployer.deploy(commit)?))
+            }
+            Intervention::FileIssue { run } => {
+                Ok(ActOutcome::IssueFiled(self.caps.issues.file(run)?))
+            }
+            Intervention::TransferGoal { goal } => {
+                self.caps.meetings.transfer_goal(goal)?;
+                Ok(ActOutcome::GoalTransferred)
+            }
+            Intervention::Report => Ok(ActOutcome::Reported),
+            Intervention::RunAudit { scope } => {
+                self.caps.auditor.run_audit(scope)?;
+                Ok(ActOutcome::Audited)
+            }
+            Intervention::Escalate { .. } => Ok(ActOutcome::Escalated),
+        }
+    }
+}
+
+/// True for interventions that spend LLM budget / spawn work.
+fn is_cost_bearing(iv: &Intervention) -> bool {
+    matches!(
+        iv,
+        Intervention::LaunchRecipe { .. } | Intervention::RunAudit { .. }
+    )
+}
+
+/// Orient: fold `Signal`s into ranked, deduplicated `Problem`s. Dedups against
+/// Simard's in-flight work (so the Overseer never fights an engineer already on
+/// the case) and against problems already collected this cycle.
+pub fn orient(signals: &[Signal], in_flight: &[InFlightItem]) -> Vec<Problem> {
+    let mut problems: Vec<Problem> = Vec::new();
+
+    for s in signals {
+        let (kind, priority, key, summary) = classify_signal(s);
+
+        // Dedup against Simard's in-flight work.
+        if in_flight.iter().any(|i| i.refs.iter().any(|r| r == &key)) {
+            continue;
+        }
+        // Merge into an existing same-key problem rather than duplicating.
+        if let Some(existing) = problems.iter_mut().find(|p| p.dedup_key == key) {
+            existing.evidence.push(s.clone());
+            continue;
+        }
+        problems.push(Problem {
+            kind,
+            priority,
+            dedup_key: key,
+            summary,
+            evidence: vec![s.clone()],
+        });
+    }
+
+    problems.sort_by_key(|p| p.priority);
+    problems
+}
+
+/// Map a single `Signal` to `(kind, priority, dedup_key, summary)`.
+fn classify_signal(s: &Signal) -> (ProblemKind, Priority, String, String) {
+    match s {
+        Signal::DistillFailureRate { pct } => (
+            ProblemKind::ProcessHealth,
+            Priority::High,
+            "process:distill_fail".to_string(),
+            format!("distillation parse-failure rate {pct:.0}%"),
+        ),
+        Signal::RestartChurn { restarts } => (
+            ProblemKind::ProcessHealth,
+            Priority::High,
+            "process:restart_churn".to_string(),
+            format!("daemon restart churn ({restarts} restarts)"),
+        ),
+        Signal::LadderExhausted { count } => (
+            ProblemKind::ProcessHealth,
+            Priority::Normal,
+            "process:ladder_exhausted".to_string(),
+            format!("reasoner decide-ladder exhausted ({count})"),
+        ),
+        Signal::BudgetPressure {
+            spent_usd,
+            budget_usd,
+        } => (
+            ProblemKind::ResourcePressure,
+            Priority::High,
+            "resource:budget".to_string(),
+            format!("LLM budget pressure (${spent_usd:.2} of ${budget_usd:.2})"),
+        ),
+        Signal::EngineerSpawnRate { live } => (
+            ProblemKind::ResourcePressure,
+            Priority::Normal,
+            "resource:engineer_spawn".to_string(),
+            format!("elevated engineer spawn ({live} live)"),
+        ),
+        Signal::MemoryGrowth { nodes_total } => (
+            ProblemKind::ResourcePressure,
+            Priority::Low,
+            "resource:memory_growth".to_string(),
+            format!("cognitive-memory growth ({nodes_total} nodes)"),
+        ),
+        Signal::GymSkipped => (
+            ProblemKind::QualityRegression,
+            Priority::Low,
+            "quality:gym_skipped".to_string(),
+            "gym self-eval skipped".to_string(),
+        ),
+        Signal::CiFailureCluster { repo, failing } => (
+            ProblemKind::QualityRegression,
+            Priority::High,
+            format!("quality:ci:{repo}"),
+            format!("CI-failure cluster in {repo} ({failing} failing)"),
+        ),
+        Signal::PrReadyToMerge { repo, pr } => (
+            ProblemKind::DeliveryReady,
+            Priority::Normal,
+            format!("delivery:pr:{repo}#{pr}"),
+            format!("PR {repo}#{pr} is green and merge-ready"),
+        ),
+        Signal::StaleGoal { goal_id } => (
+            ProblemKind::GoalHygiene,
+            Priority::Normal,
+            format!("goal:stale:{goal_id}"),
+            format!("goal {goal_id} re-litigated / stale-complete"),
+        ),
+        Signal::Anomaly { detail } => (
+            ProblemKind::ProcessHealth,
+            Priority::Normal,
+            format!("anomaly:{detail}"),
+            format!("telemetry anomaly: {detail}"),
+        ),
+    }
+}
+
+/// Decide: choose one `Intervention` for a `Problem`. Illustrative routing; a
+/// production Overseer would use a prompt-driven reasoner with this deterministic
+/// mapping as its floor (mirroring `OodaDecideBrain`'s deterministic fallback).
+pub fn decide(problem: &Problem) -> Intervention {
+    match problem.kind {
+        ProblemKind::DeliveryReady => {
+            for s in &problem.evidence {
+                if let Signal::PrReadyToMerge { repo, pr } = s {
+                    return Intervention::VerifyAndMergePr {
+                        repo: repo.clone(),
+                        pr: *pr,
+                    };
+                }
+            }
+            Intervention::Report
+        }
+        ProblemKind::QualityRegression => {
+            for s in &problem.evidence {
+                if let Signal::CiFailureCluster { repo, failing } = s {
+                    return Intervention::FileIssue {
+                        run: OrchestratorRunBrief {
+                            recipe_name: "smart-orchestrator".to_string(),
+                            failed_step: "ci".to_string(),
+                            source_module: repo.clone(),
+                            failure_kind: "ci_failure_cluster".to_string(),
+                            error_text: format!("{failing} failing checks in {repo}"),
+                        },
+                    };
+                }
+            }
+            Intervention::Report
+        }
+        ProblemKind::ProcessHealth => Intervention::LaunchRecipe {
+            brief: RecipeBrief {
+                task_description: problem.summary.clone(),
+                target_repo: "rysweet/Simard".to_string(),
+                sequence_group: None,
+            },
+        },
+        ProblemKind::CrossCutting => Intervention::LaunchRecipe {
+            brief: RecipeBrief {
+                task_description: problem.summary.clone(),
+                target_repo: "rysweet/Simard".to_string(),
+                // Mechanical sweeps on shared OODA-core files serialise here.
+                sequence_group: Some("ooda-core".to_string()),
+            },
+        },
+        ProblemKind::ResourcePressure => Intervention::Escalate {
+            reason: problem.summary.clone(),
+        },
+        ProblemKind::GoalHygiene => Intervention::TransferGoal {
+            goal: GoalBrief {
+                title: problem.summary.clone(),
+                rationale: "stale / re-litigated goal — transfer to Simard for closure".to_string(),
+                priority: 3,
+                target_repo: "rysweet/Simard".to_string(),
+            },
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::capabilities::*;
+    use super::*;
+
+    // ── Fakes: each satisfies one capability with canned values. ────────────
+    struct FakeStatus(ObservedState);
+    impl StatusReader for FakeStatus {
+        fn snapshot(&self) -> Result<ObservedState, OverseerError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    struct FakeRecipes;
+    impl RecipeLauncher for FakeRecipes {
+        fn launch(&self, _brief: &RecipeBrief) -> Result<WorkstreamHandle, OverseerError> {
+            Ok(WorkstreamHandle {
+                id: "ws-1".to_string(),
+            })
+        }
+        fn poll(&self, _h: &WorkstreamHandle) -> Result<WorkstreamStatus, OverseerError> {
+            Ok(WorkstreamStatus::Running)
+        }
+    }
+
+    struct FakePrs {
+        ready: bool,
+    }
+    impl PrOps for FakePrs {
+        fn verify(&self, _repo: &str, _pr: u32) -> Result<VerifyReport, OverseerError> {
+            Ok(VerifyReport {
+                ready: self.ready,
+                checks: vec![],
+            })
+        }
+        fn merge(&self, _repo: &str, _pr: u32) -> Result<(), OverseerError> {
+            Ok(())
+        }
+        fn resolve_conflict(&self, _repo: &str, _pr: u32) -> Result<(), OverseerError> {
+            Ok(())
+        }
+    }
+
+    struct FakeDeployer;
+    impl Deployer for FakeDeployer {
+        fn deploy(&self, commit: &str) -> Result<DeployReport, OverseerError> {
+            Ok(DeployReport {
+                deployed_commit: commit.to_string(),
+                gates_passed: true,
+            })
+        }
+        fn deployed_commit(&self) -> Result<String, OverseerError> {
+            Ok("deadbeef".to_string())
+        }
+    }
+
+    struct FakeMeetings;
+    impl MeetingHost for FakeMeetings {
+        fn transfer_goal(&self, _goal: &GoalBrief) -> Result<(), OverseerError> {
+            Ok(())
+        }
+    }
+
+    struct FakeIssues;
+    impl IssueFiler for FakeIssues {
+        fn file(&self, _run: &OrchestratorRunBrief) -> Result<IssueOutcome, OverseerError> {
+            Ok(IssueOutcome::FiledNew {
+                url: "https://example/issues/1".to_string(),
+            })
+        }
+    }
+
+    struct FakeGoals(Vec<InFlightItem>);
+    impl GoalCurator for FakeGoals {
+        fn propose(&self, _goal: &GoalBrief) -> Result<(), OverseerError> {
+            Ok(())
+        }
+        fn in_flight(&self) -> Result<Vec<InFlightItem>, OverseerError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    struct FakeAuditor;
+    impl Auditor for FakeAuditor {
+        fn run_audit(&self, scope: &AuditScope) -> Result<AuditReport, OverseerError> {
+            Ok(AuditReport {
+                scope: scope.clone(),
+                passed: true,
+                findings: vec![],
+            })
+        }
+    }
+
+    fn caps(observed: ObservedState, ready: bool, in_flight: Vec<InFlightItem>) -> Capabilities {
+        Capabilities {
+            status: Box::new(FakeStatus(observed)),
+            recipes: Box::new(FakeRecipes),
+            prs: Box::new(FakePrs { ready }),
+            deployer: Box::new(FakeDeployer),
+            meetings: Box::new(FakeMeetings),
+            issues: Box::new(FakeIssues),
+            goals: Box::new(FakeGoals(in_flight)),
+            auditor: Box::new(FakeAuditor),
+        }
+    }
+
+    #[test]
+    fn signals_only_fire_above_threshold() {
+        let below = ObservedState {
+            distill_fail_pct: Some(5.0),
+            ..ObservedState::default()
+        };
+        assert!(signals_from(&below).is_empty());
+        // the real-world ~62% case
+        let high = ObservedState {
+            distill_fail_pct: Some(62.0),
+            ..ObservedState::default()
+        };
+        let sigs = signals_from(&high);
+        assert_eq!(sigs, vec![Signal::DistillFailureRate { pct: 62.0 }]);
+    }
+
+    #[test]
+    fn orient_dedups_against_in_flight() {
+        let signals = vec![Signal::DistillFailureRate { pct: 62.0 }];
+        // An engineer is already on it (same dedup key) → no problem raised.
+        let in_flight = vec![InFlightItem {
+            id: "g1".to_string(),
+            source: "ooda".to_string(),
+            refs: vec!["process:distill_fail".to_string()],
+        }];
+        assert!(orient(&signals, &in_flight).is_empty());
+        // Nobody on it → one problem.
+        assert_eq!(orient(&signals, &[]).len(), 1);
+    }
+
+    #[test]
+    fn run_cycle_plans_a_launch_for_process_health() {
+        let st = ObservedState {
+            distill_fail_pct: Some(62.0),
+            ..ObservedState::default()
+        };
+        let mut ov = Overseer::new(caps(st, true, vec![]));
+        let report = ov.run_cycle().expect("cycle");
+        assert_eq!(report.problems.len(), 1);
+        assert_eq!(report.plan.len(), 1);
+        let planned = &report.plan[0];
+        assert!(planned.admitted);
+        assert_eq!(planned.intervention.label(), "launch_recipe");
+    }
+
+    #[test]
+    fn high_risk_deploy_is_gated_by_default() {
+        let mut ov = Overseer::new(caps(ObservedState::default(), true, vec![]));
+        // Default autonomy holds a deploy.
+        let held = ov.gate(
+            &Intervention::Deploy {
+                commit: "abc123".to_string(),
+            },
+            &ObservedState::default(),
+            &mut 0,
+        );
+        assert!(!held.admitted);
+        // Opt-in autonomy admits it.
+        let mut ov = ov.with_high_risk_autonomy(true);
+        let admitted = ov.gate(
+            &Intervention::Deploy {
+                commit: "abc123".to_string(),
+            },
+            &ObservedState::default(),
+            &mut 0,
+        );
+        assert!(admitted.admitted);
+    }
+
+    #[test]
+    fn budget_pressure_holds_launches() {
+        let observed = ObservedState {
+            spent_today_usd: Some(600.0),
+            daily_budget_usd: Some(500.0),
+            ..ObservedState::default()
+        };
+        let mut ov = Overseer::new(caps(observed.clone(), true, vec![]));
+        let held = ov.gate(
+            &Intervention::LaunchRecipe {
+                brief: RecipeBrief {
+                    task_description: "x".to_string(),
+                    target_repo: "rysweet/Simard".to_string(),
+                    sequence_group: None,
+                },
+            },
+            &observed,
+            &mut 0,
+        );
+        assert!(!held.admitted);
+    }
+
+    #[test]
+    fn anti_recursion_refuses_own_pr() {
+        let guard = RecursionGuard {
+            author_login: "simard-overseer[bot]".to_string(),
+            branch_prefix: "overseer/".to_string(),
+            goal_source_tag: "overseer:".to_string(),
+        };
+        let own = Subject::Pr {
+            repo: "rysweet/Simard".to_string(),
+            pr: 1,
+            author: "simard-overseer[bot]".to_string(),
+        };
+        assert!(guard.is_own(&own));
+        let foreign = Subject::Pr {
+            repo: "rysweet/Simard".to_string(),
+            pr: 2,
+            author: "someone-else".to_string(),
+        };
+        assert!(!guard.is_own(&foreign));
+    }
+
+    #[test]
+    fn conflict_sequencer_serialises_sweeps() {
+        let mut seq = ConflictSequencer::default();
+        assert!(seq.admit(Some("ooda-core")).is_ok());
+        // A second sweep on the same shared files is held until the first frees.
+        assert!(seq.admit(Some("ooda-core")).is_err());
+        seq.release("ooda-core");
+        assert!(seq.admit(Some("ooda-core")).is_ok());
+        // Unsequenced feature work is always admitted.
+        assert!(seq.admit(None).is_ok());
+    }
+
+    #[test]
+    fn act_dispatches_merge_when_ready() {
+        let mut ov = Overseer::new(caps(ObservedState::default(), true, vec![]));
+        let out = ov
+            .act(&Intervention::VerifyAndMergePr {
+                repo: "rysweet/Simard".to_string(),
+                pr: 7,
+            })
+            .expect("act");
+        assert_eq!(out, ActOutcome::Merged);
+    }
+
+    #[test]
+    fn act_escalates_merge_when_not_ready() {
+        let mut ov = Overseer::new(caps(ObservedState::default(), false, vec![]));
+        let out = ov
+            .act(&Intervention::VerifyAndMergePr {
+                repo: "rysweet/Simard".to_string(),
+                pr: 7,
+            })
+            .expect("act");
+        assert_eq!(out, ActOutcome::Escalated);
+    }
+}

--- a/src/overseer/signal.rs
+++ b/src/overseer/signal.rs
@@ -1,0 +1,142 @@
+//! The Overseer's `Signal` and `Problem` vocabulary — the Observe/Orient data
+//! model. `Signal`s are cheap, additive indicators derived from one Observe pass;
+//! Orient folds a set of `Signal`s into ranked, deduplicated `Problem`s.
+
+use crate::overseer::capabilities::ObservedState;
+
+/// A raw, low-level indicator derived from one Observe pass (StatusSnapshot +
+/// logs + PR/CI/goal state). Non-authoritative on its own; Orient turns a set of
+/// Signals into ranked `Problem`s. Each variant cites the durable field it comes
+/// from (see `ObservedState`).
+#[derive(Clone, Debug, PartialEq)]
+pub enum Signal {
+    /// Distillation parse-failure rate exceeds threshold (`distill_fail_pct`).
+    DistillFailureRate { pct: f64 },
+    /// Daemon self-relaunch/restart churn over the window (`restart_churn`).
+    RestartChurn { restarts: u64 },
+    /// Reasoner/brain decide-ladder exhaustion (`ladder_exhausted`).
+    LadderExhausted { count: u64 },
+    /// Daily LLM spend approaching/over budget (`spent_today_usd`/`daily_budget_usd`).
+    BudgetPressure { spent_usd: f64, budget_usd: f64 },
+    /// Engineer spawn/live count elevated (`live_engineers`).
+    EngineerSpawnRate { live: u32 },
+    /// Cognitive-memory growth beyond expectation (`memory_nodes`).
+    MemoryGrowth { nodes_total: u64 },
+    /// Gym self-eval skipped (`gym_skipped`).
+    GymSkipped,
+    /// A cluster of CI failures across recent runs (`ci_failures`).
+    CiFailureCluster { repo: String, failing: u32 },
+    /// A PR is green + merge-ready and awaiting a merge decision (`ready_prs`).
+    PrReadyToMerge { repo: String, pr: u32 },
+    /// A goal has been re-litigated / "stale-complete" repeatedly.
+    StaleGoal { goal_id: String },
+    /// A free-form anomaly surfaced by `TelemetrySignals.anomalies[]`.
+    Anomaly { detail: String },
+}
+
+/// Coarse relative importance. `Ord` sorts ascending so `Critical` comes first,
+/// mirroring `crate::cognitive_threads::Priority`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Priority {
+    Critical,
+    High,
+    Normal,
+    Low,
+}
+
+/// Problem family used by Decide to pick an intervention shape.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProblemKind {
+    /// Parse failures, restart churn, ladder exhaustion.
+    ProcessHealth,
+    /// Budget pressure, engineer-spawn spikes, memory growth.
+    ResourcePressure,
+    /// A PR ready to merge, or a conflict to resolve.
+    DeliveryReady,
+    /// CI-failure clusters, gym skipped.
+    QualityRegression,
+    /// Stale/re-litigated goals.
+    GoalHygiene,
+    /// Naming/architecture sweeps, terminology cleanups, cross-repo initiatives.
+    CrossCutting,
+}
+
+/// A classified, deduplicated, prioritised problem — the output of Orient and the
+/// input to Decide. Carries the evidence `Signal`s plus a `dedup_key` used to
+/// avoid fighting Simard's in-flight work and to avoid duplicate interventions.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Problem {
+    pub kind: ProblemKind,
+    pub priority: Priority,
+    /// Stable dedup key. An adapter should mirror
+    /// `crate::stewardship::failure_signature` semantics so the same problem does
+    /// not spawn a duplicate workstream or a duplicate issue.
+    pub dedup_key: String,
+    pub summary: String,
+    pub evidence: Vec<Signal>,
+}
+
+// Thresholds are illustrative defaults for the sketch; real values would be
+// `SIMARD_OVERSEER_*` env knobs clamped to floors (see the design doc).
+const DISTILL_FAIL_PCT_THRESHOLD: f64 = 20.0;
+const RESTART_CHURN_THRESHOLD: u64 = 3;
+const BUDGET_PRESSURE_FRACTION: f64 = 0.8;
+const ENGINEER_SPAWN_THRESHOLD: u32 = 8;
+
+/// Pure Observe→Signal derivation. No I/O; unit-testable with a hand-built
+/// `ObservedState`. Real thresholds would be env-tunable.
+pub fn signals_from(state: &ObservedState) -> Vec<Signal> {
+    let mut out = Vec::new();
+
+    if let Some(pct) = state.distill_fail_pct
+        && pct >= DISTILL_FAIL_PCT_THRESHOLD
+    {
+        out.push(Signal::DistillFailureRate { pct });
+    }
+    if let Some(restarts) = state.restart_churn
+        && restarts >= RESTART_CHURN_THRESHOLD
+    {
+        out.push(Signal::RestartChurn { restarts });
+    }
+    if let Some(count) = state.ladder_exhausted
+        && count > 0
+    {
+        out.push(Signal::LadderExhausted { count });
+    }
+    if let (Some(spent), Some(budget)) = (state.spent_today_usd, state.daily_budget_usd)
+        && budget > 0.0
+        && spent >= budget * BUDGET_PRESSURE_FRACTION
+    {
+        out.push(Signal::BudgetPressure {
+            spent_usd: spent,
+            budget_usd: budget,
+        });
+    }
+    if let Some(live) = state.live_engineers
+        && live >= ENGINEER_SPAWN_THRESHOLD
+    {
+        out.push(Signal::EngineerSpawnRate { live });
+    }
+    if state.gym_skipped {
+        out.push(Signal::GymSkipped);
+    }
+    for cf in &state.ci_failures {
+        out.push(Signal::CiFailureCluster {
+            repo: cf.repo.clone(),
+            failing: cf.failing,
+        });
+    }
+    for pr in &state.ready_prs {
+        out.push(Signal::PrReadyToMerge {
+            repo: pr.repo.clone(),
+            pr: pr.pr,
+        });
+    }
+    for detail in &state.anomalies {
+        out.push(Signal::Anomaly {
+            detail: detail.clone(),
+        });
+    }
+
+    out
+}


### PR DESCRIPTION
## Summary

Design spike (#2419) for embedding the human+Copilot **operator/observer** role as
an autonomous **`Overseer` co-process** inside the Simard daemon — all Rust,
maximal reuse of existing subsystems plus the amplihack recipe runner.

**DESIGN + SCAFFOLDING ONLY.** No daemon runtime behavior change: nothing is wired
into `main` or the daemon loop, and **nothing constructs an `Overseer`** at runtime.
`pub mod overseer;` adds definitions to the library only.

## What's in this PR

- **`docs/design/overseer.md`** — the design document:
  - Problem statement + the operator role, encoded faithfully.
  - **Architecture decision: sibling co-process, *not* a `CognitiveThread`**,
    grounded in the shipped least-authority thread contract (a `ThreadContext` has
    "no code path to `self_deploy`/`self_relaunch`/redeploy" and threads are
    capped/backed-off best-effort chores — the opposite of what the Overseer needs).
    Includes the daemon embedding seam (`src/operator_commands_ooda/daemon/mod.rs`)
    and how it shares the durable store + telemetry.
  - The observer's **own meta-OODA loop** (Observe = `StatusSnapshot` + PR/CI/goal
    state → Orient = classify + prioritize + **dedup vs Simard's in-flight work** →
    Decide → Act via reused capabilities).
  - The **capability/action map** — every `Intervention` → capability trait →
    exact existing Simard function (file:line).
  - **Guardrails**: autonomy boundary (routine autonomous, HIGH-RISK gated),
    anti-recursion (structural + identity), budget/concurrency caps,
    conflict-avoidance sequencing; persisted state; explicit boundary vs OODA.
  - **Phased roadmap M1–M4** with a reuse map + test strategy per phase.
- **`src/overseer/`** — additive Rust type/trait **sketch** (`#![allow(dead_code)]`,
  clippy-clean, **9 unit tests**): `Overseer` co-process + meta-OODA `run_cycle`;
  `Intervention`; `Signal`/`Problem`; the eight capability traits (`StatusReader`,
  `RecipeLauncher`, `PrOps`, `Deployer`, `MeetingHost`, `IssueFiler`, `GoalCurator`,
  `Auditor`) each **doc-annotated with the exact reused Simard function**; guardrails.
- **`prompt_assets/simard/overseer/`** — operator-observe, problem→fix-brief,
  pr-verify, deploy-gate prompts + a reuse README (reuses
  `smart-orchestrator`/`default-workflow`/`quality-audit` recipes; not wired live).
- **mkdocs nav** — new "Design" section.

## Key decision: the name

Recommended faculty name is **`Overseer`** (not `Operator`): `Operator` collides
with the existing `operator_cli` / `operator_commands*` **human-operator CLI
surface** (7 modules); `Copilot`/`Curator`/`Sentinel` collide or mislead. No
`Bridge` naming anywhere.

## Constraints honored

- ✅ Additive docs + Rust type sketches + prompt files; **no runtime behavior
  change**, no always-on process wired into `main`, no redeploy, no touch of the
  live daemon / `~/.simard/worktrees`.
- ✅ All Rust; maximal reuse — every capability cites the exact existing
  module/function, grounded by reading the source.
- ✅ Anti-recursion + anti-conflict + budget are first-class design concerns.
- ✅ No `Bridge` naming; single clear faculty name recommended.
- ✅ Branched off latest `origin/main`.

## Test plan / verification

Run locally, all green:

- `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo test --lib overseer::` — **9 passed** (thresholds, orient dedup, gating,
  budget hold, anti-recursion, conflict sequencing, act dispatch).
- `mkdocs build --strict` — 0 broken links / nav orphans / dead anchors.

## Scope

13 files, additive only (`+2158`). The `Bridge`/`print!`/additive/PRD diff-scans
referenced by the pr-verify checklist are **specified, not implemented** (future
milestone).

Closes #2419 (design-spike deliverable).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
