### PR TITLE
fix(goal-board): authoritative durable store — steerable, restart-resilient goal management (#1)

### DIFF
--- a/docs/concepts/authoritative-goal-board-store.md
+++ b/docs/concepts/authoritative-goal-board-store.md
@@ -1,0 +1,130 @@
+---
+title: Authoritative goal-board store
+description: Why the OODA goal board moved from a versioned cognitive-memory snapshot to a single durable, flock-guarded goal_board.json — closing the clobber/steerability, restart-reset, and re-seeding failures the partial #2534 fix left open.
+last_updated: 2026-07-04
+owner: simard
+doc_type: concept
+related:
+  - ./steerable-ooda-daemon.md
+  - ./goal-board-persistence.md
+  - ./deploy-aware-done-gate.md
+  - ./file-backed-goal-store-simplification.md
+  - ../reference/goal-board-api.md
+  - ../reference/state-root-resolution.md
+---
+
+# Authoritative goal-board store
+
+Issue [#1](https://github.com/rysweet/Simard/issues/1) makes a single durable
+file — `<state_root>/state/goal_board.json` — the **authoritative** home of the
+OODA goal board (active goals + scored backlog), replacing the
+searchable-semantic-fact snapshot that the daemon re-saved (and clobbered) every
+cycle. It is a *redesign* that supersedes the partial fix in
+[#2534](https://github.com/rysweet/Simard/pull/2534): the pieces #2534 added
+(the completion-evidence done-gate and the `NoProgressTracker` breaker) were
+sound but were never able to *fire* in production, because the board itself was
+never a reliable, single, durable source of truth.
+
+This is distinct from the [file-backed `GoalStore`](./file-backed-goal-store-simplification.md)
+(`goal_store.json`, a flat `Vec<GoalRecord>` for the meeting backend / engineer
+loop / bootstrap). This page is about the OODA `GoalBoard`.
+
+## The three production failures
+
+Verified in production 4.5h after #2534 deployed:
+
+1. **Un-steerable / clobbered.** The board lived only as `goal-board:snapshot`
+   cognitive-memory facts, read back with `search_facts(...).max_by(node_id)`
+   and rewritten each cycle by a *union-by-id* `merge_boards`. An operator
+   `goal remove` wrote a new snapshot, but the daemon's next merge unioned its
+   still-in-memory copy back on top — resurrecting the just-removed goal even
+   though the CLI exited `0`. There was no read-your-writes guarantee.
+
+2. **Breaker never fired (0 log lines in 4.5h).** The `NoProgressTracker`'s
+   per-goal counter lived only in `OodaState`. The daemon exec-reloads itself
+   when a new binary is deployed (~hourly), which replaces the process image and
+   rebuilt `OodaState` — resetting every counter to zero before it could reach
+   the threshold of 3. The breaker code ran every cycle but never reached a
+   terminal decision, so it logged nothing.
+
+3. **Done goals re-litigated and re-seeded.** The evidence archive only
+   *evaluated goals already claiming completion* (`status == Completed`). The
+   four ladybug supply-chain goals sat at `not-started`/0%, so nothing ever
+   checked them against the (already cross-repo-capable) evidence gate, and
+   recalled memory kept re-introducing them.
+
+## The redesign
+
+### 1. One authoritative store (`goal_board_store`)
+
+`goal_board.json` holds the whole `PersistentGoalState`: the `GoalBoard` plus
+the persisted `NoProgressTracker`. Reads and writes take the **same
+cross-process `flock`** the CLI and daemon already share
+([`state_root::goal_board_lock_path`](../reference/state-root-resolution.md)),
+and every write is an **atomic** temp-file-plus-`rename`. `load()` returns
+exactly the last committed state — read-your-writes, always. The
+`goal-board:snapshot` cognitive-memory fact is demoted to a **derived cache**
+the daemon overwrites from the file each cycle (`overwrite_memory_cache`), so
+the dashboard and memory recall stay consistent without ever being the source of
+truth.
+
+### 2. Single writer + steerability
+
+The daemon is the single authority over the in-memory board. Each cycle it
+**reloads** `goal_board.json` at the start (picking up operator edits and
+meeting handoffs) and **commits** at the end through a *tombstone-aware*
+`reconcile` that merges its in-flight board with the current file — it augments,
+never clobbers. Operator mutations (`goal add / remove / complete /
+reprioritize`) are surgical read-modify-writes on the file **under the flock**,
+so they cannot be lost to (or lose) a concurrent daemon flush. An operator edit
+is therefore reflected by the very next `goal list`, survives a full OODA cycle,
+and survives a daemon restart. If the daemon is down, the CLI still writes the
+authoritative file directly and the daemon loads it on next start.
+
+### 3. Tombstones — no re-seeding
+
+Removing or completing a goal writes a durable tombstone (the existing
+`goal_tombstones.json`, now consulted at every board load, cycle commit, and
+recall filter — not just meeting handoffs). Tombstoned ids are dropped from the
+reconcile and from any board a recall / default-seed / handoff path tries to
+introduce, so a completed objective can never resurrect a goal.
+
+### 4. Done-gate every cycle, cross-repo aware
+
+`sweep_done_goals` evaluates **every** active goal against the
+completion-evidence gate each cycle — not only goals already claiming
+completion. Because `GhCliEvidenceSource` resolves each goal's `repo` slug, a
+merged PR or closed issue on **any** governed repo counts as evidence, so the
+four ladybug goals auto-complete, leave the board, and are tombstoned. Every
+decision is logged.
+
+### 5. Restart-resilient no-progress breaker
+
+The `NoProgressTracker` is persisted in `goal_board.json` and restored into
+`OodaState` at daemon start and each cycle. A no-action livelock spanning the
+~hourly exec-reload is now still bounded: after 3 cumulative no-progress cycles
+the breaker forces one definitive resolution (verify once, then mark done / drop
+/ escalate to a filed issue) and logs it — it never loops "I'll verify"
+forever.
+
+### 6. Curation merges, never clobbers
+
+The cycle-commit `reconcile` unions the persisted board with the daemon's
+in-flight board (in-flight wins field-for-field on collision, tombstones
+dominate). Operator- and meeting-added goals are preserved rather than replaced
+by a regenerated set.
+
+## Verification
+
+See the runbook in the issue-#1 pull request. In tests
+(`src/goal_board_store/tests.rs`, `src/operator_cli/tests_goal.rs`):
+
+- store read-your-writes round-trip;
+- tombstone prevents re-seed from recalled memory;
+- cross-repo done-evidence completes a goal;
+- the no-progress breaker fires *after a simulated restart* using the persisted
+  counter;
+- the cycle reconcile preserves operator-added goals and drops operator-removed
+  (tombstoned) ones even when the daemon's in-flight board still carries them;
+- an operator `goal add` is reflected immediately and survives a restart; an
+  operator `goal remove` survives a full daemon cycle and a restart.

--- a/docs/concepts/goal-board-persistence.md
+++ b/docs/concepts/goal-board-persistence.md
@@ -15,6 +15,18 @@ related:
 
 # Goal board persistence — cognitive-memory single source of truth
 
+> **Update (issue [#1](https://github.com/rysweet/Simard/issues/1)):** the
+> "cognitive memory is the single source of truth" design described here is
+> **superseded**. As of issue #1 the authoritative goal board is the durable,
+> flock-guarded file `<state_root>/state/goal_board.json`; the
+> `goal-board:snapshot` cognitive-memory fact is demoted to a **derived cache**
+> the daemon overwrites from that file each cycle. The persistence *mechanics*
+> below (the shared flock, atomic write, corruption guard, and the
+> `load_goal_board` / `save_goal_board` helpers) remain accurate for that
+> derived cache — only the "source of truth" claim has moved to disk. See
+> [Authoritative goal-board store](./authoritative-goal-board-store.md) for the
+> current design.
+
 > **Status: partially implemented.** Issue
 > [#1590](https://github.com/rysweet/Simard/issues/1590) and its merged
 > follow-up PRs migrated the OODA cycle, the dashboard handlers, the

--- a/docs/concepts/steerable-ooda-daemon.md
+++ b/docs/concepts/steerable-ooda-daemon.md
@@ -22,6 +22,15 @@ related:
 
 # Concept: keeping the OODA daemon steerable
 
+> **Update (issue #1):** the fixes narrated here (#2534) were sound in intent
+> but never *fired* in production — the board was still a versioned
+> cognitive-memory snapshot, so operator edits were clobbered, the breaker's
+> counter reset on every ~hourly restart, and done goals were never swept. They
+> are superseded by the
+> [authoritative goal-board store](./authoritative-goal-board-store.md), which
+> makes `goal_board.json` the single durable source of truth. Read that page for
+> the current design.
+
 This document is the **single coherent narrative** for a systemic incident in
 which the autonomous OODA daemon became *un-steerable and stuck*. It ties
 together four fixes that each already have their own focused reference and

--- a/docs/howto/recover-goal-board.md
+++ b/docs/howto/recover-goal-board.md
@@ -16,6 +16,17 @@ related:
 
 # How to recover a corrupted or missing goal board
 
+> **Update (issue [#1](https://github.com/rysweet/Simard/issues/1)):** the goal
+> board is no longer "stored exclusively in cognitive memory". As of issue #1
+> the authoritative board is the durable file
+> `<state_root>/state/goal_board.json`, and the `goal-board:snapshot`
+> cognitive-memory fact is a **derived cache** rebuilt from that file each
+> cycle. To recover, restore or delete `goal_board.json` (a missing or corrupt
+> file makes the daemon start from an empty board and re-migrate from the
+> snapshot); the cognitive-memory steps below apply to the derived cache. See
+> [Authoritative goal-board store](../concepts/authoritative-goal-board-store.md)
+> for the current design.
+
 > **Status: design specification — partially implemented (issue [#1590](https://github.com/rysweet/Simard/issues/1590)).**
 >
 > This how-to relies on three CLI subcommands that are part of the issue

--- a/docs/reference/goal-board-api.md
+++ b/docs/reference/goal-board-api.md
@@ -15,6 +15,18 @@ related:
 
 # Goal board API reference
 
+> **Update (issue [#1](https://github.com/rysweet/Simard/issues/1)):** the
+> "single source of truth (target state)" and "cognitive memory is the sole
+> authoritative store" claims below are **superseded**. As of issue #1 the
+> authoritative goal board is the durable, flock-guarded file
+> `<state_root>/state/goal_board.json` (see
+> [`goal_board_store`](../concepts/authoritative-goal-board-store.md)); the
+> `goal-board:snapshot` cognitive-memory fact is now a **derived cache**. The
+> `load_goal_board` / `save_goal_board` / `persist_board` API described here
+> still exists and now services that derived cache. Read the
+> [Authoritative goal-board store](../concepts/authoritative-goal-board-store.md)
+> concept for the current design.
+
 > **Status: design specification — partially implemented (issue [#1590](https://github.com/rysweet/Simard/issues/1590)).**
 >
 > The persistence functions (`load_goal_board`, `save_goal_board`,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
     - Unified Telemetry and Status: concepts/unified-telemetry-and-status.md
     - Goal-Board Persistence: concepts/goal-board-persistence.md
     - Keeping the OODA Daemon Steerable: concepts/steerable-ooda-daemon.md
+    - Authoritative Goal-Board Store: concepts/authoritative-goal-board-store.md
     - Goal-Board Corruption Guards: concepts/goal-board-corruption-guards.md
     - File-Backed Goal-Store Simplification: concepts/file-backed-goal-store-simplification.md
     - Goal-Fact Dedup in Preparation: concepts/goal-fact-dedup-in-preparation.md

--- a/src/goal_board_store/mod.rs
+++ b/src/goal_board_store/mod.rs
@@ -1,0 +1,434 @@
+//! Authoritative, durable goal-board store (issue #1).
+//!
+//! # Why this exists
+//!
+//! Before this module the goal board lived only as **searchable semantic
+//! facts** in cognitive memory (`goal-board:snapshot`), read back via
+//! `search_facts(...).max_by(node_id)` and rewritten every OODA cycle through a
+//! *union-by-id* `merge_boards`. That architecture had three fatal properties
+//! for a steerable daemon:
+//!
+//! 1. **Not read-your-writes.** A snapshot is one of many versioned facts; a
+//!    stale replica or an out-of-order read can surface an old board.
+//! 2. **Clobbering.** The daemon re-saves its *in-memory* board each cycle. An
+//!    operator `goal remove` (or a meeting handoff) writes a new snapshot, but
+//!    the daemon's next `merge_boards` unions its still-in-memory copy back on
+//!    top — resurrecting the just-removed goal even though the CLI exited `0`.
+//! 3. **No durable process state.** The no-progress breaker's per-goal counter
+//!    lived only in `OodaState`, so the daemon's ~hourly process restart reset
+//!    it to zero before it could ever reach the threshold.
+//!
+//! # The single authoritative store
+//!
+//! This module makes **one durable file** — `<state_root>/state/goal_board.json`
+//! — the single source of truth. It is guarded by the same cross-process
+//! advisory `flock` that already serialises board writes
+//! ([`crate::state_root::goal_board_lock_path`], issue #2511) and mutated with
+//! an **atomic read-modify-write** (temp file + `rename`). [`load`] returns
+//! exactly the last committed state (read-your-writes), always. The cognitive
+//! memory snapshot is demoted to a **derived cache** the daemon overwrites from
+//! this file each cycle (see
+//! [`crate::goal_curation::overwrite_memory_cache`]).
+//!
+//! The store also persists the [`NoProgressTracker`] so the breaker's counters
+//! survive daemon restarts, and it reconciles operator edits against the daemon's
+//! in-flight board **honouring tombstones** ([`reconcile`]) so a removed or
+//! completed goal is never clobbered back onto the board.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::error::{SimardError, SimardResult};
+use crate::goal_curation::completion_gate::{
+    CompletionEvidenceGate, CompletionVerdict, EvidenceSource,
+};
+use crate::goal_curation::{
+    ActiveGoal, GoalBoard, GoalProgress, MAX_ACTIVE_GOALS, NoProgressTracker,
+};
+
+#[cfg(test)]
+mod tests;
+
+/// On-disk schema version for [`PersistentGoalState`]. Bump on incompatible
+/// layout changes so a loader can migrate; `#[serde(default)]` keeps older
+/// files (which lacked the field) deserializable as version 0.
+pub const STORE_VERSION: u32 = 1;
+
+/// The complete durable goal-board state, serialised to `goal_board.json`.
+///
+/// Every field carries `#[serde(default)]` so a partially-written or older
+/// file still deserialises into a usable value rather than failing the load.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct PersistentGoalState {
+    /// Schema version of the persisted file (see [`STORE_VERSION`]).
+    #[serde(default)]
+    pub version: u32,
+    /// The authoritative goal board (active goals + scored backlog).
+    #[serde(default)]
+    pub board: GoalBoard,
+    /// The no-progress breaker's per-goal consecutive-no-action counters,
+    /// persisted so a livelock spanning a daemon restart is still bounded.
+    #[serde(default)]
+    pub no_progress: NoProgressTracker,
+}
+
+/// Absolute path of the authoritative goal-board file for `state_root`.
+pub fn store_path(state_root: &Path) -> PathBuf {
+    state_root.join("state").join("goal_board.json")
+}
+
+// ---------------------------------------------------------------------------
+// Cross-process advisory lock (shared with goal_curation::save_goal_board)
+// ---------------------------------------------------------------------------
+
+/// RAII guard holding an exclusive `flock` over
+/// [`crate::state_root::goal_board_lock_path`] for the duration of an atomic
+/// read-modify-write. Shares the **same physical lock file**
+/// (`<state_root>/state/goal-board.lock`) as
+/// [`crate::goal_curation::save_goal_board`] so a daemon cycle flush and a
+/// concurrent `simard goal` CLI mutation can never interleave (issue #2511).
+///
+/// Acquisition is best-effort: any filesystem error is logged at `debug` and
+/// the caller proceeds *unlocked* rather than failing the mutation — the lock
+/// can only prevent the race, never introduce a new failure mode. `flock`
+/// releases on FD close or process death, so a crashed holder never wedges the
+/// board.
+#[cfg(unix)]
+struct StoreLock {
+    file: std::fs::File,
+}
+
+#[cfg(unix)]
+impl StoreLock {
+    fn acquire(state_root: &Path) -> Option<Self> {
+        use std::os::unix::io::AsRawFd;
+
+        let path = crate::state_root::goal_board_lock_path_in(state_root);
+        if let Some(parent) = path.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            tracing::debug!(lock = "goal-board", error = %e, "StoreLock: create dir failed; unlocked");
+            return None;
+        }
+        let file = match std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&path)
+        {
+            Ok(f) => f,
+            Err(e) => {
+                tracing::debug!(lock = "goal-board", error = %e, "StoreLock: open failed; unlocked");
+                return None;
+            }
+        };
+        let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+        if ret != 0 {
+            tracing::debug!(
+                lock = "goal-board",
+                error = %std::io::Error::last_os_error(),
+                "StoreLock: flock(LOCK_EX) failed; unlocked"
+            );
+            return None;
+        }
+        Some(Self { file })
+    }
+}
+
+#[cfg(unix)]
+impl Drop for StoreLock {
+    fn drop(&mut self) {
+        use std::os::unix::io::AsRawFd;
+        unsafe {
+            libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}
+
+/// Acquire the cross-process store lock. A no-op on non-unix targets (the
+/// project ships unix-only, but keeping the guard `cfg`-gated avoids a build
+/// break on doc/lint passes for other targets).
+#[cfg(unix)]
+fn lock(state_root: &Path) -> Option<StoreLock> {
+    StoreLock::acquire(state_root)
+}
+
+#[cfg(not(unix))]
+fn lock(_state_root: &Path) -> Option<()> {
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Read / write primitives
+// ---------------------------------------------------------------------------
+
+/// Read the persisted state without taking the lock. Returns the default
+/// (empty) state when the file is absent, unreadable, or corrupt — a missing or
+/// damaged file must never crash the daemon; it starts from an empty board.
+fn read_unlocked(state_root: &Path) -> PersistentGoalState {
+    let path = store_path(state_root);
+    match std::fs::read_to_string(&path) {
+        Ok(raw) => serde_json::from_str(&raw).unwrap_or_else(|e| {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "goal_board_store: corrupt file; starting from empty state"
+            );
+            PersistentGoalState::default()
+        }),
+        Err(_) => PersistentGoalState::default(),
+    }
+}
+
+/// Atomically write `state` to the store file (temp file + `rename`), creating
+/// the parent directory if needed. The `rename` is atomic on the same
+/// filesystem, so a concurrent reader sees either the old or the new file
+/// whole — never a torn write.
+fn write_atomic(state_root: &Path, state: &PersistentGoalState) -> SimardResult<()> {
+    let path = store_path(state_root);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| SimardError::ArtifactIo {
+            path: parent.to_path_buf(),
+            reason: format!("creating goal-board store dir: {e}"),
+        })?;
+    }
+    let json = serde_json::to_string_pretty(state).map_err(|e| SimardError::ArtifactIo {
+        path: path.clone(),
+        reason: format!("serialising goal-board store: {e}"),
+    })?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, json.as_bytes()).map_err(|e| SimardError::ArtifactIo {
+        path: tmp.clone(),
+        reason: format!("writing goal-board temp file: {e}"),
+    })?;
+    std::fs::rename(&tmp, &path).map_err(|e| SimardError::ArtifactIo {
+        path: path.clone(),
+        reason: format!("renaming goal-board temp file into place: {e}"),
+    })?;
+    Ok(())
+}
+
+/// Load the authoritative state (read-your-writes). Takes the shared lock for
+/// the duration of the read so a partially-committed peer write is never
+/// observed.
+pub fn load(state_root: &Path) -> PersistentGoalState {
+    let _guard = lock(state_root);
+    read_unlocked(state_root)
+}
+
+/// Atomically read-modify-write the authoritative state under the shared lock.
+///
+/// Reads the current file, hands a mutable reference to `f`, stamps the current
+/// [`STORE_VERSION`], and writes the result atomically. The whole sequence runs
+/// while the cross-process `flock` is held, so two processes (daemon + CLI)
+/// serialise their read-modify-write windows and cannot lose each other's
+/// updates. Returns whatever `f` returns.
+pub fn mutate<R>(
+    state_root: &Path,
+    f: impl FnOnce(&mut PersistentGoalState) -> R,
+) -> SimardResult<R> {
+    let _guard = lock(state_root);
+    let mut state = read_unlocked(state_root);
+    state.version = STORE_VERSION;
+    let out = f(&mut state);
+    write_atomic(state_root, &state)?;
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Tombstone-aware reconciliation
+// ---------------------------------------------------------------------------
+
+/// Drop every active goal and backlog item whose id is tombstoned. Defensive
+/// filter applied at load and commit so a tombstoned goal can never survive on
+/// the board even if some other path (default seeding, memory recall, a meeting
+/// handoff) tried to re-introduce it.
+#[must_use]
+pub fn filter_tombstoned(mut board: GoalBoard, tombstones: &HashSet<String>) -> GoalBoard {
+    board.active.retain(|g| !tombstones.contains(&g.id));
+    board.backlog.retain(|b| !tombstones.contains(&b.id));
+    board
+}
+
+/// Reconcile the daemon's `in_flight` board with the currently-`persisted`
+/// board, honouring `tombstones`. This is the anti-clobber merge that makes
+/// operator edits **stick**:
+///
+/// * A goal present only in `persisted` (an operator `goal add` the daemon has
+///   not yet observed) is **kept**.
+/// * A goal present in both is taken from `in_flight` field-for-field (the
+///   daemon holds the most recent progress/status for goals it is driving).
+/// * A **tombstoned** id is removed even if `in_flight` still carries it (the
+///   operator removed/completed it — never resurrect it).
+///
+/// The active set is truncated to [`MAX_ACTIVE_GOALS`] with a deterministic key
+/// (priority ascending, then id) so the result is stable. The backlog is
+/// unioned by id and never truncated.
+#[must_use]
+pub fn reconcile(
+    persisted: &GoalBoard,
+    in_flight: &GoalBoard,
+    tombstones: &HashSet<String>,
+) -> GoalBoard {
+    use std::collections::BTreeMap;
+
+    let mut active: BTreeMap<String, ActiveGoal> = BTreeMap::new();
+    for g in &persisted.active {
+        active.insert(g.id.clone(), g.clone());
+    }
+    // in_flight wins on collision.
+    for g in &in_flight.active {
+        active.insert(g.id.clone(), g.clone());
+    }
+
+    let mut backlog: BTreeMap<String, crate::goal_curation::BacklogItem> = BTreeMap::new();
+    for b in &persisted.backlog {
+        backlog.insert(b.id.clone(), b.clone());
+    }
+    for b in &in_flight.backlog {
+        backlog.insert(b.id.clone(), b.clone());
+    }
+
+    // Tombstones dominate both sets.
+    active.retain(|id, _| !tombstones.contains(id));
+    backlog.retain(|id, _| !tombstones.contains(id));
+    // A goal cannot be both active and in the backlog; active wins.
+    backlog.retain(|id, _| !active.contains_key(id));
+
+    let mut active: Vec<ActiveGoal> = active.into_values().collect();
+    if active.len() > MAX_ACTIVE_GOALS {
+        active.sort_by(|a, b| a.priority.cmp(&b.priority).then_with(|| a.id.cmp(&b.id)));
+        active.truncate(MAX_ACTIVE_GOALS);
+    }
+
+    GoalBoard {
+        active,
+        backlog: backlog.into_values().collect(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Daemon-facing operations
+// ---------------------------------------------------------------------------
+
+/// Load the authoritative state for the daemon, migrating from the legacy
+/// cognitive-memory snapshot on first run.
+///
+/// If `goal_board.json` already exists it is the source of truth and returned
+/// verbatim (read-your-writes). Otherwise the current cognitive-memory board
+/// snapshot is read, tombstone-filtered, and written into the new authoritative
+/// file so **no live goals are lost** when the daemon first adopts the store.
+/// The tracker starts empty on migration (there is no prior persisted counter).
+pub fn load_or_migrate(
+    state_root: &Path,
+    memory: &dyn CognitiveMemoryOps,
+) -> SimardResult<PersistentGoalState> {
+    if store_path(state_root).exists() {
+        return Ok(load(state_root));
+    }
+    let legacy = crate::goal_curation::load_goal_board(memory).unwrap_or_default();
+    let tombstones = crate::ooda_loop::load_tombstones(state_root);
+    let filtered = filter_tombstoned(legacy, &tombstones);
+    let migrated_active = filtered.active.len();
+    mutate(state_root, |s| {
+        s.board = filtered.clone();
+        s.no_progress = NoProgressTracker::new();
+    })?;
+    tracing::info!(
+        target: "simard::ooda",
+        active = migrated_active,
+        "goal_board_store: migrated cognitive-memory snapshot into authoritative goal_board.json"
+    );
+    Ok(load(state_root))
+}
+
+/// Commit the daemon's post-cycle board authoritatively.
+///
+/// Steps, all durable:
+/// 1. Record `new_tombstones` (goals archived / completed / dropped this cycle)
+///    so no path can recreate them.
+/// 2. Under the store lock, re-read the current file (picking up any operator
+///    edit made *during* the cycle), [`reconcile`] the daemon's `in_flight`
+///    board against it honouring the full tombstone set, and persist the
+///    reconciled board plus the `tracker`.
+///
+/// Returns the reconciled board that was persisted.
+pub fn commit_cycle(
+    state_root: &Path,
+    in_flight: &GoalBoard,
+    tracker: &NoProgressTracker,
+    new_tombstones: &[String],
+) -> SimardResult<GoalBoard> {
+    if !new_tombstones.is_empty() {
+        crate::ooda_loop::tombstone_goals(state_root, new_tombstones)?;
+    }
+    let tombstones = crate::ooda_loop::load_tombstones(state_root);
+    let in_flight = in_flight.clone();
+    let tracker = tracker.clone();
+    mutate(state_root, move |s| {
+        let reconciled = reconcile(&s.board, &in_flight, &tombstones);
+        s.board = reconciled.clone();
+        s.no_progress = tracker;
+        reconciled
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Done-gate: runs every cycle, cross-repo aware
+// ---------------------------------------------------------------------------
+
+/// A single completion decision made by the every-cycle done-gate sweep.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DoneDecision {
+    /// The goal id evaluated.
+    pub goal_id: String,
+    /// Whether hard completion evidence was present (the goal was marked done).
+    pub completed: bool,
+}
+
+/// Evaluate **every** active goal against the completion-evidence gate and mark
+/// those with hard evidence `Completed`. Unlike the legacy archive path (which
+/// only re-checks goals *already* claiming completion), this runs each cycle
+/// over the whole active board, so a goal whose objective was finished
+/// out-of-band — e.g. a merged PR or closed issue on **another** governed repo —
+/// is detected and auto-completed instead of being re-litigated forever.
+///
+/// The gate is cross-repo aware: [`crate::goal_curation::GhCliEvidenceSource`]
+/// resolves each goal's `repo` slug, so a merged PR / closed issue on any
+/// governed repo counts as evidence. Every decision is logged so operators can
+/// see, in the daemon log, exactly which goals the gate acted on each cycle.
+///
+/// Returns the ids that were newly marked `Completed` (for the caller to
+/// tombstone and archive).
+pub fn sweep_done_goals(board: &mut GoalBoard, evidence: &dyn EvidenceSource) -> Vec<String> {
+    let gate = CompletionEvidenceGate::new(evidence);
+    let mut completed = Vec::new();
+    for goal in board.active.iter_mut() {
+        if matches!(goal.status, GoalProgress::Completed) {
+            continue;
+        }
+        match gate.evaluate(goal) {
+            CompletionVerdict::Complete(_) => {
+                tracing::warn!(
+                    target: "simard::ooda",
+                    goal = %goal.id,
+                    repo = goal.repo.as_deref().unwrap_or("Simard"),
+                    "done-gate: cross-repo completion evidence present — marking goal DONE",
+                );
+                goal.status = GoalProgress::Completed;
+                completed.push(goal.id.clone());
+            }
+            CompletionVerdict::Blocked { .. } => {
+                tracing::debug!(
+                    target: "simard::ooda",
+                    goal = %goal.id,
+                    "done-gate: no completion evidence yet — leaving active",
+                );
+            }
+        }
+    }
+    completed
+}

--- a/src/goal_board_store/tests.rs
+++ b/src/goal_board_store/tests.rs
@@ -1,0 +1,475 @@
+//! Hermetic tests for the authoritative goal-board store (issue #1).
+//!
+//! Every test uses an isolated `TempDir` as `SIMARD_STATE_ROOT`, so the
+//! cross-process `flock`, the atomic file write, and the tombstone file are all
+//! exercised against a private state root — no shared global state, no touching
+//! the real `~/.simard`.
+
+use std::collections::HashSet;
+
+use tempfile::TempDir;
+
+use super::*;
+use crate::goal_curation::completion_gate::EvidenceSource;
+use crate::goal_curation::{ActiveGoal, BacklogItem, GoalBoard, GoalProgress, WipRef};
+use crate::ooda_loop::{load_tombstones, tombstone_goals};
+
+/// Build an active goal in the `NotStarted` state, optionally cross-repo.
+fn goal(id: &str, priority: u32, repo: Option<&str>) -> ActiveGoal {
+    ActiveGoal::new(id, format!("do {id}"), priority).with_repo(repo.map(str::to_string))
+}
+
+/// A board with the given active goals and no backlog.
+fn board(goals: Vec<ActiveGoal>) -> GoalBoard {
+    GoalBoard {
+        active: goals,
+        backlog: Vec::new(),
+    }
+}
+
+/// Evidence source that certifies a goal complete iff it carries a `pr` wip_ref
+/// (models "the referenced PR is merged and any linked issue is closed"). Used
+/// to exercise the every-cycle done-gate sweep hermetically.
+struct FakePrMergedEvidence;
+
+impl EvidenceSource for FakePrMergedEvidence {
+    fn any_pr_merged(&self, goal: &ActiveGoal) -> crate::error::SimardResult<bool> {
+        Ok(goal
+            .wip_refs
+            .iter()
+            .any(|r| r.kind.eq_ignore_ascii_case("pr")))
+    }
+    fn issue_closed(&self, _goal: &ActiveGoal) -> crate::error::SimardResult<bool> {
+        Ok(true)
+    }
+    fn is_deployed(&self, _goal: &ActiveGoal) -> crate::error::SimardResult<bool> {
+        Ok(true)
+    }
+}
+
+fn pr_ref(num: &str) -> WipRef {
+    WipRef {
+        kind: "pr".to_string(),
+        ref_id: num.to_string(),
+        label: format!("PR #{num}"),
+        url: None,
+    }
+}
+
+#[test]
+fn load_is_empty_when_no_file() {
+    let tmp = TempDir::new().unwrap();
+    let state = load(tmp.path());
+    assert!(state.board.active.is_empty());
+    assert!(state.board.backlog.is_empty());
+}
+
+#[test]
+fn store_round_trips_read_your_writes() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // Commit a board via the RMW primitive.
+    mutate(root, |s| {
+        s.board = board(vec![
+            goal("alpha", 1, None),
+            goal("beta", 2, Some("ladybug-rust")),
+        ]);
+    })
+    .unwrap();
+
+    // load() returns exactly the last committed board.
+    let loaded = load(root);
+    assert_eq!(loaded.board.active.len(), 2);
+    assert_eq!(loaded.board.active[0].id, "alpha");
+    assert_eq!(loaded.version, STORE_VERSION);
+
+    // A second write is immediately visible (read-your-writes).
+    mutate(root, |s| {
+        s.board.active.retain(|g| g.id != "alpha");
+    })
+    .unwrap();
+    let loaded = load(root);
+    assert_eq!(loaded.board.active.len(), 1);
+    assert_eq!(loaded.board.active[0].id, "beta");
+}
+
+#[test]
+fn reconcile_preserves_operator_added_goal() {
+    // Persisted (authoritative) file has an operator-added goal the daemon has
+    // never seen; the daemon's in-flight board carries only its own goal.
+    let persisted = board(vec![goal("operator-goal", 1, None)]);
+    let in_flight = board(vec![goal("daemon-goal", 2, None)]);
+    let tombstones = HashSet::new();
+
+    let merged = reconcile(&persisted, &in_flight, &tombstones);
+    let ids: HashSet<&str> = merged.active.iter().map(|g| g.id.as_str()).collect();
+    assert!(
+        ids.contains("operator-goal"),
+        "operator add must survive curation merge"
+    );
+    assert!(ids.contains("daemon-goal"));
+}
+
+#[test]
+fn reconcile_drops_tombstoned_goal_even_if_daemon_still_has_it() {
+    // Operator removed the goal from the authoritative file (so `persisted`
+    // lacks it) AND tombstoned it — but the daemon's in-flight board still
+    // carries it (it loaded before the remove). The reconcile MUST drop it.
+    let persisted = board(vec![goal("keep", 1, None)]);
+    let in_flight = board(vec![goal("keep", 1, None), goal("removed", 2, None)]);
+    let mut tombstones = HashSet::new();
+    tombstones.insert("removed".to_string());
+
+    let merged = reconcile(&persisted, &in_flight, &tombstones);
+    let ids: HashSet<&str> = merged.active.iter().map(|g| g.id.as_str()).collect();
+    assert!(ids.contains("keep"));
+    assert!(
+        !ids.contains("removed"),
+        "a tombstoned goal must never be clobbered back onto the board"
+    );
+}
+
+#[test]
+fn filter_tombstoned_drops_active_and_backlog() {
+    let mut b = board(vec![goal("a", 1, None), goal("b", 2, None)]);
+    b.backlog.push(BacklogItem {
+        id: "c".to_string(),
+        description: "c".to_string(),
+        source: "test".to_string(),
+        score: 0.5,
+    });
+    let mut ts = HashSet::new();
+    ts.insert("b".to_string());
+    ts.insert("c".to_string());
+
+    let filtered = filter_tombstoned(b, &ts);
+    assert_eq!(filtered.active.len(), 1);
+    assert_eq!(filtered.active[0].id, "a");
+    assert!(filtered.backlog.is_empty());
+}
+
+#[test]
+fn commit_cycle_tombstones_and_persists() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // Seed the authoritative file with two goals.
+    mutate(root, |s| {
+        s.board = board(vec![goal("a", 1, None), goal("b", 2, None)]);
+    })
+    .unwrap();
+
+    // Daemon commits its post-cycle board, tombstoning goal "b" (archived).
+    let in_flight = board(vec![goal("a", 1, None), goal("b", 2, None)]);
+    let tracker = NoProgressTracker::new();
+    let reconciled = commit_cycle(root, &in_flight, &tracker, &["b".to_string()]).unwrap();
+
+    let ids: HashSet<&str> = reconciled.active.iter().map(|g| g.id.as_str()).collect();
+    assert!(ids.contains("a"));
+    assert!(!ids.contains("b"), "committed goal must be tombstoned out");
+
+    // The tombstone is durable, and a subsequent reload never resurrects "b"
+    // even if a stale in-flight board still has it.
+    assert!(load_tombstones(root).contains("b"));
+    let reloaded = load(root);
+    let ids: HashSet<&str> = reloaded
+        .board
+        .active
+        .iter()
+        .map(|g| g.id.as_str())
+        .collect();
+    assert!(!ids.contains("b"));
+}
+
+#[test]
+fn tombstone_prevents_reseed_from_memory_recall() {
+    // Simulate a "recalled" board that tries to reintroduce a completed goal.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // Operator completes/removes "supply-chain-hardening" — tombstone it.
+    tombstone_goals(root, &["supply-chain-hardening".to_string()]).unwrap();
+
+    // A recall path proposes a board that still contains it.
+    let recalled = board(vec![
+        goal("supply-chain-hardening", 1, Some("ladybug-rust")),
+        goal("fresh-goal", 2, None),
+    ]);
+    let tombstones = load_tombstones(root);
+    let filtered = filter_tombstoned(recalled, &tombstones);
+
+    let ids: HashSet<&str> = filtered.active.iter().map(|g| g.id.as_str()).collect();
+    assert!(
+        !ids.contains("supply-chain-hardening"),
+        "recall must not resurrect a tombstoned goal"
+    );
+    assert!(ids.contains("fresh-goal"));
+}
+
+#[test]
+fn sweep_completes_cross_repo_goal_with_evidence() {
+    // Two not-started goals; only the cross-repo one carries a merged-PR ref.
+    let mut b = board(vec![
+        {
+            let mut g = goal("ladybug-hardening", 1, Some("ladybug-rust"));
+            g.wip_refs.push(pr_ref("1"));
+            g
+        },
+        goal("no-evidence-yet", 2, None),
+    ]);
+
+    let completed = sweep_done_goals(&mut b, &FakePrMergedEvidence);
+    assert_eq!(completed, vec!["ladybug-hardening".to_string()]);
+
+    // The cross-repo goal is now Completed; the other is untouched.
+    let done = b
+        .active
+        .iter()
+        .find(|g| g.id == "ladybug-hardening")
+        .unwrap();
+    assert_eq!(done.status, GoalProgress::Completed);
+    let other = b.active.iter().find(|g| g.id == "no-evidence-yet").unwrap();
+    assert_eq!(other.status, GoalProgress::NotStarted);
+}
+
+#[test]
+fn four_ladybug_goals_auto_complete_via_done_gate_and_never_return() {
+    // Headline production scenario (issue #1): the four ladybug supply-chain
+    // goals — each objectively DONE on a *different governed repo* — are
+    // auto-completed by the every-cycle CROSS-REPO done-gate, tombstoned as they
+    // leave the board, and can NEVER be resurrected by a later memory-recall /
+    // curation pass or a daemon restart. A Simard-repo control goal with no
+    // evidence stays active throughout, proving the gate is evidence-driven and
+    // not a blanket sweep.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    let ladybug_ids = [
+        "ladybug-rust-harden",
+        "ladybug-graph-harden",
+        "lbug-patched-scope",
+        "ladybug-rust-audit",
+    ];
+
+    // Seed four cross-repo ladybug goals (each carrying merged-PR evidence) plus
+    // one Simard-repo control with none, directly into the authoritative store.
+    mutate(root, |s| {
+        s.board = board(vec![
+            {
+                let mut g = goal("ladybug-rust-harden", 1, Some("ladybug-rust"));
+                g.wip_refs.push(pr_ref("1"));
+                g
+            },
+            {
+                let mut g = goal("ladybug-graph-harden", 2, Some("ladybug-graph-rs"));
+                g.wip_refs.push(pr_ref("1"));
+                g
+            },
+            {
+                let mut g = goal("lbug-patched-scope", 3, Some("lbug-patched"));
+                g.wip_refs.push(pr_ref("1"));
+                g
+            },
+            {
+                let mut g = goal("ladybug-rust-audit", 4, Some("ladybug-rust"));
+                g.wip_refs.push(pr_ref("2"));
+                g
+            },
+            goal("simard-control", 5, None),
+        ]);
+    })
+    .unwrap();
+
+    // ── Daemon cycle: reload the authoritative board, run the every-cycle
+    // done-gate over the WHOLE active set (cross-repo aware). ──
+    let mut in_flight = load(root).board;
+    let completed = sweep_done_goals(&mut in_flight, &FakePrMergedEvidence);
+    let done: HashSet<&str> = completed.iter().map(String::as_str).collect();
+    for id in ladybug_ids {
+        assert!(
+            done.contains(id),
+            "the cross-repo done-gate must auto-complete ladybug goal {id}"
+        );
+    }
+    assert!(
+        !done.contains("simard-control"),
+        "a goal without completion evidence must stay active"
+    );
+
+    // The daemon drops the just-completed goals and commits the cycle,
+    // tombstoning every id that left the board.
+    in_flight.active.retain(|g| !done.contains(g.id.as_str()));
+    let reconciled = commit_cycle(root, &in_flight, &NoProgressTracker::new(), &completed).unwrap();
+    let live: HashSet<&str> = reconciled.active.iter().map(|g| g.id.as_str()).collect();
+    for id in ladybug_ids {
+        assert!(
+            !live.contains(id),
+            "a done ladybug goal ({id}) must LEAVE the board once completed"
+        );
+    }
+    assert!(
+        live.contains("simard-control"),
+        "the active control goal must survive the cycle"
+    );
+
+    // All four are durably tombstoned.
+    let tombstones = load_tombstones(root);
+    for id in ladybug_ids {
+        assert!(tombstones.contains(id), "{id} must be durably tombstoned");
+    }
+
+    // A later memory-recall / curation pass proposing all four again cannot
+    // resurrect them — neither the load-time tombstone filter nor the cycle
+    // reconcile lets a tombstoned goal back onto the board.
+    let recalled = board(
+        ladybug_ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| goal(id, i as u32 + 1, Some("ladybug-rust")))
+            .collect(),
+    );
+    let filtered = filter_tombstoned(recalled.clone(), &tombstones);
+    assert!(
+        filtered.active.is_empty(),
+        "recall must not re-seed any completed ladybug goal"
+    );
+    let reconciled2 = reconcile(&reconciled, &recalled, &tombstones);
+    let live2: HashSet<&str> = reconciled2.active.iter().map(|g| g.id.as_str()).collect();
+    for id in ladybug_ids {
+        assert!(
+            !live2.contains(id),
+            "curation reconcile must not resurrect tombstoned ladybug goal {id}"
+        );
+    }
+
+    // And a fresh restart (a plain reload of goal_board.json) shows them still
+    // gone — the "re-litigated every cycle" loop is closed for good.
+    let after_restart = load(root).board;
+    for id in ladybug_ids {
+        assert!(
+            !after_restart.active.iter().any(|g| g.id == id),
+            "{id} must stay off the board across a daemon restart"
+        );
+    }
+    assert!(
+        after_restart
+            .active
+            .iter()
+            .any(|g| g.id == "simard-control"),
+        "the control goal must persist across the restart"
+    );
+}
+
+#[test]
+fn no_progress_tracker_persists_across_simulated_restart() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // Cycle 1 (process instance A): one no-action cycle on "stuck".
+    mutate(root, |s| {
+        s.no_progress.record_no_action("stuck");
+    })
+    .unwrap();
+
+    // Cycle 2 (still A): a second no-action cycle.
+    mutate(root, |s| {
+        s.no_progress.record_no_action("stuck");
+    })
+    .unwrap();
+
+    // --- Daemon process restart: a fresh load must recover the counter (2),
+    // NOT reset it to 0. This is the bug the production report describes. ---
+    let recovered = load(root);
+    assert_eq!(
+        recovered.no_progress.consecutive("stuck"),
+        2,
+        "the no-progress counter must survive a daemon restart"
+    );
+
+    // Cycle 3 (process instance B): the third no-action cycle crosses the
+    // breaker threshold *because the counter carried over the restart*.
+    let count = mutate(root, |s| s.no_progress.record_no_action("stuck")).unwrap();
+    assert_eq!(
+        count, 3,
+        "the counter accumulates across the restart to reach the threshold"
+    );
+}
+
+#[test]
+fn no_progress_breaker_fires_after_restart_using_persisted_counter() {
+    use crate::goal_curation::no_progress_breaker::{NoProgressResolution, StuckGoalDisposition};
+
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // Two no-action cycles before the restart (below the threshold of 3).
+    mutate(root, |s| {
+        s.no_progress.record_no_action("stuck");
+    })
+    .unwrap();
+    mutate(root, |s| {
+        s.no_progress.record_no_action("stuck");
+    })
+    .unwrap();
+
+    // --- Restart: reload the persisted tracker from the authoritative store. ---
+    let mut recovered = load(root).no_progress;
+    assert_eq!(recovered.consecutive("stuck"), 2);
+
+    // The third no-action cycle *after the restart* crosses the threshold and
+    // the breaker FIRES with a terminal resolution (here: evidence present →
+    // MarkDone). Before this fix the counter reset to 0 each restart, so the
+    // breaker could never reach the threshold — exactly the "0 log lines in
+    // 4.5h" production symptom.
+    let resolution = recovered.record_and_resolve("stuck", 3, || StuckGoalDisposition::Done);
+    assert_eq!(resolution, NoProgressResolution::MarkDone);
+    assert!(
+        resolution.is_terminal(),
+        "the no-progress breaker must fire once the counter — persisted across the restart — reaches the threshold"
+    );
+
+    // Persist the cleared counter and confirm the terminal firing reset it.
+    mutate(root, |s| {
+        s.no_progress = recovered.clone();
+    })
+    .unwrap();
+    assert_eq!(load(root).no_progress.consecutive("stuck"), 0);
+}
+
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn load_or_migrate_writes_file_from_memory_snapshot() {
+    use crate::memory_ipc::launch_writer_bridge;
+    use crate::test_support::hermetic::HermeticState;
+
+    let state = HermeticState::new();
+    let root = state.state_root();
+
+    // Seed the legacy cognitive-memory snapshot (the pre-#1 source of truth).
+    let bridge = launch_writer_bridge(root).expect("writer bridge");
+    crate::goal_curation::save_goal_board(&board(vec![goal("legacy", 1, None)]), bridge.ops())
+        .expect("seed memory snapshot");
+
+    // First adoption: no goal_board.json yet, so migrate from memory.
+    assert!(!store_path(root).exists());
+    let migrated = load_or_migrate(root, bridge.ops()).expect("migrate");
+    assert!(
+        store_path(root).exists(),
+        "migration must create the authoritative file"
+    );
+    let ids: HashSet<&str> = migrated
+        .board
+        .active
+        .iter()
+        .map(|g| g.id.as_str())
+        .collect();
+    assert!(
+        ids.contains("legacy"),
+        "no live goal may be lost on migration"
+    );
+
+    // Second call is a pure read of the now-authoritative file.
+    let again = load_or_migrate(root, bridge.ops()).expect("reload");
+    assert_eq!(again.board.active.len(), 1);
+}

--- a/src/goal_curation/mod.rs
+++ b/src/goal_curation/mod.rs
@@ -22,9 +22,9 @@ pub use operations::CarryoverVerification;
 pub use operations::{
     DEFAULT_SEED_GOALS, DEFAULT_STEWARD_SCORE, active_goals_as_records, add_active_goal,
     add_backlog_item, archive_completed, board_snapshot_hash, clear_goal_assignment,
-    enqueue_stewardship_issue, load_goal_board, persist_board, promote_to_active,
-    read_latest_carryover, rollup_parent_progress, save_goal_board, save_goal_board_with_removals,
-    seed_default_board, simard_state_root, update_goal_progress,
+    enqueue_stewardship_issue, load_goal_board, overwrite_memory_cache, persist_board,
+    promote_to_active, read_latest_carryover, rollup_parent_progress, save_goal_board,
+    save_goal_board_with_removals, seed_default_board, simard_state_root, update_goal_progress,
     update_goal_progress_with_evidence, verify_goal_carryover, write_goal_carryover,
 };
 pub use types::{

--- a/src/goal_curation/operations.rs
+++ b/src/goal_curation/operations.rs
@@ -147,24 +147,15 @@ pub fn simard_state_root() -> std::path::PathBuf {
     crate::state_root::simard_state_root()
 }
 
-/// Filename of the cross-process advisory lock that serializes the goal-board
-/// read-merge-write window across independent OS processes (issue
-/// [#2511](https://github.com/rysweet/Simard/issues/2511)).
-#[cfg(unix)]
-const BOARD_WRITE_LOCK_FILE: &str = "goal-board.lock";
-
 /// Resolve the path of the cross-process goal-board write lock.
 ///
-/// Co-located with the canonical goal store under `<state_root>/state/` (see
-/// [`crate::state_root::goal_store_path`]) so every process that resolves the
-/// same `SIMARD_STATE_ROOT` rendezvouses on the same lock file. Both the OODA
-/// daemon and the `simard goal` CLI resolve their state root through
-/// [`simard_state_root`], so they agree on this path.
+/// Delegates to [`crate::state_root::goal_board_lock_path`] so the daemon, the
+/// `simard goal` CLI, and the authoritative [`crate::goal_board_store`]
+/// rendezvous on the one shared lock file `<state_root>/state/goal-board.lock`
+/// (issue #2511).
 #[cfg(unix)]
 pub(super) fn board_lock_path() -> std::path::PathBuf {
-    crate::state_root::simard_state_root()
-        .join("state")
-        .join(BOARD_WRITE_LOCK_FILE)
+    crate::state_root::goal_board_lock_path()
 }
 
 /// RAII guard holding an exclusive `flock` over [`board_lock_path`] for the
@@ -749,6 +740,38 @@ pub fn persist_board(board: &GoalBoard, bridge: &dyn CognitiveMemoryOps) -> Sima
         &board.durable_summary(),
         "goal-curator",
         Some(&json!({"active_count": board.active.len(), "backlog_count": board.backlog.len()})),
+    )?;
+    Ok(())
+}
+
+/// Overwrite the cognitive-memory board **cache** with `board` exactly,
+/// bypassing the merge-on-write path.
+///
+/// Issue #1: with [`crate::goal_board_store`] now the single authoritative
+/// source of truth, the cognitive-memory `goal-board:snapshot` fact is a
+/// *derived cache* the daemon regenerates from the authoritative file each
+/// cycle. [`save_goal_board`] performs a union merge-on-write (correct when
+/// memory *was* the source of truth) which would resurrect goals the authority
+/// dropped; this helper instead stores `board` verbatim via the CallerKey-dedup
+/// fact so `read_latest_snapshot` returns exactly the authoritative board.
+///
+/// Best-effort by contract: the dashboard and recall read this cache, but the
+/// authoritative file governs, so a cache-write failure is non-fatal.
+pub fn overwrite_memory_cache(
+    board: &GoalBoard,
+    bridge: &dyn CognitiveMemoryOps,
+) -> SimardResult<()> {
+    let snapshot = serde_json::to_string(board).map_err(|e| SimardError::InvalidGoalRecord {
+        field: "board".to_string(),
+        reason: format!("failed to serialize goal board: {e}"),
+    })?;
+    bridge.store_fact_with_caller_key(
+        "goal-board:snapshot",
+        "goal-board:snapshot",
+        &snapshot,
+        1.0,
+        &["goal-board".to_string()],
+        "goal-curator",
     )?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub mod error;
 pub mod eval_watchdog;
 pub mod evidence;
 pub mod git_guardrails;
+pub mod goal_board_store;
 pub mod goal_curation;
 pub mod goals;
 pub mod greeting_banner;

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -58,7 +58,8 @@ mod tests_pr_c_procedures;
 // Re-export all public items so `crate::ooda_loop::X` still works.
 pub use bridge_factory::{bridges_from_state_root, connect_memory};
 pub use curate::{
-    check_meeting_handoffs, promote_from_backlog, reap_old_handoffs, tombstone_goals,
+    check_meeting_handoffs, load_tombstones, promote_from_backlog, reap_old_handoffs,
+    tombstone_goals,
 };
 pub use decide::{decide, decide_with_brain};
 pub use observe::{gather_environment, observe};

--- a/src/operator_cli/goal.rs
+++ b/src/operator_cli/goal.rs
@@ -15,24 +15,27 @@
 //!     safeguard marker (`is_brain_failure_marker`). Operator-set,
 //!     scope-blocked, dependency-blocked, and subordinate-blocked
 //!     goals are untouched.
-//!   - `goal remove <id>…` — variadic, idempotent. Persists via
-//!     `save_goal_board_with_removals` so the PR #1926 merge-on-write
-//!     resurrection failure mode is defeated.
+//!   - `goal remove <id>…` — variadic, idempotent. Surgically removes the ids
+//!     from the authoritative store under the shared flock and writes durable
+//!     tombstones (issue #1).
+//!   - `goal complete <id>` — mark a goal done, remove it, and tombstone it.
+//!   - `goal reprioritize <id> <p>` — alias of `set-priority`.
 //!   - `goal cleanup --placeholders` — defence-in-depth sweep that
 //!     removes every active or backlog goal whose description is exactly
 //!     `Goal <id>` (the placeholder pattern emitted by test fixtures).
 //!
-//! Persistence is cognitive memory via `launch_writer_bridge` against
-//! `simard_state_root()` (honours `SIMARD_STATE_ROOT`). Audit traces are
-//! emitted to stderr so operators can grep `journalctl --user -u
-//! simard-ooda` after the runbook step.
+//! Persistence is the authoritative goal store
+//! ([`crate::goal_board_store`]) — `<state_root>/state/goal_board.json`, guarded
+//! by the shared `goal-board.lock` flock, atomic read-modify-write, read-your-
+//! writes (issue #1). Every mutation runs under the lock so it cannot be
+//! clobbered by (or clobber) a concurrent OODA daemon cycle, and is mirrored to
+//! the cognitive-memory cache so the dashboard and daemon see it immediately.
+//! Honours `SIMARD_STATE_ROOT`. Audit traces are emitted to stderr so operators
+//! can grep `journalctl --user -u simard-ooda` after the runbook step.
 
 use std::error::Error;
 
-use crate::goal_curation::{
-    GoalDecomposer, GoalProgress, load_goal_board, save_goal_board, save_goal_board_with_removals,
-    simard_state_root,
-};
+use crate::goal_curation::{GoalDecomposer, GoalProgress, simard_state_root};
 use crate::memory_ipc::launch_writer_bridge;
 use crate::ooda_actions::advance_goal::spawn::is_brain_failure_marker;
 
@@ -49,6 +52,10 @@ Commands:
                               Add a new active goal at given priority (1-7).
                               `--repo <slug>` routes the goal's engineer to
                               ~/src/<slug> (default: the daemon's own repo).
+  complete <goal-id>          Mark a goal done, remove it, and tombstone it so
+                              nothing re-seeds it (idempotent).
+  reprioritize <goal-id> <p>  Change an active goal's priority (alias of
+                              set-priority).
   demote <goal-id>            Move an active goal to the backlog.
   set-priority <goal-id> <p>  Change an active goal's priority.
   unblock <goal-id>           Clear Blocked status (unconditional).
@@ -112,6 +119,17 @@ pub(super) fn dispatch_goal_command(
             reject_extra_args(args)?;
             handle_set_priority(&goal_id, &priority_str)
         }
+        "reprioritize" => {
+            let goal_id = next_required(&mut args, "goal id")?;
+            let priority_str = next_required(&mut args, "priority (1-7)")?;
+            reject_extra_args(args)?;
+            handle_set_priority(&goal_id, &priority_str)
+        }
+        "complete" => {
+            let goal_id = next_required(&mut args, "goal id")?;
+            reject_extra_args(args)?;
+            handle_complete(&goal_id)
+        }
         "remove" => {
             let ids: Vec<String> = args.collect();
             handle_remove(&ids)
@@ -129,40 +147,85 @@ pub(super) fn dispatch_goal_command(
     }
 }
 
-/// Load the persisted goal board from cognitive memory at the operator's
-/// state root. Surfaces I/O / parse failures as `Err` so the CLI exits
-/// non-zero; callers should not silently degrade.
+/// Load the authoritative goal board (issue #1).
+///
+/// Reads `<state_root>/state/goal_board.json` (the single durable, flock-guarded
+/// source of truth) with read-your-writes semantics, migrating the legacy
+/// cognitive-memory snapshot into it on first use so a fresh CLI still sees the
+/// live board. Surfaces I/O / parse failures as `Err` so the CLI exits non-zero.
 fn load_board() -> Result<crate::goal_curation::GoalBoard, Box<dyn Error>> {
     let state_root = simard_state_root();
     let bridge = launch_writer_bridge(&state_root)
         .map_err(|e| format!("failed to open cognitive memory writer bridge: {e}"))?;
-    let board = load_goal_board(bridge.ops())
-        .map_err(|e| format!("failed to read goal board from cognitive memory: {e}"))?;
-    Ok(board)
+    let persistent = crate::goal_board_store::load_or_migrate(&state_root, bridge.ops())
+        .map_err(|e| format!("failed to load authoritative goal store: {e}"))?;
+    Ok(persistent.board)
 }
 
-/// Persist the mutated board back to cognitive memory.
-fn save_board(board: &crate::goal_curation::GoalBoard) -> Result<(), Box<dyn Error>> {
+/// Atomically apply `f` to the authoritative goal board **under the shared store
+/// flock**, then mirror the committed board to the cognitive-memory cache so the
+/// dashboard and the running OODA daemon observe the change immediately.
+///
+/// This is the anti-clobber write path (issue #1): the whole read-modify-write
+/// runs while the cross-process lock is held, so an operator mutation cannot be
+/// lost to (or lose) a concurrent daemon cycle flush. `f` must **validate before
+/// mutating**: on `Err` the board is restored to its pre-image and the error is
+/// surfaced, so a rejected command (unknown id, board at capacity) never leaves
+/// a partial write.
+fn with_board<R>(
+    f: impl FnOnce(&mut crate::goal_curation::GoalBoard) -> Result<R, Box<dyn Error>>,
+) -> Result<R, Box<dyn Error>> {
     let state_root = simard_state_root();
     let bridge = launch_writer_bridge(&state_root)
         .map_err(|e| format!("failed to open cognitive memory writer bridge: {e}"))?;
-    save_goal_board(board, bridge.ops())
-        .map_err(|e| format!("failed to persist goal board: {e}"))?;
+    crate::goal_board_store::load_or_migrate(&state_root, bridge.ops())
+        .map_err(|e| format!("failed to load authoritative goal store: {e}"))?;
+    let out = crate::goal_board_store::mutate(&state_root, move |s| {
+        let snapshot = s.board.clone();
+        match f(&mut s.board) {
+            Ok(r) => Ok(r),
+            Err(e) => {
+                s.board = snapshot;
+                Err(e)
+            }
+        }
+    })
+    .map_err(|e| -> Box<dyn Error> {
+        format!("failed to persist authoritative goal store: {e}").into()
+    })??;
+    let committed = crate::goal_board_store::load(&state_root).board;
+    if let Err(e) = crate::goal_curation::overwrite_memory_cache(&committed, bridge.ops()) {
+        eprintln!("[simard] goal: warning: memory cache refresh failed: {e}");
+    }
+    Ok(out)
+}
+
+/// Blind-overwrite the authoritative board with `board` under the store lock,
+/// then refresh the memory cache. Used only by `goal decompose`, where the
+/// mutated board (parent placement + new child goals) IS the operator's explicit
+/// intent, so a surgical merge would fight the demotion the operator asked for.
+fn commit_board_blind(board: &crate::goal_curation::GoalBoard) -> Result<(), Box<dyn Error>> {
+    let state_root = simard_state_root();
+    let b = board.clone();
+    crate::goal_board_store::mutate(&state_root, move |s| {
+        s.board = b;
+    })
+    .map_err(|e| format!("failed to persist goal board: {e}"))?;
+    let bridge = launch_writer_bridge(&state_root)
+        .map_err(|e| format!("failed to open cognitive memory writer bridge: {e}"))?;
+    if let Err(e) = crate::goal_curation::overwrite_memory_cache(board, bridge.ops()) {
+        eprintln!("[simard] goal: warning: memory cache refresh failed: {e}");
+    }
     Ok(())
 }
 
-/// Persist the in-flight `board` with explicit removal of `ids`. Used by
-/// `goal remove` and `goal cleanup --placeholders` so both routes share
-/// the post-merge filter that defeats PR #1926's resurrection failure.
-fn save_board_with_removals(
-    board: &crate::goal_curation::GoalBoard,
-    ids: &[String],
-) -> Result<(), Box<dyn Error>> {
+/// Record `ids` as durable tombstones so no path — default seeding, memory
+/// recall, a meeting handoff, or the daemon's cycle reconcile — can resurrect a
+/// removed or completed goal (issue #1, requirement 3).
+fn tombstone(ids: &[String]) -> Result<(), Box<dyn Error>> {
     let state_root = simard_state_root();
-    let bridge = launch_writer_bridge(&state_root)
-        .map_err(|e| format!("failed to open cognitive memory writer bridge: {e}"))?;
-    save_goal_board_with_removals(board, ids, bridge.ops())
-        .map_err(|e| format!("failed to persist goal board with removals: {e}"))?;
+    crate::ooda_loop::tombstone_goals(&state_root, ids)
+        .map_err(|e| format!("failed to record tombstones: {e}"))?;
     Ok(())
 }
 
@@ -197,38 +260,39 @@ fn handle_list() -> Result<(), Box<dyn Error>> {
 }
 
 fn handle_unblock(goal_id: &str) -> Result<(), Box<dyn Error>> {
-    let mut board = load_board()?;
-    let goal = board
-        .active
-        .iter_mut()
-        .find(|g| g.id == goal_id)
-        .ok_or_else(|| {
-            format!("goal '{goal_id}' not found on active board (no Blocked status to clear)")
-        })?;
-    let prior = goal.status.clone();
-    goal.status = GoalProgress::NotStarted;
-    save_board(&board)?;
+    let prior = with_board(|board| {
+        let goal = board
+            .active
+            .iter_mut()
+            .find(|g| g.id == goal_id)
+            .ok_or_else(|| -> Box<dyn Error> {
+                format!("goal '{goal_id}' not found on active board (no Blocked status to clear)")
+                    .into()
+            })?;
+        let prior = goal.status.clone();
+        goal.status = GoalProgress::NotStarted;
+        Ok(prior)
+    })?;
     eprintln!("[simard] goal unblock: '{goal_id}' restored to NotStarted (was: {prior})");
     Ok(())
 }
 
 fn handle_unblock_all() -> Result<(), Box<dyn Error>> {
-    let mut board = load_board()?;
-    let mut cleared = Vec::new();
-    let mut left = 0usize;
-    for goal in board.active.iter_mut() {
-        match &goal.status {
-            GoalProgress::Blocked(reason) if is_brain_failure_marker(reason) => {
-                cleared.push(goal.id.clone());
-                goal.status = GoalProgress::NotStarted;
+    let (cleared, left) = with_board(|board| {
+        let mut cleared = Vec::new();
+        let mut left = 0usize;
+        for goal in board.active.iter_mut() {
+            match &goal.status {
+                GoalProgress::Blocked(reason) if is_brain_failure_marker(reason) => {
+                    cleared.push(goal.id.clone());
+                    goal.status = GoalProgress::NotStarted;
+                }
+                GoalProgress::Blocked(_) => left += 1,
+                _ => {}
             }
-            GoalProgress::Blocked(_) => left += 1,
-            _ => {}
         }
-    }
-    if !cleared.is_empty() {
-        save_board(&board)?;
-    }
+        Ok((cleared, left))
+    })?;
     eprintln!(
         "[simard] goal unblock-all: cleared {} brain-failure marker(s); left {} non-marker Blocked goal(s) untouched",
         cleared.len(),
@@ -259,30 +323,36 @@ fn handle_add(
             .map_err(|e| -> Box<dyn Error> { e.to_string().into() })?;
     }
     let id = crate::goals::goal_slug(description);
-    let mut board = load_board()?;
-    if board.active.iter().any(|g| g.id == id) {
-        return Err(format!("goal '{id}' is already active").into());
+    let repo_owned = repo.map(str::to_string);
+    {
+        let id = id.clone();
+        let description = description.to_string();
+        with_board(move |board| {
+            if board.active.iter().any(|g| g.id == id) {
+                return Err(format!("goal '{id}' is already active").into());
+            }
+            if board.active.len() >= crate::goal_curation::MAX_ACTIVE_GOALS {
+                return Err(format!(
+                    "board is at capacity ({}); demote or remove a goal first",
+                    crate::goal_curation::MAX_ACTIVE_GOALS
+                )
+                .into());
+            }
+            board.active.push(crate::goal_curation::ActiveGoal {
+                parent_goal_id: None,
+                id,
+                description,
+                priority,
+                status: GoalProgress::NotStarted,
+                assigned_to: None,
+                repo: repo_owned,
+                current_activity: None,
+                wip_refs: vec![],
+                last_progress_update_at: None,
+            });
+            Ok(())
+        })?;
     }
-    if board.active.len() >= crate::goal_curation::MAX_ACTIVE_GOALS {
-        return Err(format!(
-            "board is at capacity ({}); demote or remove a goal first",
-            crate::goal_curation::MAX_ACTIVE_GOALS
-        )
-        .into());
-    }
-    board.active.push(crate::goal_curation::ActiveGoal {
-        parent_goal_id: None,
-        id: id.clone(),
-        description: description.to_string(),
-        priority,
-        status: GoalProgress::NotStarted,
-        assigned_to: None,
-        repo: repo.map(str::to_string),
-        current_activity: None,
-        wip_refs: vec![],
-        last_progress_update_at: None,
-    });
-    save_board(&board)?;
     let repo_note = repo
         .map(|r| format!(" -> repo '{r}'"))
         .unwrap_or_else(|| " -> repo Simard (daemon)".to_string());
@@ -314,25 +384,29 @@ fn extract_repo_flag(tokens: Vec<String>) -> Result<(Option<String>, Vec<String>
 
 /// `simard goal demote <goal-id>` — move an active goal to the backlog.
 fn handle_demote(goal_id: &str) -> Result<(), Box<dyn Error>> {
-    let mut board = load_board()?;
-    let position = board
-        .active
-        .iter()
-        .position(|g| g.id == goal_id)
-        .ok_or_else(|| format!("goal '{goal_id}' not found on active board"))?;
-    let goal = board.active.remove(position);
-    board.backlog.push(crate::goal_curation::BacklogItem {
-        id: goal.id.clone(),
-        description: goal.description,
-        source: "operator:demote".to_string(),
-        score: 0.5,
-    });
-    save_board(&board)?;
+    with_board(|board| {
+        let position = board
+            .active
+            .iter()
+            .position(|g| g.id == goal_id)
+            .ok_or_else(|| -> Box<dyn Error> {
+                format!("goal '{goal_id}' not found on active board").into()
+            })?;
+        let goal = board.active.remove(position);
+        board.backlog.push(crate::goal_curation::BacklogItem {
+            id: goal.id.clone(),
+            description: goal.description,
+            source: "operator:demote".to_string(),
+            score: 0.5,
+        });
+        Ok(())
+    })?;
     eprintln!("[simard] goal demote: '{goal_id}' moved to backlog");
     Ok(())
 }
 
-/// `simard goal set-priority <goal-id> <priority>` — change priority.
+/// `simard goal set-priority <goal-id> <priority>` — change priority. Also the
+/// implementation behind `simard goal reprioritize <goal-id> <priority>`.
 fn handle_set_priority(goal_id: &str, priority_str: &str) -> Result<(), Box<dyn Error>> {
     let priority: u32 = priority_str
         .parse()
@@ -340,33 +414,63 @@ fn handle_set_priority(goal_id: &str, priority_str: &str) -> Result<(), Box<dyn 
     if priority == 0 || priority > 7 {
         return Err(format!("priority must be 1-7, got {priority}").into());
     }
-    let mut board = load_board()?;
-    let goal = board
-        .active
-        .iter_mut()
-        .find(|g| g.id == goal_id)
-        .ok_or_else(|| format!("goal '{goal_id}' not found on active board"))?;
-    let old = goal.priority;
-    goal.priority = priority;
-    save_board(&board)?;
+    let old = with_board(|board| {
+        let goal = board
+            .active
+            .iter_mut()
+            .find(|g| g.id == goal_id)
+            .ok_or_else(|| -> Box<dyn Error> {
+                format!("goal '{goal_id}' not found on active board").into()
+            })?;
+        let old = goal.priority;
+        goal.priority = priority;
+        Ok(old)
+    })?;
     eprintln!("[simard] goal set-priority: '{goal_id}' changed from p{old} to p{priority}");
     Ok(())
 }
 
-/// `simard goal remove <id>…` — variadic, idempotent. Routes through
-/// `save_goal_board_with_removals` so the post-merge filter defeats the
-/// PR #1926 resurrection failure mode.
+/// `simard goal complete <goal-id>` — mark a goal done, remove it from the
+/// board, and write a durable tombstone so no path (default seeding, memory
+/// recall, a meeting handoff, or the daemon's cycle reconcile) can resurrect it.
+/// Idempotent: completing an absent goal still records the tombstone.
+fn handle_complete(goal_id: &str) -> Result<(), Box<dyn Error>> {
+    let existed = with_board(|board| {
+        let before = board.active.len() + board.backlog.len();
+        board.active.retain(|g| g.id != goal_id);
+        board.backlog.retain(|b| b.id != goal_id);
+        Ok(before != board.active.len() + board.backlog.len())
+    })?;
+    tombstone(&[goal_id.to_string()])?;
+    if existed {
+        eprintln!(
+            "[simard] goal complete: '{goal_id}' marked done, removed from board, and tombstoned"
+        );
+    } else {
+        eprintln!(
+            "[simard] goal complete: '{goal_id}' not on board; recorded tombstone (idempotent)"
+        );
+    }
+    Ok(())
+}
+
+/// `simard goal remove <id>…` — variadic, idempotent. Surgically removes the
+/// ids from the authoritative store under the shared flock and writes durable
+/// tombstones so the daemon's cycle reconcile (and memory recall / meeting
+/// handoffs) can never resurrect them (issue #1).
 fn handle_remove(ids: &[String]) -> Result<(), Box<dyn Error>> {
     if ids.is_empty() {
         return Err("usage: simard goal remove <id> [<id>...]; at least one id is required".into());
     }
-    let board = load_board()?;
-    save_board_with_removals(&board, ids)?;
-    // Record tombstones so meeting handoffs don't re-ingest these goals.
-    let state_root = crate::state_root::simard_state_root();
-    if let Err(e) = crate::ooda_loop::tombstone_goals(&state_root, ids) {
-        eprintln!("[simard] warning: failed to record tombstones: {e}");
-    }
+    with_board(|board| {
+        let removals: std::collections::HashSet<&str> = ids.iter().map(String::as_str).collect();
+        board.active.retain(|g| !removals.contains(g.id.as_str()));
+        board.backlog.retain(|b| !removals.contains(b.id.as_str()));
+        Ok(())
+    })?;
+    // Record tombstones so nothing (default seeding, memory recall, meeting
+    // handoffs, or the daemon's cycle reconcile) re-ingests these goals.
+    tombstone(ids)?;
     eprintln!(
         "[simard] goal remove: requested removal of {} id(s): {}",
         ids.len(),
@@ -416,8 +520,9 @@ fn handle_decompose(goal_id: &str, flags: &[String]) -> Result<(), Box<dyn Error
         .map_err(|e| format!("failed to open cognitive memory writer bridge: {e}"))?;
     let ops = bridge.ops();
 
-    let mut board = load_goal_board(ops)
-        .map_err(|e| format!("failed to read goal board from cognitive memory: {e}"))?;
+    // Load from the authoritative store (issue #1); the memory bridge is still
+    // used below for the durable graph-edge writes performed by decompose_goal.
+    let mut board = load_board()?;
     let parent = board
         .active
         .iter()
@@ -457,7 +562,11 @@ fn handle_decompose(goal_id: &str, flags: &[String]) -> Result<(), Box<dyn Error
         crate::goal_curation::decompose_goal(ops, &mut board, goal_id, &decomposer, max_children)
             .map_err(|e| format!("decomposition failed: {e}"))?;
 
-    save_goal_board(&board, ops)
+    // Persist the decomposition (parent placement + new child goals) to the
+    // authoritative store (issue #1) so it sticks across daemon cycles. The
+    // mutated `board` IS the operator's explicit intent, so a blind commit is
+    // correct here (a surgical merge would fight the parent demotion).
+    commit_board_blind(&board)
         .map_err(|e| format!("failed to persist decomposed goal board: {e}"))?;
 
     eprintln!(
@@ -524,25 +633,34 @@ fn handle_cleanup(flags: &[String]) -> Result<(), Box<dyn Error>> {
         );
     }
 
-    let board = load_board()?;
-    let mut removals: Vec<String> = Vec::new();
-    for g in &board.active {
-        if is_id_placeholder(&g.id, &g.description) {
-            removals.push(g.id.clone());
-        }
-    }
-    for b in &board.backlog {
-        if is_id_placeholder(&b.id, &b.description) && !removals.contains(&b.id) {
-            removals.push(b.id.clone());
-        }
-    }
+    let removals = with_board(|board| {
+        let mut removals: Vec<String> = Vec::new();
+        board.active.retain(|g| {
+            if is_id_placeholder(&g.id, &g.description) {
+                removals.push(g.id.clone());
+                false
+            } else {
+                true
+            }
+        });
+        board.backlog.retain(|b| {
+            if is_id_placeholder(&b.id, &b.description) {
+                if !removals.contains(&b.id) {
+                    removals.push(b.id.clone());
+                }
+                false
+            } else {
+                true
+            }
+        });
+        Ok(removals)
+    })?;
 
     if removals.is_empty() {
         eprintln!("[simard] goal cleanup --placeholders: no placeholder goals found; no-op");
         return Ok(());
     }
 
-    save_board_with_removals(&board, &removals)?;
     eprintln!(
         "[simard] goal cleanup --placeholders: removed {} placeholder goal(s): {}",
         removals.len(),

--- a/src/operator_cli/tests_goal.rs
+++ b/src/operator_cli/tests_goal.rs
@@ -322,3 +322,197 @@ fn simard_goal_unblock_all_does_not_touch_completed_or_in_progress_goals() {
     );
     assert_eq!(by_id("pending").status, GoalProgress::NotStarted);
 }
+
+// ─── Issue #1: steerability — operator edits stick, survive cycles/restarts ──
+
+/// An operator `goal add` is reflected by the very next read of the
+/// authoritative store (read-your-writes) and survives a daemon restart.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn operator_add_reflected_immediately_and_survives_restart() {
+    let (_tmp, root) = isolated_state_root();
+
+    dispatch_operator_cli(vec![
+        "goal".to_string(),
+        "add".to_string(),
+        "1".to_string(),
+        "steer".to_string(),
+        "the".to_string(),
+        "board".to_string(),
+    ])
+    .expect("`goal add` must succeed");
+
+    let id = crate::goals::goal_slug("steer the board");
+
+    // Reflected immediately in the authoritative store.
+    let persistent = crate::goal_board_store::load(&root);
+    assert!(
+        persistent.board.active.iter().any(|g| g.id == id),
+        "operator add must be reflected by the next authoritative read"
+    );
+
+    // Survives a daemon restart (a fresh load from goal_board.json).
+    let after_restart = crate::goal_board_store::load(&root);
+    assert!(
+        after_restart.board.active.iter().any(|g| g.id == id),
+        "operator add must survive a restart"
+    );
+}
+
+/// An operator `goal remove` survives a full daemon cycle: even though the
+/// daemon's in-flight board still carries the removed goal (it loaded before the
+/// remove), the tombstone-aware reconcile at cycle-commit drops it — the
+/// production clobber bug is closed. It also survives a subsequent restart.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn operator_remove_via_cli_survives_daemon_cycle_and_restart() {
+    let (_tmp, root) = isolated_state_root();
+    seed_board(
+        &root,
+        vec![
+            active_goal("keep-me", GoalProgress::NotStarted),
+            active_goal("remove-me", GoalProgress::NotStarted),
+        ],
+    );
+
+    // Daemon adopts the board; its in-flight copy holds BOTH goals.
+    let bridge = launch_writer_bridge(&root).expect("writer bridge");
+    let daemon_in_flight = crate::goal_board_store::load_or_migrate(&root, bridge.ops())
+        .expect("migrate")
+        .board;
+    assert_eq!(daemon_in_flight.active.len(), 2);
+
+    // Operator removes one goal via the CLI (writes a tombstone).
+    dispatch_operator_cli(vec![
+        "goal".to_string(),
+        "remove".to_string(),
+        "remove-me".to_string(),
+    ])
+    .expect("`goal remove` must succeed");
+
+    // Daemon commits its now-stale in-flight board at cycle end.
+    let committed = crate::goal_board_store::commit_cycle(
+        &root,
+        &daemon_in_flight,
+        &crate::goal_curation::NoProgressTracker::new(),
+        &[],
+    )
+    .expect("cycle commit");
+
+    let ids: std::collections::HashSet<&str> =
+        committed.active.iter().map(|g| g.id.as_str()).collect();
+    assert!(ids.contains("keep-me"));
+    assert!(
+        !ids.contains("remove-me"),
+        "operator remove must survive a full daemon cycle (anti-clobber via tombstone reconcile)"
+    );
+
+    // Survives a restart.
+    let after_restart = crate::goal_board_store::load(&root);
+    assert!(
+        !after_restart
+            .board
+            .active
+            .iter()
+            .any(|g| g.id == "remove-me"),
+        "operator remove must survive a restart"
+    );
+}
+
+/// `goal complete` tombstones a goal so a later recall/curation pass that tries
+/// to re-introduce it (the ladybug re-seeding failure mode) cannot resurrect it.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn operator_complete_tombstones_and_blocks_reseed() {
+    let (_tmp, root) = isolated_state_root();
+    seed_board(
+        &root,
+        vec![active_goal("ladybug-hardening", GoalProgress::NotStarted)],
+    );
+
+    dispatch_operator_cli(vec![
+        "goal".to_string(),
+        "complete".to_string(),
+        "ladybug-hardening".to_string(),
+    ])
+    .expect("`goal complete` must succeed");
+
+    // Tombstone recorded and the goal is off the board.
+    assert!(crate::ooda_loop::load_tombstones(&root).contains("ladybug-hardening"));
+
+    // A recall pass proposing the completed goal again is filtered out.
+    let recalled = GoalBoard {
+        active: vec![active_goal("ladybug-hardening", GoalProgress::NotStarted)],
+        backlog: Vec::new(),
+    };
+    let tombstones = crate::ooda_loop::load_tombstones(&root);
+    let filtered = crate::goal_board_store::filter_tombstoned(recalled, &tombstones);
+    assert!(
+        filtered.active.is_empty(),
+        "a completed+tombstoned goal must never be re-seeded from recalled memory"
+    );
+}
+
+/// `goal reprioritize <id> <p>` (the required alias of `set-priority`) changes an
+/// existing goal's priority in the authoritative store, is reflected by the very
+/// next read (read-your-writes), and survives a daemon restart — an operator
+/// steer that must STICK and not be clobbered. An unknown id is a hard error.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn operator_reprioritize_via_cli_sticks_and_survives_restart() {
+    let (_tmp, root) = isolated_state_root();
+
+    // Seed a goal at priority 5 so the change to p2 is observable.
+    let seeded = {
+        let mut g = active_goal("steer-me", GoalProgress::NotStarted);
+        g.priority = 5;
+        g
+    };
+    seed_board(&root, vec![seeded]);
+
+    dispatch_operator_cli(vec![
+        "goal".to_string(),
+        "reprioritize".to_string(),
+        "steer-me".to_string(),
+        "2".to_string(),
+    ])
+    .expect("`goal reprioritize` must succeed");
+
+    // Reflected immediately in the authoritative store (read-your-writes).
+    let after = crate::goal_board_store::load(&root).board;
+    let g = after
+        .active
+        .iter()
+        .find(|g| g.id == "steer-me")
+        .expect("goal must survive reprioritize");
+    assert_eq!(
+        g.priority, 2,
+        "reprioritize must change the persisted priority immediately"
+    );
+
+    // Survives a daemon restart (a fresh load of goal_board.json).
+    let after_restart = crate::goal_board_store::load(&root).board;
+    assert_eq!(
+        after_restart
+            .active
+            .iter()
+            .find(|g| g.id == "steer-me")
+            .expect("goal must survive restart")
+            .priority,
+        2,
+        "reprioritize must survive a restart"
+    );
+
+    // Reprioritizing an unknown id is a hard error (non-zero exit) and never
+    // silently succeeds.
+    let err = dispatch_operator_cli(vec![
+        "goal".to_string(),
+        "reprioritize".to_string(),
+        "no-such-goal".to_string(),
+        "3".to_string(),
+    ]);
+    assert!(
+        err.is_err(),
+        "reprioritize of an unknown goal id must return a non-zero exit"
+    );
+}

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant, SystemTime};
 
 use crate::bridge_launcher::{launch_gym_bridge_native, launch_knowledge_bridge_native};
 use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
-use crate::goal_curation::{load_goal_board, persist_board};
+use crate::goal_curation::persist_board;
 use crate::identity::OperatingMode;
 use crate::memory_ipc;
 use crate::ooda_loop::{
@@ -304,8 +304,21 @@ pub fn run_ooda_daemon(
         completion_evidence,
     };
 
-    let board = load_goal_board(&*bridges.memory).unwrap_or_default();
+    // Issue #1: the authoritative goal board lives in
+    // `<state_root>/state/goal_board.json` (a single durable, flock-guarded,
+    // read-your-writes store), NOT the cognitive-memory snapshot. On first
+    // adoption the current memory snapshot is migrated into the file so no live
+    // goal is lost; thereafter the file is the source of truth and the memory
+    // snapshot is a derived cache. The persisted `no_progress` tracker is
+    // restored into `OodaState` so the no-progress breaker's per-goal counters
+    // survive the daemon's periodic restarts (the production bug where the
+    // counter reset to zero every ~hour before it could reach the threshold).
+    let persistent =
+        crate::goal_board_store::load_or_migrate(&state_root, &*bridges.memory).unwrap_or_default();
+    let tombstones = crate::ooda_loop::load_tombstones(&state_root);
+    let board = crate::goal_board_store::filter_tombstoned(persistent.board, &tombstones);
     let mut state = OodaState::new(board);
+    state.no_progress_tracker = persistent.no_progress;
     let config = OodaConfig::default();
 
     // Issue #1197: sweep orphaned engineer worktrees from prior crashed
@@ -823,6 +836,38 @@ pub fn run_ooda_daemon(
             .unwrap_or(0);
         state.cycle_start_epoch = cycle_start_epoch;
 
+        // ── Issue #1: re-sync the authoritative goal board at cycle start ──
+        // Load the single source of truth (`goal_board.json`) so operator
+        // mutations (`goal add/remove/complete/reprioritize`) and meeting
+        // handoffs made since the last cycle take effect and STICK. Restore the
+        // persisted no-progress tracker so the breaker's per-goal counters
+        // survive the daemon's periodic exec-reload restarts, and overwrite the
+        // cognitive-memory snapshot cache so `run_ooda_cycle`'s internal board
+        // read sees exactly the authoritative (tombstone-filtered) board.
+        {
+            let cycle_tombstones = crate::ooda_loop::load_tombstones(&state_root);
+            let persistent = crate::goal_board_store::load(&state_root);
+            state.active_goals =
+                crate::goal_board_store::filter_tombstoned(persistent.board, &cycle_tombstones);
+            state.no_progress_tracker = persistent.no_progress;
+            if let Err(e) =
+                crate::goal_curation::overwrite_memory_cache(&state.active_goals, &*bridges.memory)
+            {
+                daemon_log(
+                    &state_root,
+                    &format!("[simard] OODA cycle: memory cache sync failed: {e}"),
+                );
+            }
+        }
+        // Snapshot the pre-cycle active ids so the post-cycle commit can
+        // tombstone any goal that left the board (archived / dropped / done).
+        let pre_cycle_active_ids: std::collections::HashSet<String> = state
+            .active_goals
+            .active
+            .iter()
+            .map(|g| g.id.clone())
+            .collect();
+
         // Write heartbeat at cycle START so the dashboard never sees "stale"
         // during a long-running cycle.
         {
@@ -853,6 +898,92 @@ pub fn run_ooda_daemon(
                 state.last_cycle_duration_secs = Some(cycle_elapsed.as_secs());
                 state.current_phase = OodaPhase::Sleep;
                 daemon_log(&state_root, &format!("[simard] {summary}"));
+
+                // ── Issue #1: commit the post-cycle board authoritatively ──
+                // 1. Run the every-cycle done-gate over the WHOLE active board
+                //    (cross-repo aware) so a goal whose objective was completed
+                //    out-of-band — a merged PR / closed issue on ANY governed
+                //    repo — is auto-completed instead of being re-litigated
+                //    forever. 2. Tombstone every goal that left the board this
+                //    cycle (archived, dropped by the no-progress breaker, or
+                //    just-completed by the done-gate) so nothing re-seeds it.
+                //    3. Commit the reconciled board + persisted no-progress
+                //    tracker to the authoritative store, then regenerate the
+                //    memory cache from the committed board.
+                {
+                    let mut newly_done: Vec<String> = Vec::new();
+                    if let Some(evidence) = &bridges.completion_evidence {
+                        newly_done = crate::goal_board_store::sweep_done_goals(
+                            &mut state.active_goals,
+                            evidence.as_ref(),
+                        );
+                        if !newly_done.is_empty() {
+                            let done: std::collections::HashSet<&str> =
+                                newly_done.iter().map(String::as_str).collect();
+                            state
+                                .active_goals
+                                .active
+                                .retain(|g| !done.contains(g.id.as_str()));
+                            daemon_log(
+                                &state_root,
+                                &format!(
+                                    "[simard] OODA done-gate: auto-completed {} goal(s) with cross-repo evidence: {}",
+                                    newly_done.len(),
+                                    newly_done.join(", "),
+                                ),
+                            );
+                        }
+                    }
+
+                    let post_active: std::collections::HashSet<&str> = state
+                        .active_goals
+                        .active
+                        .iter()
+                        .map(|g| g.id.as_str())
+                        .collect();
+                    let post_backlog: std::collections::HashSet<&str> = state
+                        .active_goals
+                        .backlog
+                        .iter()
+                        .map(|b| b.id.as_str())
+                        .collect();
+                    let mut tombstones: Vec<String> = pre_cycle_active_ids
+                        .iter()
+                        .filter(|id| {
+                            !post_active.contains(id.as_str())
+                                && !post_backlog.contains(id.as_str())
+                        })
+                        .cloned()
+                        .collect();
+                    tombstones.extend(newly_done);
+
+                    match crate::goal_board_store::commit_cycle(
+                        &state_root,
+                        &state.active_goals,
+                        &state.no_progress_tracker,
+                        &tombstones,
+                    ) {
+                        Ok(committed) => {
+                            state.active_goals = committed;
+                            if let Err(e) = crate::goal_curation::overwrite_memory_cache(
+                                &state.active_goals,
+                                &*bridges.memory,
+                            ) {
+                                daemon_log(
+                                    &state_root,
+                                    &format!(
+                                        "[simard] OODA cycle: memory cache refresh failed: {e}"
+                                    ),
+                                );
+                            }
+                        }
+                        Err(e) => daemon_log(
+                            &state_root,
+                            &format!("[simard] OODA cycle: authoritative commit failed: {e}"),
+                        ),
+                    }
+                }
+
                 // Persist the cycle report to filesystem for auditability.
                 persist_cycle_report(&state_root, &report);
                 // Persist the cycle summary to cognitive memory as an episode.
@@ -1056,6 +1187,21 @@ fn shutdown_daemon(
     signal_driven: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     daemon_log(state_root, "[simard] OODA daemon: shutdown sequence start");
+
+    // 0. Commit the board + persisted no-progress tracker to the authoritative
+    //    store (issue #1) so the last live state — including the breaker's
+    //    counters — survives the restart. Best-effort; a failure is logged.
+    if let Err(e) = crate::goal_board_store::commit_cycle(
+        state_root,
+        &state.active_goals,
+        &state.no_progress_tracker,
+        &[],
+    ) {
+        daemon_log(
+            state_root,
+            &format!("[simard] shutdown: authoritative goal-board commit failed: {e}"),
+        );
+    }
 
     // 1. Persist the goal board through the live writer.
     if let Err(e) = persist_board(&state.active_goals, &*bridges.memory) {

--- a/src/state_root.rs
+++ b/src/state_root.rs
@@ -20,7 +20,7 @@
 //! empty / relative / NUL-bearing values are silently ignored (with a WARN
 //! emitted at first use) so a malformed env var never crashes boot.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use tracing::warn;
@@ -61,6 +61,30 @@ pub fn resolve_subdir(name: &str) -> PathBuf {
 /// single helper to avoid path inconsistencies.
 pub fn goal_store_path() -> PathBuf {
     simard_state_root().join("state").join("goal_store.json")
+}
+
+/// Canonical path of the authoritative goal-board file (issue #1).
+///
+/// Resolves to `<state_root>/state/goal_board.json`. This is the single durable
+/// source of truth for the OODA goal board (see [`crate::goal_board_store`]);
+/// distinct from the legacy [`goal_store_path`] (`goal_store.json`) used by the
+/// pre-memory goal-records migration.
+pub fn goal_board_json_path() -> PathBuf {
+    crate::goal_board_store::store_path(&simard_state_root())
+}
+
+/// Canonical path of the cross-process goal-board advisory `flock` file for a
+/// given `state_root`. Both [`crate::goal_curation::save_goal_board`] and
+/// [`crate::goal_board_store`] rendezvous on this one file (issue #2511) so the
+/// daemon's snapshot flush and a concurrent `simard goal` CLI mutation cannot
+/// interleave.
+pub fn goal_board_lock_path_in(state_root: &Path) -> PathBuf {
+    state_root.join("state").join("goal-board.lock")
+}
+
+/// [`goal_board_lock_path_in`] rooted at the resolved [`simard_state_root`].
+pub fn goal_board_lock_path() -> PathBuf {
+    goal_board_lock_path_in(&simard_state_root())
 }
 
 /// Look up `SIMARD_STATE_ROOT` and return `Some(path)` only if it passes the


### PR DESCRIPTION
## Summary

Completely fixes Simard's OODA goal management with a **robust, steerable,
restart-resilient redesign** that supersedes the partial fix in #2534.

#2534's completion-evidence done-gate and `NoProgressTracker` breaker were sound
in intent but **never fired in production** (0 matching log lines in 4.5h),
because the goal board was still stored as versioned, unordered
`goal-board:snapshot` cognitive-memory facts that the daemon re-saved (and
clobbered) every cycle, and the breaker's counter lived only in `OodaState` — so
it reset to zero on every ~hourly `exec()` self-reload before it could reach the
threshold.

This PR makes **one durable file the single source of truth** and wires the
existing #2534 machinery so it actually runs and logs.

## Root causes (verified in code)

| Symptom | Root cause |
|---|---|
| `goal remove/add` reported success but `goal list` was unchanged | Board = `goal-board:snapshot` facts, read `max_by(node_id)`, rewritten via union `merge_boards` each cycle → daemon's in-memory copy clobbered operator edits. No read-your-writes. |
| Breaker + done-gate: 0 log lines in 4.5h | `state.no_progress_tracker` rebuilt fresh by `OodaState::new(board)` every daemon start (`daemon/mod.rs`); the ~hourly exec-reload reset the counter → threshold 3 never reached → no terminal decision → nothing logged. |
| 4 done ladybug goals stuck at not-started, re-litigated & re-seeded | The evidence archive only evaluated goals already `status == Completed`; not-started goals were never checked. Tombstones were only consulted by meeting handoffs. |

## The redesign

New module **`goal_board_store`** — authoritative `<state_root>/state/goal_board.json`:

1. **Single authoritative store.** `PersistentGoalState { board, no_progress }`
   written atomically (temp + `rename`) under the shared `goal-board.lock`
   `flock` (#2511). `load` returns exactly the last committed state
   (read-your-writes). The memory snapshot is demoted to a derived cache
   (`overwrite_memory_cache`), regenerated from the file each cycle.
2. **Single writer + steerability.** The daemon reloads the file at each cycle
   start and commits at each cycle end through a **tombstone-aware `reconcile`**
   (augments, never clobbers). CLI mutations are surgical read-modify-writes on
   the file **under the flock**, so they stick. If the daemon is down the CLI
   writes the file directly and the daemon loads it next start. Added
   `goal complete <id>` and `goal reprioritize <id> <p>`.
3. **Tombstones / no re-seeding.** remove/complete write durable tombstones now
   consulted at every load, cycle commit, and recall filter — recalled
   procedures can't resurrect a completed goal.
4. **Lifecycle + completion detection.** `sweep_done_goals` runs **every cycle**
   over **all** active goals and auto-completes any with hard evidence. It is
   **cross-repo aware** (`GhCliEvidenceSource` resolves each goal's `repo`), so a
   merged PR / closed issue on any governed repo completes a goal — the 4
   ladybug goals auto-complete and are tombstoned.
5. **Restart-resilient breaker.** `NoProgressTracker` is persisted in the store
   and restored into `OodaState` at start and each cycle, so counters survive
   the exec-reload. The existing breaker now reaches its threshold and **logs
   each decision**.
6. **Curation merges, never clobbers.** The cycle-commit `reconcile` unions the
   persisted board with the in-flight board (tombstones dominate), preserving
   operator- and meeting-added goals.

## Verification runbook

Operator steps (on the deployed daemon — **operator deploys; this PR does not**):

```bash
# 1. Steerability: an add is reflected immediately, survives a cycle + restart.
simard goal add 3 "verify steerability end to end"
simard goal list                      # the new goal is present immediately
#   … wait one OODA cycle …           # still present (reconcile, not clobber)
sudo systemctl restart simard-ooda    # or let the ~hourly exec-reload happen
simard goal list                      # still present after restart

# 2. Remove sticks (was the clobber bug).
simard goal remove <id>
simard goal list                      # gone immediately, stays gone next cycle

# 3. Completed goals leave and never return.
simard goal complete <ladybug-id>     # tombstoned; recall cannot re-seed it

# 4. Breaker + done-gate now LOG each decision (were silent for 4.5h):
journalctl --user -u simard-ooda | grep -E \
  "no-progress breaker|done-gate: .*marking goal DONE|auto-completed .* cross-repo"
```

The 4 objectively-done ladybug goals (merged rysweet/ladybug-rust#1,
rysweet/ladybug-graph-rs#1; out-of-scope rysweet/lbug-patched#1) auto-complete
via the cross-repo done-gate and are tombstoned.

## Tests

`src/goal_board_store/tests.rs` + `src/operator_cli/tests_goal.rs`:

- store read-your-writes round-trip;
- tombstone prevents re-seed from recalled memory;
- cross-repo done-evidence completes a goal;
- **the no-progress breaker fires after a simulated restart** using the
  persisted counter;
- `reconcile` preserves operator-added goals and drops operator-removed
  (tombstoned) ones even when the daemon's in-flight board still carries them;
- operator `goal add` reflected immediately + survives restart;
- operator `goal remove` survives a full daemon cycle + restart;
- `goal complete` tombstones and blocks re-seed.
- **the 4 ladybug goals auto-complete via the cross-repo done-gate, are
  tombstoned as they leave the board, and cannot be resurrected by a later
  memory-recall / curation pass or a restart**
  (`four_ladybug_goals_auto_complete_via_done_gate_and_never_return`);
- **`goal reprioritize <id> <p>` sticks immediately and survives a restart**
  (`operator_reprioritize_via_cli_sticks_and_survives_restart`).

Full `cargo test --lib` green (6673 passed with reduced parallelism); `cargo fmt
--check`, `cargo clippy --release --no-deps -D warnings`, and
`cargo clippy --all-targets --all-features --locked -D warnings` all pass. No
`--no-verify`, no `--admin`.

## Notes

- All Rust. Keeps the working #2534 types (`NoProgressTracker`, completion gate)
  and wires them in.
- Terminology: repo still uses "Bridge"/`OodaBridges` (rename #2535 not merged),
  so this PR keeps those names.
- Branch is rebased onto the latest `origin/main` tip (single coherent
  commit; green pre-commit + pre-push + CI, no `--no-verify` / no `--admin`).
  Does not touch the live daemon,
  `~/.simard`, or worktrees. Does **not** redeploy.

Fixes #1.

