### PR TITLE
fix: make the OODA daemon steerable — complete the no-progress breaker (Fix 3)

### DIFF
--- a/docs/concepts/steerable-ooda-daemon.md
+++ b/docs/concepts/steerable-ooda-daemon.md
@@ -1,0 +1,355 @@
+---
+title: "Concept: keeping the OODA daemon steerable — read-your-writes, the done-gate, the no-progress breaker, and distillation banner-stripping"
+description: The retcon narrative for the systemic goal-board + OODA-livelock + distillation incident — why the daemon became un-steerable (operator goal edits appeared not to stick), why it livelocked re-selecting already-done supply-chain goals, and why distillation extracted zero facts — and how four coordinated fixes across src/goal_curation, src/goal_curation/completion_gate, the OODA advance-goal path, and src/recipe_output restore read-your-writes, evidence-gated completion, forward progress, and fact extraction.
+last_updated: 2026-07-03
+review_schedule: as-needed
+owner: simard
+doc_type: concept
+related:
+  - ./goal-board-persistence.md
+  - ./goal-board-corruption-guards.md
+  - ./deploy-aware-done-gate.md
+  - ./ooda-loop-self-detection.md
+  - ./copilot-launcher-preamble-stripping.md
+  - ../reference/goal-board-api.md
+  - ../reference/completion-evidence-gate-api.md
+  - ../reference/distill-recipe-output-capture.md
+  - ../howto/unblock-stuck-ooda-goals.md
+  - ../howto/recover-goal-board.md
+  - ../howto/diagnose-a-rejected-goal-completion.md
+  - ../howto/diagnose-decide-orient-parse-failures.md
+---
+
+# Concept: keeping the OODA daemon steerable
+
+This document is the **single coherent narrative** for a systemic incident in
+which the autonomous OODA daemon became *un-steerable and stuck*. It ties
+together four fixes that each already have their own focused reference and
+concept pages, and it reconciles the **operator-observed symptoms** with the
+**implementation that actually shipped** — the "retcon" that explains why the
+shipped design resolves what was seen in production.
+
+If you are here to change one subsystem, jump straight to its authoritative
+page:
+
+| Symptom | Root cause | Authoritative doc |
+|---|---|---|
+| Operator `goal add` / `goal remove` "didn't stick"; the next `goal list` and the next curation cycle read an old board | Stale, unordered snapshot read + a load/save asymmetry + un-serialized cross-process writes | [Goal board persistence](./goal-board-persistence.md) · [Goal board API](../reference/goal-board-api.md) |
+| Goals with objectively-complete evidence (merged PR, filed/closed issue) stayed active at 0% and were re-litigated every cycle | No evidence-driven auto-completion; completion required a subjective LLM claim | [Deploy-aware done-gate](./deploy-aware-done-gate.md) · [Completion-evidence gate API](../reference/completion-evidence-gate-api.md) |
+| Every cycle re-selected the same done goals and the brain emitted "I'll break the loop by verifying concretely…" no-action prose forever | No bounded, per-goal escalation from repeated no-action to a definitive resolution | [No-progress breaker](#the-no-progress-breaker-fix-3) (below) · [OODA loop self-detection](./ooda-loop-self-detection.md) |
+| `distill: 50 episodes -> 0 facts, 0 procedures` | The Copilot CLI launch-log banner polluted the transcript the distill parser reads | [Copilot launch-log preamble stripping](./copilot-launcher-preamble-stripping.md) · [Distill recipe-output capture](../reference/distill-recipe-output-capture.md) |
+
+---
+
+## The incident
+
+A production OODA daemon exhibited three failure modes at once, and they
+compounded each other:
+
+1. **Un-steerable.** An operator ran `simard goal remove <ids>` and
+   `simard goal add …`. Both reported success, yet the next
+   `simard goal list` still showed the *old* goals. Operator intent — the
+   whole point of steering the daemon — was silently lost.
+
+2. **Livelocked.** Every OODA cycle re-selected the **same four** supply-chain
+   goals — all objectively **done** (two merged hardening PRs, one
+   out-of-scope issue filed) — and the brain, cycle after cycle, emitted
+   variations of *"I'll break the loop by verifying concretely…"* while taking
+   **no shippable action**. The goals stayed `not-started` at 0% forever.
+
+3. **Blind.** Memory distillation reported
+   `distill: 50 episodes -> 0 facts, 0 procedures, 50 marked (100% reduction)`.
+   Fifty episodes went in; nothing came out. The daemon could not learn from
+   its own history, so it kept repeating it.
+
+The three fed one loop: the daemon could not be redirected (1), so it kept
+grinding on stale work (2), and it could not distill the experience into
+memory that would let it notice (3).
+
+---
+
+## Fix 1 — Goal-board read-your-writes
+
+**Symptom:** operator edits didn't stick; `goal list` and the next curation
+cycle read an old board.
+
+**Root cause.** The board was persisted as a cognitive-memory
+`goal-board:snapshot` fact, but the *read* did not select the **latest**
+snapshot. A newly-written snapshot became just one more fact node among many;
+an unordered, limited search could return an older revision. A separate
+load/save asymmetry (the loader ignoring what the saver had just written) and
+un-serialized cross-process writes (daemon vs. dashboard vs. `goal`-CLI IPC)
+turned "I added a goal" into "my goal vanished on the next cycle." A tight
+multi-client race could even delete production goals between cycles (issue
+[#1915](https://github.com/rysweet/Simard/issues/1915)).
+
+**What shipped.** The board has a **single source of truth** — the
+`goal-board:snapshot` fact in cognitive memory — and three properties make
+writes observable by the very next read:
+
+- **Newest-snapshot selection.** `load_goal_board` reads a *window* of
+  candidate snapshots and picks the newest deterministically
+  (`search_facts("goal-board:snapshot", 64, 0.0)` → filter →
+  `max_by(node_id)`), instead of trusting an unordered limit-1 result. The
+  loader and saver now share this one `read_latest_snapshot` helper, closing
+  the load/save asymmetry.
+- **Merge-on-write.** `save_goal_board` re-reads the latest persisted snapshot
+  and unions it by goal `id` with the in-flight board (in-flight wins on
+  collision) before storing. An operator- or meeting-added goal is therefore
+  **merged**, never clobbered, by a concurrent curation write — curation can
+  regenerate its own set without deleting operator intent.
+- **Serialized cross-process writes.** When the daemon is running, all writes
+  flow through its IPC socket; when it is not, the writer takes an advisory
+  **`flock`** over the board lock file
+  ([#2514](https://github.com/rysweet/Simard/pull/2514)) so the daemon, the
+  dashboard, and the `goal` CLI never interleave a read-modify-write.
+
+A one-shot bootstrap migration imports any legacy
+`$SIMARD_STATE_ROOT/goal_records.json` on first startup and then removes it, so
+there is exactly one authoritative store afterward.
+
+> **On the operator's "make disk authoritative" diagnosis.** The observed
+> root cause was correct — the board read was returning a stale snapshot and
+> writes were racing. The shipped resolution keeps **cognitive memory** as the
+> authoritative store (issue
+> [#1590](https://github.com/rysweet/Simard/issues/1590)) rather than promoting
+> the disk file, but it delivers the property the operator actually needed:
+> **read-your-writes**. `add` → reload shows it; `remove` → reload omits it;
+> and the next curation cycle observes the same latest board. See
+> [Goal board persistence](./goal-board-persistence.md) for the full consumer
+> matrix and the [`save_goal_board` merge rule](../reference/goal-board-api.md#save_goal_board),
+> and [Goal board corruption guards](./goal-board-corruption-guards.md) for the
+> pre-write validity gate that keeps a hallucinated Decide-phase board from
+> overwriting the snapshot.
+
+**Tests.** `tests_operations.rs`, `tests_snapshot_dedup.rs`, and
+`tests_save_with_removals.rs` cover write→load round-trips, newest-snapshot
+selection over multiple snapshots, add/remove reload behavior, and
+merge-on-write under a concurrent writer/reader.
+
+---
+
+## Fix 2 — The evidence-gated done-gate
+
+**Symptom:** goals whose work was objectively finished (a merged PR, a filed
+or closed issue) were never marked done — they stayed active at 0% and were
+re-selected every cycle.
+
+**Root cause.** Completion was a *claim*, not a *verification*. Nothing turned
+"the referenced PR is merged" or "the referenced issue is filed/closed" into an
+automatic `done` transition, so objectively-complete goals lingered on the
+active board and kept feeding the livelock.
+
+**What shipped.** The **deploy-aware done-gate**
+(`src/goal_curation/completion_gate.rs`) makes completion a function of **hard
+evidence** gathered through an injected `EvidenceSource` (so the logic is pure
+and hermetic in tests):
+
+- `CompletionEvidence { pr_merged, issue_closed, self_affecting, deployed }`.
+- A goal is complete only with a **merged PR**, a **closed linked issue**, and
+  — for changes to Simard's own running code — a **verified deploy**
+  (`!DeployDrift::needs_deploy`).
+- Anything short records a specific `MissingEvidence` blocker
+  (`PrNotMerged` / `IssueOpen` / `NotDeployed`) instead of silently archiving.
+- `has_derivable_signal` — true when the goal references a PR, an issue, or is
+  self-affecting — is the trigger that lets the gate auto-resolve a goal from
+  external state rather than re-litigating it at 0%.
+
+Applied to the incident, the four ladybug supply-chain goals each carried a
+derivable signal (a merged hardening PR, or a filed out-of-scope issue), so the
+gate would **auto-complete or auto-drop** them instead of returning them to the
+active set. See [Deploy-aware done-gate](./deploy-aware-done-gate.md) and the
+[Completion-evidence gate API](../reference/completion-evidence-gate-api.md);
+operators diagnosing a *rejected* completion use the
+[rejected-completion runbook](../howto/diagnose-a-rejected-goal-completion.md).
+
+**Tests.** The completion-gate suite exercises the merged-PR / closed-issue /
+self-affecting-not-deployed matrix, including a merged-PR-plus-filed-issue
+fixture that maps directly to the four stuck supply-chain goals.
+
+---
+
+## The no-progress breaker (Fix 3)
+
+**Symptom:** the brain kept emitting *"I'll break the loop by verifying
+concretely…"* indefinitely — a healthy brain confidently producing **no
+action** on the same goal, forever.
+
+This is the fix with the least prior documentation, so it is documented in full
+here. It is deliberately layered so that **no single layer has to be perfect**,
+and — per the incident's coordination constraint — it lives in the
+goal-selection / progress path and the OODA advance-goal dispatch, **not** deep
+inside the brain reasoners.
+
+### Why livelock is distinct from a brain failure
+
+A brain *failure* is a transport error, a JSON parse error, or an empty
+response — the brain did not produce a usable decision. A *livelock* is the
+opposite: the brain **succeeds** and emits a well-formed decision whose
+*content* is "take no action, I'll verify later." The daemon looks busy and
+makes zero shippable progress. The two need different breakers.
+
+### The three layers, and the definitive-resolution ladder
+
+1. **Prompt-level self-detection.** The Observe/Orient/Decide prompts carry an
+   explicit *"am I looping?"* judgment: a cycle that only re-triages the same
+   PRs, re-reads the same issue, or re-records the same percentage is **not
+   progress**. This is the first line of defense and requires no rebuild — see
+   [OODA loop self-detection](./ooda-loop-self-detection.md).
+
+2. **No-action classification.** When a decision resolves to a `NO ACTION` /
+   `NO_ACTION` marker on its own line, the advance-goal parser routes it to
+   `GoalAction::NoAction { reason }` (rather than spawning an engineer). This
+   gives the progress path a **countable, structured** no-progress signal
+   instead of having to pattern-match free prose.
+
+3. **Bounded escalation to a definitive resolution.** Repeated no-progress on
+   the *same* goal must terminate in a single decisive outcome — never another
+   "I'll verify" cycle. The daemon already ships the analogous safeguard for
+   brain *failures*: after **3 consecutive** failing cycles,
+   `dispatch_spawn_engineer` writes a sentinel-tagged
+   `GoalProgress::Blocked` reason
+   (`BRAIN_FAILURE_BLOCKED_PREFIX` … `BRAIN_FAILURE_BLOCKED_SUFFIX`), files a
+   tracking issue for human review, and heals automatically after one healthy
+   cycle. The **no-progress breaker** applies the same shape to *no-action*
+   cycles: after a small number (N ≈ 2–3) of consecutive no-progress cycles on
+   one goal, force **one** definitive verification, then resolve it exactly
+   once via the ladder below — and stop re-queuing the goal for another
+   "verify" cycle.
+
+```
+consecutive no-progress cycles on goal G reaches N
+        │
+        ▼
+run the concrete verification ONCE (not "I'll verify later")
+        │
+        ├─ evidence present  ──►  mark DONE via the done-gate (Fix 2)
+        ├─ goal obsolete     ──►  DROP from the active board
+        └─ neither           ──►  ESCALATE: file a GitHub issue for
+                                   human review and Block the goal
+```
+
+The verification is the **done-gate** from Fix 2: "concretely verify" means
+"ask the `EvidenceSource` whether the referenced PR is merged / the issue is
+closed / the self-change is deployed," and then commit to the answer. The four
+stuck supply-chain goals reach the first branch (evidence present → DONE) or
+the second (out-of-scope issue filed → DROP); they can never reach a fourth
+"I'll verify again" branch, because that branch does not exist.
+
+### Status and boundaries
+
+Layer 1 (prompt self-detection) and the brain-*failure* escalation of layer 3
+are shipped and documented
+([OODA loop self-detection](./ooda-loop-self-detection.md),
+[Unblock OODA goals stuck after a brain-failure lockout](../howto/unblock-stuck-ooda-goals.md)).
+Layer 2's `NO ACTION` classification is shipped in the advance-goal dispatch.
+The **no-action** counterpart of the layer-3 escalation — a per-goal
+consecutive-no-progress counter that forces the resolution ladder above — is
+the concept this page defines; it reuses the existing sentinel-`Blocked` +
+file-an-issue machinery and the done-gate rather than introducing a new
+state-machine in the reasoners, to keep the change inside
+`goal_curation` / the advance-goal path (the naming-cleanup rename owns the
+`ooda_brain` / reasoner / bridge files, so those are left untouched).
+
+**Test shape.** A goal that yields `GoalAction::NoAction` N times in a row
+triggers the breaker exactly once and terminates in DONE / DROP / ESCALATE — it
+must **not** produce an (N+1)th no-action cycle.
+
+---
+
+## Fix 4 — Distillation banner-stripping
+
+**Symptom:** `distill: 50 episodes -> 0 facts, 0 procedures`.
+
+**Root cause.** The transcript the distillation parser reads was prefixed with
+the **Copilot CLI launch-log banner** — the
+`… launching copilot binary=… version="GitHub Copilot CLI …"` line and the
+`ℹ … NODE_OPTIONS=… (saved preference)` info marker (the exact banner visible
+in this session's terminal heartbeat). That preamble sits in front of the
+agent's real `{ "facts": …, "procedures": … }` payload, so the parser sees
+noise and extracts nothing.
+
+**What shipped.** The banner and ANSI noise are stripped at the **single
+shared `recipe_output` chokepoint** (`strip_recipe_noise` /
+`is_copilot_launcher_line` in `src/recipe_output/extract.rs`). Because every
+recipe-backed brain phase **and** the distillation capture path read their
+agent output through this one function, the strip that originally fixed the
+decide/orient deadlock now also cleans the distill transcript — no per-caller
+duplication. `is_copilot_launcher_line` anchors on the launcher-line markers
+and requires *both* `NODE_OPTIONS=` and `(saved preference)` on the info-marker
+line, so genuine prose that merely mentions `NODE_OPTIONS` is never eaten. See
+[Copilot launch-log preamble stripping](./copilot-launcher-preamble-stripping.md)
+and [Distill recipe-output capture](../reference/distill-recipe-output-capture.md);
+operators diagnosing a parse failure use the
+[decide/orient parse-failure runbook](../howto/diagnose-decide-orient-parse-failures.md).
+
+**Tests.** A regression fixture feeds a **banner-prefixed** distill transcript
+through the shared chokepoint and asserts **> 0 facts** are extracted, so a
+re-introduced banner leak fails CI at the distill path, not only at
+decide/orient.
+
+---
+
+## Why these four ship together
+
+Each fix removes one leg of the same stool:
+
+- **Fix 1** makes the board **steerable** — operator and meeting intent survive
+  and are visible on the next read.
+- **Fix 2** lets objectively-finished goals **leave** the active board on
+  evidence, instead of being re-litigated at 0%.
+- **Fix 3** guarantees a goal that repeatedly produces no progress reaches a
+  **definitive** resolution instead of an endless "I'll verify" loop.
+- **Fix 4** restores **learning**, so distillation turns episodes back into the
+  facts and procedures that let the daemon notice it is repeating itself.
+
+Steerable input, evidence-based exit, bounded escalation, and working memory:
+remove any one and the daemon can slide back toward the un-steerable, stuck
+state this incident captured.
+
+---
+
+## Guarantees and non-guarantees
+
+**Guaranteed**
+
+- **Read-your-writes** for goal-board edits under the daemon IPC path or the
+  advisory `flock`: an `add`/`remove` is observed by the next `goal list` and
+  the next curation cycle (Fix 1).
+- **No evidence-free completion** and **no evidence-free perpetual re-litigation**:
+  a goal with a derivable signal is auto-resolved by the done-gate rather than
+  returned to the active set at 0% (Fix 2).
+- **Bounded no-progress**: a goal cannot emit unbounded consecutive no-action
+  cycles; it terminates in DONE / DROP / ESCALATE (Fix 3).
+- **Banner-immune distillation**: a launch-banner-prefixed transcript still
+  yields facts, verified by regression fixture (Fix 4).
+
+**Not guaranteed**
+
+- **Strict linearizability** of `save_goal_board` across separate IPC clients —
+  merge-on-write prevents goal *disappearance* in the common race, but a tight
+  read-read-write-write interleaving can still drop the earlier writer's most
+  recent *field* edit on the same `id`. Callers needing strict serializability
+  route through the daemon IPC socket. See the
+  [`save_goal_board` non-guarantees](../reference/goal-board-api.md#save_goal_board).
+- **Escalation cannot manufacture evidence.** If neither completion evidence
+  nor an obsolescence signal exists, the breaker files an issue and blocks the
+  goal for human review — it does not guess.
+- **Prompt-level self-detection is best-effort**; the layer-3 escalation exists
+  precisely because layer 1 can be fooled by a confidently-looping brain.
+
+---
+
+## See also
+
+- [Goal board persistence](./goal-board-persistence.md) — the single-source-of-truth
+  design, consumer matrix, and cycle-startup sequence.
+- [Goal board corruption guards](./goal-board-corruption-guards.md) — the
+  pre-write validity gate.
+- [Deploy-aware done-gate](./deploy-aware-done-gate.md) ·
+  [Completion-evidence gate API](../reference/completion-evidence-gate-api.md).
+- [OODA loop self-detection](./ooda-loop-self-detection.md) ·
+  [Unblock OODA goals stuck after a brain-failure lockout](../howto/unblock-stuck-ooda-goals.md).
+- [Copilot launch-log preamble stripping](./copilot-launcher-preamble-stripping.md) ·
+  [Distill recipe-output capture](../reference/distill-recipe-output-capture.md).
+- [How to recover a corrupted or missing goal board](../howto/recover-goal-board.md).

--- a/docs/concepts/steerable-ooda-daemon.md
+++ b/docs/concepts/steerable-ooda-daemon.md
@@ -198,8 +198,11 @@ makes zero shippable progress. The two need different breakers.
    [OODA loop self-detection](./ooda-loop-self-detection.md).
 
 2. **No-action classification.** When a decision resolves to a `NO ACTION` /
-   `NO_ACTION` marker on its own line, the advance-goal parser routes it to
-   `GoalAction::NoAction { reason }` (rather than spawning an engineer). This
+   `NO_ACTION` marker on its own line, the goal-session parser
+   (`parse_orchestrator_response` → `has_no_action_marker` in
+   `src/ooda_actions/goal_session/mod.rs`, reached through the advance-goal
+   dispatch) routes it to `GoalAction::NoAction { reason }` and records a no-op
+   cycle via `assess_only_outcome` (rather than spawning an engineer). This
    gives the progress path a **countable, structured** no-progress signal
    instead of having to pattern-match free prose.
 
@@ -242,7 +245,8 @@ Layer 1 (prompt self-detection) and the brain-*failure* escalation of layer 3
 are shipped and documented
 ([OODA loop self-detection](./ooda-loop-self-detection.md),
 [Unblock OODA goals stuck after a brain-failure lockout](../howto/unblock-stuck-ooda-goals.md)).
-Layer 2's `NO ACTION` classification is shipped in the advance-goal dispatch.
+Layer 2's `NO ACTION` classification is shipped in the goal-session parser
+(`src/ooda_actions/goal_session/`), reached through the advance-goal dispatch.
 The **no-action** counterpart of the layer-3 escalation — a per-goal
 consecutive-no-progress counter that forces the resolution ladder above — is
 the concept this page defines; it reuses the existing sentinel-`Blocked` +
@@ -298,8 +302,11 @@ Each fix removes one leg of the same stool:
   and are visible on the next read.
 - **Fix 2** lets objectively-finished goals **leave** the active board on
   evidence, instead of being re-litigated at 0%.
-- **Fix 3** guarantees a goal that repeatedly produces no progress reaches a
-  **definitive** resolution instead of an endless "I'll verify" loop.
+- **Fix 3** drives a goal that repeatedly produces no progress toward a
+  **definitive** resolution instead of an endless "I'll verify" loop — shipped
+  today for brain *failures*, and by design (see
+  [Status and boundaries](#status-and-boundaries)) for the *no-action* livelock
+  counterpart.
 - **Fix 4** restores **learning**, so distillation turns episodes back into the
   facts and procedures that let the daemon notice it is repeating itself.
 
@@ -319,8 +326,13 @@ state this incident captured.
 - **No evidence-free completion** and **no evidence-free perpetual re-litigation**:
   a goal with a derivable signal is auto-resolved by the done-gate rather than
   returned to the active set at 0% (Fix 2).
-- **Bounded no-progress**: a goal cannot emit unbounded consecutive no-action
-  cycles; it terminates in DONE / DROP / ESCALATE (Fix 3).
+- **Bounded no-progress** *(design defined here; the no-action breaker is not
+  yet shipped — see [Status and boundaries](#status-and-boundaries))*: a goal
+  must not emit unbounded consecutive no-action cycles; it terminates in DONE /
+  DROP / ESCALATE (Fix 3). Layer 1 (prompt self-detection) and the
+  brain-*failure* escalation are shipped today; the per-goal
+  consecutive-no-action counter that closes this guarantee is the concept this
+  page defines.
 - **Banner-immune distillation**: a launch-banner-prefixed transcript still
   yields facts, verified by regression fixture (Fix 4).
 

--- a/docs/concepts/steerable-ooda-daemon.md
+++ b/docs/concepts/steerable-ooda-daemon.md
@@ -249,15 +249,32 @@ Layer 2's `NO ACTION` classification is shipped in the goal-session parser
 (`src/ooda_actions/goal_session/`), reached through the advance-goal dispatch.
 The **no-action** counterpart of the layer-3 escalation — a per-goal
 consecutive-no-progress counter that forces the resolution ladder above — is
-the concept this page defines; it reuses the existing sentinel-`Blocked` +
-file-an-issue machinery and the done-gate rather than introducing a new
-state-machine in the reasoners, to keep the change inside
-`goal_curation` / the advance-goal path (the naming-cleanup rename owns the
+**now shipped**: the pure policy lives in
+`src/goal_curation/no_progress_breaker.rs` (`NoProgressTracker`,
+`resolve_no_progress`, `verify_stuck_goal`), and the OODA curate phase applies
+it through `src/ooda_loop/no_progress.rs`
+(`apply_no_progress_breaker`), which turns each
+`NoProgressResolution` into a board mutation (mark done / drop) or a
+sentinel-`Blocked` + `gh`-filed tracking issue. It reuses the existing
+sentinel-`Blocked` + file-an-issue machinery and the done-gate rather than
+introducing a new state-machine in the reasoners, keeping the change inside
+`goal_curation` / `ooda_loop` (the naming-cleanup rename owns the
 `ooda_brain` / reasoner / bridge files, so those are left untouched).
+
+The no-progress signal is the classifier
+`ooda_actions::outcome_made_no_progress`, co-located with the detail author
+(`assess_only_outcome`) so the two stay in lockstep. The counter lives on
+`OodaState.no_progress_tracker` (the sibling of `goal_failure_counts`) and is
+snapshot-persisted, so a livelock that spans a daemon restart is still bounded.
 
 **Test shape.** A goal that yields `GoalAction::NoAction` N times in a row
 triggers the breaker exactly once and terminates in DONE / DROP / ESCALATE — it
-must **not** produce an (N+1)th no-action cycle.
+must **not** produce an (N+1)th no-action cycle. The pure ladder is unit-tested
+in `goal_curation::tests_no_progress_breaker`; the OODA-curate wiring
+(N no-action cycles → board mutated + one issue filed; real progress resets the
+counter) in `ooda_loop::tests_no_progress`; and the no-progress classifier is
+pinned against its detail author in
+`ooda_actions::goal_session::advance::tests_no_progress_classifier`.
 
 ---
 
@@ -304,9 +321,8 @@ Each fix removes one leg of the same stool:
   evidence, instead of being re-litigated at 0%.
 - **Fix 3** drives a goal that repeatedly produces no progress toward a
   **definitive** resolution instead of an endless "I'll verify" loop — shipped
-  today for brain *failures*, and by design (see
-  [Status and boundaries](#status-and-boundaries)) for the *no-action* livelock
-  counterpart.
+  for both brain *failures* and the *no-action* livelock counterpart (see
+  [Status and boundaries](#status-and-boundaries)).
 - **Fix 4** restores **learning**, so distillation turns episodes back into the
   facts and procedures that let the daemon notice it is repeating itself.
 
@@ -326,13 +342,11 @@ state this incident captured.
 - **No evidence-free completion** and **no evidence-free perpetual re-litigation**:
   a goal with a derivable signal is auto-resolved by the done-gate rather than
   returned to the active set at 0% (Fix 2).
-- **Bounded no-progress** *(design defined here; the no-action breaker is not
-  yet shipped — see [Status and boundaries](#status-and-boundaries))*: a goal
-  must not emit unbounded consecutive no-action cycles; it terminates in DONE /
-  DROP / ESCALATE (Fix 3). Layer 1 (prompt self-detection) and the
-  brain-*failure* escalation are shipped today; the per-goal
-  consecutive-no-action counter that closes this guarantee is the concept this
-  page defines.
+- **Bounded no-progress**: a goal must not emit unbounded consecutive
+  no-action cycles; it terminates in DONE / DROP / ESCALATE (Fix 3). Layer 1
+  (prompt self-detection), the brain-*failure* escalation, **and** the per-goal
+  consecutive-no-action breaker (`ooda_loop::apply_no_progress_breaker`, wired
+  into the curate phase) are all shipped.
 - **Banner-immune distillation**: a launch-banner-prefixed transcript still
   yields facts, verified by regression fixture (Fix 4).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@ Terminal sessions and repo-grounded engineer runs now bridge through one explici
 - [How to decompose a large goal into linked sub-goals](./howto/decompose-a-large-goal.md) — break one umbrella goal into 2–6 bounded sub-goals with `simard goal decompose`, verify the parent↔child edges round-trip in the graph, and read parent progress as a roll-up (#2405).
 - [How to configure adaptive scaling](./howto/configure-adaptive-scaling.md) — enable and tune AIMD concurrency scaling.
 - [How to keep Simard's own dependency pins up to date](./howto/self-maintain-dependency-pins.md) — the reactive done-gate and proactive reconcile that bump Simard's own `Cargo.toml` git-rev pins after she lands a change upstream, so the fix runs in her own build (companion to [Safe Self-Update](./safe-self-update.md)).
+- [Concept: keeping the OODA daemon steerable](./concepts/steerable-ooda-daemon.md) — the coherent narrative for the systemic goal-board + OODA-livelock + distillation incident: why operator goal edits appeared not to stick, why the daemon re-selected already-done supply-chain goals forever, and why distillation extracted zero facts — and the four coordinated fixes (read-your-writes goal board, the evidence-gated done-gate, the no-progress breaker, and distillation banner-stripping) that restore steerability, evidence-based completion, forward progress, and learning.
 - [Concept: reconcile-and-self-deploy](./concepts/reconcile-and-self-deploy.md) — how a merged self-change is built-from-source, deployed, health-verified, and left running (or rolled back), closing the "merged != running" gap. See the [self-deploy API reference](./reference/self-deploy-api.md) and the [verify-and-roll-back runbook](./howto/verify-and-roll-back-a-self-deploy.md).
 - [Concept: deploy-aware done-gate](./concepts/deploy-aware-done-gate.md) — why a goal is complete only with a merged PR, a closed issue, and (for self-affecting changes) a verified deploy; the gate that prevents evidence-free done-claims. See the [completion-evidence gate API](./reference/completion-evidence-gate-api.md) and the [rejected-completion runbook](./howto/diagnose-a-rejected-goal-completion.md).
 
@@ -146,6 +147,7 @@ If you are changing architecture, start with the [architecture overview](./archi
 
 - [Architecture overview](./architecture/overview.md) - System diagram, core principles, component descriptions, and module map.
 - [Goal board persistence](./concepts/goal-board-persistence.md) — cognitive-memory single source of truth.
+- [Keeping the OODA daemon steerable](./concepts/steerable-ooda-daemon.md) — read-your-writes goal board, the evidence-gated done-gate, the no-progress breaker, and distillation banner-stripping, unified.
 - [File-backed goal store simplification](./concepts/file-backed-goal-store-simplification.md) — why GoalStore uses a plain JSON file instead of IPC.
 - [Adaptive scaling](./concepts/adaptive-scaling.md) — AIMD concurrency control for the OODA cycle.
 - [Goal board API reference](./reference/goal-board-api.md) — `active_goals_as_records` adapter and load/save semantics.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
     - Copilot Launch-Log Preamble Stripping: concepts/copilot-launcher-preamble-stripping.md
     - Unified Telemetry and Status: concepts/unified-telemetry-and-status.md
     - Goal-Board Persistence: concepts/goal-board-persistence.md
+    - Keeping the OODA Daemon Steerable: concepts/steerable-ooda-daemon.md
     - Goal-Board Corruption Guards: concepts/goal-board-corruption-guards.md
     - File-Backed Goal-Store Simplification: concepts/file-backed-goal-store-simplification.md
     - Goal-Fact Dedup in Preparation: concepts/goal-fact-dedup-in-preparation.md

--- a/src/goal_curation/mod.rs
+++ b/src/goal_curation/mod.rs
@@ -7,6 +7,7 @@
 //! ([`decompose`]) that breaks one large goal into bounded sub-goals.
 
 pub mod completion_gate;
+pub mod no_progress_breaker;
 mod operations;
 pub mod progress_evidence;
 pub mod progress_reviewer;
@@ -46,12 +47,20 @@ pub use completion_gate::{
     record_false_completion_rate,
 };
 
+pub use no_progress_breaker::{
+    NO_PROGRESS_BLOCKED_PREFIX, NO_PROGRESS_BLOCKED_SUFFIX, NO_PROGRESS_BREAKER_THRESHOLD,
+    NoProgressResolution, NoProgressTracker, StuckGoalDisposition, is_no_progress_marker,
+    no_progress_blocked_reason, obsolescence_reason, resolve_no_progress, verify_stuck_goal,
+};
+
 #[cfg(test)]
 mod tests;
 #[cfg(test)]
 mod tests_adapter;
 #[cfg(test)]
 mod tests_carryover;
+#[cfg(test)]
+mod tests_no_progress_breaker;
 #[cfg(test)]
 mod tests_operations;
 #[cfg(test)]

--- a/src/goal_curation/no_progress_breaker.rs
+++ b/src/goal_curation/no_progress_breaker.rs
@@ -260,8 +260,14 @@ pub fn resolve_no_progress(
 /// [`record_progress`](Self::record_progress) resets it after concrete progress,
 /// and [`record_and_resolve`](Self::record_and_resolve) folds "bump then decide"
 /// into one call, clearing the counter once the breaker fires.
-#[derive(Debug, Default, Clone)]
+///
+/// `Serialize`/`Deserialize` so the counter survives daemon restarts alongside
+/// `OodaState.goal_failure_counts` (a livelock spanning a restart must still be
+/// bounded). `#[serde(default)]` on the field keeps snapshots written before
+/// this counter existed deserializable.
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct NoProgressTracker {
+    #[serde(default)]
     counts: HashMap<String, u32>,
 }
 

--- a/src/goal_curation/no_progress_breaker.rs
+++ b/src/goal_curation/no_progress_breaker.rs
@@ -1,0 +1,320 @@
+//! No-progress breaker (Fix 3): bound consecutive no-action cycles per goal.
+//!
+//! # The livelock this closes
+//!
+//! A healthy OODA brain can *succeed* and still make zero progress: it emits a
+//! well-formed decision whose content is "take no action, I'll verify later"
+//! (`NO ACTION`). Classified by [`crate::ooda_actions::goal_session`] as
+//! [`GoalAction::NoAction`](crate::ooda_actions), each such cycle was recorded
+//! as a `success = true` no-op — so nothing counted them and nothing forced a
+//! resolution. The daemon re-selected the same "done" supply-chain goals every
+//! cycle and emitted "I'll break the loop by verifying concretely…" forever.
+//!
+//! # The breaker
+//!
+//! This module tracks, per goal, the number of *consecutive* no-action cycles
+//! ([`NoProgressTracker`], mirroring `OodaState.goal_failure_counts` but for the
+//! *no-action* livelock rather than the *brain-failure* one). After a small
+//! threshold ([`NO_PROGRESS_BREAKER_THRESHOLD`]) it runs the concrete
+//! verification **once** and commits to a definitive outcome via the ladder in
+//! [`resolve_no_progress`]:
+//!
+//! ```text
+//! consecutive no-action cycles on goal G reaches N
+//!         │
+//!         ▼
+//! run the done-gate verification ONCE (not "I'll verify later")
+//!         │
+//!         ├─ evidence present  ──►  MarkDone   (Fix 2 done-gate)
+//!         ├─ goal obsolete     ──►  Drop       (out-of-scope / tracked elsewhere)
+//!         └─ neither           ──►  Escalate   (file an issue + Block the goal)
+//! ```
+//!
+//! The verification reuses the Fix-2 [`CompletionEvidenceGate`] via
+//! [`verify_stuck_goal`], so "verify concretely" means "ask the injected
+//! [`EvidenceSource`] whether the referenced PR is merged / the issue is closed
+//! / the self-change is deployed", then commit to the answer. There is no
+//! fourth "I'll verify again" branch.
+//!
+//! The module is **pure**: side effects (marking the board, filing the GitHub
+//! issue, logging) are performed by the caller from the returned
+//! [`NoProgressResolution`], exactly as the completion-gate archive path leaves
+//! its `(archived, blocked)` side effects to its caller. This keeps the breaker
+//! hermetically testable and contained to `src/goal_curation/` — the incident's
+//! coordination constraint (the `ooda_brain`/reasoner/bridge files are owned by
+//! the naming-cleanup rename, so they are left untouched).
+//!
+//! See `docs/concepts/steerable-ooda-daemon.md` ("The no-progress breaker
+//! (Fix 3)").
+
+use std::collections::{HashMap, HashSet};
+
+use super::completion_gate::{CompletionEvidenceGate, CompletionVerdict, EvidenceSource};
+use super::types::ActiveGoal;
+
+/// Consecutive no-action cycles on one goal before the breaker fires. Kept
+/// deliberately small (2–3) so a livelock is broken quickly, matching the
+/// brain-failure safeguard's 3-cycle threshold.
+pub const NO_PROGRESS_BREAKER_THRESHOLD: u32 = 3;
+
+/// Sentinel prefix for a breaker-authored [`GoalProgress::Blocked`] reason.
+///
+/// Mirrors [`BRAIN_FAILURE_BLOCKED_PREFIX`](crate::ooda_actions) in shape (the
+/// `U+1F512` lock + `[OODA-SAFEGUARD]` token) so the same auto-recovery and
+/// `simard goal unblock-all` machinery can recognise safeguard-authored blocks
+/// and distinguish them from operator-set, scope-blocked, or dependency-blocked
+/// reasons.
+///
+/// [`GoalProgress::Blocked`]: super::types::GoalProgress::Blocked
+pub const NO_PROGRESS_BLOCKED_PREFIX: &str =
+    "\u{1F512} [OODA-SAFEGUARD] OODA goal made no shippable progress for ";
+
+/// Sentinel suffix for a breaker-authored blocked reason. Rendered as
+/// `{PREFIX}{count}{SUFFIX}`.
+pub const NO_PROGRESS_BLOCKED_SUFFIX: &str = " consecutive no-action cycles; needs human review";
+
+/// True when `reason` was authored by the no-progress breaker (both sentinel
+/// halves present). Distinct from the brain-failure marker.
+pub fn is_no_progress_marker(reason: &str) -> bool {
+    reason.starts_with(NO_PROGRESS_BLOCKED_PREFIX) && reason.contains(NO_PROGRESS_BLOCKED_SUFFIX)
+}
+
+/// Render the sentinel [`GoalProgress::Blocked`] reason for a goal escalated
+/// after `consecutive` no-action cycles.
+///
+/// [`GoalProgress::Blocked`]: super::types::GoalProgress::Blocked
+pub fn no_progress_blocked_reason(consecutive: u32) -> String {
+    format!("{NO_PROGRESS_BLOCKED_PREFIX}{consecutive}{NO_PROGRESS_BLOCKED_SUFFIX}")
+}
+
+/// The verified disposition of a stuck goal at the breaker threshold, computed
+/// by running the done-gate **once** (see [`verify_stuck_goal`]).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StuckGoalDisposition {
+    /// The done-gate certified the goal complete — hard evidence is present.
+    Done,
+    /// The goal is obsolete: its work is tracked elsewhere / out of scope, so it
+    /// should leave the active board without a completion claim.
+    Obsolete { reason: String },
+    /// Neither done nor obsolete — a derivable signal refutes completion (or the
+    /// state is unverifiable), and a human must resolve it.
+    Unresolved,
+}
+
+/// The resolution the breaker selects for a goal that produced a no-action
+/// cycle. Everything except [`NoProgressResolution::Continue`] is *terminal*:
+/// the goal leaves the no-action loop and cannot accumulate another cycle.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NoProgressResolution {
+    /// Below the threshold — record the no-op and let the goal retry next cycle.
+    Continue,
+    /// Threshold reached with evidence present — mark the goal DONE via the
+    /// done-gate (the caller archives it).
+    MarkDone,
+    /// Threshold reached and the goal is obsolete — DROP it from the active
+    /// board (the caller removes it), carrying the human-readable reason.
+    Drop { reason: String },
+    /// Threshold reached and unresolved — the caller files `issue_title` /
+    /// `issue_body` as a tracking issue and sets the goal
+    /// [`GoalProgress::Blocked`](super::types::GoalProgress::Blocked) to
+    /// `blocked_reason` (the [`is_no_progress_marker`] sentinel).
+    Escalate {
+        blocked_reason: String,
+        issue_title: String,
+        issue_body: String,
+    },
+}
+
+impl NoProgressResolution {
+    /// `true` for every resolution except [`NoProgressResolution::Continue`] —
+    /// i.e. the breaker fired and the goal is leaving the no-action loop.
+    pub fn is_terminal(&self) -> bool {
+        !matches!(self, Self::Continue)
+    }
+}
+
+/// Case-insensitive substrings that mark a goal as obsolete / handed off. When
+/// any appears in the goal's `current_activity` or an `issue` `wip_ref` label,
+/// the breaker drops the goal instead of escalating it.
+const OBSOLESCENCE_MARKERS: &[&str] = &[
+    "out of scope",
+    "out-of-scope",
+    "superseded",
+    "tracked elsewhere",
+    "obsolete",
+    "wontfix",
+    "won't fix",
+    "no longer needed",
+];
+
+/// Detect an explicit obsolescence / handoff signal on a stuck goal.
+///
+/// Returns a human reason when the goal's work has been determined out of scope
+/// and tracked elsewhere (e.g. an out-of-scope issue was filed) — the "DROP"
+/// branch of the ladder. Checks the goal's `current_activity` and its `issue`
+/// `wip_ref` labels for any [`OBSOLESCENCE_MARKERS`] token.
+pub fn obsolescence_reason(goal: &ActiveGoal) -> Option<String> {
+    fn marker_in(text: &str) -> Option<&'static str> {
+        let low = text.to_ascii_lowercase();
+        OBSOLESCENCE_MARKERS
+            .iter()
+            .copied()
+            .find(|m| low.contains(m))
+    }
+
+    if let Some(m) = goal.current_activity.as_deref().and_then(marker_in) {
+        return Some(format!("goal marked '{m}' (tracked elsewhere)"));
+    }
+    for wip in &goal.wip_refs {
+        if !wip.kind.eq_ignore_ascii_case("issue") {
+            continue;
+        }
+        if let Some(m) = marker_in(&wip.label) {
+            return Some(format!("out-of-scope issue #{} filed ('{m}')", wip.ref_id));
+        }
+    }
+    None
+}
+
+/// Verify a stuck goal **once** against the Fix-2 done-gate and map the verdict
+/// to a [`StuckGoalDisposition`]:
+///
+/// - gate says `Complete`                    → [`StuckGoalDisposition::Done`]
+/// - gate `Blocked` and the goal is obsolete → [`StuckGoalDisposition::Obsolete`]
+/// - gate `Blocked` otherwise                → [`StuckGoalDisposition::Unresolved`]
+///
+/// This is the concrete "verify, don't just say you'll verify" step at the
+/// heart of the breaker.
+pub fn verify_stuck_goal<E: EvidenceSource>(
+    goal: &ActiveGoal,
+    gate: &CompletionEvidenceGate<E>,
+) -> StuckGoalDisposition {
+    match gate.evaluate(goal) {
+        CompletionVerdict::Complete(_) => StuckGoalDisposition::Done,
+        CompletionVerdict::Blocked { .. } => match obsolescence_reason(goal) {
+            Some(reason) => StuckGoalDisposition::Obsolete { reason },
+            None => StuckGoalDisposition::Unresolved,
+        },
+    }
+}
+
+/// Build the escalation tracking-issue `(title, body)` for a goal blocked by the
+/// breaker after `consecutive` no-action cycles.
+fn escalation_issue(goal_id: &str, consecutive: u32) -> (String, String) {
+    let title = format!(
+        "OODA no-progress breaker: goal '{goal_id}' stuck ({consecutive} no-action cycles)"
+    );
+    let body = format!(
+        "The OODA daemon produced **no shippable action** on goal `{goal_id}` for \
+         {consecutive} consecutive cycles (repeated `NO ACTION` / \"I'll verify \
+         concretely…\" responses).\n\n\
+         The no-progress breaker ran the done-gate once: the goal is neither \
+         verifiably complete (no merged PR + closed issue + deploy) nor obsolete \
+         (no out-of-scope / tracked-elsewhere signal), so it has been marked \
+         Blocked pending human review.\n\n\
+         Inspect the goal's `wip_refs` and the relevant PR/issue, then either \
+         supply the missing completion evidence, mark the goal out of scope, or \
+         re-scope it.\n\n\
+         Triggered by the deterministic safeguard in \
+         `src/goal_curation/no_progress_breaker.rs` (Fix 3).",
+    );
+    (title, body)
+}
+
+/// The core policy: decide the resolution for a goal that produced a no-action
+/// cycle.
+///
+/// `consecutive_no_progress` is the count **including** the current cycle. Below
+/// `threshold` this returns [`NoProgressResolution::Continue`] and does **not**
+/// consult `disposition`. At or above `threshold` it forces exactly one
+/// definitive outcome by evaluating `disposition` (a closure so the concrete
+/// verification runs **once**, only when the breaker actually fires — never on
+/// every no-action cycle).
+pub fn resolve_no_progress(
+    goal_id: &str,
+    consecutive_no_progress: u32,
+    threshold: u32,
+    disposition: impl FnOnce() -> StuckGoalDisposition,
+) -> NoProgressResolution {
+    if consecutive_no_progress < threshold {
+        return NoProgressResolution::Continue;
+    }
+    match disposition() {
+        StuckGoalDisposition::Done => NoProgressResolution::MarkDone,
+        StuckGoalDisposition::Obsolete { reason } => NoProgressResolution::Drop { reason },
+        StuckGoalDisposition::Unresolved => {
+            let (issue_title, issue_body) = escalation_issue(goal_id, consecutive_no_progress);
+            NoProgressResolution::Escalate {
+                blocked_reason: no_progress_blocked_reason(consecutive_no_progress),
+                issue_title,
+                issue_body,
+            }
+        }
+    }
+}
+
+/// Per-goal consecutive no-action counter that drives the breaker.
+///
+/// Mirrors `OodaState.goal_failure_counts` but tracks the *no-action* livelock:
+/// [`record_no_action`](Self::record_no_action) bumps a goal's count,
+/// [`record_progress`](Self::record_progress) resets it after concrete progress,
+/// and [`record_and_resolve`](Self::record_and_resolve) folds "bump then decide"
+/// into one call, clearing the counter once the breaker fires.
+#[derive(Debug, Default, Clone)]
+pub struct NoProgressTracker {
+    counts: HashMap<String, u32>,
+}
+
+impl NoProgressTracker {
+    /// An empty tracker.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a no-action cycle for `goal_id`; returns the new consecutive count.
+    pub fn record_no_action(&mut self, goal_id: &str) -> u32 {
+        let entry = self.counts.entry(goal_id.to_string()).or_insert(0);
+        *entry += 1;
+        *entry
+    }
+
+    /// Reset `goal_id`'s counter after concrete progress (an engineer spawn, a
+    /// commit, a PR, an accepted progress bump).
+    pub fn record_progress(&mut self, goal_id: &str) {
+        self.counts.remove(goal_id);
+    }
+
+    /// Current consecutive no-action count for `goal_id` (`0` when untracked).
+    pub fn consecutive(&self, goal_id: &str) -> u32 {
+        self.counts.get(goal_id).copied().unwrap_or(0)
+    }
+
+    /// Drop counters for goals no longer on the board (mirrors the
+    /// `OodaState.goal_failure_counts` pruning), so stale ids cannot leak.
+    pub fn retain_goals(&mut self, live: &HashSet<String>) {
+        self.counts.retain(|id, _| live.contains(id));
+    }
+
+    /// Record a no-action cycle for `goal_id` and return the breaker's
+    /// resolution.
+    ///
+    /// `disposition` is evaluated lazily — only when the count reaches
+    /// `threshold` — so the concrete done-gate verification runs exactly once
+    /// per breaker firing, not on every no-action cycle. When the breaker fires
+    /// (any terminal resolution) the counter is cleared: the goal has left the
+    /// no-action loop (done / dropped / blocked) and cannot accumulate an
+    /// `(N+1)`th consecutive no-action cycle.
+    pub fn record_and_resolve(
+        &mut self,
+        goal_id: &str,
+        threshold: u32,
+        disposition: impl FnOnce() -> StuckGoalDisposition,
+    ) -> NoProgressResolution {
+        let consecutive = self.record_no_action(goal_id);
+        let resolution = resolve_no_progress(goal_id, consecutive, threshold, disposition);
+        if resolution.is_terminal() {
+            self.counts.remove(goal_id);
+        }
+        resolution
+    }
+}

--- a/src/goal_curation/tests_no_progress_breaker.rs
+++ b/src/goal_curation/tests_no_progress_breaker.rs
@@ -1,0 +1,334 @@
+//! Tests for the no-progress breaker ([`super::no_progress_breaker`], Fix 3).
+//!
+//! These are **test-first** for the un-shipped no-action livelock breaker
+//! described in `docs/concepts/steerable-ooda-daemon.md` ("The no-progress
+//! breaker (Fix 3)"). The daemon livelocked because repeated `NO ACTION`
+//! ("I'll verify concretely…") cycles on the *same* goal were recorded as
+//! `success=true` no-ops forever — nothing counted them, and nothing forced a
+//! definitive resolution.
+//!
+//! The breaker lives entirely in `src/goal_curation/` (per the incident's
+//! coordination constraint — `ooda_brain`/reasoner/bridge files are owned by
+//! the naming-cleanup rename) and reuses the Fix-2 done-gate to make the
+//! "verify concretely" step real rather than perpetual prose.
+
+use crate::error::{SimardError, SimardResult};
+use crate::goal_curation::completion_gate::{CompletionEvidenceGate, EvidenceSource};
+use crate::goal_curation::types::{ActiveGoal, GoalProgress, WipRef};
+
+use super::no_progress_breaker::{
+    NO_PROGRESS_BREAKER_THRESHOLD, NoProgressResolution, NoProgressTracker, StuckGoalDisposition,
+    is_no_progress_marker, no_progress_blocked_reason, obsolescence_reason, resolve_no_progress,
+    verify_stuck_goal,
+};
+
+// --- fixtures ---------------------------------------------------------------
+
+/// A canned, hermetic [`EvidenceSource`] mirroring the completion-gate test
+/// double — each answer is a `Result<bool, String>` so a test can model a clean
+/// verdict or a transient query failure.
+struct FakeEvidence {
+    pr_merged: Result<bool, String>,
+    issue_closed: Result<bool, String>,
+    deployed: Result<bool, String>,
+}
+
+impl FakeEvidence {
+    fn ok(pr_merged: bool, issue_closed: bool, deployed: bool) -> Self {
+        Self {
+            pr_merged: Ok(pr_merged),
+            issue_closed: Ok(issue_closed),
+            deployed: Ok(deployed),
+        }
+    }
+}
+
+fn to_result(r: &Result<bool, String>) -> SimardResult<bool> {
+    r.clone()
+        .map_err(|reason| SimardError::VerificationFailed { reason })
+}
+
+impl EvidenceSource for FakeEvidence {
+    fn any_pr_merged(&self, _goal: &ActiveGoal) -> SimardResult<bool> {
+        to_result(&self.pr_merged)
+    }
+    fn issue_closed(&self, _goal: &ActiveGoal) -> SimardResult<bool> {
+        to_result(&self.issue_closed)
+    }
+    fn is_deployed(&self, _goal: &ActiveGoal) -> SimardResult<bool> {
+        to_result(&self.deployed)
+    }
+}
+
+/// A Simard-repo goal (routes to Simard ⇒ self-affecting) stuck at 0%.
+fn stuck_goal(id: &str) -> ActiveGoal {
+    let mut g = ActiveGoal::new(id, "harden the supply chain", 1);
+    g.status = GoalProgress::NotStarted;
+    g
+}
+
+fn issue_ref(num: &str, label: &str) -> WipRef {
+    WipRef {
+        kind: "issue".to_string(),
+        ref_id: num.to_string(),
+        label: label.to_string(),
+        url: None,
+    }
+}
+
+fn pr_ref(num: &str) -> WipRef {
+    WipRef {
+        kind: "pr".to_string(),
+        ref_id: num.to_string(),
+        label: format!("PR #{num}"),
+        url: None,
+    }
+}
+
+// --- the headline guarantee: bounded no-progress ----------------------------
+
+#[test]
+fn breaker_fires_at_threshold_and_never_emits_an_extra_no_action_cycle() {
+    // The exact livelock reproduction: a goal that yields NO ACTION every cycle
+    // must NOT keep returning `Continue` forever. It Continues below the
+    // threshold, then fires exactly once at the threshold with a *terminal*
+    // resolution — and its counter is cleared so there is no (N+1)th no-op loop.
+    let threshold = NO_PROGRESS_BREAKER_THRESHOLD;
+    assert!(
+        threshold >= 2,
+        "breaker must be small (2-3), got {threshold}"
+    );
+
+    let mut tracker = NoProgressTracker::new();
+    let goal = "ladybug-supply-chain";
+
+    for cycle in 1..threshold {
+        let res = tracker.record_and_resolve(goal, threshold, || StuckGoalDisposition::Unresolved);
+        assert_eq!(
+            res,
+            NoProgressResolution::Continue,
+            "cycle {cycle} (< threshold {threshold}) must Continue"
+        );
+        assert_eq!(tracker.consecutive(goal), cycle);
+    }
+
+    // Threshold cycle: the breaker fires. NOT another Continue.
+    let fired = tracker.record_and_resolve(goal, threshold, || StuckGoalDisposition::Unresolved);
+    assert!(
+        fired.is_terminal(),
+        "breaker must produce a terminal resolution at the threshold, got {fired:?}"
+    );
+    assert!(
+        matches!(fired, NoProgressResolution::Escalate { .. }),
+        "unresolved goal must escalate, got {fired:?}"
+    );
+
+    // The counter is cleared once the breaker fires: the goal has left the
+    // no-action loop (blocked/dropped/done), so it can never accumulate an
+    // (N+1)th consecutive no-action cycle.
+    assert_eq!(
+        tracker.consecutive(goal),
+        0,
+        "counter must reset after the breaker fires"
+    );
+}
+
+#[test]
+fn real_progress_resets_the_no_action_counter() {
+    // A no-action cycle followed by concrete progress (an engineer spawn, a
+    // commit, a PR) must NOT trip the breaker — only *consecutive* no-action.
+    let threshold = NO_PROGRESS_BREAKER_THRESHOLD;
+    let mut tracker = NoProgressTracker::new();
+    let goal = "g";
+
+    for _ in 0..(threshold - 1) {
+        assert_eq!(
+            tracker.record_and_resolve(goal, threshold, || StuckGoalDisposition::Unresolved),
+            NoProgressResolution::Continue
+        );
+    }
+    tracker.record_progress(goal);
+    assert_eq!(tracker.consecutive(goal), 0);
+
+    // Next no-action starts the count over → Continue, not fire.
+    assert_eq!(
+        tracker.record_and_resolve(goal, threshold, || StuckGoalDisposition::Unresolved),
+        NoProgressResolution::Continue
+    );
+}
+
+// --- the definitive-resolution ladder ---------------------------------------
+
+#[test]
+fn ladder_marks_done_when_evidence_present() {
+    let res = resolve_no_progress("g", 3, 3, || StuckGoalDisposition::Done);
+    assert_eq!(res, NoProgressResolution::MarkDone);
+}
+
+#[test]
+fn ladder_drops_when_goal_is_obsolete() {
+    let res = resolve_no_progress("g", 3, 3, || StuckGoalDisposition::Obsolete {
+        reason: "out-of-scope issue #1 filed".to_string(),
+    });
+    match res {
+        NoProgressResolution::Drop { reason } => assert!(reason.contains("out-of-scope")),
+        other => panic!("expected Drop, got {other:?}"),
+    }
+}
+
+#[test]
+fn ladder_escalates_with_sentinel_block_and_issue_when_unresolved() {
+    let res = resolve_no_progress("stuck-goal", 3, 3, || StuckGoalDisposition::Unresolved);
+    match res {
+        NoProgressResolution::Escalate {
+            blocked_reason,
+            issue_title,
+            issue_body,
+        } => {
+            assert!(
+                is_no_progress_marker(&blocked_reason),
+                "blocked reason must carry the no-progress sentinel: {blocked_reason:?}"
+            );
+            assert!(issue_title.contains("stuck-goal"));
+            assert!(issue_body.contains("stuck-goal"));
+            assert!(
+                issue_body.contains("no_progress_breaker"),
+                "issue body should attribute the safeguard module"
+            );
+        }
+        other => panic!("expected Escalate, got {other:?}"),
+    }
+}
+
+#[test]
+fn below_threshold_always_continues_without_consulting_the_verifier() {
+    // The verification (done-gate) must run ONCE, only when the breaker fires —
+    // never on every no-action cycle. A panicking closure proves it is not
+    // consulted below the threshold.
+    let res = resolve_no_progress("g", 1, 3, || {
+        panic!("verifier must not run below threshold")
+    });
+    assert_eq!(res, NoProgressResolution::Continue);
+}
+
+// --- verify_stuck_goal reuses the Fix-2 done-gate ---------------------------
+
+#[test]
+fn verify_maps_complete_gate_verdict_to_done() {
+    let gate = CompletionEvidenceGate::new(FakeEvidence::ok(true, true, true));
+    let goal = stuck_goal("g");
+    assert_eq!(verify_stuck_goal(&goal, &gate), StuckGoalDisposition::Done);
+}
+
+#[test]
+fn verify_maps_blocked_out_of_scope_goal_to_obsolete() {
+    // Blocked by the gate (issue still open), but the linked issue is an
+    // explicit out-of-scope handoff → the goal is obsolete, not escalatable.
+    let gate = CompletionEvidenceGate::new(FakeEvidence::ok(false, false, false));
+    let mut goal = stuck_goal("g");
+    goal.wip_refs = vec![issue_ref("42", "filed as out-of-scope; tracked elsewhere")];
+    match verify_stuck_goal(&goal, &gate) {
+        StuckGoalDisposition::Obsolete { reason } => assert!(reason.contains("out-of-scope")),
+        other => panic!("expected Obsolete, got {other:?}"),
+    }
+}
+
+#[test]
+fn verify_maps_blocked_actionable_goal_to_unresolved() {
+    // Blocked with no obsolescence signal → a human must resolve it.
+    let gate = CompletionEvidenceGate::new(FakeEvidence::ok(false, true, false));
+    let mut goal = stuck_goal("g");
+    goal.wip_refs = vec![pr_ref("7")]; // an open PR that is not merged
+    assert_eq!(
+        verify_stuck_goal(&goal, &gate),
+        StuckGoalDisposition::Unresolved
+    );
+}
+
+// --- obsolescence predicate -------------------------------------------------
+
+#[test]
+fn obsolescence_detected_from_out_of_scope_issue_label() {
+    let mut goal = stuck_goal("g");
+    goal.wip_refs = vec![issue_ref("1", "out of scope — split into follow-up")];
+    assert!(obsolescence_reason(&goal).is_some());
+}
+
+#[test]
+fn obsolescence_detected_from_current_activity_marker() {
+    let mut goal = stuck_goal("g");
+    goal.current_activity = Some("superseded by the new hardening plan".to_string());
+    assert!(obsolescence_reason(&goal).is_some());
+}
+
+#[test]
+fn ordinary_goal_is_not_obsolete() {
+    let mut goal = stuck_goal("g");
+    goal.wip_refs = vec![pr_ref("9"), issue_ref("3", "harden ladybug-rust deps")];
+    goal.current_activity = Some("engineer working the PR".to_string());
+    assert!(obsolescence_reason(&goal).is_none());
+}
+
+// --- sentinel round-trip ----------------------------------------------------
+
+#[test]
+fn no_progress_sentinel_round_trips_and_is_distinct_from_other_reasons() {
+    let reason = no_progress_blocked_reason(3);
+    assert!(is_no_progress_marker(&reason));
+    assert!(!is_no_progress_marker("blocked: waiting on review"));
+    assert!(!is_no_progress_marker(
+        "\u{1F512} [OODA-SAFEGUARD] OODA brain failing for 3 consecutive cycles; needs human review"
+    ));
+}
+
+// --- the incident reproduction: the four ladybug supply-chain goals ----------
+
+#[test]
+fn four_stuck_supply_chain_goals_all_leave_the_active_loop_via_the_ladder() {
+    // The exact production livelock: four supply-chain goals re-selected every
+    // cycle, all objectively done — two merged hardening PRs, and an
+    // out-of-scope issue filed — yet stuck at 0% forever. With the breaker,
+    // after the threshold each terminates: merged-PR goals → MarkDone,
+    // out-of-scope-issue goal → Drop. NONE stays in the no-action loop.
+    let threshold = NO_PROGRESS_BREAKER_THRESHOLD;
+
+    // Two goals whose hardening PRs merged (and their linked issues closed):
+    // the done-gate certifies them Complete → MarkDone.
+    for (id, pr) in [("ladybug-rust", "1"), ("ladybug-graph-rs", "1")] {
+        let mut tracker = NoProgressTracker::new();
+        let mut goal = stuck_goal(id);
+        goal.wip_refs = vec![pr_ref(pr)];
+        let gate = CompletionEvidenceGate::new(FakeEvidence::ok(true, true, true));
+
+        let mut last = NoProgressResolution::Continue;
+        for _ in 0..threshold {
+            last = tracker.record_and_resolve(id, threshold, || verify_stuck_goal(&goal, &gate));
+        }
+        assert_eq!(
+            last,
+            NoProgressResolution::MarkDone,
+            "merged-PR goal '{id}' must auto-complete via the ladder"
+        );
+    }
+
+    // The out-of-scope goal: a filed issue marks it tracked elsewhere → Drop.
+    {
+        let id = "lbug-patched";
+        let mut tracker = NoProgressTracker::new();
+        let mut goal = stuck_goal(id);
+        goal.wip_refs = vec![issue_ref(
+            "1",
+            "out-of-scope for this daemon; filed upstream",
+        )];
+        let gate = CompletionEvidenceGate::new(FakeEvidence::ok(false, false, false));
+
+        let mut last = NoProgressResolution::Continue;
+        for _ in 0..threshold {
+            last = tracker.record_and_resolve(id, threshold, || verify_stuck_goal(&goal, &gate));
+        }
+        match last {
+            NoProgressResolution::Drop { .. } => {}
+            other => panic!("out-of-scope goal '{id}' must Drop, got {other:?}"),
+        }
+    }
+}

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -403,3 +403,183 @@ pub(crate) fn apply_goal_advance_result(
         },
     }
 }
+
+/// Classify an [`ActionOutcome`] as a *no shippable progress* cycle — the signal
+/// the Fix-3 no-progress breaker counts (see
+/// [`crate::goal_curation::no_progress_breaker`]).
+///
+/// A goal-advance cycle makes **no shippable progress** when the orchestrator
+/// resolved to `NO ACTION` and either recorded no progress marker at all
+/// ("I'll verify concretely…") **or** claimed a progress bump the reviewer
+/// **rejected**. It makes *real* progress when it spawned an engineer or when
+/// the reviewer **accepted** a progress advance.
+///
+/// This is the classifier half of the detail contract authored by
+/// [`assess_only_outcome`] in this same module — kept co-located so the two stay
+/// in lockstep (pinned by the tests below). The three success-`true` no-action
+/// details are:
+///
+/// - pure no-action: `"no-action: {reason} (goal '{id}')"`               → no progress
+/// - accepted bump:  `"no-action: {reason} (progress={pct}%, goal '{id}')"` → progress
+/// - rejected bump:  `"no-action: progress claim rejected (reviewer): … (goal '{id}', proposed={pct}%)"` → no progress
+///
+/// The accepted-bump branch is the only one that emits the deterministic
+/// `"(progress="` token, so the predicate keys on that token rather than the
+/// free-form reviewer/orchestrator prose. A `success=false` outcome (empty
+/// response, run error, or a failed progress update) is *not* a no-progress
+/// no-op — it is already counted by the brain-failure safeguard's
+/// `goal_failure_counts`, so this predicate excludes it to avoid double-counting.
+pub(crate) fn outcome_made_no_progress(outcome: &ActionOutcome) -> bool {
+    outcome.success
+        && outcome.action.goal_id.is_some()
+        && outcome.detail.starts_with("no-action:")
+        && !outcome.detail.contains("(progress=")
+}
+
+#[cfg(test)]
+mod tests_no_progress_classifier {
+    use super::*;
+    use crate::goal_curation::progress_evidence::{
+        EvidenceDecision, NoopProgressEvidenceChecker, ProgressEvidenceChecker,
+    };
+    use crate::goal_curation::{ActiveGoal, GoalBoard};
+    use crate::ooda_loop::PlannedAction;
+
+    /// A progress-evidence checker that rejects every proposed increase — models
+    /// the reviewer refuting an LLM progress claim.
+    struct RejectAllChecker;
+    impl ProgressEvidenceChecker for RejectAllChecker {
+        fn check(
+            &self,
+            _goal: &ActiveGoal,
+            _current: u32,
+            _proposed: u32,
+            _now: chrono::DateTime<Utc>,
+        ) -> EvidenceDecision {
+            EvidenceDecision::Reject {
+                reason: "no commits or PR to substantiate the claimed progress".to_string(),
+            }
+        }
+    }
+
+    fn advance_goal_action(goal_id: &str) -> PlannedAction {
+        PlannedAction {
+            kind: crate::ooda_loop::ActionKind::AdvanceGoal,
+            goal_id: Some(goal_id.to_string()),
+            description: "advance".to_string(),
+        }
+    }
+
+    fn board_with(goal_id: &str) -> GoalBoard {
+        let mut board = GoalBoard::new();
+        board
+            .active
+            .push(ActiveGoal::new(goal_id, "harden the supply chain", 1));
+        board
+    }
+
+    fn mem() -> Box<dyn crate::cognitive_memory::CognitiveMemoryOps> {
+        crate::ooda_actions::test_helpers::mock_memory()
+    }
+
+    // The classifier and `assess_only_outcome` are pinned together: these drive
+    // the REAL author so a change to either detail format or predicate fails CI.
+
+    #[test]
+    fn pure_no_action_is_no_progress() {
+        let action = advance_goal_action("g");
+        let mut board = board_with("g");
+        let outcome = assess_only_outcome(
+            &action,
+            &*mem(),
+            &NoopProgressEvidenceChecker,
+            &mut board,
+            "g",
+            "I'll verify concretely next cycle",
+            None,
+        );
+        assert!(outcome.success);
+        assert!(
+            outcome_made_no_progress(&outcome),
+            "pure no-action must count as no progress: {}",
+            outcome.detail
+        );
+    }
+
+    #[test]
+    fn accepted_progress_bump_is_progress_not_no_progress() {
+        let action = advance_goal_action("g");
+        let mut board = board_with("g");
+        let outcome = assess_only_outcome(
+            &action,
+            &*mem(),
+            &NoopProgressEvidenceChecker, // accepts the bump
+            &mut board,
+            "g",
+            "made real headway",
+            Some(40),
+        );
+        assert!(outcome.success);
+        assert!(
+            !outcome_made_no_progress(&outcome),
+            "an accepted progress advance must NOT count as no progress: {}",
+            outcome.detail
+        );
+    }
+
+    #[test]
+    fn rejected_progress_bump_is_no_progress() {
+        let action = advance_goal_action("g");
+        let mut board = board_with("g");
+        let outcome = assess_only_outcome(
+            &action,
+            &*mem(),
+            &RejectAllChecker, // reviewer refutes the claim
+            &mut board,
+            "g",
+            "claiming 60% with no evidence",
+            Some(60),
+        );
+        assert!(outcome.success);
+        assert!(
+            outcome_made_no_progress(&outcome),
+            "a rejected progress claim must count as no progress: {}",
+            outcome.detail
+        );
+    }
+
+    #[test]
+    fn spawn_engineer_outcome_is_progress() {
+        // A spawn-engineer detail does not start with "no-action:".
+        let action = advance_goal_action("g");
+        let outcome = make_outcome(
+            &action,
+            true,
+            "spawn_engineer (from prose) for goal 'g': do the work".to_string(),
+        );
+        assert!(!outcome_made_no_progress(&outcome));
+    }
+
+    #[test]
+    fn failed_no_action_update_is_not_counted() {
+        // success=false is owned by the brain-failure safeguard, not this one.
+        let action = advance_goal_action("g");
+        let outcome = make_outcome(
+            &action,
+            false,
+            "no-action failed: update_goal_progress error for goal 'g': boom".to_string(),
+        );
+        assert!(!outcome_made_no_progress(&outcome));
+    }
+
+    #[test]
+    fn outcome_without_goal_id_is_not_counted() {
+        let action = PlannedAction {
+            kind: crate::ooda_loop::ActionKind::SafeUpdate,
+            goal_id: None,
+            description: "update".to_string(),
+        };
+        let outcome = make_outcome(&action, true, "no-action: whatever".to_string());
+        assert!(!outcome_made_no_progress(&outcome));
+    }
+}

--- a/src/ooda_actions/goal_session/mod.rs
+++ b/src/ooda_actions/goal_session/mod.rs
@@ -178,6 +178,7 @@ mod advance;
 
 pub(crate) use advance::{
     advance_goal_with_session, apply_goal_advance_result, build_goal_advance_input,
+    outcome_made_no_progress,
 };
 
 #[cfg(test)]

--- a/src/ooda_actions/mod.rs
+++ b/src/ooda_actions/mod.rs
@@ -14,6 +14,11 @@ mod goal_session;
 mod session;
 mod simple_actions;
 
+// Fix 3 (no-progress breaker): the OODA cycle's curate phase reads this
+// classifier to detect a no-shippable-progress cycle. Co-located with its
+// detail author `goal_session::advance::assess_only_outcome`.
+pub(crate) use goal_session::outcome_made_no_progress;
+
 #[cfg(test)]
 pub(crate) mod test_helpers;
 #[cfg(test)]

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -544,6 +544,37 @@ fn run_ooda_cycle_inner(
         }
     }
 
+    // --- Fix 3: no-progress breaker (issue #1) ---
+    // Before curation, bound the *no-action* livelock: a goal that produced a
+    // no-shippable-progress cycle (`NO ACTION` / rejected progress claim) has
+    // its consecutive-no-action counter bumped; at the threshold the done-gate
+    // runs once and the goal is resolved definitively — marked DONE (archived
+    // below), DROPPED as obsolete, or BLOCKED + escalated to a tracking issue —
+    // instead of being re-selected forever. Only runs with an evidence source
+    // (production daemon); tests/non-daemon callers leave it `None`.
+    //
+    // `breaker_dropped` carries goals removed from the board as obsolete so the
+    // corruption guard treats them as a legitimate departure (not a "vanished"
+    // goal) and the persist step force-removes them from the snapshot.
+    let breaker_dropped: Vec<String> = if let Some(source) = &bridges.completion_evidence {
+        let report = crate::ooda_loop::no_progress::apply_no_progress_breaker(
+            state,
+            &outcomes,
+            source.as_ref(),
+            &crate::ooda_loop::no_progress::GhIssueFiler,
+        );
+        if report.fired() {
+            tracing::info!(
+                target: "simard::ooda",
+                summary = %report.log_line(),
+                "OODA no-progress breaker fired",
+            );
+        }
+        report.dropped
+    } else {
+        Vec::new()
+    };
+
     // --- Curate: archive completed goals, promote from backlog ---
     // With a deploy-aware done-gate installed (production daemon, issue #2419),
     // a completed goal archives only with hard evidence — merged PR, closed
@@ -603,11 +634,14 @@ fn run_ooda_cycle_inner(
     // Corruption guard: check that no pre-cycle active goal disappeared
     // without going through archive_completed. A goal may legitimately leave
     // active via archival — those will no longer be in active but will appear
-    // in archived. Any goal that is missing from active AND was not archived
+    // in archived — or via the Fix-3 no-progress breaker DROP (`breaker_dropped`).
+    // Any goal that is missing from active AND was neither archived nor dropped
     // this cycle is a corruption signal; restore the board from the snapshot.
     {
         let archived_ids: std::collections::HashSet<&str> =
             archived.iter().map(|g| g.id.as_str()).collect();
+        let dropped_ids: std::collections::HashSet<&str> =
+            breaker_dropped.iter().map(|s| s.as_str()).collect();
         let post_active_ids: std::collections::HashSet<&str> = state
             .active_goals
             .active
@@ -617,7 +651,11 @@ fn run_ooda_cycle_inner(
         let vanished: Vec<&str> = pre_cycle_active_ids
             .iter()
             .map(|s| s.as_str())
-            .filter(|id| !post_active_ids.contains(*id) && !archived_ids.contains(*id))
+            .filter(|id| {
+                !post_active_ids.contains(*id)
+                    && !archived_ids.contains(*id)
+                    && !dropped_ids.contains(*id)
+            })
             .collect();
         if !vanished.is_empty() {
             eprintln!(
@@ -630,10 +668,13 @@ fn run_ooda_cycle_inner(
             // last-known-good state on disk is preserved.
         } else {
             // Persist the updated board to cognitive memory and disk (best-effort).
-            // When goals were archived, use save_goal_board_with_removals so that
-            // the merge-on-write step cannot resurrect them from the persisted
-            // snapshot (issue #2264 — archived goals reappearing every cycle).
-            let archived_goal_ids: Vec<String> = archived.iter().map(|g| g.id.clone()).collect();
+            // When goals were archived (or DROPPED by the Fix-3 breaker), use
+            // save_goal_board_with_removals so that the merge-on-write step
+            // cannot resurrect them from the persisted snapshot (issue #2264 —
+            // archived/dropped goals reappearing every cycle).
+            let mut archived_goal_ids: Vec<String> =
+                archived.iter().map(|g| g.id.clone()).collect();
+            archived_goal_ids.extend(breaker_dropped.iter().cloned());
             let persist_result = if archived_goal_ids.is_empty() {
                 crate::goal_curation::persist_board(&state.active_goals, &*bridges.memory)
             } else {

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -14,6 +14,8 @@ pub mod cycle;
 mod decide;
 mod observe;
 mod orient;
+// Fix 3 (issue #1): no-progress breaker adapter for the curate phase.
+mod no_progress;
 pub mod phase_weights;
 mod priority_kind;
 mod review;
@@ -30,6 +32,10 @@ mod tests_orient_extra;
 mod tests_parse_failure_1890;
 #[cfg(test)]
 mod tests_types;
+
+// Fix 3 (issue #1): integration tests for the no-progress breaker wiring.
+#[cfg(test)]
+mod tests_no_progress;
 
 // Issue #2329: Observe-vs-Decide phase weights yield different ranked-recall
 // ordering of the same fact set, exercised against the real lbug-backed

--- a/src/ooda_loop/no_progress.rs
+++ b/src/ooda_loop/no_progress.rs
@@ -1,0 +1,247 @@
+//! Fix 3 wiring: apply the no-progress breaker in the OODA curate phase.
+//!
+//! The pure policy lives in
+//! [`crate::goal_curation::no_progress_breaker`]; this module is the thin,
+//! side-effecting adapter that the OODA cycle calls each round. It turns the
+//! breaker's [`NoProgressResolution`] into concrete board mutations and a
+//! `gh`-filed tracking issue, mirroring the brain-*failure* safeguard in
+//! [`crate::ooda_actions::advance_goal`] but for the *no-action* livelock.
+//!
+//! Kept in `ooda_loop` (the goal-selection / curate path) rather than the
+//! reasoners, per the incident's coordination constraint (the
+//! `ooda_brain`/reasoner/bridge files are owned by the naming-cleanup rename).
+//!
+//! See `docs/concepts/steerable-ooda-daemon.md` ("The no-progress breaker
+//! (Fix 3)").
+
+use std::collections::HashSet;
+
+use crate::goal_curation::GoalProgress;
+use crate::goal_curation::completion_gate::{CompletionEvidenceGate, EvidenceSource};
+use crate::goal_curation::no_progress_breaker::{
+    NO_PROGRESS_BREAKER_THRESHOLD, NoProgressResolution, verify_stuck_goal,
+};
+use crate::ooda_actions::outcome_made_no_progress;
+use crate::ooda_loop::{ActionOutcome, OodaState};
+
+/// Files a tracking issue for a goal the breaker escalated. Injected so tests
+/// exercise the escalation path without shelling out to `gh`.
+pub(crate) trait NoProgressIssueFiler {
+    /// File (or attempt to file) a tracking issue. Failures must be logged, not
+    /// propagated: the goal is already Blocked with the sentinel, and a missing
+    /// issue must never abort the cycle.
+    fn file_issue(&self, title: &str, body: &str);
+}
+
+/// Production filer: `gh issue create --label ooda-stuck`, mirroring the
+/// brain-failure safeguard in `ooda_actions::advance_goal::spawn`.
+pub(crate) struct GhIssueFiler;
+
+impl NoProgressIssueFiler for GhIssueFiler {
+    fn file_issue(&self, title: &str, body: &str) {
+        match std::process::Command::new("gh")
+            .args([
+                "issue",
+                "create",
+                "--title",
+                title,
+                "--body",
+                body,
+                "--label",
+                "ooda-stuck",
+            ])
+            .output()
+        {
+            Ok(out) if out.status.success() => {
+                tracing::warn!(
+                    target: "simard::ooda",
+                    title = %title,
+                    "no-progress breaker: tracking issue filed for stuck goal",
+                );
+            }
+            Ok(out) => {
+                tracing::error!(
+                    target: "simard::ooda",
+                    stderr = %String::from_utf8_lossy(&out.stderr),
+                    "no-progress breaker: gh issue create failed (goal still Blocked)",
+                );
+            }
+            Err(e) => {
+                tracing::error!(
+                    target: "simard::ooda",
+                    error = %e,
+                    "no-progress breaker: gh spawn failed (goal still Blocked)",
+                );
+            }
+        }
+    }
+}
+
+/// What the breaker did this cycle — returned for logging and asserted by tests.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct NoProgressBreakerReport {
+    /// Goals set `Completed` for the evidence-aware archive to pick up.
+    pub marked_done: Vec<String>,
+    /// Goals removed from the board as obsolete.
+    pub dropped: Vec<String>,
+    /// Goals set `Blocked` with the sentinel and escalated to a tracking issue.
+    pub escalated: Vec<String>,
+}
+
+impl NoProgressBreakerReport {
+    /// True when the breaker fired for at least one goal this cycle.
+    pub fn fired(&self) -> bool {
+        !self.marked_done.is_empty() || !self.dropped.is_empty() || !self.escalated.is_empty()
+    }
+
+    /// Compact one-line summary for the cycle log.
+    pub fn log_line(&self) -> String {
+        format!(
+            "done={} dropped={} escalated={}",
+            self.marked_done.len(),
+            self.dropped.len(),
+            self.escalated.len(),
+        )
+    }
+}
+
+/// Apply the Fix-3 no-progress breaker to this cycle's `outcomes` using the
+/// default [`NO_PROGRESS_BREAKER_THRESHOLD`].
+pub(crate) fn apply_no_progress_breaker(
+    state: &mut OodaState,
+    outcomes: &[ActionOutcome],
+    evidence: &dyn EvidenceSource,
+    filer: &dyn NoProgressIssueFiler,
+) -> NoProgressBreakerReport {
+    apply_no_progress_breaker_with_threshold(
+        state,
+        outcomes,
+        evidence,
+        filer,
+        NO_PROGRESS_BREAKER_THRESHOLD,
+    )
+}
+
+/// Threshold-parameterised core (tests inject a small threshold rather than
+/// coupling to the shipped constant).
+///
+/// For each outcome carrying a goal id:
+/// * a no-shippable-progress no-op ([`outcome_made_no_progress`]) bumps the
+///   goal's consecutive-no-action counter; at `threshold` the done-gate runs
+///   **once** and the goal is resolved via the ladder (mark done / drop /
+///   escalate);
+/// * any other successful goal outcome (engineer spawned, progress accepted)
+///   resets the counter.
+///
+/// Marked-done goals are set [`GoalProgress::Completed`] so the subsequent
+/// `archive_completed_evidence_aware` archives them with the same evidence;
+/// dropped goals are removed from the board; escalated goals are set
+/// [`GoalProgress::Blocked`] with the no-progress sentinel and a tracking issue
+/// is filed. Stale counters are pruned to the live board.
+pub(crate) fn apply_no_progress_breaker_with_threshold(
+    state: &mut OodaState,
+    outcomes: &[ActionOutcome],
+    evidence: &dyn EvidenceSource,
+    filer: &dyn NoProgressIssueFiler,
+    threshold: u32,
+) -> NoProgressBreakerReport {
+    let mut report = NoProgressBreakerReport::default();
+
+    // Detach the tracker from `state` so the disposition closure can borrow the
+    // board immutably while the tracker mutates. They are disjoint, but the
+    // borrow checker cannot prove it through a method call across the closure.
+    let mut tracker = std::mem::take(&mut state.no_progress_tracker);
+
+    for outcome in outcomes {
+        let Some(goal_id) = outcome.action.goal_id.as_deref() else {
+            continue;
+        };
+
+        if !outcome_made_no_progress(outcome) {
+            // Real progress (engineer spawned, or reviewer-accepted advance)
+            // resets the consecutive-no-action count. Failures (success=false)
+            // are owned by `goal_failure_counts` and left untouched here.
+            if outcome.success {
+                tracker.record_progress(goal_id);
+            }
+            continue;
+        }
+
+        // Compute the resolution in an inner scope so the immutable borrow of
+        // the board (via `goal`) ends before the match mutates the board.
+        let resolution = {
+            let Some(goal) = state.active_goals.active.iter().find(|g| g.id == goal_id) else {
+                // The goal already left the board this cycle (e.g. archived);
+                // clear any stale counter and skip.
+                tracker.record_progress(goal_id);
+                continue;
+            };
+            let gate = CompletionEvidenceGate::new(evidence);
+            tracker.record_and_resolve(goal_id, threshold, || verify_stuck_goal(goal, &gate))
+        };
+
+        match resolution {
+            NoProgressResolution::Continue => {}
+            NoProgressResolution::MarkDone => {
+                if let Some(g) = state
+                    .active_goals
+                    .active
+                    .iter_mut()
+                    .find(|g| g.id == goal_id)
+                {
+                    g.status = GoalProgress::Completed;
+                }
+                report.marked_done.push(goal_id.to_string());
+                tracing::warn!(
+                    target: "simard::ooda",
+                    goal = %goal_id,
+                    "no-progress breaker: evidence present — marking goal DONE for archival",
+                );
+            }
+            NoProgressResolution::Drop { reason } => {
+                state.active_goals.active.retain(|g| g.id != goal_id);
+                state.active_goals.backlog.retain(|b| b.id != goal_id);
+                report.dropped.push(goal_id.to_string());
+                tracing::warn!(
+                    target: "simard::ooda",
+                    goal = %goal_id,
+                    reason = %reason,
+                    "no-progress breaker: goal obsolete — DROPPING from the board",
+                );
+            }
+            NoProgressResolution::Escalate {
+                blocked_reason,
+                issue_title,
+                issue_body,
+            } => {
+                if let Some(g) = state
+                    .active_goals
+                    .active
+                    .iter_mut()
+                    .find(|g| g.id == goal_id)
+                {
+                    g.status = GoalProgress::Blocked(blocked_reason);
+                }
+                filer.file_issue(&issue_title, &issue_body);
+                report.escalated.push(goal_id.to_string());
+                tracing::warn!(
+                    target: "simard::ooda",
+                    goal = %goal_id,
+                    "no-progress breaker: unresolved after threshold — BLOCKED + tracking issue filed",
+                );
+            }
+        }
+    }
+
+    // Prune counters for goals no longer on the active board.
+    let live: HashSet<String> = state
+        .active_goals
+        .active
+        .iter()
+        .map(|g| g.id.clone())
+        .collect();
+    tracker.retain_goals(&live);
+
+    state.no_progress_tracker = tracker;
+    report
+}

--- a/src/ooda_loop/tests_no_progress.rs
+++ b/src/ooda_loop/tests_no_progress.rs
@@ -1,0 +1,347 @@
+//! Fix 3 wiring integration tests: the OODA-curate no-progress breaker
+//! (`super::no_progress`).
+//!
+//! The pure ladder is unit-tested in
+//! `crate::goal_curation::tests_no_progress_breaker`; these tests exercise the
+//! *wiring* — that a stuck goal driven through
+//! [`apply_no_progress_breaker_with_threshold`] over N cycles actually mutates
+//! the board (mark done / drop / block) and files exactly one tracking issue,
+//! and that real progress resets the counter so the breaker never fires on a
+//! goal that is being worked.
+
+use std::cell::RefCell;
+
+use super::no_progress::{NoProgressIssueFiler, apply_no_progress_breaker_with_threshold};
+use crate::error::SimardResult;
+use crate::goal_curation::completion_gate::EvidenceSource;
+use crate::goal_curation::no_progress_breaker::{
+    NO_PROGRESS_BREAKER_THRESHOLD, is_no_progress_marker,
+};
+use crate::goal_curation::{ActiveGoal, GoalBoard, GoalProgress, WipRef};
+use crate::ooda_loop::{ActionKind, ActionOutcome, OodaState, PlannedAction};
+
+// --- fixtures ---------------------------------------------------------------
+
+/// Canned evidence source: every query returns a fixed boolean.
+struct FakeEvidence {
+    pr_merged: bool,
+    issue_closed: bool,
+    deployed: bool,
+}
+
+impl EvidenceSource for FakeEvidence {
+    fn any_pr_merged(&self, _goal: &ActiveGoal) -> SimardResult<bool> {
+        Ok(self.pr_merged)
+    }
+    fn issue_closed(&self, _goal: &ActiveGoal) -> SimardResult<bool> {
+        Ok(self.issue_closed)
+    }
+    fn is_deployed(&self, _goal: &ActiveGoal) -> SimardResult<bool> {
+        Ok(self.deployed)
+    }
+}
+
+/// Records escalation issue filings so tests assert the count without `gh`.
+#[derive(Default)]
+struct RecordingFiler {
+    calls: RefCell<Vec<(String, String)>>,
+}
+
+impl NoProgressIssueFiler for RecordingFiler {
+    fn file_issue(&self, title: &str, body: &str) {
+        self.calls
+            .borrow_mut()
+            .push((title.to_string(), body.to_string()));
+    }
+}
+
+fn issue_ref(num: &str, label: &str) -> WipRef {
+    WipRef {
+        kind: "issue".to_string(),
+        ref_id: num.to_string(),
+        label: label.to_string(),
+        url: None,
+    }
+}
+
+fn pr_ref(num: &str) -> WipRef {
+    WipRef {
+        kind: "pr".to_string(),
+        ref_id: num.to_string(),
+        label: format!("PR #{num}"),
+        url: None,
+    }
+}
+
+/// A stuck, self-affecting (repo=None) goal at 0%.
+fn stuck_goal(id: &str) -> ActiveGoal {
+    let mut g = ActiveGoal::new(id, "harden the supply chain", 1);
+    g.status = GoalProgress::NotStarted;
+    g
+}
+
+fn state_with(goal: ActiveGoal) -> OodaState {
+    let mut board = GoalBoard::new();
+    board.active.push(goal);
+    OodaState::new(board)
+}
+
+/// A no-shippable-progress ("NO ACTION") outcome for `goal_id`, in the exact
+/// shape `assess_only_outcome` authors and `outcome_made_no_progress` keys on.
+fn no_action_outcome(goal_id: &str) -> ActionOutcome {
+    ActionOutcome {
+        action: PlannedAction {
+            kind: ActionKind::AdvanceGoal,
+            goal_id: Some(goal_id.to_string()),
+            description: "advance".to_string(),
+        },
+        success: true,
+        detail: format!("no-action: I'll verify concretely next cycle (goal '{goal_id}')"),
+    }
+}
+
+/// A concrete-progress outcome (engineer spawned) for `goal_id`.
+fn progress_outcome(goal_id: &str) -> ActionOutcome {
+    ActionOutcome {
+        action: PlannedAction {
+            kind: ActionKind::AdvanceGoal,
+            goal_id: Some(goal_id.to_string()),
+            description: "advance".to_string(),
+        },
+        success: true,
+        detail: format!("spawn_engineer (from prose) for goal '{goal_id}': do the work"),
+    }
+}
+
+// --- tests ------------------------------------------------------------------
+
+#[test]
+fn breaker_threshold_is_small() {
+    assert!(
+        (2..=3).contains(&NO_PROGRESS_BREAKER_THRESHOLD),
+        "breaker must be a small 2-3, got {NO_PROGRESS_BREAKER_THRESHOLD}"
+    );
+}
+
+#[test]
+fn n_consecutive_no_action_cycles_escalate_and_block_the_goal() {
+    // The exact livelock: a goal that yields NO ACTION every cycle, with no
+    // completion evidence and no obsolescence signal, must be BLOCKED with the
+    // sentinel and escalated to exactly one tracking issue after the threshold.
+    let threshold = NO_PROGRESS_BREAKER_THRESHOLD;
+    let mut goal = stuck_goal("ladybug-supply-chain");
+    goal.wip_refs = vec![pr_ref("7")]; // an open, unmerged PR
+    let mut state = state_with(goal);
+    let evidence = FakeEvidence {
+        pr_merged: false,
+        issue_closed: true,
+        deployed: false,
+    };
+    let filer = RecordingFiler::default();
+
+    // Below threshold: nothing fires, the goal stays not-started.
+    for cycle in 1..threshold {
+        let report = apply_no_progress_breaker_with_threshold(
+            &mut state,
+            &[no_action_outcome("ladybug-supply-chain")],
+            &evidence,
+            &filer,
+            threshold,
+        );
+        assert!(!report.fired(), "cycle {cycle} must not fire");
+        assert!(filer.calls.borrow().is_empty());
+        assert!(matches!(
+            state.active_goals.active[0].status,
+            GoalProgress::NotStarted
+        ));
+    }
+
+    // Threshold cycle: escalate.
+    let report = apply_no_progress_breaker_with_threshold(
+        &mut state,
+        &[no_action_outcome("ladybug-supply-chain")],
+        &evidence,
+        &filer,
+        threshold,
+    );
+    assert_eq!(report.escalated, vec!["ladybug-supply-chain".to_string()]);
+    assert_eq!(filer.calls.borrow().len(), 1, "exactly one issue filed");
+    match &state.active_goals.active[0].status {
+        GoalProgress::Blocked(reason) => assert!(
+            is_no_progress_marker(reason),
+            "blocked reason must carry the no-progress sentinel: {reason}"
+        ),
+        other => panic!("expected Blocked, got {other:?}"),
+    }
+
+    // The counter cleared: another no-action cycle does NOT immediately re-fire
+    // (no (N+1)th escalation / duplicate issue this cycle).
+    let report = apply_no_progress_breaker_with_threshold(
+        &mut state,
+        &[no_action_outcome("ladybug-supply-chain")],
+        &evidence,
+        &filer,
+        threshold,
+    );
+    assert!(!report.fired(), "counter must reset after firing");
+    assert_eq!(filer.calls.borrow().len(), 1, "no duplicate issue");
+}
+
+#[test]
+fn merged_pr_goal_is_marked_done_for_archival() {
+    // A goal whose PR merged, issue closed, and change deployed → the done-gate
+    // certifies it Complete → the breaker sets it Completed so the evidence-aware
+    // archive removes it.
+    let threshold = NO_PROGRESS_BREAKER_THRESHOLD;
+    let mut goal = stuck_goal("ladybug-rust");
+    goal.wip_refs = vec![pr_ref("1")];
+    let mut state = state_with(goal);
+    let evidence = FakeEvidence {
+        pr_merged: true,
+        issue_closed: true,
+        deployed: true,
+    };
+    let filer = RecordingFiler::default();
+
+    let mut report = Default::default();
+    for _ in 0..threshold {
+        report = apply_no_progress_breaker_with_threshold(
+            &mut state,
+            &[no_action_outcome("ladybug-rust")],
+            &evidence,
+            &filer,
+            threshold,
+        );
+    }
+    assert_eq!(report.marked_done, vec!["ladybug-rust".to_string()]);
+    assert!(matches!(
+        state.active_goals.active[0].status,
+        GoalProgress::Completed
+    ));
+    assert!(filer.calls.borrow().is_empty(), "MarkDone files no issue");
+}
+
+#[test]
+fn out_of_scope_goal_is_dropped_from_the_board() {
+    // A goal whose linked issue is an explicit out-of-scope handoff → Drop.
+    let threshold = NO_PROGRESS_BREAKER_THRESHOLD;
+    let mut goal = stuck_goal("lbug-patched");
+    goal.wip_refs = vec![issue_ref(
+        "1",
+        "out-of-scope for this daemon; filed upstream",
+    )];
+    let mut state = state_with(goal);
+    let evidence = FakeEvidence {
+        pr_merged: false,
+        issue_closed: false,
+        deployed: false,
+    };
+    let filer = RecordingFiler::default();
+
+    let mut report = Default::default();
+    for _ in 0..threshold {
+        report = apply_no_progress_breaker_with_threshold(
+            &mut state,
+            &[no_action_outcome("lbug-patched")],
+            &evidence,
+            &filer,
+            threshold,
+        );
+    }
+    assert_eq!(report.dropped, vec!["lbug-patched".to_string()]);
+    assert!(
+        state.active_goals.active.is_empty(),
+        "dropped goal must leave the active board"
+    );
+    assert!(filer.calls.borrow().is_empty(), "Drop files no issue");
+}
+
+#[test]
+fn concrete_progress_resets_the_no_action_counter() {
+    // no-action, no-action, PROGRESS, no-action → only 1 consecutive at the end,
+    // so the breaker never fires even though total no-action cycles >= threshold.
+    let threshold = NO_PROGRESS_BREAKER_THRESHOLD;
+    let mut goal = stuck_goal("g");
+    goal.wip_refs = vec![pr_ref("7")];
+    let mut state = state_with(goal);
+    let evidence = FakeEvidence {
+        pr_merged: false,
+        issue_closed: true,
+        deployed: false,
+    };
+    let filer = RecordingFiler::default();
+
+    for _ in 0..(threshold - 1) {
+        let r = apply_no_progress_breaker_with_threshold(
+            &mut state,
+            &[no_action_outcome("g")],
+            &evidence,
+            &filer,
+            threshold,
+        );
+        assert!(!r.fired());
+    }
+    // Concrete progress resets.
+    let r = apply_no_progress_breaker_with_threshold(
+        &mut state,
+        &[progress_outcome("g")],
+        &evidence,
+        &filer,
+        threshold,
+    );
+    assert!(!r.fired());
+
+    // From here, threshold-1 more no-action cycles still must not fire.
+    for _ in 0..(threshold - 1) {
+        let r = apply_no_progress_breaker_with_threshold(
+            &mut state,
+            &[no_action_outcome("g")],
+            &evidence,
+            &filer,
+            threshold,
+        );
+        assert!(
+            !r.fired(),
+            "reset must prevent firing before a fresh threshold"
+        );
+    }
+    assert!(filer.calls.borrow().is_empty());
+    assert!(matches!(
+        state.active_goals.active[0].status,
+        GoalProgress::NotStarted
+    ));
+}
+
+#[test]
+fn stale_counter_is_pruned_when_goal_leaves_the_board() {
+    // A goal that accumulates a no-action count, then leaves the board, must not
+    // leak a counter entry.
+    let threshold = NO_PROGRESS_BREAKER_THRESHOLD;
+    let mut goal = stuck_goal("g");
+    goal.wip_refs = vec![pr_ref("7")];
+    let mut state = state_with(goal);
+    let evidence = FakeEvidence {
+        pr_merged: false,
+        issue_closed: true,
+        deployed: false,
+    };
+    let filer = RecordingFiler::default();
+
+    apply_no_progress_breaker_with_threshold(
+        &mut state,
+        &[no_action_outcome("g")],
+        &evidence,
+        &filer,
+        threshold,
+    );
+    assert_eq!(state.no_progress_tracker.consecutive("g"), 1);
+
+    // Goal removed from the board (e.g. operator dropped it).
+    state.active_goals.active.clear();
+    apply_no_progress_breaker_with_threshold(&mut state, &[], &evidence, &filer, threshold);
+    assert_eq!(
+        state.no_progress_tracker.consecutive("g"),
+        0,
+        "counter for a departed goal must be pruned"
+    );
+}

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -69,6 +69,17 @@ pub struct OodaState {
     /// persisted across restarts (resets to 0); worst case is an extra
     /// distillation pass shortly after boot. Issue #2327, R4.
     pub last_distill_cycle: u32,
+    /// Per-goal consecutive *no-action* count driving the Fix-3 no-progress
+    /// breaker. The sibling of [`Self::goal_failure_counts`]: that counter
+    /// bounds repeated brain *failures* (`success == false`), this one bounds
+    /// repeated `NO ACTION` / "I'll verify concretely…" cycles that record
+    /// `success == true` but ship nothing. Incremented after the Act phase for
+    /// each goal whose outcome
+    /// [`outcome_made_no_progress`](crate::ooda_actions::outcome_made_no_progress),
+    /// reset on real progress, and — once the breaker fires — resolved via the
+    /// done-gate ladder (mark done / drop / escalate). See
+    /// `docs/concepts/steerable-ooda-daemon.md` ("The no-progress breaker (Fix 3)").
+    pub no_progress_tracker: crate::goal_curation::NoProgressTracker,
 }
 
 impl OodaState {
@@ -86,6 +97,7 @@ impl OodaState {
             goal_failure_counts: HashMap::new(),
             engineer_worktrees: HashMap::new(),
             last_distill_cycle: 0,
+            no_progress_tracker: crate::goal_curation::NoProgressTracker::new(),
         }
     }
 
@@ -101,6 +113,9 @@ impl OodaState {
             .collect();
         self.goal_failure_counts
             .retain(|id, _| active_ids.contains(id.as_str()));
+        // Keep the Fix-3 no-progress counters bounded to live goals too.
+        self.no_progress_tracker
+            .retain_goals(&active_ids.iter().map(|s| s.to_string()).collect());
     }
 }
 
@@ -342,6 +357,10 @@ pub struct OodaStateSnapshot {
     pub last_cycle_summary: Option<String>,
     pub last_cycle_duration_secs: Option<u64>,
     pub goal_failure_counts: HashMap<String, u32>,
+    /// Fix-3 no-progress breaker counters. `#[serde(default)]` so snapshots
+    /// written before this field existed still deserialize (empty tracker).
+    #[serde(default)]
+    pub no_progress_tracker: crate::goal_curation::NoProgressTracker,
 }
 
 impl From<&OodaState> for OodaStateSnapshot {
@@ -357,6 +376,7 @@ impl From<&OodaState> for OodaStateSnapshot {
             last_cycle_summary: state.last_cycle_summary.clone(),
             last_cycle_duration_secs: state.last_cycle_duration_secs,
             goal_failure_counts: state.goal_failure_counts.clone(),
+            no_progress_tracker: state.no_progress_tracker.clone(),
         }
     }
 }
@@ -375,6 +395,7 @@ impl OodaStateSnapshot {
         state.last_cycle_summary = self.last_cycle_summary;
         state.last_cycle_duration_secs = self.last_cycle_duration_secs;
         state.goal_failure_counts = self.goal_failure_counts;
+        state.no_progress_tracker = self.no_progress_tracker;
     }
 
     /// Construct a fresh [`OodaState`] from this snapshot. Worktrees start


### PR DESCRIPTION
## Summary

Fixes the systemic **goal-board + OODA-livelock + distillation** incident that made the Simard daemon un-steerable and stuck. Closes #1.

The incident had four legs. Investigation against the current `origin/main` shows **Fixes 1, 2, and 4 already shipped** in prior PRs; the **only unshipped leg was Fix 3's no-action livelock breaker**, whose pure module + unit tests existed but were **never wired into production**. This PR completes Fix 3 and reconciles the concept doc.

| Fix | Status before this PR | This PR |
|---|---|---|
| **1 — goal-board read-your-writes** | Shipped: cognitive-memory-authoritative snapshot, `read_latest_snapshot` (newest by `node_id`), CallerKey dedup (#2329), flock (#2511/#2514), `merge_boards`, `save_goal_board_with_removals`, legacy-disk migration. Tested. | — (verified) |
| **2 — evidence done-gate** | Shipped + wired: `completion_gate.rs`, `archive_completed_evidence_aware` in the curate phase, `GhCliEvidenceSource`. Tested. | — (verified) |
| **3 — no-progress livelock breaker** | Pure module `no_progress_breaker.rs` + unit tests existed, **unwired**. A `NO ACTION` cycle records `success=true`, which *resets* `goal_failure_counts`, so consecutive no-action cycles were never bounded. | **Wired end-to-end.** |
| **4 — distill banner strip** | Shipped: `strip_recipe_noise` → `is_copilot_launcher_line` strips the `NODE_OPTIONS=… (saved preference)` / `launching copilot binary=…` banner; distill routes through the shared chokepoint. Regression test feeds the exact banner and asserts facts recovered. | — (verified) |

## Fix 3 — what this PR wires

Kept in the goal-selection / advance-goal path, **not** the reasoners (the in-flight naming-cleanup rename owns `ooda_brain`/reasoner/bridge/cognitive_threads — zero edits there):

- **Classifier** `ooda_actions::outcome_made_no_progress` — detects a no-shippable-progress cycle (pure `NO ACTION`, or a reviewer-*rejected* progress claim), co-located with and pinned to its detail author `assess_only_outcome`.
- **State** `OodaState.no_progress_tracker` — a snapshot-persisted sibling of `goal_failure_counts` counting consecutive no-action cycles per goal (so a livelock spanning a restart is still bounded).
- **Adapter** `ooda_loop::no_progress::apply_no_progress_breaker` — called in the curate phase before the evidence-aware archive. At the threshold it runs the done-gate **once** and resolves the goal definitively via the ladder:
  - **DONE** (evidence present) → set `Completed`, archived by the existing evidence-aware archive;
  - **DROP** (obsolete / out-of-scope) → removed from the board, force-removed from the snapshot, and excluded from the corruption guard so it is not misread as a "vanished" goal;
  - **ESCALATE** (unresolved) → sentinel-`Blocked` + a `gh` tracking issue (label `ooda-stuck`), mirroring the brain-failure safeguard.

The four ladybug supply-chain goals from the incident (two merged hardening PRs, one filed out-of-scope issue) now reach DONE / DROP instead of being re-selected at 0% forever.

## Tests

- `goal_curation::tests_no_progress_breaker` — pure ladder + the incident's four-goal reproduction.
- `ooda_actions::…::tests_no_progress_classifier` — the classifier pinned against its real detail author (`assess_only_outcome`), incl. accepted-vs-rejected progress.
- `ooda_loop::tests_no_progress` — the curate-phase wiring: N consecutive no-action → escalate + one issue filed; merged-PR → mark-done; out-of-scope → drop; concrete progress resets; stale-counter pruning.

Full local suite: `cargo test --lib` 6602 passed / 0 failed; `cargo clippy --all-targets --all-features --locked -- -D warnings` clean; `cargo fmt --check` clean. (One unrelated test, `base_type_copilot::…::meeting_turn_plan_mentions_meeting_mode`, needs `GH_TOKEN` to shell out to the real `copilot` binary and is environment-flaky locally — untouched by this PR.)

## Constraints honored

- No redeploy (operator deploys).
- No `print!`/`println!`/`eprintln!` in new code (uses `tracing`); no `Bridge` in any new name.
- Zero edits to `ooda_brain`/reasoner/bridge/cognitive_threads; changes confined to `goal_curation` + `ooda_actions` (advance path) + `ooda_loop`.
- Branch off latest `origin/main`; live daemon / `~/.simard/worktrees` untouched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>