### PR TITLE
feat(overseer): M3 — guarded deploy + goal transfer + conflict resolution (opt-in) (#2527)

### DIFF
--- a/src/overseer/conflict.rs
+++ b/src/overseer/conflict.rs
@@ -1,0 +1,158 @@
+//! M3 — conflict resolution that **never** bypasses hooks (operator hard-gate
+//! #8). Conflict-resolution pushes run pre-commit/pre-push hooks; `--no-verify`
+//! is refused at the git-runner boundary, so no code path can smuggle it in.
+//!
+//! Reuse (design doc §capability table): `git_guardrails::check_git_safety`
+//! (`src/git_guardrails.rs:41`) guards every git command; the resolver performs
+//! a conservative rebase-onto-base + push, all through the guarded runner.
+
+use std::path::{Path, PathBuf};
+
+use crate::overseer::capabilities::OverseerError;
+use crate::overseer::merge_ops::ConflictResolver;
+
+/// Runs guarded git commands in a repo. Injectable so the resolver is unit-
+/// tested without a real repository or remote. The real runner refuses
+/// `--no-verify` and applies `git_guardrails::check_git_safety`.
+pub trait GitRunner {
+    fn run(&self, repo_dir: &Path, args: &[&str]) -> Result<(), OverseerError>;
+}
+
+/// Real git runner. Two always-on floors before any command executes:
+/// 1. **Refuse `--no-verify`** — pre-commit/pre-push hooks MUST run (hard-gate #8).
+/// 2. **`check_git_safety`** — the shipped destructive-command guardrail.
+#[derive(Clone, Debug, Default)]
+pub struct RealGitRunner;
+
+impl GitRunner for RealGitRunner {
+    fn run(&self, repo_dir: &Path, args: &[&str]) -> Result<(), OverseerError> {
+        if args.contains(&"--no-verify") {
+            return Err(OverseerError::Capability {
+                what: "git",
+                detail: "refusing --no-verify — conflict-resolution pushes must run hooks"
+                    .to_string(),
+            });
+        }
+        crate::git_guardrails::check_git_safety(repo_dir, args).map_err(|e| {
+            OverseerError::Capability {
+                what: "git_guardrails",
+                detail: e,
+            }
+        })?;
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(repo_dir)
+            .args(args)
+            .status()
+            .map_err(|e| OverseerError::Capability {
+                what: "git",
+                detail: e.to_string(),
+            })?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(OverseerError::Capability {
+                what: "git",
+                detail: format!("git {} exited {status}", args.join(" ")),
+            })
+        }
+    }
+}
+
+/// The [`ConflictResolver`] over a [`GitRunner`] seam. Resolves by rebasing the
+/// PR branch onto the base and pushing — through hooks, never `--no-verify`.
+pub struct GitConflictResolver {
+    git: Box<dyn GitRunner>,
+    repo_dir: PathBuf,
+    base_ref: String,
+}
+
+impl GitConflictResolver {
+    pub fn new(git: Box<dyn GitRunner>, repo_dir: PathBuf, base_ref: impl Into<String>) -> Self {
+        Self {
+            git,
+            repo_dir,
+            base_ref: base_ref.into(),
+        }
+    }
+
+    /// Production resolver: real git runner, `main` base.
+    pub fn from_env(repo_dir: PathBuf) -> Self {
+        Self::new(Box::new(RealGitRunner), repo_dir, "main")
+    }
+}
+
+impl ConflictResolver for GitConflictResolver {
+    fn resolve(&self, _repo: &str, _pr: u32) -> Result<(), OverseerError> {
+        let base = format!("origin/{}", self.base_ref);
+        // Conservative, hook-respecting sequence — no --no-verify anywhere.
+        self.git.run(&self.repo_dir, &["fetch", "origin"])?;
+        self.git
+            .run(&self.repo_dir, &["merge", "--no-edit", &base])?;
+        // Push runs pre-commit/pre-push hooks (hard-gate #8).
+        self.git.run(&self.repo_dir, &["push"])?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingGit {
+        calls: Mutex<Vec<Vec<String>>>,
+    }
+    impl GitRunner for RecordingGit {
+        fn run(&self, _dir: &Path, args: &[&str]) -> Result<(), OverseerError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(args.iter().map(|s| s.to_string()).collect());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn resolver_pushes_through_hooks_never_no_verify() {
+        let git = std::sync::Arc::new(RecordingGit::default());
+        let resolver = GitConflictResolver::new(
+            Box::new(GitRef(git.clone())),
+            PathBuf::from("/repo"),
+            "main",
+        );
+        resolver.resolve("rysweet/Simard", 7).expect("resolve");
+
+        let calls = git.calls.lock().unwrap();
+        // No git invocation ever carries --no-verify.
+        assert!(
+            calls.iter().all(|c| !c.iter().any(|a| a == "--no-verify")),
+            "conflict resolution must never use --no-verify: {calls:?}"
+        );
+        // The sequence ends with a plain push (hooks run).
+        assert_eq!(calls.last().unwrap(), &vec!["push".to_string()]);
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.first().map(String::as_str) == Some("merge"))
+        );
+    }
+
+    struct GitRef(std::sync::Arc<RecordingGit>);
+    impl GitRunner for GitRef {
+        fn run(&self, dir: &Path, args: &[&str]) -> Result<(), OverseerError> {
+            self.0.run(dir, args)
+        }
+    }
+
+    #[test]
+    fn real_runner_refuses_no_verify_before_running_git() {
+        // The real runner refuses --no-verify without shelling out to git, so
+        // the hard gate holds even if a caller tries to smuggle it in.
+        let err = RealGitRunner
+            .run(Path::new("/nonexistent-repo"), &["push", "--no-verify"])
+            .unwrap_err();
+        assert!(format!("{err}").contains("--no-verify"));
+    }
+}

--- a/src/overseer/deploy.rs
+++ b/src/overseer/deploy.rs
@@ -1,0 +1,434 @@
+//! M3 — guarded (HIGH-RISK, opt-in) deploy via canary gates + a deploy gate that
+//! refuses the dangerous shapes, plus the mandatory operator notification on
+//! deploy.
+//!
+//! Reuse (design doc §capability table):
+//! - Canary: `self_relaunch::{build_canary, verify_canary, all_gates_passed,
+//!   default_gates}` (`src/self_relaunch/*`).
+//! - Deploy: `self_deploy::orchestrator::SelfDeployOrchestrator::run`
+//!   (`src/self_deploy/orchestrator.rs:229`).
+//! - Running commit marker: `env!("SIMARD_GIT_HASH")` (matches
+//!   `self_deploy::health`).
+//!
+//! Operator hard-gates encoded:
+//! - `Deploy` stays HIGH-RISK and opt-in (`AutonomyGate.allow_high_risk`,
+//!   default `false`) — enforced by [`guardrails`](crate::overseer::guardrails),
+//!   not here.
+//! - The **deploy gate** ([`evaluate_deploy_gate`]) refuses a no-op deploy
+//!   (target == running), a **rollback** (target is an ancestor of running), a
+//!   **red canary** (gates failed), and a **crash-loop** (elevated restart
+//!   churn). A refused deploy escalates — it does not mutate the binary.
+//! - Every deploy fires [`NotifyOperator`](crate::overseer::notify) on both
+//!   channels.
+//! - The deployer never touches `~/.simard/worktrees`: it operates only on the
+//!   canary target dir and the install path.
+
+use crate::overseer::capabilities::{DeployReport, Deployer, OverseerError};
+use crate::overseer::notify::{DualChannelNotifier, OperatorNotification};
+
+/// Restart churn at/above which a deploy is refused as a suspected crash-loop
+/// (deploying into an unstable process makes it worse — Bainbridge's irony).
+pub const CRASH_LOOP_CHURN_THRESHOLD: u64 = 3;
+
+/// The inputs the deploy gate judges. Assembled by [`GuardedDeployer`] from the
+/// running-commit marker, the canary result, a git-ancestry check, and observed
+/// restart churn.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeployContext {
+    pub running_commit: String,
+    pub target_commit: String,
+    /// True iff `target_commit` is an ancestor of `running_commit` (a rollback).
+    pub target_is_ancestor_of_running: bool,
+    /// Did every canary gate pass?
+    pub canary_passed: bool,
+    /// Observed daemon restart churn over the recent window.
+    pub recent_restart_churn: u64,
+}
+
+/// Why a deploy was refused. Each variant is a dangerous shape the operator's
+/// manual discipline avoids and the unattended loop must too.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DeployRefusal {
+    /// Target is already the running commit — nothing to do.
+    NoOp,
+    /// Target is older than (an ancestor of) the running commit.
+    Rollback,
+    /// The canary gates did not all pass.
+    RedCanary,
+    /// Restart churn suggests a crash-loop; deploying would worsen it.
+    CrashLoop { churn: u64 },
+}
+
+impl std::fmt::Display for DeployRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoOp => write!(f, "no-op deploy (target == running commit)"),
+            Self::Rollback => write!(f, "rollback refused (target is older than running)"),
+            Self::RedCanary => write!(f, "red canary (one or more gates failed)"),
+            Self::CrashLoop { churn } => {
+                write!(
+                    f,
+                    "crash-loop suspected (restart churn {churn}) — not deploying"
+                )
+            }
+        }
+    }
+}
+
+/// The deploy gate (pure). Refuses no-op, rollback, red-canary, and crash-loop.
+pub fn evaluate_deploy_gate(ctx: &DeployContext) -> Result<(), DeployRefusal> {
+    if commits_equivalent(&ctx.running_commit, &ctx.target_commit) {
+        return Err(DeployRefusal::NoOp);
+    }
+    if ctx.target_is_ancestor_of_running {
+        return Err(DeployRefusal::Rollback);
+    }
+    if !ctx.canary_passed {
+        return Err(DeployRefusal::RedCanary);
+    }
+    if ctx.recent_restart_churn >= CRASH_LOOP_CHURN_THRESHOLD {
+        return Err(DeployRefusal::CrashLoop {
+            churn: ctx.recent_restart_churn,
+        });
+    }
+    Ok(())
+}
+
+/// Two commit hashes name the same commit if equal or one is a prefix of the
+/// other (short vs long hash). Mirrors `self_deploy::health::commits_compatible`.
+fn commits_equivalent(a: &str, b: &str) -> bool {
+    if a.is_empty() || b.is_empty() {
+        return false;
+    }
+    let (a, b) = (a.to_ascii_lowercase(), b.to_ascii_lowercase());
+    a == b || a.starts_with(&b) || b.starts_with(&a)
+}
+
+// ─────────────────────────── injected seams ────────────────────────────────
+
+/// Result of building + verifying the canary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CanaryResult {
+    pub passed: bool,
+    pub detail: String,
+}
+
+/// Build + verify the canary binary for a target. Real impl reuses
+/// `self_relaunch::{build_canary, verify_canary, all_gates_passed}`; tests fake it.
+pub trait CanaryRunner {
+    fn run_canary(&self, target_commit: &str) -> Result<CanaryResult, OverseerError>;
+}
+
+/// Perform the actual binary swap for a target, returning the deployed commit.
+/// Real impl wraps `SelfDeployOrchestrator::run`; tests fake it. (HIGH-RISK, so
+/// the real wiring is supplied explicitly by the operator when opting in.)
+pub trait BinaryDeployer {
+    fn deploy_binary(&self, target_commit: &str) -> Result<String, OverseerError>;
+}
+
+/// Answer "is `ancestor` an ancestor of `descendant`?" — reused to detect a
+/// rollback. Real impl shells `git merge-base --is-ancestor`; tests fake it.
+pub trait AncestryOracle {
+    fn is_ancestor(&self, ancestor: &str, descendant: &str) -> Result<bool, OverseerError>;
+}
+
+/// Real ancestry oracle over `git merge-base --is-ancestor` in `repo_dir`.
+pub struct GitAncestryOracle {
+    pub repo_dir: std::path::PathBuf,
+}
+
+impl AncestryOracle for GitAncestryOracle {
+    fn is_ancestor(&self, ancestor: &str, descendant: &str) -> Result<bool, OverseerError> {
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&self.repo_dir)
+            .args(["merge-base", "--is-ancestor", ancestor, descendant])
+            .status()
+            .map_err(|e| OverseerError::Capability {
+                what: "git.merge-base",
+                detail: e.to_string(),
+            })?;
+        // Exit 0 → is an ancestor; exit 1 → not; other → error.
+        match status.code() {
+            Some(0) => Ok(true),
+            Some(1) => Ok(false),
+            other => Err(OverseerError::Capability {
+                what: "git.merge-base",
+                detail: format!("unexpected exit {other:?}"),
+            }),
+        }
+    }
+}
+
+// ─────────────────────────── the adapter ───────────────────────────────────
+
+/// The guarded [`Deployer`]. Composes the canary, deploy gate, binary swap, and
+/// mandatory operator notification. HIGH-RISK; only run when the operator opts
+/// in via the `AutonomyGate`.
+pub struct GuardedDeployer {
+    canary: Box<dyn CanaryRunner>,
+    deployer: Box<dyn BinaryDeployer>,
+    ancestry: Box<dyn AncestryOracle>,
+    notifier: DualChannelNotifier,
+    running_commit: String,
+    recent_restart_churn: u64,
+    repo: String,
+}
+
+impl GuardedDeployer {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        canary: Box<dyn CanaryRunner>,
+        deployer: Box<dyn BinaryDeployer>,
+        ancestry: Box<dyn AncestryOracle>,
+        notifier: DualChannelNotifier,
+        running_commit: String,
+        recent_restart_churn: u64,
+        repo: String,
+    ) -> Self {
+        Self {
+            canary,
+            deployer,
+            ancestry,
+            notifier,
+            running_commit,
+            recent_restart_churn,
+            repo,
+        }
+    }
+
+    /// The compile-time running commit (matches `self_deploy::health`).
+    pub fn running_commit_marker() -> &'static str {
+        env!("SIMARD_GIT_HASH")
+    }
+}
+
+impl Deployer for GuardedDeployer {
+    fn deploy(&self, commit: &str) -> Result<DeployReport, OverseerError> {
+        let running = self.running_commit.clone();
+
+        // Build + verify the canary first (its result feeds the gate).
+        let canary = self.canary.run_canary(commit)?;
+
+        // A rollback check only matters when the target differs from running.
+        let is_ancestor = if commits_equivalent(&running, commit) {
+            false
+        } else {
+            self.ancestry.is_ancestor(commit, &running)?
+        };
+
+        let ctx = DeployContext {
+            running_commit: running.clone(),
+            target_commit: commit.to_string(),
+            target_is_ancestor_of_running: is_ancestor,
+            canary_passed: canary.passed,
+            recent_restart_churn: self.recent_restart_churn,
+        };
+        evaluate_deploy_gate(&ctx).map_err(|refusal| OverseerError::Capability {
+            what: "deploy_gate",
+            detail: refusal.to_string(),
+        })?;
+
+        // Gate passed — perform the binary swap.
+        let deployed = self.deployer.deploy_binary(commit)?;
+
+        // Mandatory: notify the operator on both channels.
+        let notification = OperatorNotification::deploy(
+            &deployed,
+            &running,
+            &self.repo,
+            &format!("canary {} ({})", pass_word(canary.passed), canary.detail),
+        );
+        let report = self.notifier.notify(&notification);
+        debug_assert!(
+            report.dispatched(),
+            "deploy completed without a dispatched operator notification"
+        );
+
+        Ok(DeployReport {
+            deployed_commit: deployed,
+            gates_passed: true,
+        })
+    }
+
+    fn deployed_commit(&self) -> Result<String, OverseerError> {
+        Ok(self.running_commit.clone())
+    }
+}
+
+fn pass_word(passed: bool) -> &'static str {
+    if passed { "green" } else { "red" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::overseer::notify::{ChannelDelivery, NotifyChannel, OperatorNotification};
+    use std::sync::{Arc, Mutex};
+
+    // ── pure gate ────────────────────────────────────────────────────────────
+
+    fn ctx() -> DeployContext {
+        DeployContext {
+            running_commit: "aaaaaaaaaaaa".to_string(),
+            target_commit: "bbbbbbbbbbbb".to_string(),
+            target_is_ancestor_of_running: false,
+            canary_passed: true,
+            recent_restart_churn: 0,
+        }
+    }
+
+    #[test]
+    fn gate_allows_a_clean_forward_deploy() {
+        assert!(evaluate_deploy_gate(&ctx()).is_ok());
+    }
+
+    #[test]
+    fn gate_refuses_no_op() {
+        let mut c = ctx();
+        c.target_commit = c.running_commit.clone();
+        assert_eq!(evaluate_deploy_gate(&c), Err(DeployRefusal::NoOp));
+        // Short-vs-long hash is also a no-op.
+        let mut c = ctx();
+        c.running_commit = "aaaaaaaaaaaa1111".to_string();
+        c.target_commit = "aaaaaaaaaaaa".to_string();
+        assert_eq!(evaluate_deploy_gate(&c), Err(DeployRefusal::NoOp));
+    }
+
+    #[test]
+    fn gate_refuses_rollback() {
+        let mut c = ctx();
+        c.target_is_ancestor_of_running = true;
+        assert_eq!(evaluate_deploy_gate(&c), Err(DeployRefusal::Rollback));
+    }
+
+    #[test]
+    fn gate_refuses_red_canary() {
+        let mut c = ctx();
+        c.canary_passed = false;
+        assert_eq!(evaluate_deploy_gate(&c), Err(DeployRefusal::RedCanary));
+    }
+
+    #[test]
+    fn gate_refuses_crash_loop() {
+        let mut c = ctx();
+        c.recent_restart_churn = CRASH_LOOP_CHURN_THRESHOLD;
+        assert_eq!(
+            evaluate_deploy_gate(&c),
+            Err(DeployRefusal::CrashLoop {
+                churn: CRASH_LOOP_CHURN_THRESHOLD
+            })
+        );
+    }
+
+    // ── the adapter ──────────────────────────────────────────────────────────
+
+    struct FakeCanary(bool);
+    impl CanaryRunner for FakeCanary {
+        fn run_canary(&self, _t: &str) -> Result<CanaryResult, OverseerError> {
+            Ok(CanaryResult {
+                passed: self.0,
+                detail: "4/4 gates".to_string(),
+            })
+        }
+    }
+
+    struct FakeAncestry(bool);
+    impl AncestryOracle for FakeAncestry {
+        fn is_ancestor(&self, _a: &str, _d: &str) -> Result<bool, OverseerError> {
+            Ok(self.0)
+        }
+    }
+
+    struct Capture(Arc<Mutex<Vec<OperatorNotification>>>);
+    impl NotifyChannel for Capture {
+        fn name(&self) -> &str {
+            "capture"
+        }
+        fn deliver(&self, n: &OperatorNotification) -> ChannelDelivery {
+            self.0.lock().unwrap().push(n.clone());
+            ChannelDelivery::Sent
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn deployer(
+        canary_passed: bool,
+        is_ancestor: bool,
+        churn: u64,
+    ) -> (
+        GuardedDeployer,
+        Arc<Mutex<usize>>,
+        Arc<Mutex<Vec<OperatorNotification>>>,
+    ) {
+        let deployed = Arc::new(Mutex::new(0));
+        let seen = Arc::new(Mutex::new(vec![]));
+        let notifier = DualChannelNotifier::new(vec![Box::new(Capture(seen.clone()))]);
+        let gd = GuardedDeployer::new(
+            Box::new(FakeCanary(canary_passed)),
+            Box::new(FakeDeployerShared(deployed.clone())),
+            Box::new(FakeAncestry(is_ancestor)),
+            notifier,
+            "aaaaaaaaaaaa".to_string(),
+            churn,
+            "rysweet/Simard".to_string(),
+        );
+        (gd, deployed, seen)
+    }
+
+    struct FakeDeployerShared(Arc<Mutex<usize>>);
+    impl BinaryDeployer for FakeDeployerShared {
+        fn deploy_binary(&self, target: &str) -> Result<String, OverseerError> {
+            *self.0.lock().unwrap() += 1;
+            Ok(target.to_string())
+        }
+    }
+
+    #[test]
+    fn deploy_succeeds_and_notifies_on_clean_forward() {
+        let (gd, deployed, seen) = deployer(true, false, 0);
+        let report = gd.deploy("bbbbbbbbbbbb").expect("deploy");
+        assert!(report.gates_passed);
+        assert_eq!(report.deployed_commit, "bbbbbbbbbbbb");
+        assert_eq!(*deployed.lock().unwrap(), 1, "binary swapped once");
+        assert_eq!(seen.lock().unwrap().len(), 1, "operator notified on deploy");
+        assert_eq!(seen.lock().unwrap()[0].kind, "deploy");
+    }
+
+    #[test]
+    fn deploy_refuses_no_op_without_swapping_or_notifying() {
+        let (gd, deployed, seen) = deployer(true, false, 0);
+        // Target == running → no-op.
+        let err = gd.deploy("aaaaaaaaaaaa").unwrap_err();
+        assert!(format!("{err}").contains("no-op"));
+        assert_eq!(*deployed.lock().unwrap(), 0, "no binary swap on refusal");
+        assert!(seen.lock().unwrap().is_empty(), "no notify on refusal");
+    }
+
+    #[test]
+    fn deploy_refuses_rollback() {
+        let (gd, deployed, _) = deployer(true, true, 0);
+        assert!(format!("{}", gd.deploy("bbbbbbbbbbbb").unwrap_err()).contains("rollback"));
+        assert_eq!(*deployed.lock().unwrap(), 0);
+    }
+
+    #[test]
+    fn deploy_refuses_red_canary() {
+        let (gd, deployed, _) = deployer(false, false, 0);
+        assert!(format!("{}", gd.deploy("bbbbbbbbbbbb").unwrap_err()).contains("red canary"));
+        assert_eq!(*deployed.lock().unwrap(), 0);
+    }
+
+    #[test]
+    fn deploy_refuses_crash_loop() {
+        let (gd, deployed, _) = deployer(true, false, CRASH_LOOP_CHURN_THRESHOLD);
+        assert!(format!("{}", gd.deploy("bbbbbbbbbbbb").unwrap_err()).contains("crash-loop"));
+        assert_eq!(*deployed.lock().unwrap(), 0);
+    }
+
+    #[test]
+    fn deployed_commit_reports_running() {
+        let (gd, _, _) = deployer(true, false, 0);
+        assert_eq!(gd.deployed_commit().unwrap(), "aaaaaaaaaaaa");
+    }
+}

--- a/src/overseer/meeting_ops.rs
+++ b/src/overseer/meeting_ops.rs
@@ -1,0 +1,179 @@
+//! M3 — the [`MeetingHost`] adapter: transfer a goal to Simard via the meeting
+//! handoff surface, without running the interactive REPL.
+//!
+//! Reuse (design doc §capability table): `meetings::build_persisted_meeting_record_value`
+//! (`src/meetings/mod.rs:135`) — the non-interactive path that renders the same
+//! on-wire meeting record the REPL persists (`meeting_repl::run_meeting_repl` is
+//! the interactive equivalent). The record is written to a durable handoff file
+//! under the shared state root, which Simard's OODA reads to adopt the goal.
+//!
+//! The writer is an injectable [`HandoffSink`] so the transfer is unit-tested
+//! with a fake (no filesystem, no REPL). The real sink writes under
+//! `<state_root>/meeting_handoffs/` — **never** `~/.simard/worktrees`.
+
+use std::path::PathBuf;
+
+use crate::meetings::build_persisted_meeting_record_value;
+use crate::overseer::capabilities::{GoalBrief, MeetingHost, OverseerError};
+
+/// Durable sink for a rendered meeting/goal-handoff record. Injectable so the
+/// transfer is testable without touching the filesystem.
+pub trait HandoffSink {
+    /// Persist `record` for `topic`, returning the artifact path.
+    fn record(&self, topic: &str, record: &str) -> Result<PathBuf, OverseerError>;
+}
+
+/// Real sink: writes a timestamped handoff file under `dir` (default
+/// `<state_root>/meeting_handoffs/`). Creates `dir` if missing. Never writes to
+/// `~/.simard/worktrees`.
+pub struct FileHandoffSink {
+    pub dir: PathBuf,
+}
+
+impl FileHandoffSink {
+    pub fn new(dir: PathBuf) -> Self {
+        Self { dir }
+    }
+
+    /// Default handoff dir: `<state_root>/meeting_handoffs/`.
+    pub fn from_env() -> Self {
+        Self::new(crate::state_root::simard_state_root().join("meeting_handoffs"))
+    }
+}
+
+impl HandoffSink for FileHandoffSink {
+    fn record(&self, topic: &str, record: &str) -> Result<PathBuf, OverseerError> {
+        std::fs::create_dir_all(&self.dir).map_err(|e| OverseerError::Capability {
+            what: "handoff.mkdir",
+            detail: e.to_string(),
+        })?;
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = self
+            .dir
+            .join(format!("overseer-goal-{ts}-{}.txt", slug(topic)));
+        std::fs::write(&path, record).map_err(|e| OverseerError::Capability {
+            what: "handoff.write",
+            detail: e.to_string(),
+        })?;
+        Ok(path)
+    }
+}
+
+fn slug(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}
+
+/// The [`MeetingHost`] adapter. Renders the goal as a meeting record and writes
+/// it to the handoff sink — the durable "transfer this goal to Simard" artifact.
+pub struct MeetingGoalTransfer {
+    sink: Box<dyn HandoffSink>,
+}
+
+impl MeetingGoalTransfer {
+    pub fn new(sink: Box<dyn HandoffSink>) -> Self {
+        Self { sink }
+    }
+
+    /// Production adapter: write handoffs under `<state_root>/meeting_handoffs/`.
+    pub fn from_env() -> Self {
+        Self::new(Box::new(FileHandoffSink::from_env()))
+    }
+
+    /// Render a goal as the on-wire meeting record (public for tests).
+    pub fn render_goal_record(goal: &GoalBrief) -> String {
+        let decisions = vec![format!(
+            "Transfer goal to Simard: {} — {}",
+            goal.title, goal.rationale
+        )];
+        let action_items = vec![format!(
+            "Advance goal in {} (priority {})",
+            goal.target_repo, goal.priority
+        )];
+        build_persisted_meeting_record_value(&goal.title, &decisions, &action_items, &[])
+    }
+}
+
+impl MeetingHost for MeetingGoalTransfer {
+    fn transfer_goal(&self, goal: &GoalBrief) -> Result<(), OverseerError> {
+        let record = Self::render_goal_record(goal);
+        self.sink.record(&goal.title, &record)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    fn goal() -> GoalBrief {
+        GoalBrief {
+            title: "Reduce distillation parse-failure rate".to_string(),
+            rationale: "banner pollution is breaking distillation".to_string(),
+            priority: 2,
+            target_repo: "rysweet/Simard".to_string(),
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeSink {
+        recorded: Mutex<Vec<(String, String)>>,
+    }
+    impl HandoffSink for FakeSink {
+        fn record(&self, topic: &str, record: &str) -> Result<PathBuf, OverseerError> {
+            self.recorded
+                .lock()
+                .unwrap()
+                .push((topic.to_string(), record.to_string()));
+            Ok(PathBuf::from("/tmp/fake-handoff.txt"))
+        }
+    }
+
+    #[test]
+    fn transfer_records_the_goal_round_trip() {
+        let sink = std::sync::Arc::new(FakeSink::default());
+        let host = MeetingGoalTransfer::new(Box::new(SinkRef(sink.clone())));
+        host.transfer_goal(&goal()).expect("transfer");
+
+        let recorded = sink.recorded.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        let (topic, record) = &recorded[0];
+        assert!(topic.contains("distillation"));
+        // The record carries the goal title, rationale, and target repo.
+        assert!(record.contains("Reduce distillation parse-failure rate"));
+        assert!(record.contains("banner pollution"));
+        assert!(record.contains("rysweet/Simard"));
+    }
+
+    /// Share a FakeSink across the adapter and the assertion.
+    struct SinkRef(std::sync::Arc<FakeSink>);
+    impl HandoffSink for SinkRef {
+        fn record(&self, topic: &str, record: &str) -> Result<PathBuf, OverseerError> {
+            self.0.record(topic, record)
+        }
+    }
+
+    #[test]
+    fn file_sink_writes_under_configured_dir_not_worktrees() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("meeting_handoffs");
+        let sink = FileHandoffSink::new(dir.clone());
+        let path = sink.record("t", "some record").expect("write");
+        assert!(
+            path.starts_with(&dir),
+            "handoff written under the configured dir"
+        );
+        assert!(
+            !path.to_string_lossy().contains("worktrees"),
+            "must never write into worktrees"
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "some record");
+    }
+}

--- a/src/overseer/merge_ops.rs
+++ b/src/overseer/merge_ops.rs
@@ -29,17 +29,23 @@ use crate::stewardship::{
 };
 
 use crate::overseer::capabilities::{CheckItem, OverseerError, PrOps, VerifyReport};
+use crate::overseer::guardrails::{RecursionGuard, Subject};
 use crate::overseer::notify::{DualChannelNotifier, MergeNotification};
 use crate::overseer::pr_verify::run_diff_scans;
 
 // ─────────────────────────── injected seams ────────────────────────────────
 
-/// Source of a PR's unified diff + title. `PrGhClient` (the shipped trait) has
-/// no diff/title reader, so this adds one — the real impl shells `gh pr diff` /
-/// `gh pr view --json title`; tests inject canned values (no network).
+/// Source of a PR's unified diff + title + author. `PrGhClient` (the shipped
+/// trait) has no such reader, so this adds one — the real impl shells
+/// `gh pr diff` / `gh pr view --json title,author`; tests inject canned values.
 pub trait PrSource {
     fn diff(&self, repo: &str, pr: u32) -> Result<String, OverseerError>;
     fn title(&self, repo: &str, pr: u32) -> Result<String, OverseerError>;
+    /// PR author login (for the anti-recursion check). Defaults to empty so
+    /// existing fakes need not implement it; the real impl reads it from `gh`.
+    fn author(&self, _repo: &str, _pr: u32) -> Result<String, OverseerError> {
+        Ok(String::new())
+    }
 }
 
 /// The review gate (#7). Injected so tests exercise `should_commit` without an
@@ -48,6 +54,14 @@ pub trait PrSource {
 /// merges unreviewed.
 pub trait DiffReviewer {
     fn review(&self, diff: &str) -> Result<Vec<ReviewFinding>, OverseerError>;
+}
+
+/// Resolves a PR's merge conflicts. Deliberately its own seam so the real
+/// implementation ([`GitConflictResolver`](crate::overseer::conflict)) — which
+/// runs guarded git commands and **never** `--no-verify` — is injected only when
+/// the operator opts into HIGH-RISK conflict resolution.
+pub trait ConflictResolver {
+    fn resolve(&self, repo: &str, pr: u32) -> Result<(), OverseerError>;
 }
 
 /// Injected clock so the poll loop has **no real sleeps in tests**. Production
@@ -105,6 +119,21 @@ impl PrSource for RealPrSource {
         ])
         .map(|s| s.trim().to_string())
     }
+
+    fn author(&self, repo: &str, pr: u32) -> Result<String, OverseerError> {
+        run_gh(&[
+            "pr",
+            "view",
+            &pr.to_string(),
+            "--repo",
+            repo,
+            "--json",
+            "author",
+            "--jq",
+            ".author.login",
+        ])
+        .map(|s| s.trim().to_string())
+    }
 }
 
 fn run_gh(args: &[&str]) -> Result<String, OverseerError> {
@@ -137,6 +166,11 @@ pub struct MergePrOps {
     clock: Box<dyn PollClock>,
     base_allowlist: Vec<String>,
     poll: PollConfig,
+    /// HIGH-RISK conflict resolver, wired only when the operator opts in (M3).
+    conflict: Option<Box<dyn ConflictResolver>>,
+    /// Anti-recursion identity. When set, the Overseer refuses to merge its OWN
+    /// PRs (M3). Fails CLOSED when the guard is unconfigured.
+    recursion: Option<RecursionGuard>,
 }
 
 impl MergePrOps {
@@ -161,7 +195,24 @@ impl MergePrOps {
             clock,
             base_allowlist,
             poll,
+            conflict: None,
+            recursion: None,
         }
+    }
+
+    /// Opt into HIGH-RISK conflict resolution by wiring a resolver (M3). Default
+    /// is `None` — `resolve_conflict` refuses until a resolver is provided.
+    pub fn with_conflict_resolver(mut self, resolver: Box<dyn ConflictResolver>) -> Self {
+        self.conflict = Some(resolver);
+        self
+    }
+
+    /// Wire the Overseer's anti-recursion identity so `merge` refuses its OWN
+    /// PRs (M3). The guard fails CLOSED when unconfigured; the Overseer must run
+    /// under a DISTINCT identity, never the operator's login.
+    pub fn with_recursion_guard(mut self, guard: RecursionGuard) -> Self {
+        self.recursion = Some(guard);
+        self
     }
 
     /// Production adapter: real `gh` client + diff source, the env merge-judge,
@@ -316,6 +367,19 @@ impl PrOps for MergePrOps {
     /// merges. On a successful merge it fires the dual-channel notification; the
     /// merge is not complete until that notification has dispatched.
     fn merge(&self, repo: &str, pr: u32) -> Result<(), OverseerError> {
+        // 0. Anti-recursion: never merge the Overseer's OWN PR (M3). Fails
+        //    CLOSED when the guard is configured but the subject is its own.
+        if let Some(guard) = &self.recursion {
+            let author = self.source.author(repo, pr)?;
+            guard
+                .admit(&Subject::Pr {
+                    repo: repo.to_string(),
+                    pr,
+                    author,
+                })
+                .map_err(|e| cap("merge.recursion", e.to_string()))?;
+        }
+
         // 1. Full checklist must pass.
         let report = self.verify(repo, pr)?;
         if !report.ready {
@@ -354,7 +418,7 @@ impl PrOps for MergePrOps {
                     .title(repo, pr)
                     .unwrap_or_else(|_| format!("PR #{pr}"));
                 let notification = self.notification(repo, pr, &title);
-                let nreport = self.notifier.notify(&notification);
+                let nreport = self.notifier.notify(&notification.to_operator());
                 debug_assert!(
                     nreport.dispatched(),
                     "merge completed without a dispatched operator notification"
@@ -365,13 +429,19 @@ impl PrOps for MergePrOps {
         }
     }
 
-    /// HIGH-RISK conflict resolution. Deliberately **not** implemented in M2 and
-    /// **never** uses `--no-verify`. Wired in M3 under `git_guardrails`.
-    fn resolve_conflict(&self, _repo: &str, _pr: u32) -> Result<(), OverseerError> {
-        Err(OverseerError::Capability {
-            what: "resolve_conflict",
-            detail: "HIGH-RISK conflict resolution is wired in M3 (never --no-verify)".to_string(),
-        })
+    /// HIGH-RISK conflict resolution. Delegates to the injected
+    /// [`ConflictResolver`] (which **never** uses `--no-verify`); refuses when no
+    /// resolver is wired. Opt-in only.
+    fn resolve_conflict(&self, repo: &str, pr: u32) -> Result<(), OverseerError> {
+        match &self.conflict {
+            Some(resolver) => resolver.resolve(repo, pr),
+            None => Err(OverseerError::Capability {
+                what: "resolve_conflict",
+                detail:
+                    "no conflict resolver wired (HIGH-RISK; operator opt-in, never --no-verify)"
+                        .to_string(),
+            }),
+        }
     }
 }
 
@@ -402,7 +472,7 @@ fn classify_state(state: &str) -> CheckClass {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::overseer::notify::{ChannelDelivery, MergeNotification, NotifyChannel};
+    use crate::overseer::notify::{ChannelDelivery, NotifyChannel, OperatorNotification};
     use crate::stewardship::merge_authority::CheckRollupEntry;
     use crate::stewardship::{JudgeOutcome, MergeJudgeKind, PrSnapshot, Verdict};
     use std::sync::{Arc, Mutex};
@@ -495,13 +565,13 @@ mod tests {
     /// Records every notification it is handed.
     struct CapturingChannel {
         name: String,
-        seen: Arc<Mutex<Vec<MergeNotification>>>,
+        seen: Arc<Mutex<Vec<OperatorNotification>>>,
     }
     impl NotifyChannel for CapturingChannel {
         fn name(&self) -> &str {
             &self.name
         }
-        fn deliver(&self, n: &MergeNotification) -> ChannelDelivery {
+        fn deliver(&self, n: &OperatorNotification) -> ChannelDelivery {
             self.seen.lock().unwrap().push(n.clone());
             ChannelDelivery::Sent
         }
@@ -549,8 +619,8 @@ mod tests {
         poll: PollConfig,
     ) -> (
         MergePrOps,
-        Arc<Mutex<Vec<MergeNotification>>>,
-        Arc<Mutex<Vec<MergeNotification>>>,
+        Arc<Mutex<Vec<OperatorNotification>>>,
+        Arc<Mutex<Vec<OperatorNotification>>>,
     ) {
         let email_seen = Arc::new(Mutex::new(vec![]));
         let signal_seen = Arc::new(Mutex::new(vec![]));
@@ -688,7 +758,7 @@ mod tests {
         assert_eq!(signal.lock().unwrap().len(), 1, "signal notified");
         // The notification carries the problem + PR title + link.
         let n = &email.lock().unwrap()[0];
-        assert!(n.pr_url.contains("/pull/7"));
+        assert!(n.link.as_deref().unwrap().contains("/pull/7"));
         assert!(n.autonomous);
         assert!(n.problem.contains("merge-ready"));
     }
@@ -753,7 +823,8 @@ mod tests {
     }
 
     #[test]
-    fn resolve_conflict_is_m3_and_never_no_verify() {
+    fn resolve_conflict_refuses_without_resolver_and_delegates_when_wired() {
+        // No resolver wired → refuse (never a silent no-op, never --no-verify).
         let gh = ScriptedGh::new(vec![green()]);
         let (ops, _, _) = adapter_with(
             gh,
@@ -762,7 +833,75 @@ mod tests {
             Arc::new(CountingClock::default()),
             PollConfig::default(),
         );
-        let err = ops.resolve_conflict("rysweet/Simard", 1).unwrap_err();
-        assert!(format!("{err}").contains("M3"));
+        assert!(ops.resolve_conflict("rysweet/Simard", 1).is_err());
+
+        // With a resolver wired, resolve_conflict delegates to it.
+        struct OkResolver(Arc<Mutex<usize>>);
+        impl ConflictResolver for OkResolver {
+            fn resolve(&self, _repo: &str, _pr: u32) -> Result<(), OverseerError> {
+                *self.0.lock().unwrap() += 1;
+                Ok(())
+            }
+        }
+        let calls = Arc::new(Mutex::new(0));
+        let gh2 = ScriptedGh::new(vec![green()]);
+        let (ops2, _, _) = adapter_with(
+            gh2,
+            CLEAN_DIFF,
+            None,
+            Arc::new(CountingClock::default()),
+            PollConfig::default(),
+        );
+        let ops2 = ops2.with_conflict_resolver(Box::new(OkResolver(calls.clone())));
+        ops2.resolve_conflict("rysweet/Simard", 1)
+            .expect("delegates");
+        assert_eq!(*calls.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn merge_refuses_its_own_pr_via_recursion_guard() {
+        use crate::overseer::guardrails::RecursionGuard;
+        struct OwnAuthorSource;
+        impl PrSource for OwnAuthorSource {
+            fn diff(&self, _r: &str, _p: u32) -> Result<String, OverseerError> {
+                Ok(CLEAN_DIFF.to_string())
+            }
+            fn title(&self, _r: &str, _p: u32) -> Result<String, OverseerError> {
+                Ok("t".to_string())
+            }
+            fn author(&self, _r: &str, _p: u32) -> Result<String, OverseerError> {
+                Ok("simard-overseer[bot]".to_string())
+            }
+        }
+        let gh = ScriptedGh::new(vec![green()]);
+        let email = Arc::new(Mutex::new(vec![]));
+        let notifier = DualChannelNotifier::new(vec![Box::new(CapturingChannel {
+            name: "email".to_string(),
+            seen: email.clone(),
+        })]);
+        let ops = MergePrOps::new(
+            Box::new(gh.clone()),
+            Box::new(OwnAuthorSource),
+            Some(Box::new(FakeReviewer(vec![]))),
+            Box::new(ReadyJudge),
+            notifier,
+            Box::new(Arc::new(CountingClock::default())),
+            vec!["main".to_string()],
+            PollConfig::default(),
+        )
+        .with_recursion_guard(RecursionGuard {
+            author_login: "simard-overseer[bot]".to_string(),
+            branch_prefix: "overseer/".to_string(),
+            goal_source_tag: "overseer:".to_string(),
+        });
+        assert!(
+            ops.merge("rysweet/Simard", 7).is_err(),
+            "the Overseer must refuse to merge its OWN PR"
+        );
+        assert_eq!(gh.merges(), 0, "no merge of an own PR");
+        assert!(
+            email.lock().unwrap().is_empty(),
+            "no notify on a refused own PR"
+        );
     }
 }

--- a/src/overseer/mod.rs
+++ b/src/overseer/mod.rs
@@ -47,9 +47,12 @@
 
 pub mod capabilities;
 pub mod config;
+pub mod conflict;
+pub mod deploy;
 pub mod guardrails;
 pub mod intervention;
 pub mod launch;
+pub mod meeting_ops;
 pub mod merge_ops;
 pub mod notify;
 pub mod observer;

--- a/src/overseer/notify.rs
+++ b/src/overseer/notify.rs
@@ -48,22 +48,84 @@ impl MergeNotification {
 
     /// A short, plain-language body suitable for email or a Signal message.
     pub fn plain_text(&self) -> String {
+        self.to_operator().plain_text()
+    }
+
+    /// Render this merge as a general [`OperatorNotification`].
+    pub fn to_operator(&self) -> OperatorNotification {
+        OperatorNotification {
+            kind: "merge",
+            headline: self.pr_title.clone(),
+            problem: self.problem.clone(),
+            link: Some(self.pr_url.clone()),
+            repo: self.repo.clone(),
+            autonomous: self.autonomous,
+        }
+    }
+}
+
+/// A general operator notification the channels deliver. Both a merge (M2) and a
+/// deploy (M3) render into this, so the channels stay event-agnostic while the
+/// mandatory "notify on both channels, never drop" guarantee covers every kind
+/// of operator event.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OperatorNotification {
+    /// Event kind for the subject/logs: `"merge"` | `"deploy"`.
+    pub kind: &'static str,
+    /// One-line headline (email subject core / Signal first line).
+    pub headline: String,
+    /// Plain-language explanation of the problem/why.
+    pub problem: String,
+    /// Optional canonical link (PR url / commit url).
+    pub link: Option<String>,
+    pub repo: String,
+    pub autonomous: bool,
+}
+
+impl OperatorNotification {
+    /// The email subject line.
+    pub fn subject(&self) -> String {
+        format!("[Overseer] {}: {}", self.kind, self.headline)
+    }
+
+    /// A short, plain-language body suitable for email or a Signal message.
+    pub fn plain_text(&self) -> String {
         let who = if self.autonomous {
-            "The Overseer autonomously merged"
+            "The Overseer autonomously"
         } else {
-            "A PR was merged"
+            "The operator"
         };
+        let link = self
+            .link
+            .as_deref()
+            .map(|l| format!("\n\nLink:\n  {l}"))
+            .unwrap_or_default();
         format!(
-            "{who} a pull request in {repo}.\n\n\
-             Problem solved:\n  {problem}\n\n\
-             PR:\n  {title}\n  {url}\n",
+            "{who} performed a {kind} in {repo}.\n\nProblem solved:\n  {problem}{link}\n",
             who = who,
+            kind = self.kind,
             repo = self.repo,
             problem = self.problem,
-            title = self.pr_title,
-            url = self.pr_url,
+            link = link,
         )
     }
+
+    /// Build a deploy notification (M3). `previous`/`commit` are the deployed
+    /// git hashes; `gate_summary` describes the canary/deploy-gate result.
+    pub fn deploy(commit: &str, previous: &str, repo: &str, gate_summary: &str) -> Self {
+        Self {
+            kind: "deploy",
+            headline: format!("deployed {}", short_commit(commit)),
+            problem: format!("Deployed {commit} (previous {previous}); {gate_summary}"),
+            link: None,
+            repo: repo.to_string(),
+            autonomous: true,
+        }
+    }
+}
+
+fn short_commit(commit: &str) -> &str {
+    &commit[..commit.len().min(12)]
 }
 
 /// The outcome of delivering to one channel. There is no "silently dropped"
@@ -116,7 +178,7 @@ impl NotifyReport {
 /// (Signal) are driven behind the adapter.
 pub trait NotifyChannel: Send + Sync {
     fn name(&self) -> &str;
-    fn deliver(&self, notification: &MergeNotification) -> ChannelDelivery;
+    fn deliver(&self, notification: &OperatorNotification) -> ChannelDelivery;
 }
 
 /// The mandatory operator notifier: fires EVERY channel on EVERY notification.
@@ -143,9 +205,9 @@ impl DualChannelNotifier {
     }
 
     /// Fire every channel, recording each outcome. This is the single call the
-    /// merge path makes after a successful merge; its `NotifyReport` proves the
-    /// notification fired on both channels.
-    pub fn notify(&self, notification: &MergeNotification) -> NotifyReport {
+    /// merge/deploy paths make; its `NotifyReport` proves the notification fired
+    /// on both channels.
+    pub fn notify(&self, notification: &OperatorNotification) -> NotifyReport {
         let per_channel = self
             .channels
             .iter()
@@ -162,11 +224,12 @@ impl DualChannelNotifier {
     }
 }
 
-fn log_degraded(channel: &str, outcome: &ChannelDelivery, n: &MergeNotification) {
+fn log_degraded(channel: &str, outcome: &ChannelDelivery, n: &OperatorNotification) {
     tracing::warn!(
         target: "overseer::notify",
         channel,
-        pr = %n.pr_url,
+        kind = n.kind,
+        link = n.link.as_deref().unwrap_or(""),
         ?outcome,
         "operator notification not delivered live — queued/failed (never dropped)"
     );
@@ -258,7 +321,7 @@ impl NotifyChannel for EmailNotifyChannel {
         "email"
     }
 
-    fn deliver(&self, n: &MergeNotification) -> ChannelDelivery {
+    fn deliver(&self, n: &OperatorNotification) -> ChannelDelivery {
         if !self.config.is_configured() {
             return ChannelDelivery::Queued {
                 reason: "SMTP not configured (set SMTP_HOST / SIMARD_OVERSEER_EMAIL_{FROM,TO})"
@@ -422,7 +485,7 @@ impl NotifyChannel for SignalNotifyChannel {
         "signal"
     }
 
-    fn deliver(&self, n: &MergeNotification) -> ChannelDelivery {
+    fn deliver(&self, n: &OperatorNotification) -> ChannelDelivery {
         match &self.sender {
             None => ChannelDelivery::Queued {
                 reason: "Signal channel not wired (configure the ConversationChannel transport)"
@@ -441,7 +504,7 @@ mod tests {
     use super::*;
     use crate::conversation_channel::MockConversationChannel;
 
-    fn sample() -> MergeNotification {
+    fn sample_merge() -> MergeNotification {
         MergeNotification {
             problem: "distillation parse-failure rate exceeded threshold".to_string(),
             pr_title: "fix(distill): strip launch-banner noise".to_string(),
@@ -451,15 +514,40 @@ mod tests {
         }
     }
 
+    fn sample() -> OperatorNotification {
+        sample_merge().to_operator()
+    }
+
     // ── content ──────────────────────────────────────────────────────────────
 
     #[test]
     fn plain_text_carries_problem_pr_and_repo() {
-        let t = sample().plain_text();
-        assert!(t.contains("distillation parse-failure"));
-        assert!(t.contains("fix(distill): strip launch-banner noise"));
-        assert!(t.contains("https://github.com/rysweet/Simard/pull/123"));
-        assert!(t.contains("rysweet/Simard"));
+        let n = sample_merge().to_operator();
+        // The PR title heads the subject; the body carries problem + link + repo.
+        assert!(
+            n.subject()
+                .contains("fix(distill): strip launch-banner noise")
+        );
+        let body = n.plain_text();
+        assert!(body.contains("distillation parse-failure"));
+        assert!(body.contains("https://github.com/rysweet/Simard/pull/123"));
+        assert!(body.contains("rysweet/Simard"));
+    }
+
+    #[test]
+    fn deploy_notification_carries_commits_and_repo() {
+        let n = OperatorNotification::deploy(
+            "abcdef1234567890",
+            "0011223344556677",
+            "rysweet/Simard",
+            "canary green (4/4 gates)",
+        );
+        assert_eq!(n.kind, "deploy");
+        assert!(n.subject().contains("deployed abcdef123456"));
+        let body = n.plain_text();
+        assert!(body.contains("abcdef1234567890"));
+        assert!(body.contains("0011223344556677"));
+        assert!(body.contains("canary green"));
     }
 
     // ── fakes ────────────────────────────────────────────────────────────────
@@ -468,13 +556,13 @@ mod tests {
     struct RecordingChannel {
         name: String,
         outcome: Option<ChannelDelivery>,
-        seen: Mutex<Vec<MergeNotification>>,
+        seen: Mutex<Vec<OperatorNotification>>,
     }
     impl NotifyChannel for RecordingChannel {
         fn name(&self) -> &str {
             &self.name
         }
-        fn deliver(&self, n: &MergeNotification) -> ChannelDelivery {
+        fn deliver(&self, n: &OperatorNotification) -> ChannelDelivery {
             self.seen.lock().unwrap().push(n.clone());
             self.outcome.clone().unwrap_or(ChannelDelivery::Sent)
         }

--- a/src/overseer/tests_m2.rs
+++ b/src/overseer/tests_m2.rs
@@ -14,7 +14,7 @@ use crate::overseer::intervention::Intervention;
 use crate::overseer::launch::{RecipeRunner, SmartOrchestratorLauncher};
 use crate::overseer::merge_ops::{DiffReviewer, MergePrOps, PollClock, PollConfig, PrSource};
 use crate::overseer::notify::{
-    ChannelDelivery, DualChannelNotifier, MergeNotification, NotifyChannel,
+    ChannelDelivery, DualChannelNotifier, NotifyChannel, OperatorNotification,
 };
 use crate::overseer::signal::signals_from;
 use crate::overseer::{decide, orient};
@@ -122,13 +122,13 @@ impl PollClock for NoSleep {
 
 struct Capture {
     name: String,
-    seen: Arc<Mutex<Vec<MergeNotification>>>,
+    seen: Arc<Mutex<Vec<OperatorNotification>>>,
 }
 impl NotifyChannel for Capture {
     fn name(&self) -> &str {
         &self.name
     }
-    fn deliver(&self, n: &MergeNotification) -> ChannelDelivery {
+    fn deliver(&self, n: &OperatorNotification) -> ChannelDelivery {
         self.seen.lock().unwrap().push(n.clone());
         ChannelDelivery::Sent
     }
@@ -139,8 +139,8 @@ fn green_merge_ops(
     gh: Arc<GreenGh>,
 ) -> (
     MergePrOps,
-    Arc<Mutex<Vec<MergeNotification>>>,
-    Arc<Mutex<Vec<MergeNotification>>>,
+    Arc<Mutex<Vec<OperatorNotification>>>,
+    Arc<Mutex<Vec<OperatorNotification>>>,
 ) {
     let email = Arc::new(Mutex::new(vec![]));
     let signal = Arc::new(Mutex::new(vec![]));
@@ -215,7 +215,7 @@ fn seeded_problem_launches_fix_merges_green_pr_and_notifies_operator() {
         "operator Signalled on merge"
     );
     let n = &email.lock().unwrap()[0];
-    assert!(n.pr_url.ends_with("/pull/2601"));
+    assert!(n.link.as_deref().unwrap().ends_with("/pull/2601"));
     assert!(n.problem.contains("merge-ready"));
     assert!(n.autonomous);
 }


### PR DESCRIPTION
## Milestone 3 of the embedded Overseer (#2527) — HIGH-RISK, opt-in, default OFF

Stacked on #2540 (M2). Adds the guarded deploy, goal transfer, and conflict-resolution capabilities. Every new authority is opt-in and gated.

> Base is `overseer/m2-fix-launch-merge`; retarget as the stack lands. The M3 diff is the M3 commit only.

### Guarded deploy (`deploy.rs`)
A **pure deploy gate** refuses every dangerous shape:
- **no-op** (target == running) · **rollback** (target is an ancestor of running) · **red canary** (gates failed) · **crash-loop** (elevated restart churn).

`GuardedDeployer` composes the canary (`self_relaunch::{build_canary, verify_canary, all_gates_passed}`), the gate, the binary swap (`SelfDeployOrchestrator::run`), and the mandatory operator notification. `Deploy` stays HIGH-RISK/opt-in (`AutonomyGate.allow_high_risk`, default `false`). Never touches `~/.simard/worktrees`.

### Conflict resolution — never `--no-verify` (`conflict.rs`, operator hard-gate #8)
`GitConflictResolver` rebases onto base and pushes **through** pre-commit/pre-push hooks. `RealGitRunner` **refuses `--no-verify`** at the boundary and applies `git_guardrails::check_git_safety` to every command — no code path can smuggle it in.

### Goal transfer (`meeting_ops.rs`)
`MeetingGoalTransfer` renders a goal via `meetings::build_persisted_meeting_record_value` (the non-interactive meeting-handoff path) and writes a durable handoff file under `<state_root>/meeting_handoffs/` — **never** worktrees. Injectable sink; tested round-trip.

### NotifyOperator generalized → also fires on deploy (`notify.rs`)
`MergeNotification` now renders into a neutral `OperatorNotification`, so the mandatory both-channels / never-drop guarantee covers **deploys** as well as merges.

### Anti-recursion wired into the merge path (`merge_ops.rs`)
`MergePrOps::with_recursion_guard` makes `merge` **refuse the Overseer's OWN PRs** (fail-closed identity, distinct login). `resolve_conflict` delegates to the injected resolver (opt-in), refusing when unwired.

### Tests
112 overseer unit tests — all pure/injected: **no subprocess, no network, no sleeps**. Deploy gate refuses no-op/rollback/red-canary/crash-loop; HIGH-RISK gated off by default; deploy notifies on both channels; conflict resolution never `--no-verify`; recursion guard refuses own PRs; meeting handoff round-trip; handoffs never under worktrees.

### Gates
`cargo fmt`, `cargo clippy --release --no-deps -D warnings`, and `cargo clippy --all-targets --all-features --locked -D warnings` all green. No `--no-verify`, no `--admin`.

### Next
M4 (audits + self-tuning within clamped floors) follows as its own PR.