### PR TITLE
fix(memory): snapshot loader falls back to older valid snapshot on corrupt tip

### DIFF
--- a/docs/operations/cognitive-memory-durability.md
+++ b/docs/operations/cognitive-memory-durability.md
@@ -195,6 +195,35 @@ let restored = restore_from_backup(bridge, file_store, &backup_dir)?;
 imports the cognitive snapshot and file-backed records. If a backup fails
 verification, choose the next-most-recent directory from `list_backups`.
 
+### Session-boundary snapshot recovery
+
+Separate from the `memory_backup/` verified backups above, a session teardown
+writes a JSON snapshot of cognitive memory to `~/.simard/snapshots/`
+(`memory_snapshot::save_session_snapshot`) through the crash-safe writer
+(temp + fsync + rename + parent fsync, issue #1918) and prunes to the 10 most
+recent (`prune_snapshots`). The writer is atomic, so a crash *during* a save
+leaves only an unrenamed temp file — never a corrupt final snapshot.
+
+On reload, `memory_snapshot::load_latest_snapshot` walks the retained snapshots
+**newest → oldest** and returns the first one that loads. If the newest snapshot
+is unreadable — a partial write from a binary that predates the crash-safe
+writer, on-disk corruption, or a payload the current schema can no longer parse
+— the loader transparently degrades to the most recent snapshot that *does*
+load rather than returning "no memory" and discarding the entire retained
+history. Only when **every** snapshot in the directory fails to load does it
+report `None`. Skipped files and the all-unreadable case are logged to stderr
+with the `[simard] snapshot:` prefix:
+
+```text
+[simard] snapshot: failed to load .../agent-1750000200.json (1 of 10): ...; trying an older snapshot
+[simard] snapshot: recovered older snapshot .../agent-1750000100.json after skipping 1 newer unreadable snapshot(s)
+```
+
+This is the same graceful-degradation contract as `restore_from_backup` above
+(fall back to the next-most-recent good copy): a single bad snapshot at the tip
+of the retained history must never silently wipe durable recall across a
+restart.
+
 ---
 
 ## Current public API

--- a/src/memory_snapshot.rs
+++ b/src/memory_snapshot.rs
@@ -70,10 +70,23 @@ pub fn save_session_snapshot(
     Ok(path)
 }
 
-/// Find the most recent snapshot file in `dir` and load it.
+/// Find the most recent *loadable* snapshot in `dir` and return it.
 ///
-/// Returns `None` when the directory is empty or contains no valid
-/// snapshot files.
+/// Snapshots are tried newest → oldest. If the newest snapshot file is
+/// corrupt or otherwise unreadable — e.g. a partial write from an older
+/// binary that predates the crash-safe writer (issue #1918), on-disk
+/// corruption, or a payload the current schema can no longer parse — the
+/// loader transparently falls back to the most recent snapshot that *does*
+/// load instead of discarding the entire retained snapshot history. A
+/// session teardown persists up to `keep` snapshots (see
+/// [`prune_snapshots`]), so a single bad snapshot at the tip must never
+/// silently wipe memory across a restart; graceful degradation to the last
+/// good snapshot preserves durable recall. This mirrors the library
+/// backend's own "fall back to the most recent verified backup" startup
+/// recovery.
+///
+/// Returns `None` only when the directory is empty, cannot be read, or
+/// contains no loadable snapshot file.
 #[allow(deprecated)] // we intentionally use the legacy snapshot API
 pub fn load_latest_snapshot(dir: &Path) -> Option<MemorySnapshot> {
     let mut entries: Vec<PathBuf> = match std::fs::read_dir(dir) {
@@ -101,21 +114,41 @@ pub fn load_latest_snapshot(dir: &Path) -> Option<MemorySnapshot> {
         return None;
     }
 
-    // Sort by filename descending — filenames contain an epoch timestamp so
-    // lexicographic order == chronological order.
+    // Sort by filename ascending — filenames embed an epoch timestamp so
+    // lexicographic order == chronological order. Walk newest → oldest so a
+    // corrupt or unreadable newest snapshot degrades to the most recent VALID
+    // snapshot rather than returning `None` and discarding the entire retained
+    // history (durable recall: one bad snapshot must not silently wipe memory
+    // across a restart).
     entries.sort();
-    let latest = entries.last().expect("entries is non-empty after sort");
-
-    match crate::remote_transfer::load_snapshot_from_file(latest) {
-        Ok(snapshot) => Some(snapshot),
-        Err(e) => {
-            eprintln!(
-                "[simard] snapshot: failed to load {}: {e}",
-                latest.display()
-            );
-            None
+    let total = entries.len();
+    for (skipped, path) in entries.iter().rev().enumerate() {
+        match crate::remote_transfer::load_snapshot_from_file(path) {
+            Ok(snapshot) => {
+                if skipped > 0 {
+                    eprintln!(
+                        "[simard] snapshot: recovered older snapshot {} after skipping {} newer unreadable snapshot(s)",
+                        path.display(),
+                        skipped
+                    );
+                }
+                return Some(snapshot);
+            }
+            Err(e) => {
+                eprintln!(
+                    "[simard] snapshot: failed to load {} ({} of {total}): {e}; trying an older snapshot",
+                    path.display(),
+                    skipped + 1
+                );
+            }
         }
     }
+
+    eprintln!(
+        "[simard] snapshot: all {total} snapshot(s) in {} were unreadable; no memory restored",
+        dir.display()
+    );
+    None
 }
 
 /// Prune old snapshot files, retaining only the `keep` most recent.
@@ -243,6 +276,77 @@ mod tests {
         assert_eq!(count, 1);
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Issue: durable recall must survive a corrupt/partial "tip" snapshot.
+    // A session teardown persists up to `keep` snapshots; if the newest one is
+    // unreadable (e.g. a partial write from a pre-#1918 binary, on-disk
+    // corruption, or a payload the current schema can no longer parse), the
+    // loader must fall back to the most recent snapshot that *does* load rather
+    // than returning `None` and silently discarding the entire history.
+    #[test]
+    fn load_latest_snapshot_falls_back_to_older_valid_when_newest_corrupt() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+
+        // Older, VALID snapshot (bare legacy format is accepted by the loader).
+        std::fs::write(
+            dir.join("agent-0000000100.json"),
+            r#"{"facts":[],"procedures":[],"exported_at":100,"source_agent":"old-valid"}"#,
+        )
+        .expect("write valid snapshot");
+        // Newer, CORRUPT snapshot (simulates an interrupted/partial write).
+        std::fs::write(
+            dir.join("agent-0000000200.json"),
+            b"{ this is not valid json",
+        )
+        .expect("write corrupt snapshot");
+
+        let loaded = load_latest_snapshot(dir)
+            .expect("must fall back to the older valid snapshot instead of returning None");
+        assert_eq!(
+            loaded.source_agent, "old-valid",
+            "loader must recover the most recent LOADABLE snapshot, not surface None for a corrupt tip"
+        );
+    }
+
+    #[test]
+    fn load_latest_snapshot_returns_none_when_all_snapshots_corrupt() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+
+        std::fs::write(dir.join("agent-0000000100.json"), b"not json either")
+            .expect("write corrupt snapshot");
+        std::fs::write(dir.join("agent-0000000200.json"), b"{ broken")
+            .expect("write corrupt snapshot");
+
+        assert!(
+            load_latest_snapshot(dir).is_none(),
+            "when no snapshot in the directory is loadable the loader must report None"
+        );
+    }
+
+    #[test]
+    fn load_latest_snapshot_prefers_newest_when_valid() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+
+        std::fs::write(
+            dir.join("agent-0000000100.json"),
+            r#"{"facts":[],"procedures":[],"exported_at":100,"source_agent":"older"}"#,
+        )
+        .expect("write older snapshot");
+        std::fs::write(
+            dir.join("agent-0000000200.json"),
+            r#"{"facts":[],"procedures":[],"exported_at":200,"source_agent":"newer"}"#,
+        )
+        .expect("write newer snapshot");
+
+        let loaded = load_latest_snapshot(dir).expect("load newest valid snapshot");
+        assert_eq!(
+            loaded.source_agent, "newer",
+            "when the newest snapshot is valid it must be returned unchanged (no needless fallback)"
+        );
     }
 
     #[test]

--- a/tests/qa-scenarios/cognitive-memory-snapshot-load-fallback.yaml
+++ b/tests/qa-scenarios/cognitive-memory-snapshot-load-fallback.yaml
@@ -1,0 +1,63 @@
+name: cognitive-memory-snapshot-load-fallback
+app_type: cli
+description: |
+  Verify that session-boundary cognitive-memory recall survives a corrupt or
+  partial "tip" snapshot. A session teardown persists up to 10 JSON snapshots to
+  ~/.simard/snapshots/ and prunes older ones; on reload `load_latest_snapshot`
+  previously tried ONLY the single newest file and returned None on any load
+  failure — silently discarding the entire retained history and wiping memory
+  across a restart (same failure class as amplihack-memory-lib #15: one failed
+  step must not silently destroy durable state).
+
+  The hardened loader walks snapshots newest -> oldest and returns the most
+  recent one that loads, only reporting None when EVERY snapshot is unreadable.
+  Behavior is proven by hermetic tempdir unit tests (no destructive action
+  against the live host). The CLI runner rejects any non-zero exit, so a failing
+  test fails the scenario. First invocation may compile the test binary;
+  subsequent filters reuse it.
+agents:
+  - name: simard-cli
+    type: cli
+    command: cargo
+steps:
+  # A corrupt NEWEST snapshot must degrade to the most recent VALID one, not None.
+  - action: run
+    params:
+      command: "cargo test --locked --lib memory_snapshot::tests::load_latest_snapshot_falls_back_to_older_valid_when_newest_corrupt"
+    timeout: 600000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # When NO snapshot in the directory is loadable, the loader reports None.
+  - action: run
+    params:
+      command: "cargo test --locked --lib memory_snapshot::tests::load_latest_snapshot_returns_none_when_all_snapshots_corrupt"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # No needless fallback: when the newest snapshot is valid it is returned as-is.
+  - action: run
+    params:
+      command: "cargo test --locked --lib memory_snapshot::tests::load_latest_snapshot_prefers_newest_when_valid"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000


### PR DESCRIPTION
## Summary

Hardens **session-boundary cognitive-memory recall** against a corrupt or partial "tip" snapshot. `memory_snapshot::load_latest_snapshot` previously tried **only the single newest** snapshot file under `~/.simard/snapshots/` and returned `None` on *any* load failure — silently discarding **all** older, still-valid snapshots. Because a session teardown persists up to **10** snapshots (`runtime/session.rs`), the retained history existed but was never consulted: one unreadable newest file = **total memory loss on restart**.

The loader now walks snapshots **newest → oldest** and returns the first one that loads, reporting `None` only when the directory is empty/unreadable or **every** snapshot fails. This is the same durability principle behind the motivating upstream bug **`amplihack-memory-lib` #15** ("episode consolidation doesn't rollback on failure → silent corruption") and mirrors this repo's existing library-backend recovery ("fall back to the most recent verified backup").

### Why this scope
The literal #15 fix lives in the pinned external `amplihack-memory` crate, not in this worktree, and this engineer worktree opens PRs against **this** repo. The genuine, in-repo instance of the *same failure class* (one failed step silently destroying durable state) is this snapshot loader. Simard's own consolidation path (`distillation.rs`) is already defensively ordered (stores-before-marks + dedup/upsert guards) and the snapshot **write** path is already crash-safe (temp+fsync+rename, #1918); the **load** path was the remaining gap.

## Changes (focused diff — 3 files)
- `src/memory_snapshot.rs` — `load_latest_snapshot` newest→oldest fallback + docstring; 3 regression tests.
- `tests/qa-scenarios/cognitive-memory-snapshot-load-fallback.yaml` — gadugi scenario driving the 3 tests.
- `docs/operations/cognitive-memory-durability.md` — "Session-boundary snapshot recovery" subsection.

## Merge-ready evidence

**1. qa-team scenarios (gadugi-test)** — `tests/qa-scenarios/cognitive-memory-snapshot-load-fallback.yaml`
- `gadugi-test validate -f ...` → `✓ Scenario ... is valid` (1 valid, 0 invalid).
- `gadugi-test run -d tests/qa-scenarios -s cognitive-memory-snapshot-load-fallback` → **✓ Passed: 1, Failed: 0** (all 3 hermetic `cargo test` steps exit 0, `test result: ok`).

**2. Docs** — user-facing durability runbook updated with the new session-snapshot recovery contract, placed alongside the existing `restore_from_backup` next-most-recent fallback it mirrors.

**3. quality-audit (≥3 SEEK→VALIDATE→FIX cycles, clean final)**
- Cycle 1: identified the gap (load-side discards valid history); implemented fallback; unit tests pass.
- Cycle 2: caught a brace/compile regression in the test module; fixed; recompiled green.
- Cycle 3 (final, clean): high-signal code review verified newest→oldest ordering correct, happy-path preserved (newest-valid returned with no extra logging), **no panics** (removed the original `entries.last().expect(...)`), correct `skipped`/`total` log indices, and that tests genuinely exercise the fallback. **Zero critical/high/medium findings.**

**4. CI-equivalent gates green (local)**
- `cargo fmt --all -- --check` → clean.
- `cargo clippy --all-targets --all-features --locked -- -D warnings` → clean.
- `cargo test --lib memory_snapshot` → **8 passed; 0 failed** (5 existing + 3 new).
- Pre-push hooks on `git push` all **Passed**: Rust-only gate, fmt, `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)`, full clippy. Rebased onto latest `origin/main` (v0.25.0) before push; full CI runs here.

**6. Focused diff** — only the loader + its tests + the matching gadugi scenario + the durability doc. No unrelated edits.

## Test plan
```
cargo test --lib memory_snapshot
gadugi-test run -d tests/qa-scenarios -s cognitive-memory-snapshot-load-fallback
```
New tests:
- `load_latest_snapshot_falls_back_to_older_valid_when_newest_corrupt` — corrupt newest + valid older ⇒ returns the older valid snapshot (not `None`).
- `load_latest_snapshot_returns_none_when_all_snapshots_corrupt` — every file unreadable ⇒ `None`.
- `load_latest_snapshot_prefers_newest_when_valid` — newest valid ⇒ returned unchanged (no needless fallback).
