### PR TITLE
feat(overseer): M4 — audits + bounded self-tuning within clamped floors (#2527)

### DIFF
--- a/src/overseer/audit.rs
+++ b/src/overseer/audit.rs
@@ -1,0 +1,244 @@
+//! M4 — the [`Auditor`] adapter: run crusty-old-engineer-gated quality audits on
+//! demand and on a recurring cadence.
+//!
+//! Reuse (design doc §capability table): `self_quality_audit::run_self_quality_audit`
+//! (`src/self_quality_audit.rs:260`) drives the shipped
+//! `monthly-self-quality-audit.yaml` recipe (SEEK→VALIDATE→FIX waves, each merge
+//! crusty-old-engineer-gated); `self_quality_audit::{read_last_run, write_last_run}`
+//! provide the durable cadence marker (no new schema).
+//!
+//! The recipe subprocess is behind an injectable [`AuditRunner`] seam so scope
+//! routing and cadence are unit-tested with a fake — no subprocess, no network.
+
+use std::path::PathBuf;
+
+use crate::overseer::capabilities::{AuditReport, AuditScope, Auditor, OverseerError};
+
+/// The outcome of one quality-audit run, projected from
+/// `self_quality_audit::SelfQualityAuditReport`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QualityAuditOutcome {
+    pub scope: AuditScope,
+    pub waves_completed: u32,
+    pub prs_opened: Vec<String>,
+    pub prs_merged: Vec<String>,
+    /// PRs the bounded crusty-old-engineer loop could not resolve — surfaced for
+    /// human follow-up (a non-empty list means the audit did NOT fully pass).
+    pub crusty_unresolved: Vec<String>,
+    pub summary: String,
+}
+
+/// Runs a quality audit for a scope. Injectable so cadence + routing are tested
+/// without spawning the recipe. Production uses [`SelfQualityAuditRunner`].
+pub trait AuditRunner {
+    fn run(&self, scope: &AuditScope) -> Result<QualityAuditOutcome, OverseerError>;
+}
+
+/// Real runner over the shipped self-quality-audit recipe.
+pub struct SelfQualityAuditRunner {
+    pub repo_root: PathBuf,
+    pub state_root: PathBuf,
+}
+
+impl AuditRunner for SelfQualityAuditRunner {
+    fn run(&self, scope: &AuditScope) -> Result<QualityAuditOutcome, OverseerError> {
+        let report = crate::self_quality_audit::run_self_quality_audit(
+            &self.repo_root,
+            &self.state_root,
+            None,
+        )
+        .map_err(|e| OverseerError::Capability {
+            what: "self_quality_audit",
+            detail: e.to_string(),
+        })?;
+        Ok(QualityAuditOutcome {
+            scope: scope.clone(),
+            waves_completed: report.waves_completed,
+            prs_opened: report.prs_opened.clone(),
+            prs_merged: report.prs_merged.clone(),
+            crusty_unresolved: report.crusty_unresolved.clone(),
+            summary: report.summary(),
+        })
+    }
+}
+
+/// The [`Auditor`]. Routes a scope through the runner and reports pass/fail
+/// (fail iff the crusty loop left PRs unresolved). Also drives a recurring
+/// self-audit via a durable last-run marker.
+pub struct SelfQualityAuditor {
+    runner: Box<dyn AuditRunner>,
+    marker_path: PathBuf,
+    interval_secs: u64,
+}
+
+impl SelfQualityAuditor {
+    pub fn new(runner: Box<dyn AuditRunner>, marker_path: PathBuf, interval_secs: u64) -> Self {
+        Self {
+            runner,
+            marker_path,
+            interval_secs,
+        }
+    }
+
+    /// Production auditor: real recipe runner, a marker under the state root, and
+    /// a monthly cadence (matching `monthly-self-quality-audit.yaml`).
+    pub fn from_env(repo_root: PathBuf, state_root: PathBuf) -> Self {
+        let marker = state_root.join("overseer/self_quality_audit.last_run");
+        Self::new(
+            Box::new(SelfQualityAuditRunner {
+                repo_root,
+                state_root,
+            }),
+            marker,
+            MONTHLY_SECS,
+        )
+    }
+
+    /// True iff a recurring self-audit is due at `now_epoch` (never run, or the
+    /// interval has elapsed since the last run).
+    pub fn recurring_due(&self, now_epoch: u64) -> bool {
+        match crate::self_quality_audit::read_last_run(&self.marker_path) {
+            None => true,
+            Some(last) => now_epoch.saturating_sub(last) >= self.interval_secs,
+        }
+    }
+
+    /// Run the recurring self-health audit if due, stamping the marker. Returns
+    /// `None` when not due (no work, no side effect).
+    pub fn run_recurring(&self, now_epoch: u64) -> Option<Result<AuditReport, OverseerError>> {
+        if !self.recurring_due(now_epoch) {
+            return None;
+        }
+        let result = self.run_audit(&AuditScope::SelfHealth);
+        // Stamp the marker even on failure so a red audit does not hot-loop; the
+        // findings surface the crusty-unresolved PRs for human follow-up.
+        let _ = crate::self_quality_audit::write_last_run(&self.marker_path, now_epoch);
+        Some(result)
+    }
+}
+
+/// A recurring self-audit cadence of ~30 days (monthly recipe).
+pub const MONTHLY_SECS: u64 = 30 * 24 * 60 * 60;
+
+impl Auditor for SelfQualityAuditor {
+    fn run_audit(&self, scope: &AuditScope) -> Result<AuditReport, OverseerError> {
+        let outcome = self.runner.run(scope)?;
+        // A clean audit is one the crusty-old-engineer gate fully resolved.
+        let passed = outcome.crusty_unresolved.is_empty();
+        let mut findings = Vec::new();
+        findings.push(outcome.summary.clone());
+        for pr in &outcome.crusty_unresolved {
+            findings.push(format!("crusty-unresolved (needs human): {pr}"));
+        }
+        Ok(AuditReport {
+            scope: outcome.scope,
+            passed,
+            findings,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct FakeRunner {
+        seen: Mutex<Vec<AuditScope>>,
+        unresolved: Vec<String>,
+    }
+    impl FakeRunner {
+        fn new(unresolved: Vec<String>) -> Self {
+            Self {
+                seen: Mutex::new(vec![]),
+                unresolved,
+            }
+        }
+    }
+    impl AuditRunner for std::sync::Arc<FakeRunner> {
+        fn run(&self, scope: &AuditScope) -> Result<QualityAuditOutcome, OverseerError> {
+            self.seen.lock().unwrap().push(scope.clone());
+            Ok(QualityAuditOutcome {
+                scope: scope.clone(),
+                waves_completed: 3,
+                prs_opened: vec!["pr1".to_string()],
+                prs_merged: vec!["pr1".to_string()],
+                crusty_unresolved: self.unresolved.clone(),
+                summary: "audit done".to_string(),
+            })
+        }
+    }
+
+    fn auditor(
+        runner: std::sync::Arc<FakeRunner>,
+        marker: PathBuf,
+        interval: u64,
+    ) -> SelfQualityAuditor {
+        SelfQualityAuditor::new(Box::new(runner), marker, interval)
+    }
+
+    #[test]
+    fn audit_routes_each_scope_to_the_runner() {
+        let runner = std::sync::Arc::new(FakeRunner::new(vec![]));
+        let tmp = tempfile::tempdir().unwrap();
+        let a = auditor(runner.clone(), tmp.path().join("m"), 100);
+        for scope in [
+            AuditScope::SelfHealth,
+            AuditScope::Repo {
+                slug: "rysweet/amplihack".to_string(),
+            },
+            AuditScope::CrossCutting,
+        ] {
+            let report = a.run_audit(&scope).unwrap();
+            assert_eq!(report.scope, scope);
+        }
+        let seen = runner.seen.lock().unwrap();
+        assert_eq!(seen.len(), 3, "every scope routed to the runner");
+        assert!(seen.contains(&AuditScope::SelfHealth));
+        assert!(seen.contains(&AuditScope::CrossCutting));
+    }
+
+    #[test]
+    fn audit_passes_only_when_crusty_resolved_everything() {
+        let tmp = tempfile::tempdir().unwrap();
+        let clean = auditor(
+            std::sync::Arc::new(FakeRunner::new(vec![])),
+            tmp.path().join("a"),
+            100,
+        );
+        assert!(clean.run_audit(&AuditScope::SelfHealth).unwrap().passed);
+
+        let dirty = auditor(
+            std::sync::Arc::new(FakeRunner::new(vec!["pr-stuck".to_string()])),
+            tmp.path().join("b"),
+            100,
+        );
+        let report = dirty.run_audit(&AuditScope::SelfHealth).unwrap();
+        assert!(!report.passed, "unresolved crusty PRs fail the audit");
+        assert!(report.findings.iter().any(|f| f.contains("pr-stuck")));
+    }
+
+    #[test]
+    fn recurring_is_due_when_never_run_then_respects_interval() {
+        let runner = std::sync::Arc::new(FakeRunner::new(vec![]));
+        let tmp = tempfile::tempdir().unwrap();
+        let marker = tmp.path().join("last_run");
+        let a = auditor(runner.clone(), marker.clone(), 1000);
+
+        // Never run → due.
+        assert!(a.recurring_due(5_000));
+        // Run it → stamps the marker.
+        assert!(a.run_recurring(5_000).is_some());
+        // Immediately after → not due.
+        assert!(!a.recurring_due(5_500));
+        // After the interval → due again.
+        assert!(a.recurring_due(6_000));
+        // Not-due window runs nothing.
+        assert!(a.run_recurring(5_500).is_none());
+        assert_eq!(
+            runner.seen.lock().unwrap().len(),
+            1,
+            "only the due run executed"
+        );
+    }
+}

--- a/src/overseer/mod.rs
+++ b/src/overseer/mod.rs
@@ -45,6 +45,7 @@
 
 #![allow(dead_code)]
 
+pub mod audit;
 pub mod capabilities;
 pub mod config;
 pub mod guardrails;
@@ -56,6 +57,7 @@ pub mod observer;
 pub mod pr_verify;
 pub mod sensor;
 pub mod signal;
+pub mod tuning;
 
 #[cfg(test)]
 mod tests_m1;

--- a/src/overseer/tuning.rs
+++ b/src/overseer/tuning.rs
@@ -1,0 +1,245 @@
+//! M4 — bounded self-tuning of the `SIMARD_OVERSEER_*` thresholds within
+//! **clamped floors/ceilings**. The Overseer may adapt its own sensitivity, but
+//! never off a cliff: every knob is clamped, so self-tuning can never drive a
+//! threshold to zero (a hot loop) or to infinity (blindness).
+//!
+//! This is deliberately pure — the tuning logic has no I/O — so "stays within
+//! clamps" and "no unbounded growth" are exhaustively unit-tested. Applying the
+//! tuned values (as env overrides) is the caller's job.
+
+use crate::overseer::config::{DEFAULT_OVERSEER_INTERVAL_SECS, MIN_OVERSEER_INTERVAL_SECS};
+
+/// A single tunable knob clamped to `[floor, ceil]`. `raise`/`lower` step by
+/// `step` and saturate at the bounds — never beyond.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ClampedKnob {
+    value: f64,
+    floor: f64,
+    ceil: f64,
+    step: f64,
+}
+
+impl ClampedKnob {
+    /// Construct, clamping `value` into `[floor, ceil]`. `floor <= ceil` and
+    /// `step > 0` are assumed; a degenerate range collapses to `floor`.
+    pub fn new(value: f64, floor: f64, ceil: f64, step: f64) -> Self {
+        let (floor, ceil) = if floor <= ceil {
+            (floor, ceil)
+        } else {
+            (ceil, floor)
+        };
+        Self {
+            value: value.clamp(floor, ceil),
+            floor,
+            ceil,
+            step: step.abs(),
+        }
+    }
+
+    pub fn value(&self) -> f64 {
+        self.value
+    }
+
+    pub fn floor(&self) -> f64 {
+        self.floor
+    }
+
+    pub fn ceil(&self) -> f64 {
+        self.ceil
+    }
+
+    /// Raise by one step, saturating at the ceiling.
+    pub fn raise(&mut self) -> f64 {
+        self.value = (self.value + self.step).min(self.ceil);
+        self.value
+    }
+
+    /// Lower by one step, saturating at the floor.
+    pub fn lower(&mut self) -> f64 {
+        self.value = (self.value - self.step).max(self.floor);
+        self.value
+    }
+
+    /// Tune in response to feedback. For a *threshold* knob, raising it reduces
+    /// noise (fires less), lowering it increases sensitivity.
+    pub fn tune(&mut self, feedback: Feedback) {
+        match feedback {
+            Feedback::TooNoisy => {
+                self.raise();
+            }
+            Feedback::TooQuiet => {
+                self.lower();
+            }
+            Feedback::Stable => {}
+        }
+    }
+
+    /// Invariant: the value is always within `[floor, ceil]`.
+    pub fn within_clamps(&self) -> bool {
+        self.value >= self.floor && self.value <= self.ceil
+    }
+}
+
+/// Signal-quality feedback that drives a tuning step.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Feedback {
+    /// Too many low-value signals (false positives) — reduce sensitivity.
+    TooNoisy,
+    /// Real problems slipped through — increase sensitivity.
+    TooQuiet,
+    /// Signal quality is good — hold.
+    Stable,
+}
+
+/// The Overseer's tunable thresholds, each clamped. Floors/ceilings are derived
+/// from the config knobs so tuning can never diverge from the shipped bounds
+/// (e.g. the observer cadence can never dip below `MIN_OVERSEER_INTERVAL_SECS`).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct OverseerTuning {
+    /// Distillation parse-failure percentage that raises a signal.
+    pub distill_pct: ClampedKnob,
+    /// Observer cadence (seconds), clamped to the config floor.
+    pub interval_secs: ClampedKnob,
+    /// Fraction of the daily budget at which budget pressure fires.
+    pub budget_fraction: ClampedKnob,
+}
+
+impl Default for OverseerTuning {
+    fn default() -> Self {
+        Self {
+            distill_pct: ClampedKnob::new(20.0, 10.0, 60.0, 5.0),
+            interval_secs: ClampedKnob::new(
+                DEFAULT_OVERSEER_INTERVAL_SECS as f64,
+                MIN_OVERSEER_INTERVAL_SECS as f64,
+                3600.0,
+                300.0,
+            ),
+            budget_fraction: ClampedKnob::new(0.8, 0.5, 0.95, 0.05),
+        }
+    }
+}
+
+impl OverseerTuning {
+    /// Apply one feedback step to the sensitivity knobs. A noisy observer both
+    /// raises its firing threshold AND lengthens its cadence; a too-quiet one
+    /// does the reverse — always within clamps.
+    pub fn apply(&mut self, feedback: Feedback) {
+        self.distill_pct.tune(feedback);
+        self.interval_secs.tune(feedback);
+        // Budget fraction is deliberately conservative: only widen (raise) it
+        // under noise, never lower it below its floor.
+        if feedback == Feedback::TooNoisy {
+            self.budget_fraction.raise();
+        }
+    }
+
+    /// True iff every knob is within its clamps (a total invariant).
+    pub fn within_clamps(&self) -> bool {
+        self.distill_pct.within_clamps()
+            && self.interval_secs.within_clamps()
+            && self.budget_fraction.within_clamps()
+    }
+
+    /// The tuned observer cadence in whole seconds (clamped ≥ floor).
+    pub fn interval_secs_u64(&self) -> u64 {
+        self.interval_secs.value().round() as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-9
+    }
+
+    #[test]
+    fn new_clamps_out_of_range_input() {
+        assert!(approx(ClampedKnob::new(-5.0, 0.0, 10.0, 1.0).value(), 0.0));
+        assert!(approx(ClampedKnob::new(99.0, 0.0, 10.0, 1.0).value(), 10.0));
+        // Reversed bounds are normalised.
+        let k = ClampedKnob::new(5.0, 10.0, 0.0, 1.0);
+        assert!(approx(k.floor(), 0.0) && approx(k.ceil(), 10.0));
+    }
+
+    #[test]
+    fn raise_never_exceeds_ceiling_no_unbounded_growth() {
+        let mut k = ClampedKnob::new(20.0, 10.0, 60.0, 5.0);
+        for _ in 0..1000 {
+            k.raise();
+        }
+        assert!(approx(k.value(), 60.0), "saturates at the ceiling");
+        assert!(k.within_clamps());
+    }
+
+    #[test]
+    fn lower_never_drops_below_floor() {
+        let mut k = ClampedKnob::new(20.0, 10.0, 60.0, 5.0);
+        for _ in 0..1000 {
+            k.lower();
+        }
+        assert!(approx(k.value(), 10.0), "saturates at the floor");
+        assert!(k.within_clamps());
+    }
+
+    #[test]
+    fn tune_direction_matches_feedback() {
+        let mut k = ClampedKnob::new(20.0, 10.0, 60.0, 5.0);
+        k.tune(Feedback::TooNoisy);
+        assert!(approx(k.value(), 25.0), "noisy raises the threshold");
+        k.tune(Feedback::TooQuiet);
+        assert!(approx(k.value(), 20.0), "quiet lowers it back");
+        k.tune(Feedback::Stable);
+        assert!(approx(k.value(), 20.0), "stable holds");
+    }
+
+    #[test]
+    fn overseer_tuning_stays_within_clamps_under_any_sequence() {
+        let mut t = OverseerTuning::default();
+        assert!(t.within_clamps());
+        // Hammer it with a long, adversarial feedback sequence.
+        let seq = [
+            Feedback::TooNoisy,
+            Feedback::TooNoisy,
+            Feedback::TooQuiet,
+            Feedback::Stable,
+        ];
+        for i in 0..10_000 {
+            t.apply(seq[i % seq.len()]);
+            assert!(t.within_clamps(), "every knob stays clamped at step {i}");
+        }
+    }
+
+    #[test]
+    fn interval_never_tunes_below_the_config_floor() {
+        let mut t = OverseerTuning::default();
+        for _ in 0..1000 {
+            t.apply(Feedback::TooQuiet); // pushes the cadence down
+        }
+        assert!(
+            t.interval_secs_u64() >= MIN_OVERSEER_INTERVAL_SECS,
+            "self-tuning can never breach the observer-cadence floor (no hot loop)"
+        );
+    }
+
+    #[test]
+    fn budget_fraction_only_widens_and_stays_bounded() {
+        let mut t = OverseerTuning::default();
+        let start = t.budget_fraction.value();
+        for _ in 0..1000 {
+            t.apply(Feedback::TooQuiet);
+        }
+        assert!(
+            approx(t.budget_fraction.value(), start),
+            "quiet feedback never lowers the budget fraction"
+        );
+        for _ in 0..1000 {
+            t.apply(Feedback::TooNoisy);
+        }
+        assert!(
+            t.budget_fraction.value() <= 0.95 + 1e-9,
+            "bounded by the ceiling"
+        );
+    }
+}


### PR DESCRIPTION
## Milestone 4 of the embedded Overseer (#2527) — final milestone

Stacked on #2541 (M3). Adds the crusty-old-engineer-gated quality-audit capability and bounded threshold self-tuning.

> Base is `overseer/m3-deploy-goal-transfer`; retarget as the stack lands. The M4 diff is the M4 commit only.

### Audits (`audit.rs`)
`SelfQualityAuditor` implements the `Auditor` capability, routing each `AuditScope` (SelfHealth / Repo / CrossCutting) through the shipped `self_quality_audit::run_self_quality_audit` — the `monthly-self-quality-audit.yaml` recipe's SEEK→VALIDATE→FIX waves, each merge **crusty-old-engineer-gated**. An audit passes only when the crusty loop left **no unresolved PRs**; unresolved PRs surface as findings for human follow-up. The recurring self-audit uses the durable last-run marker (`read_last_run`/`write_last_run`) at a monthly cadence — **no new schema**. Injectable `AuditRunner` seam.

### Self-tuning within clamped floors (`tuning.rs`)
`ClampedKnob` + `OverseerTuning`: the Overseer may adapt its own `SIMARD_OVERSEER_*` sensitivity (distill threshold, observer cadence, budget-pressure fraction), but **every knob is clamped**. Self-tuning can never drive the observer cadence below `MIN_OVERSEER_INTERVAL_SECS` (no hot loop) nor a threshold to infinity (no blindness). Pure and exhaustively tested: raise/lower saturate at the bounds, a 10k-step adversarial feedback sequence never breaches a clamp, and the cadence never dips below the config floor.

### Tests
122 overseer unit tests — all pure/injected: **no subprocess, no network, no sleeps**. Audit scope routing; recurring cadence due-logic; tuning stays within clamps; no unbounded growth.

### Gates
`cargo fmt`, `cargo clippy --release --no-deps -D warnings`, and `cargo clippy --all-targets --all-features --locked -D warnings` all green. No `--no-verify`, no `--admin`.

### Stack summary (all of #2527)
- **M1** #2539 — read-only observer (Observe/Orient/Report + deduped issue-filing).
- **M2** #2540 — fix-launching + PR verify/merge + mandatory NotifyOperator (opt-in).
- **M3** #2541 — guarded deploy + goal transfer + conflict resolution (opt-in).
- **M4** (this) — audits + bounded self-tuning.

All additive + flag-gated (`SIMARD_OVERSEER_*`, default OFF); the daemon's default behaviour is unchanged. Operator merges + deploys.