### PR TITLE
feat(overseer): M1 — read-only observer (Observe/Orient/Report + deduped issue-filing) (#2527)

### DIFF
--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -552,6 +552,19 @@ pub fn run_ooda_daemon(
         mind.register(Box::new(
             crate::cognitive_threads::EngineerLogAnalysisThread::from_env(),
         ));
+        // Overseer M1 read-only observer sensor. Additive and default-OFF: only
+        // registered when SIMARD_OVERSEER_ENABLED is truthy (see
+        // `crate::overseer::config`). It Observes → Orients → Reports → files
+        // DEDUPLICATED issues and takes no write action beyond issue-filing, so
+        // it fits the least-authority ThreadContext. The daemon's default
+        // behaviour is unchanged when the flag is unset.
+        if crate::overseer::overseer_enabled() {
+            mind.register(Box::new(crate::overseer::OverseerSensorThread::from_env()));
+            daemon_log(
+                &state_root,
+                "[simard] OODA daemon: Overseer read-only observer ENABLED (M1 sensor; SIMARD_OVERSEER_ENABLED)",
+            );
+        }
         daemon_log(
             &state_root,
             &format!(

--- a/src/overseer/config.rs
+++ b/src/overseer/config.rs
@@ -1,0 +1,208 @@
+//! M1 configuration: the `SIMARD_OVERSEER_*` flag-gate (default **OFF**) and the
+//! single-sourced daily-budget knob.
+//!
+//! Everything here is pure and env-**injectable** (`impl Fn(&str) -> Option<String>`),
+//! so the gating and budget-resolution logic is unit-tested with zero process
+//! environment mutation (no global state, no `set_var` races between parallel
+//! tests). The `*_env` production entry points are the only functions that read
+//! the real `std::env`.
+//!
+//! Two operator hard-gates live here:
+//! - The Overseer is **additive and default-off**: absent/empty/unrecognised
+//!   `SIMARD_OVERSEER_ENABLED` keeps the daemon behaving exactly as before.
+//! - The daily budget is **single-sourced** from `SIMARD_DAILY_BUDGET_USD`
+//!   (crusty risk #6) so the Overseer's [`BudgetGate`](crate::overseer::BudgetGate)
+//!   can never drift from the OODA loop's ceiling.
+
+/// Master flag that gates the Overseer on. Default **OFF**: while unset (or set
+/// to a non-truthy value) nothing constructs or schedules an `Overseer` and the
+/// daemon's behaviour is unchanged.
+pub const OVERSEER_ENABLED_ENV: &str = "SIMARD_OVERSEER_ENABLED";
+
+/// Daily LLM-budget ceiling, shared with the OODA loop. Single-sourcing this
+/// (rather than hardcoding a duplicate) keeps the Overseer's budget gate and the
+/// daemon's spend ceiling from silently diverging.
+pub const DAILY_BUDGET_ENV: &str = "SIMARD_DAILY_BUDGET_USD";
+
+/// Cadence (seconds) of the M1 read-only observer sensor. Clamped to a floor so
+/// self-tuning (M4) can never drive the observer into a hot loop.
+pub const OVERSEER_INTERVAL_ENV: &str = "SIMARD_OVERSEER_INTERVAL_SECS";
+
+/// Default observer cadence: 15 minutes — frequent enough to catch churn, far
+/// below any launch/merge cadence (M1 files at most one deduped issue per
+/// recurring signature, so a tighter interval adds no writes).
+pub const DEFAULT_OVERSEER_INTERVAL_SECS: u64 = 900;
+
+/// Hard floor on the observer cadence (crusty risk #4 / M4 clamp): never tick
+/// more often than once a minute regardless of env or self-tuning.
+pub const MIN_OVERSEER_INTERVAL_SECS: u64 = 60;
+
+/// Ultimate fallback when `SIMARD_DAILY_BUDGET_USD` is unset, empty, unparseable,
+/// or non-positive. Mirrors the OODA loop's historical default.
+pub const DEFAULT_DAILY_BUDGET_USD: f64 = 500.0;
+
+/// Resolve the Overseer master flag from an env resolver. Fail-safe: only an
+/// explicit truthy value (`1`/`true`/`yes`/`on`, case-insensitive) enables the
+/// Overseer; everything else — including an unset var — leaves it OFF.
+pub fn overseer_enabled_from(lookup: impl Fn(&str) -> Option<String>) -> bool {
+    match lookup(OVERSEER_ENABLED_ENV) {
+        Some(v) => is_truthy(&v),
+        None => false,
+    }
+}
+
+/// Production entry point: read the real process environment.
+pub fn overseer_enabled() -> bool {
+    overseer_enabled_from(|k| std::env::var(k).ok())
+}
+
+/// Resolve the daily budget from an env resolver, falling back to
+/// [`DEFAULT_DAILY_BUDGET_USD`] when the value is unset, empty, unparseable, or
+/// non-positive. This is the single source of truth the [`BudgetGate`] reads.
+///
+/// [`BudgetGate`]: crate::overseer::BudgetGate
+pub fn resolve_daily_budget_usd(lookup: impl Fn(&str) -> Option<String>) -> f64 {
+    match lookup(DAILY_BUDGET_ENV).as_deref().map(str::trim) {
+        Some(s) if !s.is_empty() => match s.parse::<f64>() {
+            Ok(v) if v.is_finite() && v > 0.0 => v,
+            _ => DEFAULT_DAILY_BUDGET_USD,
+        },
+        _ => DEFAULT_DAILY_BUDGET_USD,
+    }
+}
+
+/// Production entry point: read the real process environment.
+pub fn daily_budget_usd() -> f64 {
+    resolve_daily_budget_usd(|k| std::env::var(k).ok())
+}
+
+/// Resolve the observer cadence from an env resolver, clamped to
+/// [`MIN_OVERSEER_INTERVAL_SECS`]. Unset/empty/unparseable → the default.
+pub fn resolve_interval_secs(lookup: impl Fn(&str) -> Option<String>) -> u64 {
+    let requested = match lookup(OVERSEER_INTERVAL_ENV).as_deref().map(str::trim) {
+        Some(s) if !s.is_empty() => s.parse::<u64>().unwrap_or(DEFAULT_OVERSEER_INTERVAL_SECS),
+        _ => DEFAULT_OVERSEER_INTERVAL_SECS,
+    };
+    requested.max(MIN_OVERSEER_INTERVAL_SECS)
+}
+
+/// Production entry point: read the real process environment.
+pub fn overseer_interval_secs() -> u64 {
+    resolve_interval_secs(|k| std::env::var(k).ok())
+}
+
+/// Recognise an explicit truthy env value. Case-insensitive; trims surrounding
+/// whitespace. Anything else (including `0`/`false`/empty) is falsey.
+fn is_truthy(v: &str) -> bool {
+    let norm = v.trim().to_ascii_lowercase();
+    matches!(norm.as_str(), "1" | "true" | "yes" | "on")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Build an injectable env resolver from a fixed map — no `std::env` mutation.
+    fn env(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |k: &str| map.get(k).cloned()
+    }
+
+    fn approx(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-9
+    }
+
+    #[test]
+    fn overseer_disabled_by_default_when_unset() {
+        assert!(!overseer_enabled_from(env(&[])));
+    }
+
+    #[test]
+    fn overseer_enabled_only_on_explicit_truthy_values() {
+        for truthy in ["1", "true", "TRUE", "True", "yes", "YES", "on", "  on  "] {
+            assert!(
+                overseer_enabled_from(env(&[(OVERSEER_ENABLED_ENV, truthy)])),
+                "{truthy:?} should enable the Overseer"
+            );
+        }
+    }
+
+    #[test]
+    fn overseer_stays_off_for_falsey_or_garbage_values() {
+        for falsey in ["0", "false", "no", "off", "", "  ", "maybe", "2"] {
+            assert!(
+                !overseer_enabled_from(env(&[(OVERSEER_ENABLED_ENV, falsey)])),
+                "{falsey:?} must NOT enable the Overseer"
+            );
+        }
+    }
+
+    #[test]
+    fn budget_falls_back_to_default_when_unset() {
+        assert!(approx(
+            resolve_daily_budget_usd(env(&[])),
+            DEFAULT_DAILY_BUDGET_USD
+        ));
+    }
+
+    #[test]
+    fn budget_reads_explicit_value() {
+        assert!(approx(
+            resolve_daily_budget_usd(env(&[(DAILY_BUDGET_ENV, "750")])),
+            750.0
+        ));
+        assert!(approx(
+            resolve_daily_budget_usd(env(&[(DAILY_BUDGET_ENV, "  1234.5 ")])),
+            1234.5
+        ));
+    }
+
+    #[test]
+    fn budget_falls_back_on_unparseable_empty_or_nonpositive() {
+        for bad in ["abc", "", "  ", "0", "-5", "-0.01", "nan", "inf"] {
+            assert!(
+                approx(
+                    resolve_daily_budget_usd(env(&[(DAILY_BUDGET_ENV, bad)])),
+                    DEFAULT_DAILY_BUDGET_USD
+                ),
+                "{bad:?} must fall back to the default budget"
+            );
+        }
+    }
+
+    #[test]
+    fn interval_defaults_when_unset() {
+        assert_eq!(
+            resolve_interval_secs(env(&[])),
+            DEFAULT_OVERSEER_INTERVAL_SECS
+        );
+    }
+
+    #[test]
+    fn interval_reads_explicit_value_above_floor() {
+        assert_eq!(
+            resolve_interval_secs(env(&[(OVERSEER_INTERVAL_ENV, "1800")])),
+            1800
+        );
+    }
+
+    #[test]
+    fn interval_clamps_to_floor() {
+        // Below-floor / zero / garbage values never produce a hot loop.
+        for below in ["1", "0", "59", "abc", ""] {
+            assert!(
+                resolve_interval_secs(env(&[(OVERSEER_INTERVAL_ENV, below)]))
+                    >= MIN_OVERSEER_INTERVAL_SECS,
+                "{below:?} must clamp to the floor"
+            );
+        }
+        assert_eq!(
+            resolve_interval_secs(env(&[(OVERSEER_INTERVAL_ENV, "1")])),
+            MIN_OVERSEER_INTERVAL_SECS
+        );
+    }
+}

--- a/src/overseer/guardrails.rs
+++ b/src/overseer/guardrails.rs
@@ -110,8 +110,36 @@ impl RecursionGuard {
         }
     }
 
-    /// Convenience: refuse acting on own work with a typed error.
+    /// True only when every identity field is populated. A guard missing any
+    /// field cannot reliably recognise its own artifacts, so `admit` must fail
+    /// CLOSED (see below) rather than silently wave work through.
+    pub fn is_configured(&self) -> bool {
+        !self.author_login.is_empty()
+            && !self.branch_prefix.is_empty()
+            && !self.goal_source_tag.is_empty()
+    }
+
+    /// Gate acting on a subject. Fails **CLOSED** (crusty risk #3): when the
+    /// identity needed to classify `subject` is unconfigured, REFUSE rather than
+    /// allow — an anti-recursion guard that disables itself when misconfigured is
+    /// worse than none. PR/commit subjects require `author_login`; branch
+    /// subjects require `branch_prefix`; goal subjects require `goal_source_tag`.
+    /// When configured, refuse only the Overseer's OWN work (`is_own`).
+    ///
+    /// The Overseer must run under a DISTINCT identity (never the human
+    /// operator's login), so a correctly-configured guard admits the operator's
+    /// PRs while still refusing its own.
     pub fn admit(&self, subject: &Subject) -> Result<(), OverseerError> {
+        let unconfigured = match subject {
+            Subject::Pr { .. } | Subject::Commit { .. } => self.author_login.is_empty(),
+            Subject::Branch { .. } => self.branch_prefix.is_empty(),
+            Subject::Goal { .. } => self.goal_source_tag.is_empty(),
+        };
+        if unconfigured {
+            return Err(OverseerError::Recursion {
+                subject: format!("unconfigured-identity: {subject:?}"),
+            });
+        }
         if self.is_own(subject) {
             Err(OverseerError::Recursion {
                 subject: format!("{subject:?}"),
@@ -134,14 +162,27 @@ pub struct BudgetGate {
 
 impl Default for BudgetGate {
     fn default() -> Self {
-        // Mirrors the OODA loop's default daily budget.
-        Self {
-            daily_budget_usd: 500.0,
-        }
+        // Single-sourced from `SIMARD_DAILY_BUDGET_USD` (crusty risk #6): the
+        // Overseer's ceiling can never drift from the OODA loop's. The 500.0
+        // fallback lives in one place — `config::resolve_daily_budget_usd`.
+        Self::from_env()
     }
 }
 
 impl BudgetGate {
+    /// Construct from the single-sourced `SIMARD_DAILY_BUDGET_USD` env knob.
+    pub fn from_env() -> Self {
+        Self {
+            daily_budget_usd: crate::overseer::config::daily_budget_usd(),
+        }
+    }
+
+    /// Construct with an explicit ceiling (used by callers that already resolved
+    /// the budget, and by tests).
+    pub fn with_budget(daily_budget_usd: f64) -> Self {
+        Self { daily_budget_usd }
+    }
+
     pub fn admit(&self, spent_today_usd: f64) -> Result<(), OverseerError> {
         if self.daily_budget_usd > 0.0 && spent_today_usd >= self.daily_budget_usd {
             Err(OverseerError::Budget {
@@ -185,5 +226,121 @@ impl ConflictSequencer {
     /// Release a sequence group when its sweep completes.
     pub fn release(&mut self, group: &str) {
         self.active_groups.retain(|a| a != group);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn configured_guard() -> RecursionGuard {
+        RecursionGuard {
+            author_login: "simard-overseer[bot]".to_string(),
+            branch_prefix: "overseer/".to_string(),
+            goal_source_tag: "overseer:".to_string(),
+        }
+    }
+
+    // ── item 4: RecursionGuard must fail CLOSED ──────────────────────────────
+
+    #[test]
+    fn admit_fails_closed_when_identity_unconfigured() {
+        // A default guard has empty identity — it cannot recognise its own work,
+        // so `admit` must REFUSE, not allow (a guard that silently disables
+        // itself when misconfigured is worse than none).
+        let guard = RecursionGuard::default();
+        assert!(!guard.is_configured());
+
+        let pr = Subject::Pr {
+            repo: "rysweet/Simard".to_string(),
+            pr: 1,
+            author: "anyone".to_string(),
+        };
+        let commit = Subject::Commit {
+            sha: "abc123".to_string(),
+            author: "anyone".to_string(),
+        };
+        let branch = Subject::Branch {
+            name: "feature/x".to_string(),
+        };
+        let goal = Subject::Goal {
+            id: "g1".to_string(),
+            source: "ooda".to_string(),
+        };
+
+        assert!(
+            guard.admit(&pr).is_err(),
+            "unconfigured guard must refuse a PR subject (fail closed)"
+        );
+        assert!(
+            guard.admit(&commit).is_err(),
+            "unconfigured guard must refuse a commit subject (fail closed)"
+        );
+        assert!(
+            guard.admit(&branch).is_err(),
+            "unconfigured guard must refuse a branch subject (fail closed)"
+        );
+        assert!(
+            guard.admit(&goal).is_err(),
+            "unconfigured guard must refuse a goal subject (fail closed)"
+        );
+    }
+
+    #[test]
+    fn admit_refuses_own_work_when_configured() {
+        let guard = configured_guard();
+        assert!(guard.is_configured());
+
+        let own_pr = Subject::Pr {
+            repo: "rysweet/Simard".to_string(),
+            pr: 1,
+            author: "simard-overseer[bot]".to_string(),
+        };
+        let own_branch = Subject::Branch {
+            name: "overseer/fix-distill".to_string(),
+        };
+        let own_goal = Subject::Goal {
+            id: "g1".to_string(),
+            source: "overseer:distill".to_string(),
+        };
+        assert!(guard.admit(&own_pr).is_err());
+        assert!(guard.admit(&own_branch).is_err());
+        assert!(guard.admit(&own_goal).is_err());
+    }
+
+    #[test]
+    fn admit_allows_operator_work_under_distinct_identity() {
+        // The Overseer runs under a DISTINCT login, so a correctly-configured
+        // guard admits the human operator's PRs (they are not the Overseer's own).
+        let guard = configured_guard();
+        let operator_pr = Subject::Pr {
+            repo: "rysweet/Simard".to_string(),
+            pr: 2,
+            author: "rysweet".to_string(),
+        };
+        let foreign_branch = Subject::Branch {
+            name: "feature/human-work".to_string(),
+        };
+        assert!(guard.admit(&operator_pr).is_ok());
+        assert!(guard.admit(&foreign_branch).is_ok());
+    }
+
+    // ── item 7: BudgetGate is single-sourced from the env knob ───────────────
+
+    #[test]
+    fn budget_gate_holds_at_or_over_ceiling() {
+        let gate = BudgetGate::with_budget(500.0);
+        assert!(gate.admit(499.99).is_ok());
+        assert!(gate.admit(500.0).is_err(), "spend at ceiling must hold");
+        assert!(gate.admit(600.0).is_err(), "spend over ceiling must hold");
+    }
+
+    #[test]
+    fn budget_gate_from_env_has_positive_ceiling() {
+        // Correctness of env parsing is covered by `config` unit tests; here we
+        // only assert the default/from_env path yields a usable positive ceiling
+        // (never the removed hardcoded duplicate).
+        assert!(BudgetGate::from_env().daily_budget_usd > 0.0);
+        assert!(BudgetGate::default().daily_budget_usd > 0.0);
     }
 }

--- a/src/overseer/mod.rs
+++ b/src/overseer/mod.rs
@@ -46,18 +46,30 @@
 #![allow(dead_code)]
 
 pub mod capabilities;
+pub mod config;
 pub mod guardrails;
 pub mod intervention;
+pub mod observer;
+pub mod sensor;
 pub mod signal;
+
+#[cfg(test)]
+mod tests_m1;
 
 pub use capabilities::{
     Auditor, Deployer, GoalCurator, IssueFiler, MeetingHost, ObservedState, OrchestratorRunBrief,
     OverseerError, PrOps, RecipeBrief, RecipeLauncher, StatusReader,
 };
+pub use config::{daily_budget_usd, overseer_enabled};
 pub use guardrails::{
     AutonomyGate, BudgetGate, ConflictSequencer, RecursionGuard, RiskClass, Subject, classify,
 };
 pub use intervention::{Intervention, PlannedIntervention};
+pub use observer::{StewardshipIssueFiler, decide_read_only, is_m1_permitted};
+pub use sensor::{
+    ObserverReport, OverseerSensorThread, SnapshotSource, SnapshotStatusReader,
+    in_flight_from_board, observed_from_snapshot, run_observer_cycle,
+};
 pub use signal::{Priority, Problem, ProblemKind, Signal, signals_from};
 
 use capabilities::{DeployReport, GoalBrief, InFlightItem, IssueOutcome, WorkstreamHandle};

--- a/src/overseer/observer.rs
+++ b/src/overseer/observer.rs
@@ -1,0 +1,664 @@
+//! M1 — the Overseer's **read-only observer** surface.
+//!
+//! M1 is the "observe → orient → report → file deduped issues" milestone. It
+//! deliberately takes **no write action beyond issue-filing**: it never launches
+//! recipes, verifies/merges PRs, resolves conflicts, deploys, or transfers goals.
+//! This module supplies the two M1-specific pieces on top of the shared
+//! Observe/Orient vocabulary in [`signal`](crate::overseer::signal):
+//!
+//! - [`StewardshipIssueFiler`] — a real [`IssueFiler`] backed by the shipped
+//!   stewardship loop (`crate::stewardship::process_orchestrator_run`), so
+//!   recurring failures produce a single **deduplicated** GitHub issue and
+//!   re-observing the same failure is idempotent.
+//! - [`decide_read_only`] + [`is_m1_permitted`] — the M1 restriction of `decide`
+//!   that maps every `Problem` to a write-free intervention, with a
+//!   machine-checkable predicate proving M1's exit criterion.
+//!
+//! Reuse map (see `docs/design/overseer.md` §capability table):
+//! `stewardship::process_orchestrator_run` (`src/stewardship/mod.rs:51`),
+//! dedup via `stewardship::failure_signature` (`src/stewardship/dedup.rs`),
+//! backlog enqueue via `goal_curation::enqueue_stewardship_issue`.
+
+use std::sync::{Arc, Mutex};
+
+use crate::goal_curation::GoalBoard;
+use crate::overseer::capabilities::{
+    IssueFiler, IssueOutcome, OrchestratorRunBrief, OverseerError,
+};
+use crate::overseer::intervention::Intervention;
+use crate::overseer::signal::{Problem, ProblemKind, Signal};
+use crate::stewardship::{
+    GhClient, OrchestratorRunSummary, StewardshipOutcome, failure_signature,
+    process_orchestrator_run,
+};
+
+/// A real [`IssueFiler`] backed by Simard's stewardship loop. Wraps
+/// `stewardship::process_orchestrator_run`, which searches the routed repo for
+/// an OPEN issue carrying the same `failure_signature` and files a new one only
+/// when none exists — so repeated Observe cycles over the same failure are
+/// idempotent (`FiledNew` once, `MatchedExisting` thereafter).
+///
+/// The `gh` handle is the ONLY network surface (a `RealGhClient` in the daemon,
+/// a fake in tests). The goal board is held behind a `Mutex` so `file(&self, …)`
+/// can enqueue the resulting issue without requiring `&mut self`.
+pub struct StewardshipIssueFiler {
+    gh: Arc<dyn GhClient + Send + Sync>,
+    board: Mutex<GoalBoard>,
+}
+
+impl StewardshipIssueFiler {
+    /// Construct with a fresh, empty goal board.
+    pub fn new(gh: Arc<dyn GhClient + Send + Sync>) -> Self {
+        Self {
+            gh,
+            board: Mutex::new(GoalBoard::new()),
+        }
+    }
+
+    /// Construct over an existing board (e.g. the loaded persistent board).
+    pub fn with_board(gh: Arc<dyn GhClient + Send + Sync>, board: GoalBoard) -> Self {
+        Self {
+            gh,
+            board: Mutex::new(board),
+        }
+    }
+
+    /// Snapshot the current backlog length (used by tests / reporting).
+    pub fn backlog_len(&self) -> usize {
+        self.board
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .backlog
+            .len()
+    }
+}
+
+impl IssueFiler for StewardshipIssueFiler {
+    fn file(&self, run: &OrchestratorRunBrief) -> Result<IssueOutcome, OverseerError> {
+        let summary = brief_to_summary(run);
+        let mut board = self
+            .board
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let outcome =
+            process_orchestrator_run(&summary, self.gh.as_ref(), &mut board).map_err(|e| {
+                OverseerError::Capability {
+                    what: "file_issue",
+                    detail: e.to_string(),
+                }
+            })?;
+        Ok(match outcome {
+            StewardshipOutcome::FiledNew { url, .. } => IssueOutcome::FiledNew { url },
+            StewardshipOutcome::MatchedExisting { url, .. } => {
+                IssueOutcome::MatchedExisting { url }
+            }
+        })
+    }
+}
+
+/// Convert an Overseer [`OrchestratorRunBrief`] into a stewardship
+/// [`OrchestratorRunSummary`]. The brief carries no `run_id`; we synthesise a
+/// STABLE one from the failure signature so re-observing the same failure keeps
+/// the same run identity and dedups to the same issue (the signature itself
+/// depends only on `failure_kind` + `error_text`).
+pub fn brief_to_summary(run: &OrchestratorRunBrief) -> OrchestratorRunSummary {
+    let signature = failure_signature(&run.failure_kind, &run.error_text);
+    OrchestratorRunSummary {
+        run_id: format!("overseer-{signature}"),
+        recipe_name: run.recipe_name.clone(),
+        failed_step: run.failed_step.clone(),
+        source_module: run.source_module.clone(),
+        failure_kind: run.failure_kind.clone(),
+        error_text: run.error_text.clone(),
+    }
+}
+
+/// The M1 restriction of `decide`: every `Problem` maps to a **write-free**
+/// intervention. Recurring *defects* (process-health, quality regressions, goal
+/// hygiene, cross-cutting) become a single DEDUPLICATED
+/// [`Intervention::FileIssue`] — the read-only observer's durable finding
+/// (stewardship rule: "durable findings are GitHub issues or code"). Transient
+/// operational pressure and positive delivery states are surfaced in the
+/// periodic [`Intervention::Report`] instead of filing an issue. Unlike the
+/// full `decide`, M1 NEVER emits `LaunchRecipe`, `VerifyAndMergePr`,
+/// `ResolveConflict`, `Deploy`, or `TransferGoal` — autonomy is earned in later
+/// milestones, not defaulted.
+pub fn decide_read_only(problem: &Problem) -> Intervention {
+    match problem.kind {
+        // Recurring defects the operator should track → one deduplicated issue.
+        ProblemKind::ProcessHealth
+        | ProblemKind::QualityRegression
+        | ProblemKind::GoalHygiene
+        | ProblemKind::CrossCutting => Intervention::FileIssue {
+            run: problem_to_run_brief(problem),
+        },
+        // Transient resource pressure / positive delivery signals — report, do
+        // not file. Filing per-cycle issues for e.g. momentary budget pressure
+        // would be noise; the value is in the rolled-up Report.
+        ProblemKind::ResourcePressure | ProblemKind::DeliveryReady => Intervention::Report,
+    }
+}
+
+/// Build the deduplicated stewardship brief for a filed problem. The brief is
+/// consumed by [`StewardshipIssueFiler`] → `stewardship::process_orchestrator_run`,
+/// which routes on `source_module` and dedups on
+/// `failure_signature(failure_kind, error_text)`.
+fn problem_to_run_brief(problem: &Problem) -> OrchestratorRunBrief {
+    OrchestratorRunBrief {
+        recipe_name: "overseer-observer".to_string(),
+        failed_step: kind_step_label(problem.kind).to_string(),
+        source_module: routable_source_module(problem),
+        failure_kind: problem.dedup_key.clone(),
+        error_text: stable_error_text(problem),
+    }
+}
+
+/// A `source_module` string that `stewardship::route_failure` always resolves
+/// (never `StewardshipRoutingAmbiguous`). CI-failure clusters route to the
+/// affected repo; every other Overseer finding is about Simard's OWN process and
+/// routes to Simard. The token is a FIXED routable prefix, so free-form dedup
+/// keys (e.g. anomaly text) can never accidentally re-route the issue.
+fn routable_source_module(problem: &Problem) -> String {
+    for s in &problem.evidence {
+        if let Signal::CiFailureCluster { repo, .. } = s
+            && repo.to_ascii_lowercase().contains("amplihack")
+        {
+            return "amplihack::overseer".to_string();
+        }
+    }
+    "simard::overseer".to_string()
+}
+
+/// A short, stable phase label per problem kind (the stewardship `failed_step`).
+fn kind_step_label(kind: ProblemKind) -> &'static str {
+    match kind {
+        ProblemKind::ProcessHealth => "process_health",
+        ProblemKind::ResourcePressure => "resource_pressure",
+        ProblemKind::DeliveryReady => "delivery_ready",
+        ProblemKind::QualityRegression => "quality_regression",
+        ProblemKind::GoalHygiene => "goal_hygiene",
+        ProblemKind::CrossCutting => "cross_cutting",
+    }
+}
+
+/// STABLE error text (no fluctuating metric values) so `failure_signature` folds
+/// every recurrence of the same problem into ONE deduplicated issue. Live metric
+/// values live in the periodic Report / `simard status` telemetry, not the issue
+/// body. Keyed on the (already stable) `dedup_key` plus the evidence signal
+/// kinds — both invariant across observation cycles for a given problem.
+fn stable_error_text(problem: &Problem) -> String {
+    format!(
+        "Overseer read-only observer detected a recurring {kind:?} problem \
+         (dedup key `{key}`; evidence: {kinds}). Filed once per recurring \
+         signature — see `simard status` telemetry for current values.",
+        kind = problem.kind,
+        key = problem.dedup_key,
+        kinds = evidence_kind_labels(&problem.evidence),
+    )
+}
+
+/// De-duplicated, order-stable list of the signal *variant* names backing a
+/// problem (values omitted — only kinds, so the string is invariant per cycle).
+fn evidence_kind_labels(evidence: &[Signal]) -> String {
+    let mut labels: Vec<&'static str> = evidence.iter().map(signal_kind_label).collect();
+    labels.sort_unstable();
+    labels.dedup();
+    if labels.is_empty() {
+        "none".to_string()
+    } else {
+        labels.join(", ")
+    }
+}
+
+/// Stable variant name for a signal (no embedded values).
+fn signal_kind_label(s: &Signal) -> &'static str {
+    match s {
+        Signal::DistillFailureRate { .. } => "DistillFailureRate",
+        Signal::RestartChurn { .. } => "RestartChurn",
+        Signal::LadderExhausted { .. } => "LadderExhausted",
+        Signal::BudgetPressure { .. } => "BudgetPressure",
+        Signal::EngineerSpawnRate { .. } => "EngineerSpawnRate",
+        Signal::MemoryGrowth { .. } => "MemoryGrowth",
+        Signal::GymSkipped => "GymSkipped",
+        Signal::CiFailureCluster { .. } => "CiFailureCluster",
+        Signal::PrReadyToMerge { .. } => "PrReadyToMerge",
+        Signal::StaleGoal { .. } => "StaleGoal",
+        Signal::Anomaly { .. } => "Anomaly",
+    }
+}
+
+/// True iff `iv` performs **no write action beyond deduplicated issue-filing** —
+/// the machine-checkable invariant behind M1's exit criterion ("provably takes
+/// no write action beyond issue-filing"). Only [`Intervention::Report`],
+/// [`Intervention::FileIssue`], and [`Intervention::Escalate`] (notify-only) are
+/// permitted; every other intervention launches, merges, resolves, deploys, or
+/// transfers and is therefore an M2+ action.
+pub fn is_m1_permitted(iv: &Intervention) -> bool {
+    matches!(
+        iv,
+        Intervention::Report | Intervention::FileIssue { .. } | Intervention::Escalate { .. }
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::{SimardError, SimardResult};
+    use crate::overseer::decide;
+    use crate::overseer::signal::Priority;
+    use crate::stewardship::GhIssue;
+
+    /// Stateful, **no-network** fake: `create_issue` registers the issue so a
+    /// later `search_issues` for the same signature returns it — exactly how the
+    /// real `gh` would behave across two Observe cycles. No re-seeding needed,
+    /// so idempotency is exercised end-to-end through the adapter.
+    #[derive(Default)]
+    struct StatefulFakeGh {
+        issues: Mutex<Vec<GhIssue>>,
+        next_number: Mutex<u64>,
+        search_calls: Mutex<usize>,
+        create_calls: Mutex<usize>,
+    }
+
+    impl StatefulFakeGh {
+        fn new() -> Self {
+            Self {
+                next_number: Mutex::new(1),
+                ..Default::default()
+            }
+        }
+        fn search_calls(&self) -> usize {
+            *self.search_calls.lock().unwrap()
+        }
+        fn create_calls(&self) -> usize {
+            *self.create_calls.lock().unwrap()
+        }
+    }
+
+    impl GhClient for StatefulFakeGh {
+        fn search_issues(&self, _repo: &str, signature: &str) -> SimardResult<Vec<GhIssue>> {
+            *self.search_calls.lock().unwrap() += 1;
+            let needle = format!("stewardship-signature: {signature}");
+            Ok(self
+                .issues
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|i| i.body.contains(&needle))
+                .cloned()
+                .collect())
+        }
+        fn create_issue(&self, repo: &str, title: &str, body: &str) -> SimardResult<GhIssue> {
+            *self.create_calls.lock().unwrap() += 1;
+            let number = {
+                let mut n = self.next_number.lock().unwrap();
+                let cur = *n;
+                *n += 1;
+                cur
+            };
+            let issue = GhIssue {
+                number,
+                url: format!("https://github.com/{repo}/issues/{number}"),
+                title: title.to_string(),
+                body: body.to_string(),
+            };
+            self.issues.lock().unwrap().push(issue.clone());
+            Ok(issue)
+        }
+    }
+
+    /// A fake whose `search_issues` always errors — used to prove capability
+    /// failures surface as `OverseerError::Capability`, not panics.
+    struct FailingGh;
+    impl GhClient for FailingGh {
+        fn search_issues(&self, _repo: &str, _signature: &str) -> SimardResult<Vec<GhIssue>> {
+            Err(SimardError::StewardshipGhCommandFailed {
+                reason: "boom".to_string(),
+            })
+        }
+        fn create_issue(&self, _repo: &str, _title: &str, _body: &str) -> SimardResult<GhIssue> {
+            unreachable!("create must not be called after a search failure")
+        }
+    }
+
+    fn sample_brief() -> OrchestratorRunBrief {
+        OrchestratorRunBrief {
+            recipe_name: "smart-orchestrator".to_string(),
+            failed_step: "distill".to_string(),
+            source_module: "simard::engineer_loop".to_string(),
+            failure_kind: "PanicInStep".to_string(),
+            error_text: "panic at /home/user/src/foo.rs:42:7\nbacktrace deadbeef".to_string(),
+        }
+    }
+
+    fn url_of(outcome: &IssueOutcome) -> &str {
+        match outcome {
+            IssueOutcome::FiledNew { url } | IssueOutcome::MatchedExisting { url } => url,
+        }
+    }
+
+    #[test]
+    fn issue_filer_is_idempotent_across_cycles_no_network() {
+        let gh = Arc::new(StatefulFakeGh::new());
+        let filer = StewardshipIssueFiler::new(gh.clone());
+        let brief = sample_brief();
+
+        let first = filer.file(&brief).expect("first file");
+        assert!(
+            matches!(first, IssueOutcome::FiledNew { .. }),
+            "first cycle files a NEW issue, got {first:?}"
+        );
+
+        let second = filer.file(&brief).expect("second file");
+        assert!(
+            matches!(second, IssueOutcome::MatchedExisting { .. }),
+            "second cycle MATCHES the existing issue, got {second:?}"
+        );
+
+        // Same issue both times; exactly one create despite two cycles.
+        assert_eq!(
+            url_of(&first),
+            url_of(&second),
+            "same issue URL both cycles"
+        );
+        assert_eq!(gh.create_calls(), 1, "no duplicate issue created");
+        assert_eq!(gh.search_calls(), 2, "each cycle searches exactly once");
+        assert_eq!(
+            filer.backlog_len(),
+            1,
+            "second cycle must not duplicate the backlog row"
+        );
+    }
+
+    #[test]
+    fn issue_filer_surfaces_capability_failure_without_panic() {
+        let filer = StewardshipIssueFiler::new(Arc::new(FailingGh));
+        let err = filer
+            .file(&sample_brief())
+            .expect_err("search failure surfaces");
+        assert!(
+            matches!(
+                err,
+                OverseerError::Capability {
+                    what: "file_issue",
+                    ..
+                }
+            ),
+            "gh failure must surface as a capability error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn brief_to_summary_synthesises_stable_run_id_from_signature() {
+        let brief = sample_brief();
+        let summary = brief_to_summary(&brief);
+        let sig = failure_signature(&brief.failure_kind, &brief.error_text);
+        assert_eq!(summary.run_id, format!("overseer-{sig}"));
+        assert_eq!(summary.recipe_name, brief.recipe_name);
+        assert_eq!(summary.failed_step, brief.failed_step);
+        assert_eq!(summary.source_module, brief.source_module);
+        assert_eq!(summary.failure_kind, brief.failure_kind);
+        assert_eq!(summary.error_text, brief.error_text);
+    }
+
+    #[test]
+    fn dedup_signature_ignores_recipe_and_step_differences() {
+        // Two briefs describing the SAME underlying failure (same kind + text)
+        // but different recipe/step must share a signature → same issue.
+        let a = sample_brief();
+        let mut b = sample_brief();
+        b.recipe_name = "default-workflow".to_string();
+        b.failed_step = "orient".to_string();
+        assert_eq!(
+            failure_signature(&a.failure_kind, &a.error_text),
+            failure_signature(&b.failure_kind, &b.error_text)
+        );
+
+        let gh = Arc::new(StatefulFakeGh::new());
+        let filer = StewardshipIssueFiler::new(gh.clone());
+        assert!(matches!(
+            filer.file(&a).unwrap(),
+            IssueOutcome::FiledNew { .. }
+        ));
+        assert!(
+            matches!(
+                filer.file(&b).unwrap(),
+                IssueOutcome::MatchedExisting { .. }
+            ),
+            "a differently-labelled run of the same failure must match, not re-file"
+        );
+        assert_eq!(gh.create_calls(), 1);
+    }
+
+    // ── M1 read-only guarantee ───────────────────────────────────────────────
+
+    fn problem(kind: ProblemKind, evidence: Vec<Signal>) -> Problem {
+        Problem {
+            kind,
+            priority: Priority::Normal,
+            dedup_key: "k".to_string(),
+            summary: "s".to_string(),
+            evidence,
+        }
+    }
+
+    #[test]
+    fn m1_decide_is_write_free_for_every_problem_kind() {
+        for kind in [
+            ProblemKind::ProcessHealth,
+            ProblemKind::ResourcePressure,
+            ProblemKind::DeliveryReady,
+            ProblemKind::QualityRegression,
+            ProblemKind::GoalHygiene,
+            ProblemKind::CrossCutting,
+        ] {
+            let iv = decide_read_only(&problem(kind, vec![]));
+            assert!(
+                is_m1_permitted(&iv),
+                "{kind:?} → {iv:?} must be M1-permitted (no launch/merge/deploy/transfer)"
+            );
+        }
+    }
+
+    #[test]
+    fn m1_files_deduped_issue_for_ci_cluster() {
+        let iv = decide_read_only(&problem(
+            ProblemKind::QualityRegression,
+            vec![Signal::CiFailureCluster {
+                repo: "rysweet/Simard".to_string(),
+                failing: 4,
+            }],
+        ));
+        assert!(matches!(iv, Intervention::FileIssue { .. }));
+        assert!(is_m1_permitted(&iv));
+    }
+
+    #[test]
+    fn m1_files_not_launches_even_when_full_decide_would() {
+        // ProcessHealth: the full `decide` LAUNCHES a recipe; M1 must instead
+        // file a deduplicated issue and never launch.
+        let p = problem(
+            ProblemKind::ProcessHealth,
+            vec![Signal::DistillFailureRate { pct: 62.0 }],
+        );
+        assert!(
+            matches!(decide_read_only(&p), Intervention::FileIssue { .. }),
+            "M1 files an issue for a process-health defect, never launches"
+        );
+        assert!(is_m1_permitted(&decide_read_only(&p)));
+        assert!(
+            matches!(decide(&p), Intervention::LaunchRecipe { .. }),
+            "sanity: the full (M2+) decide DOES launch for ProcessHealth"
+        );
+        assert!(
+            !is_m1_permitted(&decide(&p)),
+            "the launch the full decide plans is NOT M1-permitted"
+        );
+    }
+
+    #[test]
+    fn resource_and_delivery_problems_report_not_file() {
+        // Transient pressure / positive delivery states are surfaced in the
+        // Report, never filed as recurring-defect issues.
+        for kind in [ProblemKind::ResourcePressure, ProblemKind::DeliveryReady] {
+            assert_eq!(
+                decide_read_only(&problem(kind, vec![])),
+                Intervention::Report,
+                "{kind:?} must report, not file"
+            );
+        }
+    }
+
+    #[test]
+    fn every_filed_problem_routes_without_ambiguity() {
+        use crate::stewardship::route_failure;
+        // A representative problem per defect kind (those that FILE issues). Each
+        // filed brief's source_module MUST resolve — never StewardshipRoutingAmbiguous.
+        let cases = [
+            problem(
+                ProblemKind::ProcessHealth,
+                vec![Signal::DistillFailureRate { pct: 62.0 }],
+            ),
+            problem(
+                ProblemKind::QualityRegression,
+                vec![Signal::CiFailureCluster {
+                    repo: "rysweet/Simard".to_string(),
+                    failing: 3,
+                }],
+            ),
+            problem(
+                ProblemKind::QualityRegression,
+                vec![Signal::CiFailureCluster {
+                    repo: "rysweet/amplihack".to_string(),
+                    failing: 1,
+                }],
+            ),
+            problem(
+                ProblemKind::GoalHygiene,
+                vec![Signal::StaleGoal {
+                    goal_id: "g1".to_string(),
+                }],
+            ),
+            problem(
+                ProblemKind::CrossCutting,
+                vec![Signal::Anomaly {
+                    detail: "rename sweep".to_string(),
+                }],
+            ),
+        ];
+        for p in &cases {
+            match decide_read_only(p) {
+                Intervention::FileIssue { run } => assert!(
+                    route_failure(&run.source_module).is_ok(),
+                    "filed source_module {:?} must route",
+                    run.source_module
+                ),
+                other => panic!("{:?} must file an issue, got {other:?}", p.kind),
+            }
+        }
+    }
+
+    #[test]
+    fn amplihack_ci_cluster_routes_to_amplihack() {
+        use crate::stewardship::{TargetRepo, route_failure};
+        let p = problem(
+            ProblemKind::QualityRegression,
+            vec![Signal::CiFailureCluster {
+                repo: "rysweet/amplihack".to_string(),
+                failing: 2,
+            }],
+        );
+        let Intervention::FileIssue { run } = decide_read_only(&p) else {
+            panic!("amplihack CI cluster must file an issue");
+        };
+        assert_eq!(
+            route_failure(&run.source_module).unwrap(),
+            TargetRepo::Amplihack,
+            "an amplihack CI cluster routes its issue to amplihack"
+        );
+    }
+
+    #[test]
+    fn same_process_problem_dedups_to_one_issue_across_cycles() {
+        // Two observation cycles of the SAME recurring process problem must file
+        // exactly one issue (stable error_text → stable failure signature).
+        let gh = Arc::new(StatefulFakeGh::new());
+        let filer = StewardshipIssueFiler::new(gh.clone());
+        let mut p = problem(
+            ProblemKind::ProcessHealth,
+            vec![Signal::DistillFailureRate { pct: 62.0 }],
+        );
+        p.dedup_key = "process:distill_fail".to_string();
+
+        let Intervention::FileIssue { run: run1 } = decide_read_only(&p) else {
+            panic!("cycle 1 must file");
+        };
+        // A LATER cycle observes a different live pct — the brief text is stable,
+        // so it must still dedup to the same issue.
+        let mut p2 = p.clone();
+        p2.evidence = vec![Signal::DistillFailureRate { pct: 71.0 }];
+        let Intervention::FileIssue { run: run2 } = decide_read_only(&p2) else {
+            panic!("cycle 2 must file");
+        };
+
+        assert!(matches!(
+            filer.file(&run1).unwrap(),
+            IssueOutcome::FiledNew { .. }
+        ));
+        assert!(
+            matches!(
+                filer.file(&run2).unwrap(),
+                IssueOutcome::MatchedExisting { .. }
+            ),
+            "a later cycle of the same problem must match, not re-file"
+        );
+        assert_eq!(
+            gh.create_calls(),
+            1,
+            "a recurring process problem files exactly one issue"
+        );
+    }
+
+    #[test]
+    fn write_actions_are_not_m1_permitted() {
+        use crate::overseer::capabilities::{AuditScope, GoalBrief, RecipeBrief};
+        let writes = [
+            Intervention::LaunchRecipe {
+                brief: RecipeBrief {
+                    task_description: "x".to_string(),
+                    target_repo: "rysweet/Simard".to_string(),
+                    sequence_group: None,
+                },
+            },
+            Intervention::VerifyAndMergePr {
+                repo: "rysweet/Simard".to_string(),
+                pr: 1,
+            },
+            Intervention::ResolveConflict {
+                repo: "rysweet/Simard".to_string(),
+                pr: 1,
+            },
+            Intervention::Deploy {
+                commit: "abc123".to_string(),
+            },
+            Intervention::TransferGoal {
+                goal: GoalBrief {
+                    title: "t".to_string(),
+                    rationale: "r".to_string(),
+                    priority: 3,
+                    target_repo: "rysweet/Simard".to_string(),
+                },
+            },
+            Intervention::RunAudit {
+                scope: AuditScope::SelfHealth,
+            },
+        ];
+        for iv in &writes {
+            assert!(
+                !is_m1_permitted(iv),
+                "{} must NOT be M1-permitted",
+                iv.label()
+            );
+        }
+    }
+}

--- a/src/overseer/sensor.rs
+++ b/src/overseer/sensor.rs
@@ -1,0 +1,691 @@
+//! M1 — the Overseer packaged as an **optional, read-only `CognitiveThread`
+//! sensor**, plus the real Observe adapter over the shipped `StatusSnapshot`.
+//!
+//! This is the concrete, runnable M1 surface described in the design doc's
+//! "Embedding seam": a least-authority `impl CognitiveThread` that Observes →
+//! Orients → Reports → files **deduplicated** issues, and takes **no write
+//! action beyond issue-filing** (no launches, merges, conflict-resolution,
+//! deploys, or goal transfers). Because it needs none of the guarded
+//! capabilities, it fits the least-authority `ThreadContext` and can be
+//! registered next to `MaintenanceThread` / `EngineerLogAnalysisThread` behind
+//! the `SIMARD_OVERSEER_ENABLED` flag (default OFF) with no default behaviour
+//! change.
+//!
+//! Reuse map (see `docs/design/overseer.md` §capability table / grounding ledger):
+//! - Observe: `status::assemble` → `StatusSnapshot` (`src/status/provider.rs:58`).
+//! - Report: `status::render::to_terminal` / `status::json::to_string_pretty`.
+//! - Dedup vs in-flight: `goal_curation::load_goal_board` (read via `ThreadContext.memory`).
+//! - File deduped issues: `stewardship::process_orchestrator_run` (via
+//!   [`StewardshipIssueFiler`](crate::overseer::observer::StewardshipIssueFiler)).
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+
+use crate::cognitive_threads::{
+    CognitiveThread, Priority, SchedulePolicy, ThreadContext, ThreadHealth, ThreadKind,
+    ThreadOutcome,
+};
+use crate::goal_curation::{GoalBoard, load_goal_board};
+use crate::status::{AssembleOptions, StatusSnapshot, assemble};
+use crate::stewardship::RealGhClient;
+
+use crate::overseer::capabilities::{
+    InFlightItem, IssueFiler, IssueOutcome, ObservedState, OverseerError, StatusReader,
+};
+use crate::overseer::config;
+use crate::overseer::intervention::Intervention;
+use crate::overseer::observer::{StewardshipIssueFiler, decide_read_only, is_m1_permitted};
+use crate::overseer::orient;
+use crate::overseer::signal::{Problem, Signal, signals_from};
+
+// ─────────────────────────── Observe adapter ───────────────────────────────
+
+/// Source of the full `StatusSnapshot`. Kept distinct from the design's
+/// [`StatusReader`] (which yields the flattened [`ObservedState`]) because the
+/// M1 Report renders the *whole* snapshot via `status::render`.
+pub trait SnapshotSource {
+    fn assemble_snapshot(&self) -> Result<StatusSnapshot, OverseerError>;
+}
+
+/// The real Observe adapter. Wraps `crate::status::assemble` — the exact value
+/// `simard status` renders — and is read-only over `~/.simard` telemetry. It
+/// satisfies BOTH capability traits: [`SnapshotSource`] (full snapshot, for the
+/// M1 Report) and [`StatusReader`] (flattened [`ObservedState`], reused by the
+/// M2 `Overseer::run_cycle`). `assemble` is infallible (degraded sections come
+/// back as `None`), so both methods always `Ok`.
+#[derive(Clone, Debug)]
+pub struct SnapshotStatusReader {
+    opts: AssembleOptions,
+}
+
+impl SnapshotStatusReader {
+    pub fn new(opts: AssembleOptions) -> Self {
+        Self { opts }
+    }
+
+    /// Construct from the process environment defaults (`~/.simard` state root,
+    /// `simard.service` unit).
+    pub fn from_env() -> Self {
+        Self {
+            opts: AssembleOptions::default(),
+        }
+    }
+}
+
+impl Default for SnapshotStatusReader {
+    fn default() -> Self {
+        Self::from_env()
+    }
+}
+
+impl SnapshotSource for SnapshotStatusReader {
+    fn assemble_snapshot(&self) -> Result<StatusSnapshot, OverseerError> {
+        Ok(assemble(&self.opts))
+    }
+}
+
+impl StatusReader for SnapshotStatusReader {
+    fn snapshot(&self) -> Result<ObservedState, OverseerError> {
+        Ok(observed_from_snapshot(&assemble(&self.opts)))
+    }
+}
+
+/// Pure projection of a `StatusSnapshot` onto the Overseer's [`ObservedState`].
+/// Every field cites the exact snapshot path; a **degraded** section
+/// (`SectionEnvelope.data == None`) maps to `None`, never a panic. PR/CI reads
+/// (`ready_prs` / `ci_failures`) are an M2 capability, so they stay empty at M1.
+pub fn observed_from_snapshot(snap: &StatusSnapshot) -> ObservedState {
+    let telemetry = snap.telemetry.data.as_ref();
+    let daemon = snap.daemon.data.as_ref();
+    let resources = snap.resources.data.as_ref();
+    let llm = snap.llm.data.as_ref();
+    let memory = snap.memory.data.as_ref();
+    let gym = snap.gym.data.as_ref();
+
+    ObservedState {
+        distill_fail_pct: telemetry.and_then(|t| t.distill_fail_pct),
+        restart_churn: telemetry
+            .and_then(|t| t.restart_churn)
+            .or_else(|| daemon.and_then(|d| d.n_restarts)),
+        ladder_exhausted: memory.and_then(|m| m.decide_ladder_exhausted),
+        spent_today_usd: llm
+            .and_then(|l| l.ledger_today.as_ref())
+            .map(|w| w.cost_usd),
+        daily_budget_usd: llm.and_then(|l| l.daily_budget_usd),
+        live_engineers: resources.and_then(|r| r.live_engineers),
+        memory_nodes: memory.and_then(|m| m.nodes_total),
+        gym_skipped: gym.map(|g| g.skip_gym).unwrap_or(false)
+            || telemetry.map(|t| t.gym_skipped).unwrap_or(false),
+        anomalies: telemetry.map(|t| t.anomalies.clone()).unwrap_or_default(),
+        ready_prs: Vec::new(),
+        ci_failures: Vec::new(),
+    }
+}
+
+/// Map Simard's in-flight goal board onto the dedup [`InFlightItem`]s Orient
+/// checks against, so the Overseer never fights an engineer already on a case.
+/// Read-only. Each active/backlog goal contributes its id and any WIP refs
+/// (PR/issue/branch/session ids). Overseer-launched workstreams (M2+) stamp
+/// their `dedup_key` here, which is where board-dedup becomes load-bearing.
+pub fn in_flight_from_board(board: &GoalBoard) -> Vec<InFlightItem> {
+    let mut items = Vec::with_capacity(board.active.len() + board.backlog.len());
+    for g in &board.active {
+        let mut refs: Vec<String> = g
+            .wip_refs
+            .iter()
+            .map(|w| format!("{}:{}", w.kind, w.ref_id))
+            .collect();
+        refs.push(g.id.clone());
+        items.push(InFlightItem {
+            id: g.id.clone(),
+            source: g.assigned_to.clone().unwrap_or_else(|| "ooda".to_string()),
+            refs,
+        });
+    }
+    for b in &board.backlog {
+        items.push(InFlightItem {
+            id: b.id.clone(),
+            source: b.source.clone(),
+            refs: vec![b.id.clone()],
+        });
+    }
+    items
+}
+
+// ─────────────────────────── Read-only cycle ───────────────────────────────
+
+/// The result of one read-only observer pass. Side-effect free apart from the
+/// deduplicated issues recorded in `issues_filed` (suppressed under `dry_run`).
+#[derive(Clone, Debug)]
+pub struct ObserverReport {
+    pub observed: ObservedState,
+    pub signals: Vec<Signal>,
+    pub problems: Vec<Problem>,
+    /// Issues actually filed this pass (empty under `dry_run`).
+    pub issues_filed: Vec<IssueOutcome>,
+    /// Per-issue capability errors — a failed file degrades one finding, never
+    /// the whole cycle (failure isolation).
+    pub file_errors: Vec<String>,
+    /// How many `FileIssue` interventions were planned (filed or dry-run).
+    pub planned_file_count: usize,
+    pub report_terminal: String,
+    pub report_json: String,
+}
+
+/// Run one read-only Observe → Orient → Report(+file deduped issues) pass.
+///
+/// The **hard M1 invariant** — no write action beyond deduplicated issue-filing
+/// — is enforced two ways: a `debug_assert!` on [`is_m1_permitted`], and the
+/// match arm that only ever dispatches `FileIssue`. A `Report`/`Escalate` plan
+/// carries no side effect; no other `Intervention` variant is reachable from
+/// [`decide_read_only`].
+pub fn run_observer_cycle(
+    snapshot: &StatusSnapshot,
+    in_flight: &[InFlightItem],
+    issues: &dyn IssueFiler,
+    dry_run: bool,
+) -> ObserverReport {
+    let observed = observed_from_snapshot(snapshot);
+    let signals = signals_from(&observed);
+    let problems = orient(&signals, in_flight);
+
+    let mut issues_filed = Vec::new();
+    let mut file_errors = Vec::new();
+    let mut planned_file_count = 0usize;
+
+    for p in &problems {
+        let iv = decide_read_only(p);
+        debug_assert!(
+            is_m1_permitted(&iv),
+            "M1 observer planned a non-read-only action: {iv:?}"
+        );
+        if let Intervention::FileIssue { run } = iv {
+            planned_file_count += 1;
+            if !dry_run {
+                match issues.file(&run) {
+                    Ok(outcome) => issues_filed.push(outcome),
+                    Err(e) => file_errors.push(e.to_string()),
+                }
+            }
+        }
+    }
+
+    let report_terminal = crate::status::render::to_terminal(snapshot);
+    let report_json = crate::status::json::to_string_pretty(snapshot)
+        .unwrap_or_else(|e| format!("{{\"error\":\"status json render failed: {e}\"}}"));
+
+    ObserverReport {
+        observed,
+        signals,
+        problems,
+        issues_filed,
+        file_errors,
+        planned_file_count,
+        report_terminal,
+        report_json,
+    }
+}
+
+// ─────────────────────────── CognitiveThread sensor ────────────────────────
+
+/// Stable thread id for the M1 observer sensor.
+pub const OVERSEER_SENSOR_ID: &str = "overseer-observer";
+
+/// The M1 Overseer as a least-authority background sensor. Holds only two
+/// injectable capabilities — an Observe source and a deduplicated issue filer —
+/// so it can take **no** high-risk action. Constructed via [`from_env`] in the
+/// daemon (behind the flag) or with fakes in tests.
+///
+/// [`from_env`]: OverseerSensorThread::from_env
+pub struct OverseerSensorThread {
+    snapshots: Box<dyn SnapshotSource + Send>,
+    issues: Box<dyn IssueFiler + Send>,
+    interval_secs: u64,
+    enabled: bool,
+    last_run_epoch: Option<u64>,
+    next_run_epoch: Option<u64>,
+    last_success: Option<bool>,
+    consecutive_errors: u32,
+}
+
+impl OverseerSensorThread {
+    /// Construct with injected capabilities (tests inject fakes).
+    pub fn new(
+        snapshots: Box<dyn SnapshotSource + Send>,
+        issues: Box<dyn IssueFiler + Send>,
+        interval_secs: u64,
+        enabled: bool,
+    ) -> Self {
+        Self {
+            snapshots,
+            issues,
+            interval_secs,
+            enabled,
+            last_run_epoch: None,
+            next_run_epoch: None,
+            last_success: None,
+            consecutive_errors: 0,
+        }
+    }
+
+    /// Construct the real daemon sensor: Observe over `~/.simard` telemetry,
+    /// file issues through the real `gh` client. Enablement + cadence come from
+    /// the `SIMARD_OVERSEER_*` env knobs (default OFF, clamped cadence).
+    pub fn from_env() -> Self {
+        Self::new(
+            Box::new(SnapshotStatusReader::from_env()),
+            Box::new(StewardshipIssueFiler::new(Arc::new(RealGhClient::new()))),
+            config::overseer_interval_secs(),
+            config::overseer_enabled(),
+        )
+    }
+}
+
+impl CognitiveThread for OverseerSensorThread {
+    fn id(&self) -> &str {
+        OVERSEER_SENSOR_ID
+    }
+
+    fn kind(&self) -> ThreadKind {
+        // A read-only observer over Simard's own telemetry — a sensory faculty.
+        ThreadKind::SensoryProcessing
+    }
+
+    fn policy(&self) -> SchedulePolicy {
+        SchedulePolicy::Interval(Duration::from_secs(self.interval_secs))
+    }
+
+    fn priority(&self) -> Priority {
+        // Background, never-critical: it must never steal budget from OODA.
+        Priority::Low
+    }
+
+    fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn tick(&mut self, ctx: &mut ThreadContext<'_>) -> ThreadOutcome {
+        let start = Instant::now();
+
+        if !self.enabled {
+            return ThreadOutcome::skipped();
+        }
+
+        // Observe — a snapshot failure aborts THIS cycle cleanly (no partial act).
+        let snapshot = match self.snapshots.assemble_snapshot() {
+            Ok(s) => s,
+            Err(e) => {
+                self.last_run_epoch = Some(ctx.now_epoch);
+                self.next_run_epoch = Some(ctx.now_epoch.saturating_add(self.interval_secs));
+                self.last_success = Some(false);
+                self.consecutive_errors = self.consecutive_errors.saturating_add(1);
+                return ThreadOutcome::failed(
+                    format!("overseer observe failed: {e}"),
+                    start.elapsed(),
+                );
+            }
+        };
+
+        // Orient dedup input: Simard's in-flight goals (read-only; a board-read
+        // failure degrades to "no dedup", never a crash).
+        let in_flight = load_goal_board(ctx.memory)
+            .map(|b| in_flight_from_board(&b))
+            .unwrap_or_default();
+
+        // Under dry_run the observer plans but files nothing (its only write).
+        let report = run_observer_cycle(&snapshot, &in_flight, self.issues.as_ref(), ctx.dry_run);
+
+        self.last_run_epoch = Some(ctx.now_epoch);
+        self.next_run_epoch = Some(ctx.now_epoch.saturating_add(self.interval_secs));
+
+        let summary = format!(
+            "overseer observer: {} signal(s), {} problem(s), {} issue(s) filed{}",
+            report.signals.len(),
+            report.problems.len(),
+            report.issues_filed.len(),
+            if report.file_errors.is_empty() {
+                String::new()
+            } else {
+                format!(", {} file error(s)", report.file_errors.len())
+            },
+        );
+
+        let detail = json!({
+            "signals": report.signals.len(),
+            "problems": report
+                .problems
+                .iter()
+                .map(|p| json!({
+                    "kind": format!("{:?}", p.kind),
+                    "priority": format!("{:?}", p.priority),
+                    "dedup_key": p.dedup_key,
+                }))
+                .collect::<Vec<_>>(),
+            "issues_filed": report
+                .issues_filed
+                .iter()
+                .map(issue_outcome_json)
+                .collect::<Vec<_>>(),
+            "planned_file_count": report.planned_file_count,
+            "file_errors": report.file_errors,
+            "dry_run": ctx.dry_run,
+            "read_only": true,
+        });
+
+        if report.file_errors.is_empty() {
+            self.last_success = Some(true);
+            self.consecutive_errors = 0;
+            ThreadOutcome::ok(summary, start.elapsed()).with_detail(detail)
+        } else {
+            self.last_success = Some(false);
+            self.consecutive_errors = self.consecutive_errors.saturating_add(1);
+            ThreadOutcome::failed(summary, start.elapsed()).with_detail(detail)
+        }
+    }
+
+    fn health(&self) -> ThreadHealth {
+        ThreadHealth {
+            id: OVERSEER_SENSOR_ID.to_string(),
+            enabled: self.enabled,
+            last_run_epoch: self.last_run_epoch,
+            next_run_epoch: self.next_run_epoch,
+            last_success: self.last_success,
+            consecutive_errors: self.consecutive_errors,
+            backoff_until_epoch: None,
+        }
+    }
+}
+
+fn issue_outcome_json(o: &IssueOutcome) -> serde_json::Value {
+    match o {
+        IssueOutcome::FiledNew { url } => json!({ "outcome": "filed_new", "url": url }),
+        IssueOutcome::MatchedExisting { url } => {
+            json!({ "outcome": "matched_existing", "url": url })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
+    use crate::status::{SectionEnvelope, TelemetrySignals};
+    use std::path::Path;
+    use std::sync::Mutex;
+    use std::sync::atomic::AtomicBool;
+
+    // ── Observe mapping ──────────────────────────────────────────────────────
+
+    fn snapshot_with_telemetry(t: TelemetrySignals) -> StatusSnapshot {
+        let mut snap = StatusSnapshot::empty();
+        snap.telemetry = SectionEnvelope::live(t, None);
+        snap
+    }
+
+    #[test]
+    fn observed_from_degraded_snapshot_is_all_none_no_panic() {
+        let observed = observed_from_snapshot(&StatusSnapshot::empty());
+        assert_eq!(observed, ObservedState::default());
+    }
+
+    #[test]
+    fn observed_from_snapshot_maps_telemetry_fields() {
+        let observed = observed_from_snapshot(&snapshot_with_telemetry(TelemetrySignals {
+            distill_fail_pct: Some(62.0),
+            restart_churn: Some(4),
+            gym_skipped: true,
+            anomalies: vec!["banner pollution".to_string()],
+            ..TelemetrySignals::default()
+        }));
+        assert_eq!(observed.distill_fail_pct, Some(62.0));
+        assert_eq!(observed.restart_churn, Some(4));
+        assert!(observed.gym_skipped);
+        assert_eq!(observed.anomalies, vec!["banner pollution".to_string()]);
+    }
+
+    // ── run_observer_cycle: read-only, files deduped issues, renders report ──
+
+    /// A no-network `IssueFiler` fake that just counts and returns FiledNew.
+    #[derive(Default)]
+    struct CountingFiler {
+        filed: Mutex<usize>,
+    }
+    impl CountingFiler {
+        fn count(&self) -> usize {
+            *self.filed.lock().unwrap()
+        }
+    }
+    impl IssueFiler for CountingFiler {
+        fn file(
+            &self,
+            _run: &crate::overseer::capabilities::OrchestratorRunBrief,
+        ) -> Result<IssueOutcome, OverseerError> {
+            let mut n = self.filed.lock().unwrap();
+            *n += 1;
+            Ok(IssueOutcome::FiledNew {
+                url: format!("https://example/issues/{n}"),
+            })
+        }
+    }
+
+    #[test]
+    fn quiet_snapshot_files_nothing_but_still_renders_report() {
+        let filer = CountingFiler::default();
+        let report = run_observer_cycle(&StatusSnapshot::empty(), &[], &filer, false);
+        assert!(report.signals.is_empty());
+        assert!(report.problems.is_empty());
+        assert_eq!(report.planned_file_count, 0);
+        assert_eq!(filer.count(), 0);
+        assert!(
+            !report.report_terminal.is_empty(),
+            "Report must always render the snapshot"
+        );
+    }
+
+    #[test]
+    fn process_defect_files_exactly_one_issue_and_reports() {
+        let filer = CountingFiler::default();
+        let snap = snapshot_with_telemetry(TelemetrySignals {
+            distill_fail_pct: Some(62.0),
+            ..TelemetrySignals::default()
+        });
+        let report = run_observer_cycle(&snap, &[], &filer, false);
+        assert_eq!(report.problems.len(), 1);
+        assert_eq!(report.planned_file_count, 1);
+        assert_eq!(report.issues_filed.len(), 1);
+        assert_eq!(filer.count(), 1);
+        assert!(report.file_errors.is_empty());
+    }
+
+    #[test]
+    fn dry_run_plans_but_files_no_issue() {
+        let filer = CountingFiler::default();
+        let snap = snapshot_with_telemetry(TelemetrySignals {
+            distill_fail_pct: Some(62.0),
+            ..TelemetrySignals::default()
+        });
+        let report = run_observer_cycle(&snap, &[], &filer, true);
+        assert_eq!(report.planned_file_count, 1, "the file is planned");
+        assert_eq!(filer.count(), 0, "but dry_run files nothing");
+        assert!(report.issues_filed.is_empty());
+    }
+
+    // ── The CognitiveThread sensor: end-to-end, no network ───────────────────
+
+    struct FakeSnapshots(StatusSnapshot);
+    impl SnapshotSource for FakeSnapshots {
+        fn assemble_snapshot(&self) -> Result<StatusSnapshot, OverseerError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    /// Stateful, no-network `gh` fake: `create_issue` registers the issue so a
+    /// later `search_issues` for the same signature returns it — so the sensor's
+    /// dedup is exercised end-to-end across ticks with zero network.
+    #[derive(Default)]
+    struct StatefulFakeGh {
+        issues: Mutex<Vec<crate::stewardship::GhIssue>>,
+        next_number: Mutex<u64>,
+        create_calls: Mutex<usize>,
+    }
+    impl StatefulFakeGh {
+        fn new() -> Self {
+            Self {
+                next_number: Mutex::new(1),
+                ..Default::default()
+            }
+        }
+        fn create_calls(&self) -> usize {
+            *self.create_calls.lock().unwrap()
+        }
+    }
+    impl crate::stewardship::GhClient for StatefulFakeGh {
+        fn search_issues(
+            &self,
+            _repo: &str,
+            signature: &str,
+        ) -> crate::error::SimardResult<Vec<crate::stewardship::GhIssue>> {
+            let needle = format!("stewardship-signature: {signature}");
+            Ok(self
+                .issues
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|i| i.body.contains(&needle))
+                .cloned()
+                .collect())
+        }
+        fn create_issue(
+            &self,
+            repo: &str,
+            title: &str,
+            body: &str,
+        ) -> crate::error::SimardResult<crate::stewardship::GhIssue> {
+            *self.create_calls.lock().unwrap() += 1;
+            let number = {
+                let mut n = self.next_number.lock().unwrap();
+                let cur = *n;
+                *n += 1;
+                cur
+            };
+            let issue = crate::stewardship::GhIssue {
+                number,
+                url: format!("https://github.com/{repo}/issues/{number}"),
+                title: title.to_string(),
+                body: body.to_string(),
+            };
+            self.issues.lock().unwrap().push(issue.clone());
+            Ok(issue)
+        }
+    }
+
+    fn sensor_with(
+        snap: StatusSnapshot,
+        gh: Arc<StatefulFakeGh>,
+        enabled: bool,
+    ) -> OverseerSensorThread {
+        OverseerSensorThread::new(
+            Box::new(FakeSnapshots(snap)),
+            Box::new(StewardshipIssueFiler::new(gh)),
+            config::DEFAULT_OVERSEER_INTERVAL_SECS,
+            enabled,
+        )
+    }
+
+    /// Owns the borrowed resources a `ThreadContext` needs (mirrors the shipped
+    /// cognitive-thread test harness): an in-memory store, a current-thread
+    /// runtime, and a temp state root — zero network, zero real `~/.simard`.
+    struct TestEnv {
+        rt: tokio::runtime::Runtime,
+        mem: LibraryCognitiveMemory,
+        shutdown: AtomicBool,
+        tmp: tempfile::TempDir,
+    }
+    impl TestEnv {
+        fn new() -> Self {
+            Self {
+                rt: tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("runtime"),
+                mem: LibraryCognitiveMemory::in_memory().expect("in-memory store"),
+                shutdown: AtomicBool::new(false),
+                tmp: tempfile::tempdir().expect("tempdir"),
+            }
+        }
+        fn ctx(&self, now_epoch: u64, dry_run: bool) -> ThreadContext<'_> {
+            ThreadContext {
+                state_root: self.tmp.path() as &Path,
+                repo_root: self.tmp.path() as &Path,
+                memory: &self.mem as &dyn CognitiveMemoryOps,
+                runtime: self.rt.handle().clone(),
+                shutdown: &self.shutdown,
+                now_epoch,
+                dry_run,
+            }
+        }
+    }
+
+    #[test]
+    fn disabled_sensor_skips() {
+        let env = TestEnv::new();
+        let gh = Arc::new(StatefulFakeGh::new());
+        let mut sensor = sensor_with(StatusSnapshot::empty(), gh, false);
+        let outcome = sensor.tick(&mut env.ctx(100, false));
+        assert!(!outcome.ran, "a disabled sensor must not run");
+        assert!(!sensor.enabled());
+    }
+
+    #[test]
+    fn sensor_tick_files_one_deduped_issue_and_is_idempotent() {
+        let env = TestEnv::new();
+        let gh = Arc::new(StatefulFakeGh::new());
+        let snap = snapshot_with_telemetry(TelemetrySignals {
+            distill_fail_pct: Some(62.0),
+            ..TelemetrySignals::default()
+        });
+        let mut sensor = sensor_with(snap, gh.clone(), true);
+
+        let first = sensor.tick(&mut env.ctx(100, false));
+        assert!(first.ran && first.success, "first tick runs and succeeds");
+        assert_eq!(
+            gh.create_calls(),
+            1,
+            "one issue filed for the distill defect"
+        );
+
+        // A second cycle over the same recurring problem must NOT duplicate.
+        let second = sensor.tick(&mut env.ctx(200, false));
+        assert!(second.ran && second.success);
+        assert_eq!(gh.create_calls(), 1, "recurring problem stays one issue");
+
+        let health = sensor.health();
+        assert_eq!(health.last_run_epoch, Some(200));
+        assert_eq!(
+            health.next_run_epoch,
+            Some(200 + config::DEFAULT_OVERSEER_INTERVAL_SECS)
+        );
+        assert_eq!(health.consecutive_errors, 0);
+    }
+
+    #[test]
+    fn sensor_dry_run_files_nothing() {
+        let env = TestEnv::new();
+        let gh = Arc::new(StatefulFakeGh::new());
+        let snap = snapshot_with_telemetry(TelemetrySignals {
+            distill_fail_pct: Some(62.0),
+            ..TelemetrySignals::default()
+        });
+        let mut sensor = sensor_with(snap, gh.clone(), true);
+        let outcome = sensor.tick(&mut env.ctx(100, true));
+        assert!(outcome.ran);
+        assert_eq!(gh.create_calls(), 0, "dry_run files no issues");
+    }
+
+    #[test]
+    fn in_flight_from_empty_board_is_empty() {
+        assert!(in_flight_from_board(&GoalBoard::new()).is_empty());
+    }
+}

--- a/src/overseer/tests_m1.rs
+++ b/src/overseer/tests_m1.rs
@@ -1,0 +1,280 @@
+//! M1 unit tests for the pure Observe→Orient core: `signals_from` threshold
+//! boundaries and `orient` dedup / merge / prioritisation.
+//!
+//! These are the two unit tests M1's exit criteria call out explicitly
+//! ("`signals_from` thresholds; `orient` dedup vs in-flight"). They are pure —
+//! no sleeps, no network, no clock — matching the shipped cognitive-thread test
+//! discipline. Boundary cases assert the fence sits exactly where the threshold
+//! constant says (`>=` fires, one-below does not).
+
+use crate::overseer::capabilities::{CiFailure, InFlightItem, ObservedState, PrRef};
+use crate::overseer::orient;
+use crate::overseer::signal::{Priority, Signal, signals_from};
+
+// ─────────────────────────── signals_from thresholds ───────────────────────
+
+#[test]
+fn no_signals_from_a_default_snapshot() {
+    assert!(signals_from(&ObservedState::default()).is_empty());
+}
+
+#[test]
+fn distill_failure_fires_at_and_above_threshold_only() {
+    // Threshold is 20.0.
+    let below = ObservedState {
+        distill_fail_pct: Some(19.9),
+        ..ObservedState::default()
+    };
+    assert!(signals_from(&below).is_empty(), "19.9% is below the fence");
+
+    let at = ObservedState {
+        distill_fail_pct: Some(20.0),
+        ..ObservedState::default()
+    };
+    assert_eq!(
+        signals_from(&at),
+        vec![Signal::DistillFailureRate { pct: 20.0 }],
+        "exactly at threshold must fire"
+    );
+
+    let high = ObservedState {
+        distill_fail_pct: Some(62.0),
+        ..ObservedState::default()
+    };
+    assert_eq!(
+        signals_from(&high),
+        vec![Signal::DistillFailureRate { pct: 62.0 }],
+        "the observed ~62% case must fire"
+    );
+}
+
+#[test]
+fn restart_churn_fires_at_and_above_threshold_only() {
+    // Threshold is 3.
+    let below = ObservedState {
+        restart_churn: Some(2),
+        ..ObservedState::default()
+    };
+    assert!(signals_from(&below).is_empty());
+
+    let at = ObservedState {
+        restart_churn: Some(3),
+        ..ObservedState::default()
+    };
+    assert_eq!(
+        signals_from(&at),
+        vec![Signal::RestartChurn { restarts: 3 }]
+    );
+}
+
+#[test]
+fn ladder_exhausted_fires_above_zero() {
+    let zero = ObservedState {
+        ladder_exhausted: Some(0),
+        ..ObservedState::default()
+    };
+    assert!(signals_from(&zero).is_empty(), "zero exhaustions is quiet");
+
+    let some = ObservedState {
+        ladder_exhausted: Some(1),
+        ..ObservedState::default()
+    };
+    assert_eq!(
+        signals_from(&some),
+        vec![Signal::LadderExhausted { count: 1 }]
+    );
+}
+
+#[test]
+fn budget_pressure_fires_at_eighty_percent_and_guards_zero_budget() {
+    // Fraction is 0.8 of the daily budget.
+    let below = ObservedState {
+        spent_today_usd: Some(399.0),
+        daily_budget_usd: Some(500.0),
+        ..ObservedState::default()
+    };
+    assert!(signals_from(&below).is_empty(), "79.8% is below the fence");
+
+    let at = ObservedState {
+        spent_today_usd: Some(400.0),
+        daily_budget_usd: Some(500.0),
+        ..ObservedState::default()
+    };
+    assert_eq!(
+        signals_from(&at),
+        vec![Signal::BudgetPressure {
+            spent_usd: 400.0,
+            budget_usd: 500.0
+        }],
+        "80% of budget must fire"
+    );
+
+    // A zero/negative budget must never divide-or-fire (guard against bad config).
+    let zero_budget = ObservedState {
+        spent_today_usd: Some(400.0),
+        daily_budget_usd: Some(0.0),
+        ..ObservedState::default()
+    };
+    assert!(
+        signals_from(&zero_budget).is_empty(),
+        "zero budget cannot fire"
+    );
+
+    // Missing either side → no signal.
+    let missing_budget = ObservedState {
+        spent_today_usd: Some(400.0),
+        daily_budget_usd: None,
+        ..ObservedState::default()
+    };
+    assert!(signals_from(&missing_budget).is_empty());
+}
+
+#[test]
+fn engineer_spawn_fires_at_and_above_threshold_only() {
+    // Threshold is 8.
+    let below = ObservedState {
+        live_engineers: Some(7),
+        ..ObservedState::default()
+    };
+    assert!(signals_from(&below).is_empty());
+
+    let at = ObservedState {
+        live_engineers: Some(8),
+        ..ObservedState::default()
+    };
+    assert_eq!(
+        signals_from(&at),
+        vec![Signal::EngineerSpawnRate { live: 8 }]
+    );
+}
+
+#[test]
+fn gym_skip_fires_when_true() {
+    let skipped = ObservedState {
+        gym_skipped: true,
+        ..ObservedState::default()
+    };
+    assert_eq!(signals_from(&skipped), vec![Signal::GymSkipped]);
+}
+
+#[test]
+fn ci_failures_ready_prs_and_anomalies_fan_out_one_signal_each() {
+    let state = ObservedState {
+        ci_failures: vec![
+            CiFailure {
+                repo: "rysweet/Simard".to_string(),
+                failing: 3,
+            },
+            CiFailure {
+                repo: "rysweet/amplihack".to_string(),
+                failing: 1,
+            },
+        ],
+        ready_prs: vec![PrRef {
+            repo: "rysweet/Simard".to_string(),
+            pr: 42,
+        }],
+        anomalies: vec!["banner pollution".to_string()],
+        ..ObservedState::default()
+    };
+    let sigs = signals_from(&state);
+    assert!(sigs.contains(&Signal::CiFailureCluster {
+        repo: "rysweet/Simard".to_string(),
+        failing: 3
+    }));
+    assert!(sigs.contains(&Signal::CiFailureCluster {
+        repo: "rysweet/amplihack".to_string(),
+        failing: 1
+    }));
+    assert!(sigs.contains(&Signal::PrReadyToMerge {
+        repo: "rysweet/Simard".to_string(),
+        pr: 42
+    }));
+    assert!(sigs.contains(&Signal::Anomaly {
+        detail: "banner pollution".to_string()
+    }));
+    assert_eq!(sigs.len(), 4, "one signal per observed item, no more");
+}
+
+// ─────────────────────────── orient dedup / merge / order ──────────────────
+
+#[test]
+fn orient_raises_one_problem_per_distinct_key_when_nothing_in_flight() {
+    let signals = signals_from(&ObservedState {
+        distill_fail_pct: Some(62.0),
+        gym_skipped: true,
+        ..ObservedState::default()
+    });
+    let problems = orient(&signals, &[]);
+    assert_eq!(
+        problems.len(),
+        2,
+        "two distinct problems, nothing in flight"
+    );
+}
+
+#[test]
+fn orient_dedups_against_matching_in_flight_only() {
+    let signals = vec![Signal::DistillFailureRate { pct: 62.0 }, Signal::GymSkipped];
+    // An engineer already owns the distill problem (same dedup key) — drop it,
+    // keep the gym problem (nobody on it).
+    let in_flight = vec![InFlightItem {
+        id: "g1".to_string(),
+        source: "ooda".to_string(),
+        refs: vec!["process:distill_fail".to_string()],
+    }];
+    let problems = orient(&signals, &in_flight);
+    assert_eq!(problems.len(), 1, "only the un-owned problem survives");
+    assert_eq!(problems[0].dedup_key, "quality:gym_skipped");
+}
+
+#[test]
+fn orient_merges_same_key_signals_into_one_problem() {
+    // Two distill signals collapse to a single problem carrying both as evidence.
+    let signals = vec![
+        Signal::DistillFailureRate { pct: 40.0 },
+        Signal::DistillFailureRate { pct: 62.0 },
+    ];
+    let problems = orient(&signals, &[]);
+    assert_eq!(problems.len(), 1, "same dedup key → one problem");
+    assert_eq!(
+        problems[0].evidence.len(),
+        2,
+        "both signals kept as evidence"
+    );
+    assert_eq!(problems[0].dedup_key, "process:distill_fail");
+}
+
+#[test]
+fn orient_sorts_problems_by_priority_ascending() {
+    // A mix spanning High / Normal / Low priorities.
+    let signals = vec![
+        Signal::GymSkipped,                       // Low
+        Signal::DistillFailureRate { pct: 62.0 }, // High
+        Signal::LadderExhausted { count: 2 },     // Normal
+    ];
+    let problems = orient(&signals, &[]);
+    assert_eq!(problems.len(), 3);
+    // Ord sorts Critical < High < Normal < Low, so the vector is non-decreasing.
+    assert!(
+        problems.windows(2).all(|w| w[0].priority <= w[1].priority),
+        "problems must be ordered most-important first"
+    );
+    assert_eq!(
+        problems[0].priority,
+        Priority::High,
+        "High comes first here"
+    );
+    assert_eq!(problems[2].priority, Priority::Low, "Low comes last");
+}
+
+#[test]
+fn orient_is_empty_when_every_problem_is_in_flight() {
+    let signals = vec![Signal::DistillFailureRate { pct: 62.0 }];
+    let in_flight = vec![InFlightItem {
+        id: "g1".to_string(),
+        source: "ooda".to_string(),
+        refs: vec!["process:distill_fail".to_string()],
+    }];
+    assert!(orient(&signals, &in_flight).is_empty());
+}


### PR DESCRIPTION
## Milestone 1 of the embedded Overseer co-process (#2527)

First shippable milestone of the design in `docs/design/overseer.md`. A **flag-gated (`SIMARD_OVERSEER_ENABLED`, default OFF), read-only** `CognitiveThread` sensor that watches Simard's own health and files deduplicated issues — and **provably takes no write action beyond issue-filing** (no launches, merges, conflict-resolution, deploys, or goal transfers).

### What it does (meta-OODA, read-only)
- **Observe** — `SnapshotStatusReader` wraps `status::assemble` → `StatusSnapshot`; `observed_from_snapshot` projects it onto `ObservedState` (degraded `SectionEnvelope<T>.data == None` → `None`, never a panic).
- **Orient** — `signals_from` → thresholded `Signal`s → `orient` folds them into deduplicated, prioritised `Problem`s, dedup'd against Simard's in-flight goals (`goal_curation::load_goal_board`, read via `ThreadContext.memory`).
- **Report** — renders the snapshot via `status::render::to_terminal` / `status::json::to_string_pretty`.
- **FileIssue** — recurring *defects* become a single **deduplicated** GitHub issue via `stewardship::process_orchestrator_run` + `failure_signature` + `route_failure`; `error_text` is **stable** (no fluctuating metrics) so recurrences fold into one issue. Transient resource pressure / positive delivery states are reported, not filed.

### Operator hard-gates encoded
- **#4 RecursionGuard fails CLOSED** when identity (author/branch/goal-tag) is unconfigured — `admit()` refuses rather than silently disabling anti-recursion.
- **#7 daily budget single-sourced** from `SIMARD_DAILY_BUDGET_USD` (removed the hardcoded `500.0` duplicate in `BudgetGate::default`).
- Observer cadence **clamped to a 60s floor** (no hot loop; forward-compatible with M4 self-tuning).

### Additive + default-off
The sensor registers next to `MaintenanceThread` / `EngineerLogAnalysisThread` **only when the flag is set**; the daemon's default behaviour is unchanged. All edits are confined to `src/overseer/` plus a ~13-line flag-gated registration in the daemon. No `Bridge` naming; orient-decide-act terminology throughout.

### Tests (pure / injected-clock — no sleeps, no network)
57 overseer unit tests: `signals_from` threshold boundaries, `orient` dedup-vs-in-flight / merge / priority order, issue-filer idempotency across cycles (fake `GhClient`), snapshot→`ObservedState` mapping, routable filing (no `StewardshipRoutingAmbiguous`), and the sensor `tick` (in-memory cognitive store): read-only, files exactly one deduped issue, idempotent across ticks, dry-run files nothing.

### Gates
`cargo fmt`, `cargo clippy --release --no-deps -D warnings`, and `cargo clippy --all-targets --all-features --locked -D warnings` all green. No `--no-verify`, no `--admin`.

### Scope / next
- Depends conceptually on the design reconciliation in #2537 (docs only; independent files).
- M2 (autonomous fix-launching + PR verify/merge + `NotifyOperator`), M3 (guarded deploy + goal transfer), M4 (audits + self-tuning) follow as their own PRs. `VerifyAndMergePr` stays opt-in until M1 signals are proven (crusty risk #1).

Exit criteria met: runs behind the flag, emits a report + files deduped issues, provably takes no write action beyond issue-filing.