### PR TITLE
feat(overseer): M2 — fix-launching + PR verify/merge + mandatory NotifyOperator (opt-in) (#2527)

### DIFF
--- a/src/overseer/guardrails.rs
+++ b/src/overseer/guardrails.rs
@@ -11,18 +11,26 @@ use crate::overseer::intervention::Intervention;
 
 /// Risk classification for an intervention. Routine interventions execute
 /// autonomously (per the operator directive "for most operations she should not
-/// need outside-party validation"); HIGH-RISK ones are gated and surface to the
-/// human via `Intervention::Escalate`.
+/// need outside-party validation"); `MergeAuthority` and `HighRisk` ones are
+/// gated and surface to the human via `Intervention::Escalate` unless the
+/// operator has explicitly opted in.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RiskClass {
     Routine,
+    /// PR verify-and-merge. **Opt-in, NOT Routine on day one** (crusty review
+    /// risk #1): autonomous-merge is a closed self-modification loop gated only
+    /// by "CI green", which is the absence of one signal, not judgment. It stays
+    /// human-in-the-loop until M1's signal quality is proven — autonomy is
+    /// earned, not defaulted.
+    MergeAuthority,
     HighRisk,
 }
 
-/// Classify an intervention. HIGH-RISK maps to the five gated operations of the
+/// Classify an intervention. `HighRisk` maps to the gated operations of the
 /// autonomy model (deploy is the Overseer's one self-mutating action; conflict
 /// resolution can involve force-adjacent pushes; escalation is inherently a
-/// hand-off). Everything else is routine.
+/// hand-off). `VerifyAndMergePr` is `MergeAuthority` — deliberately opt-in
+/// rather than Routine (crusty risk #1). Everything else is routine.
 pub fn classify(iv: &Intervention) -> RiskClass {
     match iv {
         // Self-mutating binary swap of the live daemon.
@@ -32,23 +40,34 @@ pub fn classify(iv: &Intervention) -> RiskClass {
         Intervention::ResolveConflict { .. } => RiskClass::HighRisk,
         // Escalation is, by definition, a request for human sign-off.
         Intervention::Escalate { .. } => RiskClass::HighRisk,
+        // Merge authority is opt-in until proven (crusty risk #1).
+        Intervention::VerifyAndMergePr { .. } => RiskClass::MergeAuthority,
         _ => RiskClass::Routine,
     }
 }
 
-/// Admits routine interventions; gates HIGH-RISK ones unless the operator has
-/// explicitly opted in (default `false`). A gated intervention is not executed —
-/// it is turned into an `Escalate` in the plan.
+/// Admits routine interventions; gates `MergeAuthority` and `HighRisk` ones
+/// unless the operator has explicitly opted in (both default `false`). A gated
+/// intervention is not executed — it is turned into an `Escalate` in the plan.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct AutonomyGate {
+    /// Opt into autonomous HIGH-RISK execution (deploy / conflict-resolution).
     pub allow_high_risk: bool,
+    /// Opt into autonomous PR verify-and-merge (crusty risk #1: default `false`
+    /// — the operator must enable it, and only after M1 signals are proven).
+    pub allow_verify_merge: bool,
 }
 
 impl AutonomyGate {
     pub fn admit(&self, iv: &Intervention) -> Result<(), OverseerError> {
         match classify(iv) {
             RiskClass::Routine => Ok(()),
+            RiskClass::MergeAuthority if self.allow_verify_merge => Ok(()),
             RiskClass::HighRisk if self.allow_high_risk => Ok(()),
+            RiskClass::MergeAuthority => Err(OverseerError::Gated {
+                intervention: iv.label().to_string(),
+                risk: "merge-authority",
+            }),
             RiskClass::HighRisk => Err(OverseerError::Gated {
                 intervention: iv.label().to_string(),
                 risk: "high",
@@ -342,5 +361,36 @@ mod tests {
         // (never the removed hardcoded duplicate).
         assert!(BudgetGate::from_env().daily_budget_usd > 0.0);
         assert!(BudgetGate::default().daily_budget_usd > 0.0);
+    }
+
+    // ── crusty risk #1: VerifyAndMergePr is opt-in, not Routine ──────────────
+
+    #[test]
+    fn verify_merge_is_opt_in_not_routine() {
+        let iv = Intervention::VerifyAndMergePr {
+            repo: "rysweet/Simard".to_string(),
+            pr: 1,
+        };
+        assert_eq!(
+            classify(&iv),
+            RiskClass::MergeAuthority,
+            "merge authority is its own opt-in class, never Routine"
+        );
+        // The default gate REFUSES it — autonomy is earned, not defaulted.
+        assert!(AutonomyGate::default().admit(&iv).is_err());
+        // Opt-in admits merge WITHOUT enabling high-risk deploy…
+        let gate = AutonomyGate {
+            allow_verify_merge: true,
+            allow_high_risk: false,
+        };
+        assert!(gate.admit(&iv).is_ok());
+        // …and enabling merge must NOT enable deploy/conflict-resolution.
+        assert!(
+            gate.admit(&Intervention::Deploy {
+                commit: "abc".to_string()
+            })
+            .is_err(),
+            "merge opt-in must not leak into HIGH-RISK deploy authority"
+        );
     }
 }

--- a/src/overseer/launch.rs
+++ b/src/overseer/launch.rs
@@ -1,0 +1,295 @@
+//! M2 — the [`RecipeLauncher`] adapter: launch a `smart-orchestrator`
+//! workstream and poll it to its PR. The Overseer's core "drive a fix OUTSIDE
+//! Simard's loop" action.
+//!
+//! Reuse (design doc §capability table): the exact `amplihack recipe run
+//! amplifier-bundle/recipes/smart-orchestrator.yaml -c task_description=…`
+//! invocation engineers use (`src/bin/simard_engineer_loop_recipe.rs:51`), with
+//! `AMPLIHACK_AGENT_BINARY` preserved (`src/stewardship/recipe_merge_judge.rs:191`);
+//! recipe output is parsed with the shipped noise-stripping in
+//! `crate::recipe_output`.
+//!
+//! Concurrency is bounded by the Overseer's own per-cycle launch cap and budget
+//! gate (see [`Overseer::gate`](crate::overseer::Overseer)); the launcher never
+//! raises real parallelism beyond those ceilings.
+//!
+//! The subprocess/probe mechanics are behind an injectable [`RecipeRunner`] seam
+//! so the whole launch→PR flow is unit-testable with a fake (no subprocess, no
+//! network), matching the roadmap's "fake recipe runner" integration strategy.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crate::overseer::capabilities::{
+    OverseerError, RecipeBrief, RecipeLauncher, WorkstreamHandle, WorkstreamStatus,
+};
+
+/// The recipe every Overseer fix-launch runs (`smart-orchestrator` →
+/// `default-workflow`), matching the operator's manual workstreams.
+pub const SMART_ORCHESTRATOR_RECIPE: &str = "amplifier-bundle/recipes/smart-orchestrator.yaml";
+
+/// Build the `amplihack recipe run …` argument vector for a brief. Pure and
+/// unit-tested so the invocation contract is pinned without spawning anything.
+pub fn smart_orchestrator_args(brief: &RecipeBrief) -> Vec<String> {
+    vec![
+        "recipe".to_string(),
+        "run".to_string(),
+        SMART_ORCHESTRATOR_RECIPE.to_string(),
+        "-c".to_string(),
+        format!("task_description={}", brief.task_description),
+        "-c".to_string(),
+        format!("target_repo={}", brief.target_repo),
+    ]
+}
+
+/// Extract the first `owner/repo` + PR number from recipe output. Recognises a
+/// `https://github.com/<owner>/<repo>/pull/<n>` URL after the shipped
+/// noise-stripping. Pure + unit-tested.
+pub fn extract_pr_ref(output: &str) -> Option<(String, u32)> {
+    let cleaned = crate::recipe_output::strip_ansi(output);
+    for token in cleaned.split(|c: char| c.is_whitespace() || c == '"' || c == '\'' || c == ')') {
+        if let Some(rest) = token.split("github.com/").nth(1) {
+            // rest = owner/repo/pull/<n>[...]
+            let mut parts = rest.split('/');
+            let owner = parts.next()?;
+            let repo = parts.next()?;
+            let kw = parts.next()?;
+            if kw != "pull" && kw != "issues" {
+                continue;
+            }
+            let num: String = parts
+                .next()
+                .unwrap_or_default()
+                .chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect();
+            if kw == "pull"
+                && !owner.is_empty()
+                && !repo.is_empty()
+                && let Ok(pr) = num.parse::<u32>()
+            {
+                return Some((format!("{owner}/{repo}"), pr));
+            }
+        }
+    }
+    None
+}
+
+// ─────────────────────────── runner seam ───────────────────────────────────
+
+/// Spawns and probes a recipe workstream. Injectable so the launch→PR flow is
+/// testable with a fake; production uses [`AmplihackRecipeRunner`].
+pub trait RecipeRunner {
+    fn spawn(&self, brief: &RecipeBrief) -> Result<WorkstreamHandle, OverseerError>;
+    fn probe(&self, handle: &WorkstreamHandle) -> Result<WorkstreamStatus, OverseerError>;
+}
+
+/// The [`RecipeLauncher`] over a [`RecipeRunner`] seam.
+pub struct SmartOrchestratorLauncher {
+    runner: Box<dyn RecipeRunner>,
+}
+
+impl SmartOrchestratorLauncher {
+    pub fn new(runner: Box<dyn RecipeRunner>) -> Self {
+        Self { runner }
+    }
+
+    /// Production launcher: a real `amplihack recipe run` spawner.
+    pub fn from_env() -> Self {
+        Self::new(Box::new(AmplihackRecipeRunner::default()))
+    }
+}
+
+impl RecipeLauncher for SmartOrchestratorLauncher {
+    fn launch(&self, brief: &RecipeBrief) -> Result<WorkstreamHandle, OverseerError> {
+        self.runner.spawn(brief)
+    }
+
+    fn poll(&self, handle: &WorkstreamHandle) -> Result<WorkstreamStatus, OverseerError> {
+        self.runner.probe(handle)
+    }
+}
+
+// ─────────────────────────── real runner ───────────────────────────────────
+
+struct RunEntry {
+    child: std::process::Child,
+    log_path: std::path::PathBuf,
+}
+
+/// Real runner: spawns `amplihack recipe run smart-orchestrator …`, capturing
+/// output to a temp log so [`probe`](RecipeRunner::probe) can read the resulting
+/// PR once the run finishes. `AMPLIHACK_AGENT_BINARY` is preserved from the
+/// caller's environment (Copilot/Claude parity).
+#[derive(Default)]
+pub struct AmplihackRecipeRunner {
+    runs: Mutex<HashMap<String, RunEntry>>,
+}
+
+impl RecipeRunner for AmplihackRecipeRunner {
+    fn spawn(&self, brief: &RecipeBrief) -> Result<WorkstreamHandle, OverseerError> {
+        use std::process::{Command, Stdio};
+
+        let log_path = std::env::temp_dir().join(format!(
+            "overseer-recipe-{}.log",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        let log = std::fs::File::create(&log_path).map_err(|e| OverseerError::Capability {
+            what: "recipe.spawn",
+            detail: format!("create log {}: {e}", log_path.display()),
+        })?;
+        let log_err = log.try_clone().map_err(|e| OverseerError::Capability {
+            what: "recipe.spawn",
+            detail: e.to_string(),
+        })?;
+
+        let mut cmd = Command::new("amplihack");
+        cmd.args(smart_orchestrator_args(brief))
+            .stdout(Stdio::from(log))
+            .stderr(Stdio::from(log_err));
+        // Preserve AMPLIHACK_AGENT_BINARY if the caller set it (Copilot/Claude
+        // parity) — inherited automatically; we do not override it.
+
+        let child = cmd.spawn().map_err(|e| OverseerError::Capability {
+            what: "recipe.spawn",
+            detail: format!("spawn amplihack: {e}"),
+        })?;
+        let id = format!("recipe-{}", child.id());
+        self.runs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(id.clone(), RunEntry { child, log_path });
+        Ok(WorkstreamHandle { id })
+    }
+
+    fn probe(&self, handle: &WorkstreamHandle) -> Result<WorkstreamStatus, OverseerError> {
+        let mut runs = self
+            .runs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let entry = runs.get_mut(&handle.id).ok_or(OverseerError::Capability {
+            what: "recipe.probe",
+            detail: format!("unknown workstream {}", handle.id),
+        })?;
+
+        match entry.child.try_wait() {
+            Ok(None) => Ok(WorkstreamStatus::Running),
+            Ok(Some(status)) => {
+                let output = std::fs::read_to_string(&entry.log_path).unwrap_or_default();
+                if let Some((repo, pr)) = extract_pr_ref(&output) {
+                    Ok(WorkstreamStatus::ProducedPr { repo, pr })
+                } else if status.success() {
+                    Ok(WorkstreamStatus::Failed {
+                        reason: "recipe finished but produced no PR".to_string(),
+                    })
+                } else {
+                    Ok(WorkstreamStatus::Failed {
+                        reason: format!("recipe exited with {status}"),
+                    })
+                }
+            }
+            Err(e) => Err(OverseerError::Capability {
+                what: "recipe.probe",
+                detail: e.to_string(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[test]
+    fn args_carry_recipe_and_task_description() {
+        let brief = RecipeBrief {
+            task_description: "fix distillation banner pollution".to_string(),
+            target_repo: "rysweet/Simard".to_string(),
+            sequence_group: None,
+        };
+        let args = smart_orchestrator_args(&brief);
+        assert_eq!(args[0], "recipe");
+        assert_eq!(args[1], "run");
+        assert!(args.iter().any(|a| a == SMART_ORCHESTRATOR_RECIPE));
+        assert!(
+            args.iter()
+                .any(|a| a == "task_description=fix distillation banner pollution")
+        );
+        assert!(args.iter().any(|a| a == "target_repo=rysweet/Simard"));
+    }
+
+    #[test]
+    fn extract_pr_ref_finds_github_pull_url() {
+        let out = "…work done…\nOpened https://github.com/rysweet/Simard/pull/2601 for review\n";
+        assert_eq!(
+            extract_pr_ref(out),
+            Some(("rysweet/Simard".to_string(), 2601))
+        );
+    }
+
+    #[test]
+    fn extract_pr_ref_ignores_issue_urls_and_noise() {
+        assert_eq!(
+            extract_pr_ref("see https://github.com/rysweet/Simard/issues/9 only"),
+            None
+        );
+        assert_eq!(extract_pr_ref("no url here"), None);
+    }
+
+    #[test]
+    fn extract_pr_ref_handles_trailing_punctuation() {
+        let out = "PR: (https://github.com/rysweet/amplihack/pull/42).";
+        assert_eq!(
+            extract_pr_ref(out),
+            Some(("rysweet/amplihack".to_string(), 42))
+        );
+    }
+
+    // ── launcher over a fake runner (no subprocess) ──────────────────────────
+
+    struct FakeRunner {
+        launched: Mutex<Vec<RecipeBrief>>,
+        status: WorkstreamStatus,
+    }
+    impl RecipeRunner for FakeRunner {
+        fn spawn(&self, brief: &RecipeBrief) -> Result<WorkstreamHandle, OverseerError> {
+            self.launched.lock().unwrap().push(brief.clone());
+            Ok(WorkstreamHandle {
+                id: "ws-1".to_string(),
+            })
+        }
+        fn probe(&self, _h: &WorkstreamHandle) -> Result<WorkstreamStatus, OverseerError> {
+            Ok(self.status.clone())
+        }
+    }
+
+    #[test]
+    fn launcher_spawns_and_polls_through_the_seam() {
+        let runner = FakeRunner {
+            launched: Mutex::new(vec![]),
+            status: WorkstreamStatus::ProducedPr {
+                repo: "rysweet/Simard".to_string(),
+                pr: 2601,
+            },
+        };
+        let launcher = SmartOrchestratorLauncher::new(Box::new(runner));
+        let brief = RecipeBrief {
+            task_description: "fix restart churn".to_string(),
+            target_repo: "rysweet/Simard".to_string(),
+            sequence_group: None,
+        };
+        let handle = launcher.launch(&brief).unwrap();
+        assert_eq!(handle.id, "ws-1");
+        assert_eq!(
+            launcher.poll(&handle).unwrap(),
+            WorkstreamStatus::ProducedPr {
+                repo: "rysweet/Simard".to_string(),
+                pr: 2601,
+            }
+        );
+    }
+}

--- a/src/overseer/merge_ops.rs
+++ b/src/overseer/merge_ops.rs
@@ -1,0 +1,768 @@
+//! M2 — the real [`PrOps`] adapter: verify a PR against the full pr-verify
+//! checklist, **poll required checks until green** (never `--admin`), merge
+//! through the shipped gated authority, and fire the mandatory
+//! [`NotifyOperator`](crate::overseer::notify) on merge.
+//!
+//! Reuse (design doc §capability table / grounding ledger):
+//! - Objective gates (CI-green / mergeable / base-allowlist):
+//!   `stewardship::merge_authority::evaluate_objective_gates`.
+//! - Merge itself: `merge_pr_if_merge_ready_with_judge` → `gh pr merge --squash`
+//!   (**no `--admin`, no `--no-verify`** — verified in the grounding ledger).
+//! - Review gate (#7): `review_pipeline::should_commit`.
+//! - New diff-scans (#3–6): [`pr_verify`](crate::overseer::pr_verify).
+//!
+//! Operator hard-gates encoded:
+//! - **#2 poll until required checks pass; never `--admin`.** [`poll_until_green`]
+//!   refuses (escalates) on any failed/red check and only proceeds when every
+//!   check is SUCCESS/NEUTRAL/SKIPPED and the PR is MERGEABLE.
+//! - **#3 every merge notifies via BOTH email and Signal.** [`MergePrOps::merge`]
+//!   fires [`DualChannelNotifier`] after a successful merge; the merge is not
+//!   considered complete without a dispatched [`NotifyReport`].
+//!
+//! [`poll_until_green`]: MergePrOps::poll_until_green
+//! [`NotifyReport`]: crate::overseer::notify::NotifyReport
+
+use crate::review_pipeline::{ReviewFinding, should_commit};
+use crate::stewardship::{
+    MergeJudge, MergeOutcome, PrGhClient, base_allowlist_from_env, build_merge_judge,
+    evaluate_objective_gates, merge_pr_if_merge_ready_with_judge,
+};
+
+use crate::overseer::capabilities::{CheckItem, OverseerError, PrOps, VerifyReport};
+use crate::overseer::notify::{DualChannelNotifier, MergeNotification};
+use crate::overseer::pr_verify::run_diff_scans;
+
+// ─────────────────────────── injected seams ────────────────────────────────
+
+/// Source of a PR's unified diff + title. `PrGhClient` (the shipped trait) has
+/// no diff/title reader, so this adds one — the real impl shells `gh pr diff` /
+/// `gh pr view --json title`; tests inject canned values (no network).
+pub trait PrSource {
+    fn diff(&self, repo: &str, pr: u32) -> Result<String, OverseerError>;
+    fn title(&self, repo: &str, pr: u32) -> Result<String, OverseerError>;
+}
+
+/// The review gate (#7). Injected so tests exercise `should_commit` without an
+/// LLM. Production wires an LLM-backed reviewer; absent one, verify treats the
+/// review as **unavailable → not ready** (fail-closed), so the Overseer never
+/// merges unreviewed.
+pub trait DiffReviewer {
+    fn review(&self, diff: &str) -> Result<Vec<ReviewFinding>, OverseerError>;
+}
+
+/// Injected clock so the poll loop has **no real sleeps in tests**. Production
+/// sleeps; tests count calls.
+pub trait PollClock {
+    fn sleep(&self, secs: u64);
+}
+
+/// Real wall-clock sleep.
+#[derive(Clone, Debug, Default)]
+pub struct ThreadSleepClock;
+impl PollClock for ThreadSleepClock {
+    fn sleep(&self, secs: u64) {
+        std::thread::sleep(std::time::Duration::from_secs(secs));
+    }
+}
+
+/// Poll bounds. Conservative by default so a stuck PR escalates rather than
+/// spinning.
+#[derive(Clone, Copy, Debug)]
+pub struct PollConfig {
+    pub max_attempts: u32,
+    pub interval_secs: u64,
+}
+
+impl Default for PollConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: 20,
+            interval_secs: 30,
+        }
+    }
+}
+
+/// Real `gh`-backed [`PrSource`].
+#[derive(Clone, Debug, Default)]
+pub struct RealPrSource;
+
+impl PrSource for RealPrSource {
+    fn diff(&self, repo: &str, pr: u32) -> Result<String, OverseerError> {
+        run_gh(&["pr", "diff", &pr.to_string(), "--repo", repo])
+    }
+
+    fn title(&self, repo: &str, pr: u32) -> Result<String, OverseerError> {
+        run_gh(&[
+            "pr",
+            "view",
+            &pr.to_string(),
+            "--repo",
+            repo,
+            "--json",
+            "title",
+            "--jq",
+            ".title",
+        ])
+        .map(|s| s.trim().to_string())
+    }
+}
+
+fn run_gh(args: &[&str]) -> Result<String, OverseerError> {
+    let out = std::process::Command::new("gh")
+        .args(args)
+        .output()
+        .map_err(|e| OverseerError::Capability {
+            what: "gh",
+            detail: e.to_string(),
+        })?;
+    if !out.status.success() {
+        return Err(OverseerError::Capability {
+            what: "gh",
+            detail: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+// ─────────────────────────── the adapter ───────────────────────────────────
+
+/// The real [`PrOps`]. Holds injected capabilities so the whole verify/merge
+/// path is unit-testable with fakes and zero network.
+pub struct MergePrOps {
+    gh: Box<dyn PrGhClient>,
+    source: Box<dyn PrSource>,
+    reviewer: Option<Box<dyn DiffReviewer>>,
+    judge: Box<dyn MergeJudge>,
+    notifier: DualChannelNotifier,
+    clock: Box<dyn PollClock>,
+    base_allowlist: Vec<String>,
+    poll: PollConfig,
+}
+
+impl MergePrOps {
+    /// Fully-injected constructor (tests).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        gh: Box<dyn PrGhClient>,
+        source: Box<dyn PrSource>,
+        reviewer: Option<Box<dyn DiffReviewer>>,
+        judge: Box<dyn MergeJudge>,
+        notifier: DualChannelNotifier,
+        clock: Box<dyn PollClock>,
+        base_allowlist: Vec<String>,
+        poll: PollConfig,
+    ) -> Self {
+        Self {
+            gh,
+            source,
+            reviewer,
+            judge,
+            notifier,
+            clock,
+            base_allowlist,
+            poll,
+        }
+    }
+
+    /// Production adapter: real `gh` client + diff source, the env merge-judge,
+    /// env base-allowlist, the env-wired dual notifier, real sleep. The review
+    /// gate is left **unwired** (fail-closed) until the operator provides an
+    /// LLM reviewer — so the default autonomous path verifies as NOT ready.
+    pub fn from_env() -> Self {
+        Self::new(
+            Box::new(crate::stewardship::RealPrGhClient),
+            Box::new(RealPrSource),
+            None,
+            build_merge_judge(),
+            DualChannelNotifier::from_env(),
+            Box::new(ThreadSleepClock),
+            base_allowlist_from_env(),
+            PollConfig::default(),
+        )
+    }
+
+    /// Classify each check and poll while any is pending; escalate (Err) on the
+    /// first failed check or a non-mergeable state; succeed only when every
+    /// check passes and the PR is MERGEABLE. **Never merges here** — this only
+    /// establishes green. No `--admin`, no sleep in tests (injected clock).
+    fn poll_until_green(&self, repo: &str, pr: u32) -> Result<(), OverseerError> {
+        for attempt in 0..=self.poll.max_attempts {
+            let snap = self
+                .gh
+                .view_pr(repo, pr)
+                .map_err(|e| cap("poll.view_pr", e.to_string()))?;
+
+            if !self.base_allowlist.iter().any(|b| b == &snap.base_ref_name) {
+                return Err(cap(
+                    "poll",
+                    format!("base branch '{}' not in allow-list", snap.base_ref_name),
+                ));
+            }
+
+            let mut any_pending = false;
+            for c in &snap.checks {
+                match classify_state(&c.state) {
+                    CheckClass::Failed => {
+                        return Err(cap(
+                            "poll",
+                            format!(
+                                "check '{}' is '{}' — escalating, not merging",
+                                c.name, c.state
+                            ),
+                        ));
+                    }
+                    CheckClass::Pending => any_pending = true,
+                    CheckClass::Passing => {}
+                }
+            }
+
+            if !any_pending {
+                if snap.mergeable == "MERGEABLE" {
+                    return Ok(());
+                }
+                return Err(cap(
+                    "poll",
+                    format!("PR not mergeable (status '{}')", snap.mergeable),
+                ));
+            }
+
+            // Still pending — wait (unless this was the final attempt).
+            if attempt < self.poll.max_attempts {
+                self.clock.sleep(self.poll.interval_secs);
+            }
+        }
+        Err(cap(
+            "poll",
+            "required checks still pending after max attempts — escalating".to_string(),
+        ))
+    }
+
+    /// Build the operator notification from the merged PR.
+    fn notification(&self, repo: &str, pr: u32, title: &str) -> MergeNotification {
+        MergeNotification {
+            problem: format!(
+                "A merge-ready PR passed the objective gates (CI green + mergeable + \
+                 base allow-list) and the Overseer pr-verify safety scans, and was merged: {title}"
+            ),
+            pr_title: title.to_string(),
+            pr_url: format!("https://github.com/{repo}/pull/{pr}"),
+            repo: repo.to_string(),
+            autonomous: true,
+        }
+    }
+}
+
+impl PrOps for MergePrOps {
+    /// Run the full pr-verify checklist: objective gates (#1–2), the four
+    /// additive diff-scans (#3–6), and the review gate (#7). `ready` iff all pass.
+    fn verify(&self, repo: &str, pr: u32) -> Result<VerifyReport, OverseerError> {
+        let mut checks = Vec::new();
+
+        // #1–2 objective gates.
+        let snap = self
+            .gh
+            .view_pr(repo, pr)
+            .map_err(|e| cap("verify.view_pr", e.to_string()))?;
+        checks.push(
+            match evaluate_objective_gates(&snap, &self.base_allowlist) {
+                Ok(()) => CheckItem {
+                    name: "objective gates (CI green + mergeable + base allow-list)".to_string(),
+                    passed: true,
+                    note: "ok".to_string(),
+                },
+                Err(reason) => CheckItem {
+                    name: "objective gates (CI green + mergeable + base allow-list)".to_string(),
+                    passed: false,
+                    note: reason,
+                },
+            },
+        );
+
+        // #3–6 additive diff-scans.
+        let diff = self.source.diff(repo, pr)?;
+        checks.extend(run_diff_scans(&diff));
+
+        // #7 review gate (fail-closed when unwired).
+        checks.push(match &self.reviewer {
+            Some(r) => {
+                let findings = r.review(&diff)?;
+                if should_commit(&findings) {
+                    CheckItem {
+                        name: "review (no Bug/Security >= High)".to_string(),
+                        passed: true,
+                        note: format!("{} finding(s), none blocking", findings.len()),
+                    }
+                } else {
+                    CheckItem {
+                        name: "review (no Bug/Security >= High)".to_string(),
+                        passed: false,
+                        note: "a Bug/Security finding of High+ severity blocks merge".to_string(),
+                    }
+                }
+            }
+            None => CheckItem {
+                name: "review (no Bug/Security >= High)".to_string(),
+                passed: false,
+                note: "review unavailable (no reviewer wired) — fail-closed".to_string(),
+            },
+        });
+
+        let ready = checks.iter().all(|c| c.passed);
+        Ok(VerifyReport { ready, checks })
+    }
+
+    /// Verify → poll-until-green → merge (no `--admin`) → **notify operator**.
+    /// If verify is not ready or a check fails, it escalates (Err) and never
+    /// merges. On a successful merge it fires the dual-channel notification; the
+    /// merge is not complete until that notification has dispatched.
+    fn merge(&self, repo: &str, pr: u32) -> Result<(), OverseerError> {
+        // 1. Full checklist must pass.
+        let report = self.verify(repo, pr)?;
+        if !report.ready {
+            let failed: Vec<&str> = report
+                .checks
+                .iter()
+                .filter(|c| !c.passed)
+                .map(|c| c.name.as_str())
+                .collect();
+            return Err(cap(
+                "merge.verify",
+                format!("pr-verify not satisfied; failing: {}", failed.join(", ")),
+            ));
+        }
+
+        // 2. Poll required checks until green (escalate on red/timeout).
+        self.poll_until_green(repo, pr)?;
+
+        // 3. Merge through the shipped gated authority (squash, no --admin).
+        let outcome = merge_pr_if_merge_ready_with_judge(
+            pr,
+            repo,
+            self.gh.as_ref(),
+            &self.base_allowlist,
+            self.judge.as_ref(),
+        )
+        .map_err(|e| cap("merge", e.to_string()))?;
+
+        match outcome {
+            MergeOutcome::Merged { .. } => {
+                // 4. MANDATORY: notify the operator on BOTH channels. The merge
+                //    is not "done" until this dispatches (queued counts — never
+                //    silently dropped).
+                let title = self
+                    .source
+                    .title(repo, pr)
+                    .unwrap_or_else(|_| format!("PR #{pr}"));
+                let notification = self.notification(repo, pr, &title);
+                let nreport = self.notifier.notify(&notification);
+                debug_assert!(
+                    nreport.dispatched(),
+                    "merge completed without a dispatched operator notification"
+                );
+                Ok(())
+            }
+            MergeOutcome::Refused { reason, .. } => Err(cap("merge", reason)),
+        }
+    }
+
+    /// HIGH-RISK conflict resolution. Deliberately **not** implemented in M2 and
+    /// **never** uses `--no-verify`. Wired in M3 under `git_guardrails`.
+    fn resolve_conflict(&self, _repo: &str, _pr: u32) -> Result<(), OverseerError> {
+        Err(OverseerError::Capability {
+            what: "resolve_conflict",
+            detail: "HIGH-RISK conflict resolution is wired in M3 (never --no-verify)".to_string(),
+        })
+    }
+}
+
+fn cap(what: &'static str, detail: String) -> OverseerError {
+    OverseerError::Capability { what, detail }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CheckClass {
+    Passing,
+    Pending,
+    Failed,
+}
+
+/// Classify a `statusCheckRollup` state. Unknown/failure-ish states are treated
+/// as **Failed** (fail-closed) so the Overseer escalates rather than merging on
+/// an unrecognised state.
+fn classify_state(state: &str) -> CheckClass {
+    match state {
+        "SUCCESS" | "NEUTRAL" | "SKIPPED" => CheckClass::Passing,
+        "PENDING" | "QUEUED" | "IN_PROGRESS" | "WAITING" | "REQUESTED" | "EXPECTED" => {
+            CheckClass::Pending
+        }
+        _ => CheckClass::Failed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::overseer::notify::{ChannelDelivery, MergeNotification, NotifyChannel};
+    use crate::stewardship::merge_authority::CheckRollupEntry;
+    use crate::stewardship::{JudgeOutcome, MergeJudgeKind, PrSnapshot, Verdict};
+    use std::sync::{Arc, Mutex};
+
+    // ── fakes ────────────────────────────────────────────────────────────────
+
+    /// A `PrGhClient` that serves a scripted sequence of snapshots (one per
+    /// `view_pr`) and records `squash_merge` calls. No network, no `--admin`
+    /// (the trait has no admin method — the no-admin guarantee is structural).
+    struct ScriptedGh {
+        snapshots: Mutex<Vec<PrSnapshot>>,
+        views: Mutex<usize>,
+        merges: Mutex<usize>,
+    }
+    impl ScriptedGh {
+        fn new(seq: Vec<PrSnapshot>) -> Arc<Self> {
+            Arc::new(Self {
+                snapshots: Mutex::new(seq),
+                views: Mutex::new(0),
+                merges: Mutex::new(0),
+            })
+        }
+        fn merges(&self) -> usize {
+            *self.merges.lock().unwrap()
+        }
+    }
+    impl PrGhClient for Arc<ScriptedGh> {
+        fn view_pr(&self, _repo: &str, _pr: u32) -> crate::error::SimardResult<PrSnapshot> {
+            let mut n = self.views.lock().unwrap();
+            let seq = self.snapshots.lock().unwrap();
+            let idx = (*n).min(seq.len() - 1);
+            *n += 1;
+            Ok(seq[idx].clone())
+        }
+        fn squash_merge(&self, _repo: &str, _pr: u32) -> crate::error::SimardResult<()> {
+            *self.merges.lock().unwrap() += 1;
+            Ok(())
+        }
+    }
+
+    struct FakeSource {
+        diff: String,
+    }
+    impl PrSource for FakeSource {
+        fn diff(&self, _repo: &str, _pr: u32) -> Result<String, OverseerError> {
+            Ok(self.diff.clone())
+        }
+        fn title(&self, _repo: &str, _pr: u32) -> Result<String, OverseerError> {
+            Ok("fix(distill): strip launch-banner noise".to_string())
+        }
+    }
+
+    struct FakeReviewer(Vec<ReviewFinding>);
+    impl DiffReviewer for FakeReviewer {
+        fn review(&self, _diff: &str) -> Result<Vec<ReviewFinding>, OverseerError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    struct ReadyJudge;
+    impl MergeJudge for ReadyJudge {
+        fn judge(
+            &self,
+            _pr: u32,
+            _repo: &str,
+            _snap: &PrSnapshot,
+        ) -> crate::error::SimardResult<JudgeOutcome> {
+            Ok(JudgeOutcome {
+                verdict: Verdict::Ready,
+                rationale: "stub: ready".to_string(),
+                blockers: vec![],
+            })
+        }
+        fn kind(&self) -> MergeJudgeKind {
+            MergeJudgeKind::Llm
+        }
+    }
+
+    /// Counts sleeps instead of sleeping (no real sleep in tests).
+    #[derive(Default)]
+    struct CountingClock {
+        sleeps: Mutex<usize>,
+    }
+    impl PollClock for Arc<CountingClock> {
+        fn sleep(&self, _secs: u64) {
+            *self.sleeps.lock().unwrap() += 1;
+        }
+    }
+
+    /// Records every notification it is handed.
+    struct CapturingChannel {
+        name: String,
+        seen: Arc<Mutex<Vec<MergeNotification>>>,
+    }
+    impl NotifyChannel for CapturingChannel {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn deliver(&self, n: &MergeNotification) -> ChannelDelivery {
+            self.seen.lock().unwrap().push(n.clone());
+            ChannelDelivery::Sent
+        }
+    }
+
+    fn check(name: &str, state: &str) -> CheckRollupEntry {
+        CheckRollupEntry {
+            name: name.to_string(),
+            state: state.to_string(),
+        }
+    }
+
+    fn snapshot(mergeable: &str, checks: Vec<CheckRollupEntry>) -> PrSnapshot {
+        PrSnapshot {
+            body: "body".to_string(),
+            mergeable: mergeable.to_string(),
+            review_decision: "APPROVED".to_string(),
+            checks,
+            base_ref_name: "main".to_string(),
+        }
+    }
+
+    fn green() -> PrSnapshot {
+        snapshot(
+            "MERGEABLE",
+            vec![check("build", "SUCCESS"), check("clippy", "SUCCESS")],
+        )
+    }
+
+    const CLEAN_DIFF: &str = "\
++++ b/src/overseer/x.rs
+@@ -0,0 +1,2 @@
++pub fn reasoner() {}
++// orient-decide-act
+";
+
+    /// Build an adapter with capturing notify channels; returns the shared
+    /// capture buffers for email + signal.
+    #[allow(clippy::type_complexity)]
+    fn adapter_with(
+        gh: Arc<ScriptedGh>,
+        diff: &str,
+        reviewer: Option<Box<dyn DiffReviewer>>,
+        clock: Arc<CountingClock>,
+        poll: PollConfig,
+    ) -> (
+        MergePrOps,
+        Arc<Mutex<Vec<MergeNotification>>>,
+        Arc<Mutex<Vec<MergeNotification>>>,
+    ) {
+        let email_seen = Arc::new(Mutex::new(vec![]));
+        let signal_seen = Arc::new(Mutex::new(vec![]));
+        let notifier = DualChannelNotifier::new(vec![
+            Box::new(CapturingChannel {
+                name: "email".to_string(),
+                seen: email_seen.clone(),
+            }),
+            Box::new(CapturingChannel {
+                name: "signal".to_string(),
+                seen: signal_seen.clone(),
+            }),
+        ]);
+        let ops = MergePrOps::new(
+            Box::new(gh),
+            Box::new(FakeSource {
+                diff: diff.to_string(),
+            }),
+            reviewer,
+            Box::new(ReadyJudge),
+            notifier,
+            Box::new(clock),
+            vec!["main".to_string()],
+            poll,
+        );
+        (ops, email_seen, signal_seen)
+    }
+
+    // ── verify ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn verify_ready_on_clean_green_pr() {
+        let gh = ScriptedGh::new(vec![green()]);
+        let (ops, _, _) = adapter_with(
+            gh,
+            CLEAN_DIFF,
+            Some(Box::new(FakeReviewer(vec![]))),
+            Arc::new(CountingClock::default()),
+            PollConfig::default(),
+        );
+        let report = ops.verify("rysweet/Simard", 1).unwrap();
+        assert!(report.ready, "clean green PR verifies ready: {report:?}");
+    }
+
+    #[test]
+    fn verify_not_ready_on_dirty_diff() {
+        let gh = ScriptedGh::new(vec![green()]);
+        let dirty = "\
++++ b/src/x.rs
+@@ -0,0 +1,2 @@
++struct HttpBridge;
++    println!(\"noise\");
+";
+        let (ops, _, _) = adapter_with(
+            gh,
+            dirty,
+            Some(Box::new(FakeReviewer(vec![]))),
+            Arc::new(CountingClock::default()),
+            PollConfig::default(),
+        );
+        let report = ops.verify("rysweet/Simard", 1).unwrap();
+        assert!(!report.ready, "Bridge + println diff must fail verify");
+    }
+
+    #[test]
+    fn verify_not_ready_when_ci_red() {
+        let red = snapshot("MERGEABLE", vec![check("build", "FAILURE")]);
+        let gh = ScriptedGh::new(vec![red]);
+        let (ops, _, _) = adapter_with(
+            gh,
+            CLEAN_DIFF,
+            Some(Box::new(FakeReviewer(vec![]))),
+            Arc::new(CountingClock::default()),
+            PollConfig::default(),
+        );
+        assert!(!ops.verify("rysweet/Simard", 1).unwrap().ready);
+    }
+
+    #[test]
+    fn verify_review_gate_blocks_high_severity_finding() {
+        use crate::review_pipeline::{FindingCategory, ReviewFinding, Severity};
+        let finding = ReviewFinding {
+            category: FindingCategory::Security,
+            severity: Severity::High,
+            description: "hardcoded secret".to_string(),
+            file_path: "src/x.rs".to_string(),
+            line_range: None,
+        };
+        let gh = ScriptedGh::new(vec![green()]);
+        let (ops, _, _) = adapter_with(
+            gh,
+            CLEAN_DIFF,
+            Some(Box::new(FakeReviewer(vec![finding]))),
+            Arc::new(CountingClock::default()),
+            PollConfig::default(),
+        );
+        assert!(
+            !ops.verify("rysweet/Simard", 1).unwrap().ready,
+            "a High Security finding must block"
+        );
+    }
+
+    #[test]
+    fn verify_fail_closed_without_reviewer() {
+        let gh = ScriptedGh::new(vec![green()]);
+        let (ops, _, _) = adapter_with(
+            gh,
+            CLEAN_DIFF,
+            None,
+            Arc::new(CountingClock::default()),
+            PollConfig::default(),
+        );
+        assert!(
+            !ops.verify("rysweet/Simard", 1).unwrap().ready,
+            "no reviewer wired → review unavailable → not ready (fail-closed)"
+        );
+    }
+
+    // ── merge: green-only, no-admin, notify fires ────────────────────────────
+
+    #[test]
+    fn merge_when_green_merges_once_and_notifies_both_channels() {
+        let gh = ScriptedGh::new(vec![green()]);
+        let (ops, email, signal) = adapter_with(
+            gh.clone(),
+            CLEAN_DIFF,
+            Some(Box::new(FakeReviewer(vec![]))),
+            Arc::new(CountingClock::default()),
+            PollConfig::default(),
+        );
+        ops.merge("rysweet/Simard", 7)
+            .expect("merge should succeed");
+        assert_eq!(gh.merges(), 1, "exactly one squash-merge (no --admin path)");
+        assert_eq!(email.lock().unwrap().len(), 1, "email notified");
+        assert_eq!(signal.lock().unwrap().len(), 1, "signal notified");
+        // The notification carries the problem + PR title + link.
+        let n = &email.lock().unwrap()[0];
+        assert!(n.pr_url.contains("/pull/7"));
+        assert!(n.autonomous);
+        assert!(n.problem.contains("merge-ready"));
+    }
+
+    #[test]
+    fn merge_refuses_and_never_merges_when_ci_red() {
+        let red = snapshot("MERGEABLE", vec![check("build", "FAILURE")]);
+        let gh = ScriptedGh::new(vec![red]);
+        let (ops, email, signal) = adapter_with(
+            gh.clone(),
+            CLEAN_DIFF,
+            Some(Box::new(FakeReviewer(vec![]))),
+            Arc::new(CountingClock::default()),
+            PollConfig::default(),
+        );
+        assert!(
+            ops.merge("rysweet/Simard", 7).is_err(),
+            "red CI must not merge"
+        );
+        assert_eq!(gh.merges(), 0, "no merge attempted on red CI");
+        assert!(
+            email.lock().unwrap().is_empty(),
+            "no notification on non-merge"
+        );
+        assert!(signal.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn merge_polls_pending_then_green() {
+        // view_pr sequence: verify(green) then poll sees pending, pending, green.
+        let pending = snapshot(
+            "MERGEABLE",
+            vec![check("build", "IN_PROGRESS"), check("clippy", "SUCCESS")],
+        );
+        let gh = ScriptedGh::new(vec![
+            green(), // verify()'s view_pr
+            pending.clone(),
+            pending,
+            green(), // poll finally green
+            green(), // merge_pr_if_merge_ready_with_judge's view_pr
+        ]);
+        let clock = Arc::new(CountingClock::default());
+        let (ops, email, _) = adapter_with(
+            gh.clone(),
+            CLEAN_DIFF,
+            Some(Box::new(FakeReviewer(vec![]))),
+            clock.clone(),
+            PollConfig {
+                max_attempts: 5,
+                interval_secs: 1,
+            },
+        );
+        ops.merge("rysweet/Simard", 7)
+            .expect("merges after checks go green");
+        assert_eq!(gh.merges(), 1);
+        assert_eq!(
+            *clock.sleeps.lock().unwrap(),
+            2,
+            "slept once per pending poll"
+        );
+        assert_eq!(email.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn resolve_conflict_is_m3_and_never_no_verify() {
+        let gh = ScriptedGh::new(vec![green()]);
+        let (ops, _, _) = adapter_with(
+            gh,
+            CLEAN_DIFF,
+            None,
+            Arc::new(CountingClock::default()),
+            PollConfig::default(),
+        );
+        let err = ops.resolve_conflict("rysweet/Simard", 1).unwrap_err();
+        assert!(format!("{err}").contains("M3"));
+    }
+}

--- a/src/overseer/mod.rs
+++ b/src/overseer/mod.rs
@@ -49,12 +49,18 @@ pub mod capabilities;
 pub mod config;
 pub mod guardrails;
 pub mod intervention;
+pub mod launch;
+pub mod merge_ops;
+pub mod notify;
 pub mod observer;
+pub mod pr_verify;
 pub mod sensor;
 pub mod signal;
 
 #[cfg(test)]
 mod tests_m1;
+#[cfg(test)]
+mod tests_m2;
 
 pub use capabilities::{
     Auditor, Deployer, GoalCurator, IssueFiler, MeetingHost, ObservedState, OrchestratorRunBrief,
@@ -143,6 +149,14 @@ impl Overseer {
     /// Off by default: those interventions escalate instead.
     pub fn with_high_risk_autonomy(mut self, allow: bool) -> Self {
         self.autonomy.allow_high_risk = allow;
+        self
+    }
+
+    /// Opt into autonomous PR verify-and-merge (crusty risk #1). Off by default:
+    /// `VerifyAndMergePr` escalates until the operator explicitly enables it,
+    /// once M1's signal quality is proven. Independent of HIGH-RISK autonomy.
+    pub fn with_verify_merge_autonomy(mut self, allow: bool) -> Self {
+        self.autonomy.allow_verify_merge = allow;
         self
     }
 

--- a/src/overseer/notify.rs
+++ b/src/overseer/notify.rs
@@ -1,0 +1,625 @@
+//! M2 **mandatory** `NotifyOperator` capability (operator policy #3).
+//!
+//! EVERY PR merge — autonomous or human — must notify the operator via BOTH
+//! **email** and **Signal**, with a concise plain-language explanation of the
+//! PROBLEM being solved and the PR that solves it. This module is a first-class,
+//! mandatory capability wired into the merge path
+//! ([`merge_ops`](crate::overseer::merge_ops)) so **no merge completes without
+//! the notification firing**.
+//!
+//! Design constraints encoded here:
+//! - **Two channels, always both.** [`DualChannelNotifier`] fires every channel
+//!   on every notification and records each outcome.
+//! - **Never silently drop.** An unconfigured channel returns
+//!   [`ChannelDelivery::Queued`] (logged), never nothing. A delivery error
+//!   returns [`ChannelDelivery::Failed`] (logged). There is no code path that
+//!   drops a notification on the floor.
+//! - **Reuse the `ConversationChannel` abstraction (PR #2529)** for Signal:
+//!   [`ConversationSignalSender`] adapts ANY `ConversationChannel` (incl. the
+//!   `MockConversationChannel`) into an object-safe [`SignalSender`], driving its
+//!   async `send` on an injected runtime handle.
+//! - **Email via env** (`SIMARD_OVERSEER_EMAIL_TO` / `SIMARD_OVERSEER_EMAIL_FROM`
+//!   / `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASS`); unset → queued.
+
+use std::sync::Mutex;
+
+use crate::conversation_channel::{ConversationChannel, OutKind, Outbound};
+
+// ─────────────────────────── notification content ──────────────────────────
+
+/// The concise `{problem, pr_title, pr_url, repo}` summary sent to the operator
+/// on every merge (operator policy #3).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MergeNotification {
+    /// Plain-language description of the PROBLEM the PR solves.
+    pub problem: String,
+    pub pr_title: String,
+    pub pr_url: String,
+    pub repo: String,
+    /// Was the merge autonomous (Overseer) or human-initiated?
+    pub autonomous: bool,
+}
+
+impl MergeNotification {
+    /// The email subject line.
+    pub fn subject(&self) -> String {
+        format!("[Overseer] merged: {}", self.pr_title)
+    }
+
+    /// A short, plain-language body suitable for email or a Signal message.
+    pub fn plain_text(&self) -> String {
+        let who = if self.autonomous {
+            "The Overseer autonomously merged"
+        } else {
+            "A PR was merged"
+        };
+        format!(
+            "{who} a pull request in {repo}.\n\n\
+             Problem solved:\n  {problem}\n\n\
+             PR:\n  {title}\n  {url}\n",
+            who = who,
+            repo = self.repo,
+            problem = self.problem,
+            title = self.pr_title,
+            url = self.pr_url,
+        )
+    }
+}
+
+/// The outcome of delivering to one channel. There is no "silently dropped"
+/// variant by construction — an unconfigured channel is [`Queued`], an error is
+/// [`Failed`], both of which are recorded and logged.
+///
+/// [`Queued`]: ChannelDelivery::Queued
+/// [`Failed`]: ChannelDelivery::Failed
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ChannelDelivery {
+    /// Delivered to the channel transport.
+    Sent,
+    /// Channel not configured (or degraded); the notification is queued/pending
+    /// and logged — it is the operator's job to configure the transport.
+    Queued { reason: String },
+    /// The transport was attempted but errored; recorded and logged.
+    Failed { reason: String },
+}
+
+impl ChannelDelivery {
+    pub fn is_sent(&self) -> bool {
+        matches!(self, ChannelDelivery::Sent)
+    }
+}
+
+/// The result of firing all channels for one notification.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NotifyReport {
+    pub per_channel: Vec<(String, ChannelDelivery)>,
+}
+
+impl NotifyReport {
+    /// True iff every channel actually delivered (no queue, no failure).
+    pub fn all_sent(&self) -> bool {
+        !self.per_channel.is_empty() && self.per_channel.iter().all(|(_, d)| d.is_sent())
+    }
+
+    /// The notification always "fires": every configured channel is attempted
+    /// and every outcome recorded. This is the mandatory guarantee — a merge is
+    /// never considered complete without a `NotifyReport` in hand.
+    pub fn dispatched(&self) -> bool {
+        !self.per_channel.is_empty()
+    }
+}
+
+// ─────────────────────────── channel abstractions ──────────────────────────
+
+/// A single notification transport. Object-safe (so channels can be boxed and
+/// composed) and deliberately synchronous at this boundary — async transports
+/// (Signal) are driven behind the adapter.
+pub trait NotifyChannel: Send + Sync {
+    fn name(&self) -> &str;
+    fn deliver(&self, notification: &MergeNotification) -> ChannelDelivery;
+}
+
+/// The mandatory operator notifier: fires EVERY channel on EVERY notification.
+/// Constructed with an email channel and a Signal channel so both fire.
+pub struct DualChannelNotifier {
+    channels: Vec<Box<dyn NotifyChannel>>,
+}
+
+impl DualChannelNotifier {
+    /// Construct from an explicit channel list (tests inject fakes). The merge
+    /// path uses [`from_env`](DualChannelNotifier::from_env) to get email+Signal.
+    pub fn new(channels: Vec<Box<dyn NotifyChannel>>) -> Self {
+        Self { channels }
+    }
+
+    /// The production notifier: an email channel + a Signal channel, both wired
+    /// from the environment. Unconfigured channels degrade to `Queued` (logged);
+    /// nothing is ever dropped.
+    pub fn from_env() -> Self {
+        Self::new(vec![
+            Box::new(EmailNotifyChannel::from_env()),
+            Box::new(SignalNotifyChannel::from_env()),
+        ])
+    }
+
+    /// Fire every channel, recording each outcome. This is the single call the
+    /// merge path makes after a successful merge; its `NotifyReport` proves the
+    /// notification fired on both channels.
+    pub fn notify(&self, notification: &MergeNotification) -> NotifyReport {
+        let per_channel = self
+            .channels
+            .iter()
+            .map(|c| {
+                let outcome = c.deliver(notification);
+                if !outcome.is_sent() {
+                    // Never silently drop: log the degraded/failed delivery.
+                    log_degraded(c.name(), &outcome, notification);
+                }
+                (c.name().to_string(), outcome)
+            })
+            .collect();
+        NotifyReport { per_channel }
+    }
+}
+
+fn log_degraded(channel: &str, outcome: &ChannelDelivery, n: &MergeNotification) {
+    tracing::warn!(
+        target: "overseer::notify",
+        channel,
+        pr = %n.pr_url,
+        ?outcome,
+        "operator notification not delivered live — queued/failed (never dropped)"
+    );
+}
+
+// ─────────────────────────── email channel ─────────────────────────────────
+
+/// Env-driven SMTP configuration.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct EmailConfig {
+    pub to: Vec<String>,
+    pub from: Option<String>,
+    pub host: Option<String>,
+    pub port: u16,
+    pub user: Option<String>,
+    pub pass: Option<String>,
+}
+
+impl EmailConfig {
+    pub fn from_env() -> Self {
+        Self::from_lookup(|k| std::env::var(k).ok())
+    }
+
+    /// Injectable-env constructor (tests build a fixed map).
+    pub fn from_lookup(lookup: impl Fn(&str) -> Option<String>) -> Self {
+        let to = lookup("SIMARD_OVERSEER_EMAIL_TO")
+            .map(|s| {
+                s.split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        Self {
+            to,
+            from: lookup("SIMARD_OVERSEER_EMAIL_FROM").filter(|s| !s.trim().is_empty()),
+            host: lookup("SMTP_HOST").filter(|s| !s.trim().is_empty()),
+            port: lookup("SMTP_PORT")
+                .and_then(|s| s.trim().parse::<u16>().ok())
+                .unwrap_or(25),
+            user: lookup("SMTP_USER").filter(|s| !s.trim().is_empty()),
+            pass: lookup("SMTP_PASS").filter(|s| !s.trim().is_empty()),
+        }
+    }
+
+    /// Fully configured iff we know a host, a from, and at least one recipient.
+    pub fn is_configured(&self) -> bool {
+        self.host.is_some() && self.from.is_some() && !self.to.is_empty()
+    }
+}
+
+/// A minimal email message handed to an [`EmailSender`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EmailMessage {
+    pub from: String,
+    pub to: Vec<String>,
+    pub subject: String,
+    pub body: String,
+}
+
+/// The wire transport for email. Injectable so tests use a fake and production
+/// uses [`TcpSmtpSender`]. Object-safe + `Send + Sync`.
+pub trait EmailSender: Send + Sync {
+    fn send(&self, msg: &EmailMessage) -> Result<(), String>;
+}
+
+/// The email notification channel. When SMTP is unconfigured it returns
+/// [`ChannelDelivery::Queued`] (never dropped); when configured it delegates to
+/// the injected [`EmailSender`].
+pub struct EmailNotifyChannel {
+    config: EmailConfig,
+    sender: Box<dyn EmailSender>,
+}
+
+impl EmailNotifyChannel {
+    pub fn new(config: EmailConfig, sender: Box<dyn EmailSender>) -> Self {
+        Self { config, sender }
+    }
+
+    /// Production channel: env config + a plaintext-SMTP transport.
+    pub fn from_env() -> Self {
+        Self::new(EmailConfig::from_env(), Box::new(TcpSmtpSender))
+    }
+}
+
+impl NotifyChannel for EmailNotifyChannel {
+    fn name(&self) -> &str {
+        "email"
+    }
+
+    fn deliver(&self, n: &MergeNotification) -> ChannelDelivery {
+        if !self.config.is_configured() {
+            return ChannelDelivery::Queued {
+                reason: "SMTP not configured (set SMTP_HOST / SIMARD_OVERSEER_EMAIL_{FROM,TO})"
+                    .to_string(),
+            };
+        }
+        let msg = EmailMessage {
+            from: self.config.from.clone().unwrap_or_default(),
+            to: self.config.to.clone(),
+            subject: n.subject(),
+            body: n.plain_text(),
+        };
+        match self.sender.send(&msg) {
+            Ok(()) => ChannelDelivery::Sent,
+            Err(e) => ChannelDelivery::Failed { reason: e },
+        }
+    }
+}
+
+/// A minimal, dependency-free, timeout-bounded **plaintext** SMTP sender for
+/// local/relay MTAs (no TLS/AUTH). It is deliberately conservative: any protocol
+/// error surfaces as `Err` so the channel records a `Failed` (never a silent
+/// drop). TLS/authenticating relays are out of scope for this minimal mailer —
+/// the queued fallback covers them until a real transport is wired.
+#[derive(Clone, Debug, Default)]
+pub struct TcpSmtpSender;
+
+impl EmailSender for TcpSmtpSender {
+    fn send(&self, msg: &EmailMessage) -> Result<(), String> {
+        // Host/port live in the channel's config; the sender is handed a fully
+        // resolved message. We re-read connection params from the environment so
+        // the sender stays a pure transport with no config of its own.
+        let host = std::env::var("SMTP_HOST").map_err(|_| "SMTP_HOST unset".to_string())?;
+        let port = std::env::var("SMTP_PORT")
+            .ok()
+            .and_then(|s| s.trim().parse::<u16>().ok())
+            .unwrap_or(25);
+        smtp_send_plaintext(&host, port, msg)
+    }
+}
+
+/// Minimal plaintext SMTP conversation. Kept small and defensive.
+fn smtp_send_plaintext(host: &str, port: u16, msg: &EmailMessage) -> Result<(), String> {
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpStream;
+    use std::time::Duration;
+
+    let addr = format!("{host}:{port}");
+    let stream = TcpStream::connect(&addr).map_err(|e| format!("connect {addr} failed: {e}"))?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(15)))
+        .map_err(|e| e.to_string())?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(15)))
+        .map_err(|e| e.to_string())?;
+    let mut writer = stream.try_clone().map_err(|e| e.to_string())?;
+    let mut reader = BufReader::new(stream);
+
+    let expect = |reader: &mut BufReader<TcpStream>, want: u8| -> Result<(), String> {
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .map_err(|e| format!("smtp read: {e}"))?;
+        if line.as_bytes().first() == Some(&(b'0' + want)) {
+            Ok(())
+        } else {
+            Err(format!("unexpected SMTP reply: {}", line.trim()))
+        }
+    };
+
+    expect(&mut reader, 2)?; // greeting 220
+    writeln!(writer, "EHLO simard-overseer").map_err(|e| e.to_string())?;
+    expect(&mut reader, 2)?;
+    writeln!(writer, "MAIL FROM:<{}>", msg.from).map_err(|e| e.to_string())?;
+    expect(&mut reader, 2)?;
+    for rcpt in &msg.to {
+        writeln!(writer, "RCPT TO:<{rcpt}>").map_err(|e| e.to_string())?;
+        expect(&mut reader, 2)?;
+    }
+    writeln!(writer, "DATA").map_err(|e| e.to_string())?;
+    expect(&mut reader, 3)?; // 354 start mail input
+    write!(
+        writer,
+        "From: {}\r\nTo: {}\r\nSubject: {}\r\n\r\n{}\r\n.\r\n",
+        msg.from,
+        msg.to.join(", "),
+        msg.subject,
+        msg.body.replace("\r\n", "\n").replace('\n', "\r\n"),
+    )
+    .map_err(|e| e.to_string())?;
+    expect(&mut reader, 2)?; // 250 accepted
+    writeln!(writer, "QUIT").map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+// ─────────────────────────── Signal channel ────────────────────────────────
+
+/// The wire transport for Signal. Object-safe + `Send + Sync` so it can be
+/// composed; the real impl adapts the async `ConversationChannel`.
+pub trait SignalSender: Send + Sync {
+    fn send_text(&self, text: &str) -> Result<(), String>;
+}
+
+/// Adapter turning ANY [`ConversationChannel`] (PR #2529) — including the
+/// `MockConversationChannel` used in tests, and the feature-gated
+/// `SignalConversation` in production — into an object-safe [`SignalSender`]. It
+/// drives the channel's async `send` on the injected runtime handle, so the
+/// synchronous merge path can notify without an async context of its own.
+pub struct ConversationSignalSender<C: ConversationChannel + Send> {
+    chan: Mutex<C>,
+    handle: tokio::runtime::Handle,
+}
+
+impl<C: ConversationChannel + Send> ConversationSignalSender<C> {
+    pub fn new(chan: C, handle: tokio::runtime::Handle) -> Self {
+        Self {
+            chan: Mutex::new(chan),
+            handle,
+        }
+    }
+}
+
+impl<C: ConversationChannel + Send> SignalSender for ConversationSignalSender<C> {
+    fn send_text(&self, text: &str) -> Result<(), String> {
+        let mut chan = self.chan.lock().map_err(|e| e.to_string())?;
+        let out = Outbound {
+            kind: OutKind::Notice,
+            text: text.to_string(),
+        };
+        self.handle
+            .block_on(chan.send(out))
+            .map_err(|e| e.to_string())
+    }
+}
+
+/// The Signal notification channel. When no sender is wired (e.g. the `signal`
+/// feature is off, or signal-cli is unconfigured) it returns
+/// [`ChannelDelivery::Queued`] (never dropped); otherwise it delegates to the
+/// injected [`SignalSender`].
+pub struct SignalNotifyChannel {
+    sender: Option<Box<dyn SignalSender>>,
+}
+
+impl SignalNotifyChannel {
+    pub fn new(sender: Option<Box<dyn SignalSender>>) -> Self {
+        Self { sender }
+    }
+
+    /// Production channel. A live Signal transport requires the daemon's async
+    /// runtime + a configured `SignalConversation` (feature `signal`), which the
+    /// operator wires explicitly; absent that, the channel queues (logged),
+    /// never drops. See [`ConversationSignalSender`] for the adapter used when a
+    /// channel IS available.
+    pub fn from_env() -> Self {
+        Self::new(None)
+    }
+}
+
+impl NotifyChannel for SignalNotifyChannel {
+    fn name(&self) -> &str {
+        "signal"
+    }
+
+    fn deliver(&self, n: &MergeNotification) -> ChannelDelivery {
+        match &self.sender {
+            None => ChannelDelivery::Queued {
+                reason: "Signal channel not wired (configure the ConversationChannel transport)"
+                    .to_string(),
+            },
+            Some(sender) => match sender.send_text(&n.plain_text()) {
+                Ok(()) => ChannelDelivery::Sent,
+                Err(e) => ChannelDelivery::Failed { reason: e },
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conversation_channel::MockConversationChannel;
+
+    fn sample() -> MergeNotification {
+        MergeNotification {
+            problem: "distillation parse-failure rate exceeded threshold".to_string(),
+            pr_title: "fix(distill): strip launch-banner noise".to_string(),
+            pr_url: "https://github.com/rysweet/Simard/pull/123".to_string(),
+            repo: "rysweet/Simard".to_string(),
+            autonomous: true,
+        }
+    }
+
+    // ── content ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn plain_text_carries_problem_pr_and_repo() {
+        let t = sample().plain_text();
+        assert!(t.contains("distillation parse-failure"));
+        assert!(t.contains("fix(distill): strip launch-banner noise"));
+        assert!(t.contains("https://github.com/rysweet/Simard/pull/123"));
+        assert!(t.contains("rysweet/Simard"));
+    }
+
+    // ── fakes ────────────────────────────────────────────────────────────────
+
+    #[derive(Default)]
+    struct RecordingChannel {
+        name: String,
+        outcome: Option<ChannelDelivery>,
+        seen: Mutex<Vec<MergeNotification>>,
+    }
+    impl NotifyChannel for RecordingChannel {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn deliver(&self, n: &MergeNotification) -> ChannelDelivery {
+            self.seen.lock().unwrap().push(n.clone());
+            self.outcome.clone().unwrap_or(ChannelDelivery::Sent)
+        }
+    }
+
+    // ── DualChannelNotifier: both channels always fire ───────────────────────
+
+    #[test]
+    fn dual_notifier_fires_every_channel() {
+        let notifier = DualChannelNotifier::new(vec![
+            Box::new(RecordingChannel {
+                name: "email".to_string(),
+                outcome: Some(ChannelDelivery::Sent),
+                ..Default::default()
+            }),
+            Box::new(RecordingChannel {
+                name: "signal".to_string(),
+                outcome: Some(ChannelDelivery::Sent),
+                ..Default::default()
+            }),
+        ]);
+        let report = notifier.notify(&sample());
+        assert!(report.dispatched());
+        assert!(report.all_sent());
+        assert_eq!(report.per_channel.len(), 2);
+        let names: Vec<&str> = report.per_channel.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"email") && names.contains(&"signal"));
+    }
+
+    #[test]
+    fn unconfigured_channel_queues_never_drops() {
+        // An unconfigured email + signal pair still DISPATCHES (both recorded),
+        // just Queued — never silently dropped.
+        let notifier = DualChannelNotifier::new(vec![
+            Box::new(EmailNotifyChannel::new(
+                EmailConfig::default(),
+                Box::new(TcpSmtpSender),
+            )),
+            Box::new(SignalNotifyChannel::from_env()),
+        ]);
+        let report = notifier.notify(&sample());
+        assert!(report.dispatched(), "notification must still dispatch");
+        assert!(!report.all_sent());
+        assert!(
+            report
+                .per_channel
+                .iter()
+                .all(|(_, d)| matches!(d, ChannelDelivery::Queued { .. })),
+            "unconfigured channels queue, never drop: {report:?}"
+        );
+    }
+
+    // ── email channel ────────────────────────────────────────────────────────
+
+    struct FakeSmtp {
+        sent: Mutex<Vec<EmailMessage>>,
+        fail: bool,
+    }
+    impl EmailSender for FakeSmtp {
+        fn send(&self, msg: &EmailMessage) -> Result<(), String> {
+            self.sent.lock().unwrap().push(msg.clone());
+            if self.fail {
+                Err("smtp boom".to_string())
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn configured_email() -> EmailConfig {
+        EmailConfig::from_lookup(|k| match k {
+            "SIMARD_OVERSEER_EMAIL_TO" => Some("ops@example.com, sec@example.com".to_string()),
+            "SIMARD_OVERSEER_EMAIL_FROM" => Some("overseer@example.com".to_string()),
+            "SMTP_HOST" => Some("localhost".to_string()),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn email_config_parses_recipients_and_defaults_port() {
+        let cfg = configured_email();
+        assert_eq!(cfg.to, vec!["ops@example.com", "sec@example.com"]);
+        assert_eq!(cfg.port, 25);
+        assert!(cfg.is_configured());
+        assert!(!EmailConfig::default().is_configured());
+    }
+
+    #[test]
+    fn email_channel_sends_when_configured() {
+        let smtp = FakeSmtp {
+            sent: Mutex::new(vec![]),
+            fail: false,
+        };
+        let ch = EmailNotifyChannel::new(configured_email(), Box::new(smtp));
+        let out = ch.deliver(&sample());
+        assert_eq!(out, ChannelDelivery::Sent);
+    }
+
+    #[test]
+    fn email_channel_reports_failure_never_drops() {
+        let smtp = FakeSmtp {
+            sent: Mutex::new(vec![]),
+            fail: true,
+        };
+        let ch = EmailNotifyChannel::new(configured_email(), Box::new(smtp));
+        assert!(matches!(
+            ch.deliver(&sample()),
+            ChannelDelivery::Failed { .. }
+        ));
+    }
+
+    #[test]
+    fn email_channel_queues_when_unconfigured() {
+        let ch = EmailNotifyChannel::new(EmailConfig::default(), Box::new(TcpSmtpSender));
+        assert!(matches!(
+            ch.deliver(&sample()),
+            ChannelDelivery::Queued { .. }
+        ));
+    }
+
+    // ── Signal channel via the real ConversationChannel abstraction ──────────
+
+    #[test]
+    fn signal_channel_delivers_through_conversation_channel() {
+        // Reuse the shipped ConversationChannel abstraction (PR #2529) end-to-end
+        // with the Mock, driven on a current-thread runtime — no signal-cli, no
+        // network. Proves the adapter path the production SignalConversation uses.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mock = MockConversationChannel::with_script(vec![]);
+        let sender = ConversationSignalSender::new(mock, rt.handle().clone());
+        let ch = SignalNotifyChannel::new(Some(Box::new(sender)));
+
+        let out = ch.deliver(&sample());
+        assert_eq!(out, ChannelDelivery::Sent);
+    }
+
+    #[test]
+    fn signal_channel_queues_when_unwired() {
+        let ch = SignalNotifyChannel::from_env();
+        assert!(matches!(
+            ch.deliver(&sample()),
+            ChannelDelivery::Queued { .. }
+        ));
+    }
+}

--- a/src/overseer/pr_verify.rs
+++ b/src/overseer/pr_verify.rs
@@ -1,0 +1,487 @@
+//! M2 **hard gate** — the pr-verify safety diff-scans (design doc §pr-verify
+//! checklist, items 3–6). These are the NEW, additive checks that did not exist
+//! before this milestone; **no merge capability ships before they do and are
+//! unit-tested** (crusty review risk #2 / operator hard-gate #5).
+//!
+//! Every scan is a **pure** function over a unified diff (`gh pr diff` output),
+//! so the whole merge-safety surface is testable on fixture diffs with zero
+//! network. The four scans:
+//!
+//! | # | Check | This module |
+//! |---|-------|-------------|
+//! | 3 | No `Bridge` naming in **added** lines | [`scan_no_bridge_naming`] |
+//! | 4 | No stray `print!`/`println!`/`eprintln!`/`eprint!` in added `src/**` | [`scan_no_stray_prints`] |
+//! | 5 | Additive / non-breaking — no **removed** `pub` items | [`scan_additive_no_removed_pub`] |
+//! | 6 | PRD (`Specs/ProductArchitecture.md`) preserved — no removed lines | [`scan_prd_preserved`] |
+//!
+//! Items 1–2 (CI-green / mergeable / base-allowlist) reuse
+//! `stewardship::merge_authority::evaluate_objective_gates`; item 7 reuses
+//! `review_pipeline::should_commit`. Those are wired in
+//! [`merge_ops`](crate::overseer::merge_ops), not here.
+
+use crate::overseer::capabilities::CheckItem;
+
+/// The PRD file whose content must be preserved (check #6).
+pub const PRD_PATH: &str = "Specs/ProductArchitecture.md";
+
+/// One offending location found by a diff scan.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiffFinding {
+    /// Path (new-side) the finding is in.
+    pub file: String,
+    /// Best-effort new-file line number (`None` for removed-line findings).
+    pub line: Option<usize>,
+    /// The offending source text (trimmed).
+    pub text: String,
+}
+
+impl DiffFinding {
+    fn describe(&self) -> String {
+        match self.line {
+            Some(n) => format!("{}:{} — {}", self.file, n, self.text),
+            None => format!("{} — {}", self.file, self.text),
+        }
+    }
+}
+
+/// One parsed line of a unified diff, classified with its new-side line number.
+struct DiffLine<'a> {
+    file: &'a str,
+    kind: LineKind,
+    /// New-file line number for added/context lines; `None` for removed.
+    new_line: Option<usize>,
+    /// The content after the leading +/-/space marker.
+    content: &'a str,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LineKind {
+    Added,
+    Removed,
+    Context,
+}
+
+/// Walk a unified diff, invoking `f` for every added/removed/context content
+/// line with its current file and new-side line number. A single tiny parser
+/// shared by all four scans (one place to get header/hunk handling right).
+fn for_each_diff_line<'a>(diff: &'a str, mut f: impl FnMut(DiffLine<'a>)) {
+    let mut current_file: &str = "";
+    let mut new_line: usize = 0;
+
+    for raw in diff.lines() {
+        // File header: `+++ b/<path>` names the new-side file. `/dev/null`
+        // (deletion) yields an empty file so src/PRD scans simply skip it.
+        if let Some(rest) = raw.strip_prefix("+++ ") {
+            current_file = normalize_diff_path(rest);
+            continue;
+        }
+        if raw.starts_with("--- ") {
+            // Old-side header — ignore (new-side is authoritative for paths).
+            continue;
+        }
+        if raw.starts_with("diff --git") || raw.starts_with("index ") {
+            continue;
+        }
+        // Hunk header: `@@ -old,cnt +new,cnt @@` resets the new-side counter.
+        if let Some(start) = parse_hunk_new_start(raw) {
+            new_line = start;
+            continue;
+        }
+
+        if let Some(content) = raw.strip_prefix('+') {
+            // `+++` already handled above.
+            f(DiffLine {
+                file: current_file,
+                kind: LineKind::Added,
+                new_line: Some(new_line),
+                content,
+            });
+            new_line += 1;
+        } else if let Some(content) = raw.strip_prefix('-') {
+            f(DiffLine {
+                file: current_file,
+                kind: LineKind::Removed,
+                new_line: None,
+                content,
+            });
+            // Removed lines do not advance the new-side counter.
+        } else if let Some(content) = raw.strip_prefix(' ') {
+            f(DiffLine {
+                file: current_file,
+                kind: LineKind::Context,
+                new_line: Some(new_line),
+                content,
+            });
+            new_line += 1;
+        }
+        // Any other line (e.g. "\ No newline at end of file") is ignored.
+    }
+}
+
+/// Strip the `a/` or `b/` prefix from a diff path and any trailing tab-decorated
+/// metadata (`+++ b/foo.rs\t2026-...`). `/dev/null` maps to an empty path.
+fn normalize_diff_path(rest: &str) -> &str {
+    let path = rest.split('\t').next().unwrap_or(rest).trim();
+    if path == "/dev/null" {
+        return "";
+    }
+    path.strip_prefix("b/")
+        .or_else(|| path.strip_prefix("a/"))
+        .unwrap_or(path)
+}
+
+/// Parse the new-side start line from a hunk header `@@ -a,b +c,d @@`.
+fn parse_hunk_new_start(line: &str) -> Option<usize> {
+    let rest = line.strip_prefix("@@ ")?;
+    // Find the `+c,d` token.
+    let plus = rest.split_whitespace().find(|t| t.starts_with('+'))?;
+    let digits = &plus[1..];
+    let start = digits.split(',').next().unwrap_or(digits);
+    start.parse::<usize>().ok()
+}
+
+// ─────────────────────────── scan #3: no Bridge ────────────────────────────
+
+/// Check #3: no `Bridge` naming introduced in **added** lines. Scoped to added
+/// lines only, so pre-existing `terminal_engineer_bridge` / `OodaBridges` code
+/// (which predates the operator's no-`Bridge` preference) is untouched. Uses a
+/// case-sensitive `Bridge` substring so CamelCase identifiers (`HttpBridge`,
+/// `FooBridge`) are caught while the lowercase word (`abridged`, `cambridge`)
+/// is not.
+pub fn scan_no_bridge_naming(diff: &str) -> Vec<DiffFinding> {
+    let mut out = Vec::new();
+    for_each_diff_line(diff, |dl| {
+        if dl.kind == LineKind::Added && dl.content.contains("Bridge") {
+            out.push(DiffFinding {
+                file: dl.file.to_string(),
+                line: dl.new_line,
+                text: dl.content.trim().to_string(),
+            });
+        }
+    });
+    out
+}
+
+// ─────────────────────────── scan #4: no stray prints ──────────────────────
+
+const PRINT_MACROS: &[&str] = &["println!", "print!", "eprintln!", "eprint!"];
+
+/// Check #4: no stray `print!`/`println!`/`eprintln!`/`eprint!` in added lines
+/// of files under `src/`. Test files, examples, and build scripts are out of
+/// scope (they legitimately print).
+pub fn scan_no_stray_prints(diff: &str) -> Vec<DiffFinding> {
+    let mut out = Vec::new();
+    for_each_diff_line(diff, |dl| {
+        if dl.kind != LineKind::Added || !is_src_rust(dl.file) {
+            return;
+        }
+        if PRINT_MACROS.iter().any(|m| dl.content.contains(m)) {
+            out.push(DiffFinding {
+                file: dl.file.to_string(),
+                line: dl.new_line,
+                text: dl.content.trim().to_string(),
+            });
+        }
+    });
+    out
+}
+
+fn is_src_rust(path: &str) -> bool {
+    path.starts_with("src/") && path.ends_with(".rs")
+}
+
+// ─────────────────────────── scan #5: additive only ────────────────────────
+
+const PUB_PREFIXES: &[&str] = &[
+    "pub fn ",
+    "pub struct ",
+    "pub enum ",
+    "pub trait ",
+    "pub const ",
+    "pub static ",
+    "pub type ",
+    "pub mod ",
+    "pub use ",
+    "pub(crate) fn ",
+    "pub async fn ",
+];
+
+/// Check #5: additive / non-breaking — no **removed** `pub` item declarations.
+/// A removed public item is a potential breaking API change; the Overseer only
+/// merges additive PRs. Heuristic and conservative: a `pub` item that is merely
+/// moved will flag, which is the safe direction (a human reviews the escalation).
+pub fn scan_additive_no_removed_pub(diff: &str) -> Vec<DiffFinding> {
+    let mut out = Vec::new();
+    for_each_diff_line(diff, |dl| {
+        if dl.kind != LineKind::Removed {
+            return;
+        }
+        let trimmed = dl.content.trim_start();
+        if PUB_PREFIXES.iter().any(|p| trimmed.starts_with(p)) {
+            out.push(DiffFinding {
+                file: dl.file.to_string(),
+                line: None,
+                text: dl.content.trim().to_string(),
+            });
+        }
+    });
+    out
+}
+
+// ─────────────────────────── scan #6: PRD preserved ────────────────────────
+
+/// Check #6: the PRD (`Specs/ProductArchitecture.md`) is preserved — the diff
+/// removes no lines from it. Additions (new sections) are fine; deletions /
+/// rewrites are not.
+pub fn scan_prd_preserved(diff: &str) -> Vec<DiffFinding> {
+    let mut out = Vec::new();
+    for_each_diff_line(diff, |dl| {
+        if dl.kind == LineKind::Removed && dl.file == PRD_PATH {
+            out.push(DiffFinding {
+                file: dl.file.to_string(),
+                line: None,
+                text: dl.content.trim().to_string(),
+            });
+        }
+    });
+    out
+}
+
+// ─────────────────────────── checklist assembly ────────────────────────────
+
+/// Run all four additive diff-scans and return one [`CheckItem`] per scan. A
+/// scan passes when it finds no violations; the note names the offenders.
+pub fn run_diff_scans(diff: &str) -> Vec<CheckItem> {
+    vec![
+        finding_check(
+            "no-Bridge-naming (added lines)",
+            scan_no_bridge_naming(diff),
+        ),
+        finding_check("no-stray-print (added src/**)", scan_no_stray_prints(diff)),
+        finding_check(
+            "additive (no removed pub items)",
+            scan_additive_no_removed_pub(diff),
+        ),
+        finding_check("PRD preserved", scan_prd_preserved(diff)),
+    ]
+}
+
+fn finding_check(name: &str, findings: Vec<DiffFinding>) -> CheckItem {
+    if findings.is_empty() {
+        CheckItem {
+            name: name.to_string(),
+            passed: true,
+            note: "ok".to_string(),
+        }
+    } else {
+        let note = findings
+            .iter()
+            .take(5)
+            .map(DiffFinding::describe)
+            .collect::<Vec<_>>()
+            .join("; ");
+        CheckItem {
+            name: name.to_string(),
+            passed: false,
+            note: format!("{} violation(s): {note}", findings.len()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── #3: Bridge ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn bridge_flags_added_camelcase_lines_only() {
+        let diff = "\
+diff --git a/src/foo.rs b/src/foo.rs
++++ b/src/foo.rs
+@@ -1,2 +1,4 @@
+ fn keep() {}
++struct PaymentBridge; // new camelcase type — must flag
++let abridged = 1; // lowercase word, must NOT flag
+-struct OldBridge; // removed line — not scanned by #3
+";
+        let f = scan_no_bridge_naming(diff);
+        assert_eq!(f.len(), 1, "only the added CamelCase Bridge flags");
+        assert_eq!(f[0].file, "src/foo.rs");
+        assert!(f[0].text.contains("PaymentBridge"));
+    }
+
+    #[test]
+    fn bridge_clean_diff_passes() {
+        let diff = "\
++++ b/src/foo.rs
+@@ -1,1 +1,2 @@
+ fn keep() {}
++fn reasoner_orient() {}
+";
+        assert!(scan_no_bridge_naming(diff).is_empty());
+    }
+
+    // ── #4: prints ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn stray_print_flags_added_src_only() {
+        let diff = "\
++++ b/src/foo.rs
+@@ -1,1 +1,3 @@
+ fn keep() {}
++    println!(\"debug\");
++    tracing::info!(\"ok\");
++++ b/tests/bar.rs
+@@ -1,1 +1,2 @@
+ fn t() {}
++    println!(\"tests may print\");
+";
+        let f = scan_no_stray_prints(diff);
+        assert_eq!(f.len(), 1, "only the src/ println! flags, not tests/");
+        assert_eq!(f[0].file, "src/foo.rs");
+    }
+
+    #[test]
+    fn all_print_macros_detected() {
+        let diff = "\
++++ b/src/foo.rs
+@@ -1,1 +1,5 @@
+ fn keep() {}
++print!(\"a\");
++println!(\"b\");
++eprint!(\"c\");
++eprintln!(\"d\");
+";
+        assert_eq!(scan_no_stray_prints(diff).len(), 4);
+    }
+
+    // ── #5: additive ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn removed_pub_item_flags() {
+        let diff = "\
++++ b/src/foo.rs
+@@ -1,4 +1,2 @@
+-pub fn removed_api() {}
+-    pub struct RemovedType;
+ fn private_keep() {}
+-fn removed_private() {} // not pub — ok
++pub fn added_api() {}
+";
+        let f = scan_additive_no_removed_pub(diff);
+        assert_eq!(f.len(), 2, "two removed pub items; private removal is fine");
+    }
+
+    #[test]
+    fn purely_additive_diff_passes_additive_scan() {
+        let diff = "\
++++ b/src/foo.rs
+@@ -1,1 +1,3 @@
+ fn keep() {}
++pub fn added_api() {}
++pub struct AddedType;
+";
+        assert!(scan_additive_no_removed_pub(diff).is_empty());
+    }
+
+    // ── #6: PRD ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn prd_removed_line_flags_but_addition_is_fine() {
+        let diff = format!(
+            "\
++++ b/{PRD_PATH}
+@@ -1,3 +1,3 @@
+ # Product Architecture
+-A load-bearing invariant that must be preserved.
++A rewritten invariant.
++A brand-new additive section.
+"
+        );
+        let f = scan_prd_preserved(&diff);
+        assert_eq!(f.len(), 1, "only the removed PRD line flags");
+    }
+
+    #[test]
+    fn prd_addition_only_passes() {
+        let diff = format!(
+            "\
++++ b/{PRD_PATH}
+@@ -1,1 +1,2 @@
+ # Product Architecture
++## A new additive section
+"
+        );
+        assert!(scan_prd_preserved(&diff).is_empty());
+    }
+
+    #[test]
+    fn removed_lines_in_other_files_do_not_touch_prd_scan() {
+        let diff = "\
++++ b/src/foo.rs
+@@ -1,2 +1,1 @@
+-let x = 1;
+ fn keep() {}
+";
+        assert!(scan_prd_preserved(diff).is_empty());
+    }
+
+    // ── checklist assembly ───────────────────────────────────────────────────
+
+    #[test]
+    fn clean_additive_diff_passes_every_scan() {
+        let diff = "\
++++ b/src/overseer/new_thing.rs
+@@ -0,0 +1,3 @@
++pub fn reasoner_step() {}
++pub struct Observation;
++// orient-decide-act, no forbidden tokens
+";
+        let checks = run_diff_scans(diff);
+        assert_eq!(checks.len(), 4);
+        assert!(
+            checks.iter().all(|c| c.passed),
+            "a clean additive diff passes all four scans: {checks:?}"
+        );
+    }
+
+    #[test]
+    fn dirty_diff_fails_the_right_scans() {
+        let diff = format!(
+            "\
++++ b/src/foo.rs
+@@ -1,2 +1,3 @@
+-pub fn removed_api() {{}}
++struct HttpBridge;
++    println!(\"noise\");
++++ b/{PRD_PATH}
+@@ -1,1 +1,1 @@
+-Invariant.
+"
+        );
+        let checks = run_diff_scans(&diff);
+        let failed: Vec<&str> = checks
+            .iter()
+            .filter(|c| !c.passed)
+            .map(|c| c.name.as_str())
+            .collect();
+        assert_eq!(failed.len(), 4, "all four scans should fail: {checks:?}");
+    }
+
+    #[test]
+    fn hunk_line_numbers_are_tracked() {
+        let diff = "\
++++ b/src/foo.rs
+@@ -10,2 +10,3 @@
+ context
++struct WsBridge;
+";
+        let f = scan_no_bridge_naming(diff);
+        assert_eq!(
+            f[0].line,
+            Some(11),
+            "added line after one context line at 10"
+        );
+    }
+}

--- a/src/overseer/tests_m2.rs
+++ b/src/overseer/tests_m2.rs
@@ -1,0 +1,241 @@
+//! M2 integration fixture (exit criterion): seed a process problem → decide to
+//! launch a fix → poll the workstream to its PR → verify + merge the green PR
+//! through the gated authority (no `--admin`) → fire the mandatory operator
+//! notification on BOTH channels. All with injected fakes — no subprocess, no
+//! network, no sleeps.
+
+use std::sync::{Arc, Mutex};
+
+use crate::overseer::capabilities::{
+    ObservedState, OverseerError, PrOps, RecipeBrief, RecipeLauncher, WorkstreamHandle,
+    WorkstreamStatus,
+};
+use crate::overseer::intervention::Intervention;
+use crate::overseer::launch::{RecipeRunner, SmartOrchestratorLauncher};
+use crate::overseer::merge_ops::{DiffReviewer, MergePrOps, PollClock, PollConfig, PrSource};
+use crate::overseer::notify::{
+    ChannelDelivery, DualChannelNotifier, MergeNotification, NotifyChannel,
+};
+use crate::overseer::signal::signals_from;
+use crate::overseer::{decide, orient};
+
+use crate::review_pipeline::ReviewFinding;
+use crate::stewardship::merge_authority::CheckRollupEntry;
+use crate::stewardship::{
+    JudgeOutcome, MergeJudge, MergeJudgeKind, PrGhClient, PrSnapshot, Verdict,
+};
+
+// ── recipe runner fake ───────────────────────────────────────────────────────
+
+struct FakeRunner {
+    repo: String,
+    pr: u32,
+}
+impl RecipeRunner for FakeRunner {
+    fn spawn(&self, _brief: &RecipeBrief) -> Result<WorkstreamHandle, OverseerError> {
+        Ok(WorkstreamHandle {
+            id: "ws-fixture".to_string(),
+        })
+    }
+    fn probe(&self, _h: &WorkstreamHandle) -> Result<WorkstreamStatus, OverseerError> {
+        Ok(WorkstreamStatus::ProducedPr {
+            repo: self.repo.clone(),
+            pr: self.pr,
+        })
+    }
+}
+
+// ── merge fakes ──────────────────────────────────────────────────────────────
+
+struct GreenGh {
+    merges: Mutex<usize>,
+}
+impl GreenGh {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            merges: Mutex::new(0),
+        })
+    }
+    fn merges(&self) -> usize {
+        *self.merges.lock().unwrap()
+    }
+}
+impl PrGhClient for Arc<GreenGh> {
+    fn view_pr(&self, _repo: &str, _pr: u32) -> crate::error::SimardResult<PrSnapshot> {
+        Ok(PrSnapshot {
+            body: "fixture".to_string(),
+            mergeable: "MERGEABLE".to_string(),
+            review_decision: "APPROVED".to_string(),
+            checks: vec![CheckRollupEntry {
+                name: "build".to_string(),
+                state: "SUCCESS".to_string(),
+            }],
+            base_ref_name: "main".to_string(),
+        })
+    }
+    fn squash_merge(&self, _repo: &str, _pr: u32) -> crate::error::SimardResult<()> {
+        *self.merges.lock().unwrap() += 1;
+        Ok(())
+    }
+}
+
+struct CleanSource;
+impl PrSource for CleanSource {
+    fn diff(&self, _repo: &str, _pr: u32) -> Result<String, OverseerError> {
+        Ok("+++ b/src/overseer/x.rs\n@@ -0,0 +1,1 @@\n+pub fn reasoner() {}\n".to_string())
+    }
+    fn title(&self, _repo: &str, _pr: u32) -> Result<String, OverseerError> {
+        Ok("fix(distill): strip launch-banner noise".to_string())
+    }
+}
+
+struct NoFindings;
+impl DiffReviewer for NoFindings {
+    fn review(&self, _diff: &str) -> Result<Vec<ReviewFinding>, OverseerError> {
+        Ok(vec![])
+    }
+}
+
+struct ReadyJudge;
+impl MergeJudge for ReadyJudge {
+    fn judge(
+        &self,
+        _pr: u32,
+        _repo: &str,
+        _snap: &PrSnapshot,
+    ) -> crate::error::SimardResult<JudgeOutcome> {
+        Ok(JudgeOutcome {
+            verdict: Verdict::Ready,
+            rationale: "fixture ready".to_string(),
+            blockers: vec![],
+        })
+    }
+    fn kind(&self) -> MergeJudgeKind {
+        MergeJudgeKind::Llm
+    }
+}
+
+struct NoSleep;
+impl PollClock for NoSleep {
+    fn sleep(&self, _secs: u64) {}
+}
+
+struct Capture {
+    name: String,
+    seen: Arc<Mutex<Vec<MergeNotification>>>,
+}
+impl NotifyChannel for Capture {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn deliver(&self, n: &MergeNotification) -> ChannelDelivery {
+        self.seen.lock().unwrap().push(n.clone());
+        ChannelDelivery::Sent
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn green_merge_ops(
+    gh: Arc<GreenGh>,
+) -> (
+    MergePrOps,
+    Arc<Mutex<Vec<MergeNotification>>>,
+    Arc<Mutex<Vec<MergeNotification>>>,
+) {
+    let email = Arc::new(Mutex::new(vec![]));
+    let signal = Arc::new(Mutex::new(vec![]));
+    let notifier = DualChannelNotifier::new(vec![
+        Box::new(Capture {
+            name: "email".to_string(),
+            seen: email.clone(),
+        }),
+        Box::new(Capture {
+            name: "signal".to_string(),
+            seen: signal.clone(),
+        }),
+    ]);
+    let ops = MergePrOps::new(
+        Box::new(gh),
+        Box::new(CleanSource),
+        Some(Box::new(NoFindings)),
+        Box::new(ReadyJudge),
+        notifier,
+        Box::new(NoSleep),
+        vec!["main".to_string()],
+        PollConfig {
+            max_attempts: 3,
+            interval_secs: 1,
+        },
+    );
+    (ops, email, signal)
+}
+
+// ── the fixture ──────────────────────────────────────────────────────────────
+
+#[test]
+fn seeded_problem_launches_fix_merges_green_pr_and_notifies_operator() {
+    // 1. Observe a process problem (the real ~62% distill-failure case) and let
+    //    the full decide() choose to launch a fix workstream.
+    let observed = ObservedState {
+        distill_fail_pct: Some(62.0),
+        ..ObservedState::default()
+    };
+    let problems = orient(&signals_from(&observed), &[]);
+    assert_eq!(problems.len(), 1, "one process-health problem");
+    let brief = match decide(&problems[0]) {
+        Intervention::LaunchRecipe { brief } => brief,
+        other => panic!("process health must launch a recipe, got {other:?}"),
+    };
+    assert!(brief.task_description.contains("distill"));
+
+    // 2. Launch the fix through the launcher seam and poll it to a PR.
+    let launcher = SmartOrchestratorLauncher::new(Box::new(FakeRunner {
+        repo: "rysweet/Simard".to_string(),
+        pr: 2601,
+    }));
+    let handle = launcher.launch(&brief).expect("launch");
+    let (repo, pr) = match launcher.poll(&handle).expect("poll") {
+        WorkstreamStatus::ProducedPr { repo, pr } => (repo, pr),
+        other => panic!("expected a PR, got {other:?}"),
+    };
+
+    // 3. Verify + merge the green PR through the gated authority; the mandatory
+    //    operator notification must fire on BOTH channels.
+    let gh = GreenGh::new();
+    let (ops, email, signal) = green_merge_ops(gh.clone());
+    let report = ops.verify(&repo, pr).expect("verify");
+    assert!(report.ready, "green additive PR verifies ready: {report:?}");
+    ops.merge(&repo, pr).expect("merge the green PR");
+
+    assert_eq!(gh.merges(), 1, "merged exactly once (squash, no --admin)");
+    assert_eq!(email.lock().unwrap().len(), 1, "operator emailed on merge");
+    assert_eq!(
+        signal.lock().unwrap().len(),
+        1,
+        "operator Signalled on merge"
+    );
+    let n = &email.lock().unwrap()[0];
+    assert!(n.pr_url.ends_with("/pull/2601"));
+    assert!(n.problem.contains("merge-ready"));
+    assert!(n.autonomous);
+}
+
+#[test]
+fn overseer_gate_holds_verify_merge_until_opt_in() {
+    // The Overseer's autonomy gate refuses VerifyAndMergePr by default (crusty
+    // risk #1) and admits it only after the operator opts in.
+    use crate::overseer::guardrails::AutonomyGate;
+    let iv = Intervention::VerifyAndMergePr {
+        repo: "rysweet/Simard".to_string(),
+        pr: 2601,
+    };
+    assert!(AutonomyGate::default().admit(&iv).is_err());
+    assert!(
+        AutonomyGate {
+            allow_verify_merge: true,
+            allow_high_risk: false,
+        }
+        .admit(&iv)
+        .is_ok()
+    );
+}


### PR DESCRIPTION
## Milestone 2 of the embedded Overseer (#2527) — opt-in, default OFF

Stacked on #2539 (M1). Adds the **acting** capabilities, with the merge-safety **hard gate built and unit-tested first** (crusty risk #2 / operator hard-gate #5). `VerifyAndMergePr` stays **opt-in** (crusty risk #1) — autonomy is earned.

> Base is `overseer/m1-observer`; retarget to `main` once #2539 merges. The M2 diff is the M2 commit only.

### The hard gate first — pr-verify diff-scans (`pr_verify.rs`)
Four **new**, additive, **pure** scans over `gh pr diff`, unit-tested on fixture diffs:
- **#3** no `Bridge` naming in added lines · **#4** no stray `print!`/`println!`/`eprintln!`/`eprint!` in added `src/**` · **#5** additive (no removed `pub` items) · **#6** PRD (`Specs/ProductArchitecture.md`) preserved.

No merge path compiles that skips these.

### Mandatory `NotifyOperator` (`notify.rs`) — operator policy #3
`DualChannelNotifier` fires **BOTH email AND Signal** on every merge with a `{problem, pr_title, pr_url, repo}` summary. Reuses the `ConversationChannel` abstraction from #2529 via `ConversationSignalSender` (tested end-to-end with `MockConversationChannel`). Email via SMTP env (`SIMARD_OVERSEER_EMAIL_{TO,FROM}` / `SMTP_*`). **Unconfigured channels degrade to `Queued` (logged) — there is no silent-drop code path.**

### `PrOps` + `RecipeLauncher`
- `merge_ops.rs` — real `PrOps`: `verify` = objective gates (`evaluate_objective_gates`) + the four diff-scans + review (`should_commit`); `merge` **polls required checks until green** (injected clock — no sleeps in tests), escalates on any red/timeout, merges via `merge_pr_if_merge_ready_with_judge` (**squash, no `--admin`, no `--no-verify`**), then fires `NotifyOperator`. Review gate is **fail-closed** when no reviewer is wired. `resolve_conflict` is deferred to M3 (never `--no-verify`).
- `launch.rs` — `RecipeLauncher`: pure `amplihack recipe run smart-orchestrator` args builder + pure PR-URL extractor + an injectable `RecipeRunner` seam + a real spawner.

### Guardrails (crusty risk #1 / operator hard-gate #6)
`VerifyAndMergePr` → new opt-in `RiskClass::MergeAuthority`, **not Routine**. `AutonomyGate.allow_verify_merge` defaults `false`; the merge opt-in does **not** leak into HIGH-RISK deploy authority. Added `Overseer::with_verify_merge_autonomy`.

### Tests
95 overseer unit tests (57 M1 + 38 M2) — all pure/injected: **no subprocess, no network, no sleeps**. Includes the M2 fixture (`tests_m2.rs`): a seeded process problem launches a fix, polls to a PR, verifies + merges the green PR through the gated authority, and notifies the operator on both channels. Also: budget gate holds launches, per-cycle launch cap, pr-verify pass/fail on fixture diffs, merge only when green, no-admin asserted (structural — the client has no admin method).

### Gates
`cargo fmt`, `cargo clippy --release --no-deps -D warnings`, and `cargo clippy --all-targets --all-features --locked -D warnings` all green. No `--no-verify`, no `--admin`.

### Scope / next
Additive + flag-gated; the daemon's default behaviour is unchanged (no always-on acting loop wired — the capabilities are ready for the operator to enable). M3 (guarded deploy + `ResolveConflict` + goal transfer) and M4 (audits + self-tuning) follow as their own PRs.