### PR TITLE
fix(memory): durable WAL-recovery contract + snapshot restore/auto-restore + complete snapshots (#2550)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=26d49bf864ac2c03b80c4ab075c4a907c51f82a8#26d49bf864ac2c03b80c4ab075c4a907c51f82a8"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=38af5bf569e3a1c007825567e24973ac728508a4#38af5bf569e3a1c007825567e24973ac728508a4"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -1074,7 +1074,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1208,7 +1208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2444,7 +2444,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3431,7 +3431,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3490,7 +3490,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4187,7 +4187,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5118,7 +5118,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=e36b1761c98927154a3f9c8652d843b1e49a3282#e36b1761c98927154a3f9c8652d843b1e49a3282"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=3c9d956a7e0648f12ef229f587bf3ead79787fe9#3c9d956a7e0648f12ef229f587bf3ead79787fe9"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,11 +58,13 @@ path = "src/bin/simard_tui/main.rs"
 # leaving records only in the quarantined WAL — which a later open reset to empty,
 # permanently dropping tens of thousands of memories), AND the read-only
 # `get_all_prospective` enumerator (Simard #2550) the verified-backup snapshot
-# needs to capture prospective memories. This rev is amplihack-memory-lib PR #110
-# (durable recovery, on `main`) with PR #111's pure-read `get_all_prospective`
-# cherry-picked on top — no lbug/engine change, so the store format stays v41.
-# Lib branch: feat/2550-durable-recovery-plus-get-all-prospective.
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "e36b1761c98927154a3f9c8652d843b1e49a3282", features = ["persistent"] }
+# needs to capture prospective memories. This rev is the squash-merge commit of
+# amplihack-memory-lib PR #111 on `main`: it layers the pure-read
+# `get_all_prospective` enumerator on top of PR #110's durable corrupt-WAL open
+# recovery fix, with no lbug/engine change, so the store format stays v41. The
+# pin now points at an upstream-`main` commit (not a feature branch), so the
+# build can never be frozen against an unmerged, GC-able ref.
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "3c9d956a7e0648f12ef229f587bf3ead79787fe9", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,10 +51,13 @@ path = "src/bin/simard_tui/main.rs"
 # `lbug = "=0.17.1"` crate.
 #
 # Pinned to the amplihack-memory-lib commit that carries the lbug 0.15.4 -> 0.17.1
-# engine migration AND the issue #107 silent-empty-read fix (the `_deleted`
-# tombstone read-path fix + the empty-read safety gate). This rev is the
-# squash-merge commit of amplihack-memory-lib PR #108 on `main`.
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "26d49bf864ac2c03b80c4ab075c4a907c51f82a8", features = ["persistent"] }
+# engine migration, the issue #107 silent-empty-read fix (the `_deleted`
+# tombstone read-path fix + the empty-read safety gate), AND the read-only
+# `get_all_prospective` enumerator (Simard #2550) the verified-backup snapshot
+# needs to capture prospective memories. This rev branches off amplihack-memory-lib
+# `main` (PR #109) and adds only that pure-read method — no lbug/engine change,
+# so the store format stays v41. Lib branch: feat/2550-get-all-prospective.
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "38af5bf569e3a1c007825567e24973ac728508a4", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream

--- a/docs/operations/cognitive-memory-durability.md
+++ b/docs/operations/cognitive-memory-durability.md
@@ -98,6 +98,17 @@ is the most recent verified backup under `state_root/backups`.
   per-write fsync barrier after a lost-write incident. That barrier was deleted
   with `NativeCognitiveMemory` in issue #2307; it is not a current API or current
   guarantee.
+- **2026-07-04 / issue #2550** — a corrupt WAL
+  (`wal/wal_record.cpp:76 UNREACHABLE_CODE`) triggered a resilient prefix-recovery
+  that salvaged 40,488 records, but the **checkpoint after recovery failed**
+  (`Cannot open … cognitive.wal(.checkpoint)`), so nothing durable landed; a later
+  open re-quarantined and **reset the store to empty**, dropping ~20,480 memories
+  to 128, with no restore path. The #2550 change locks durable prefix-recovery
+  with a boundary regression test (the pinned library already recovers without
+  resetting a store that salvaged records), adds `simard memory import` + startup
+  auto-restore, completes the snapshot to all durable memory types, and preserves
+  recovery assets. See the
+  [Cognitive-Memory WAL Recovery Runbook](cognitive-memory-wal-recovery-runbook.md).
 
 ---
 
@@ -223,6 +234,24 @@ This is the same graceful-degradation contract as `restore_from_backup` above
 (fall back to the next-most-recent good copy): a single bad snapshot at the tip
 of the retained history must never silently wipe durable recall across a
 restart.
+### Operator restore and self-healing (issue #2550)
+
+Two operator-facing paths built on the same snapshot format make a
+corruption-reset recoverable without a code harness:
+
+- **`simard memory import <snapshot.json>`** ingests a backup's
+  `cognitive_snapshot.json` back into the store, deduplicating by content so it
+  is idempotent and safe to re-run or run onto a partially-populated store. See
+  the [Memory introspection CLI](../reference/simard-memory-cli.md#simard-memory-import).
+- **Startup auto-restore.** When the daemon starts and finds the live store
+  empty **and** a newer non-empty snapshot on disk, it restores from
+  the newest good snapshot and logs a `store was empty — auto-restored <n>
+  memories from … cognitive_snapshot.json` line, so a corruption-reset self-heals
+  instead of losing everything.
+
+For a corruption incident (recover the pre-reset store, choose a snapshot, and
+run the import), follow the
+[Cognitive-Memory WAL Recovery Runbook](cognitive-memory-wal-recovery-runbook.md).
 
 ---
 
@@ -393,8 +422,11 @@ Review them only for migration forensics; current live data is under
 
 - [`docs/memory.md`](../memory.md) — cognitive-memory data model
 - [`docs/daemon-mode.md`](../daemon-mode.md) — OODA daemon overview
+- [Cognitive-Memory WAL Recovery Runbook](cognitive-memory-wal-recovery-runbook.md) — corrupt-WAL recovery, `memory import`, startup auto-restore
+- [Verified Backups of the Live Cognitive Store](verified-backups.md) — verify-before-prune, whole-store export, bounded quarantines
 - [`CONTRIBUTING.md`](https://github.com/rysweet/Simard/blob/main/CONTRIBUTING.md) — contributor durability notes
 - [GitHub issue #2307](https://github.com/rysweet/Simard/issues/2307) — native cognitive-memory fork deletion
 - [GitHub issue #2420](https://github.com/rysweet/Simard/issues/2420) — verified backup of the live library store
+- [GitHub issue #2550](https://github.com/rysweet/Simard/issues/2550) — durable WAL recovery + snapshot import/auto-restore
 - [GitHub issue #1631](https://github.com/rysweet/Simard/issues/1631) — SIGTERM-safe shutdown
 - [GitHub issue #1973](https://github.com/rysweet/Simard/issues/1973) — historical native per-write barrier

--- a/docs/operations/cognitive-memory-wal-recovery-runbook.md
+++ b/docs/operations/cognitive-memory-wal-recovery-runbook.md
@@ -1,0 +1,279 @@
+---
+title: Cognitive-memory WAL corruption recovery runbook
+description: Operator runbook for the 2026-07-04 WAL-corruption data-loss class — durable prefix-recovery, snapshot restore via `simard memory import`, startup auto-restore, and the recovery-asset preservation contract (issue #2550).
+last_updated: 2026-07-04
+owner: cognitive-memory
+doc_type: howto
+---
+
+# Cognitive-Memory WAL Corruption Recovery Runbook
+
+> **Issue #2550.** Hardens the library-backed cognitive store against the
+> corrupt-WAL → salvage → reset **data-loss** class first observed in production
+> on 2026-07-04. It complements
+> [Cognitive Memory Durability](cognitive-memory-durability.md) (SIGTERM-safe
+> shutdown, WAL/CHECKPOINT model) and
+> [Verified Backups of the Live Cognitive Store](verified-backups.md)
+> (verify-before-prune, bounded quarantines). Read this page when the daemon
+> logs a corrupt-WAL recovery, when `simard memory stats` shows a store that
+> collapsed to a near-empty count, or when you need to restore from a snapshot.
+
+---
+
+## The incident this runbook exists for
+
+On **2026-07-04 00:16** the live cognitive store failed a data-loss sequence
+with **no automatic recovery path**:
+
+1. **WAL corrupt on open.** LadybugDB tripped an assertion opening the
+   write-ahead log:
+
+   ```text
+   Assertion failed ... wal/wal_record.cpp line 76: UNREACHABLE_CODE
+   ```
+
+2. **Resilient recovery salvaged the good prefix.** The `amplihack-memory`
+   backend recovered the store from the corrupt WAL and logged success:
+
+   ```text
+   recovered from corrupt WAL, good prefix replayed + checkpointed
+   ```
+
+   **40,488 records** were salvaged in memory.
+
+3. **The checkpoint after recovery FAILED.** Persisting the salvaged store back
+   to disk did not complete:
+
+   ```text
+   Cannot open .../cognitive.wal
+   Cannot open .../cognitive.wal.checkpoint
+   Error removing .../cognitive.wal
+   ```
+
+   The recovered store therefore lived only in memory — nothing durable landed.
+
+4. **A later open re-quarantined and RESET the store to empty.** Because the
+   on-disk store still looked corrupt, the next open re-flagged it, quarantined
+   the bad bytes, and **reset the live store to a fresh empty database** —
+   dropping roughly **20,480 memories to 128**.
+
+5. **No restore path existed.** Periodic backups were present at
+   `~/.simard/backups/<ts>/cognitive_snapshot.json`, but they held **only facts
+   and procedures** — not episodes or prospective/triggers — and there was **no
+   operator command** to import a snapshot back into the store. The reset was
+   effectively **permanent**.
+
+The four fixes below close each link in that chain so the same corruption
+degrades to a durable prefix-recovery (and, worst case, a self-healing
+auto-restore) instead of silent, permanent loss.
+
+---
+
+## What changed (issue #2550)
+
+| # | Fix | Failure it removes |
+|---|---|---|
+| 1 | **Durable WAL recovery.** After a successful prefix-recovery (`recovered_records > 0`) the salvaged store is checkpointed/persisted so later opens succeed. The "checkpoint after recovery failed / cannot open `cognitive.wal(.checkpoint)`" path is handled, and a store that just recovered records is **never** re-quarantined and reset. | Steps 3–4: recovered records lost, store reset to empty. |
+| 2 | **Snapshot restore + startup auto-restore.** `simard memory import <snapshot.json>` ingests a `cognitive_snapshot.json` back into the store (idempotent / dedup by content). On daemon startup, if the live store is **empty** (as a corruption-reset leaves it, before bootstrap seeding) **and** a newer non-empty snapshot exists, the daemon **auto-restores** from the newest good snapshot and logs it. | Step 5: no restore path; a reset stays permanent. |
+| 3 | **Complete snapshots.** The periodic snapshot export now includes **all** durable memory types — episodes and prospective/triggers — not just facts + procedures, so a restore is faithful. (Provenance/similarity edges are not serialized: they are reconstructable and their endpoints change across a content-dedup restore.) | Step 5: snapshots too thin to fully restore. |
+| 4 | **Preserve recovery assets.** The corruption/cleanup path keeps the quarantined `cognitive.corrupt-*` store and recent `cognitive_snapshot.json` backups long enough to recover from — they are not swept or rotated away prematurely. | Loss of the only forensic + recovery inputs before an operator can act. |
+
+Where each fix lives:
+
+- **Fix 1** is in the store/recovery layer, which lives in
+  [`amplihack-memory-lib`](../architecture/cognitive-memory-library-adapter.md)
+  (`lbug_store::open_with_recovery`). The pinned dependency (`26d49bf8`)
+  **already recovers durably**: it quarantines the corrupt WAL *before* the
+  resilient open (copied aside, never deleted), replays the good prefix,
+  checkpoints, and — critically — if that checkpoint fails it still **keeps** the
+  recovered store rather than resetting. A reset (`RebuiltAfterCorruption`) only
+  happens for a genuinely corrupt *main* database with **zero** recovered
+  records, and it moves the store aside rather than deleting it. The #2550
+  contribution here is a **boundary regression test**
+  (`tests/wal_recovery_durability_2550.rs`) that pins the contract — *a store
+  that recovered records is persisted, not reset* — so it can never regress. The
+  dependency bump in this change adds a read-only prospective enumerator for
+  Fix 3, **not** a recovery change.
+- **Fix 2** adds `simard memory import` in `src/operator_cli/memory.rs` and the
+  startup auto-restore (`memory_backup::auto_restore_if_empty`, wired in
+  `src/operator_commands_ooda/daemon/mod.rs`).
+- **Fix 3** extends `remote_transfer::export_full_memory_snapshot` (the export
+  `backup_memory` uses) to cover episodes and prospective/triggers via new
+  `CognitiveMemoryOps::list_all_episodes` / `list_all_prospective` enumerators
+  (the latter backed by the library's read-only `get_all_prospective`).
+- **Fix 4** widens the quarantine retention age and protects the largest
+  (recovery-asset) quarantine from the age/count caps in
+  `src/cmd_cleanup/disk.rs`, while the existing verified-backup retention
+  (`prune_old_backups`, keep-newest-N + age) preserves recent snapshots.
+
+---
+
+## Detect: am I hitting this?
+
+Look for the recovery / reset signatures in the journal, then confirm the live
+count with the read-only introspection CLI (see
+[Memory introspection CLI](../reference/simard-memory-cli.md)).
+
+```bash
+# 1) Recovery + checkpoint-failure signatures
+journalctl -u simard-ooda --since "2 hours ago" \
+  | grep -E "corrupt WAL|good prefix|recovered .*records|Cannot open .*cognitive\.wal|reset .*empty|auto-restored"
+
+# 2) Current live count (near-empty after a reset)
+simard memory stats            # human table
+simard memory stats --json     # scriptable; check counts.total
+```
+
+Interpretation:
+
+| Journal evidence | State | Action |
+|---|---|---|
+| `recovered … records, good prefix replayed + checkpointed` and **no** later `Cannot open cognitive.wal` / `reset` | Durable recovery succeeded (fix 1). | None — the salvaged store persisted. Confirm `simard memory stats` count is healthy. |
+| `auto-restored <n> memories from … cognitive_snapshot.json` on startup | Store was empty; daemon self-healed from the newest snapshot (fix 2). | None — verify the restored count; investigate the original corruption. |
+| `Cannot open … cognitive.wal.checkpoint` **followed by** a near-empty `simard memory stats` and no auto-restore line | Reset without recovery — manual restore needed. | Follow **Manual recovery** below. |
+
+---
+
+## Manual recovery
+
+Use this when the store reset and auto-restore did not fire (for example on a
+build that predates issue #2550, or when no newer snapshot was available). The
+recovery inputs are the **preserved quarantine** and the **most recent good
+snapshot**. On the 2026-07-04 host the pre-reset assets were copied out of the
+live tree to `~/simard-memory-recovery/` — prefer those originals when present.
+
+> **Do not** run these steps against a live daemon. Restore/import is a write
+> path; stop the daemon first so nothing writes concurrently.
+
+### 1. Stop the daemon and snapshot current state
+
+```bash
+sudo systemctl stop simard-ooda
+simard memory stats --json | tee /tmp/memory-before-restore.json   # record the near-empty count
+```
+
+### 2. Locate the newest good snapshot
+
+Verified backups are timestamped, newest-first by directory name. Each holds a
+`cognitive_snapshot.json`.
+
+```bash
+# Newest verified-backup snapshots (host default root):
+ls -1dt ~/.simard/backups/*/ | head -5
+# Preserved recovery copies from the incident, if present:
+ls -1dt ~/simard-memory-recovery/*/ 2>/dev/null | head -5
+
+# Pick the newest snapshot whose item count is non-trivial:
+for d in $(ls -1dt ~/.simard/backups/*/); do
+  f="$d/cognitive_snapshot.json"
+  [ -f "$f" ] && echo "$f  facts=$(grep -c '"concept"' "$f")"
+done | head
+```
+
+Choose the newest snapshot with a healthy count. Post-#2550 snapshots also carry
+`episodes` and `prospective`/triggers, so a restore from one of those round-trips
+every durable memory node; older snapshots restore facts + procedures only.
+
+### 3. Import the snapshot
+
+`simard memory import` ingests a `cognitive_snapshot.json` back into the store.
+It is **idempotent** — re-running it or importing onto a store that already
+holds some of the records deduplicates by content, so it is safe to run more
+than once and safe to run onto a partially-populated store.
+
+```bash
+simard memory import ~/.simard/backups/<TS>/cognitive_snapshot.json
+# → imported N items (M new, K deduplicated)
+```
+
+If the live store still holds partial/corrupt data and you want a clean target,
+move it aside first so the import lands on an empty store (the quarantine is
+preserved for forensics either way):
+
+```bash
+mv ~/.simard/cognitive ~/.simard/cognitive.prerestore-$(date +%Y%m%d_%H%M%S)
+simard memory import ~/.simard/backups/<TS>/cognitive_snapshot.json
+```
+
+### 4. Verify and restart
+
+```bash
+simard memory stats            # confirm counts recovered to the expected range
+sudo systemctl start simard-ooda
+journalctl -u simard-ooda -n 50
+```
+
+Confirm `simard memory stats --json` reports a `counts.total` consistent with
+the snapshot you imported, then confirm the daemon came up cleanly with no fresh
+corrupt-WAL lines.
+
+---
+
+## Preserve the recovery assets
+
+Fix 4 keeps the inputs this runbook depends on, but if you are recovering on an
+older build, **copy them out before anything sweeps them**:
+
+```bash
+mkdir -p ~/simard-memory-recovery/$(date +%Y%m%d_%H%M%S)
+cp -a ~/.simard/cognitive.corrupt-* ~/simard-memory-recovery/$(date +%Y%m%d_%H%M%S)/ 2>/dev/null || true
+cp -a ~/.simard/backups            ~/simard-memory-recovery/$(date +%Y%m%d_%H%M%S)/ 2>/dev/null || true
+```
+
+Do **not** run `simard cleanup` until you have recovered or copied out the
+quarantine and the newest snapshots — cleanup applies the age/count caps to
+`cognitive.corrupt-*` quarantines and to backups (see
+[Bounded corrupt-quarantine retention](verified-backups.md#bounded-corrupt-quarantine-retention)).
+Post-#2550 the retention floors keep enough generations to recover from, but the
+caps still eventually reclaim them.
+
+---
+
+## Prevention checklist
+
+- **Keep periodic verified backups healthy.** Confirm a fresh
+  `~/.simard/backups/<ts>/` appears on the daemon's backup cadence
+  (`SIMARD_BACKUP_INTERVAL_SECS`, default daily) — see
+  [Verified Backups](verified-backups.md). A snapshot you never wrote cannot be
+  restored.
+- **Watch for repeated corruption.** A `cognitive.corrupt-*` quarantine every
+  cycle is a hardware/filesystem signal, not just cleanup fodder — capture a
+  sample and file a `durability` issue.
+- **Do not delete quarantines during an active incident.** They are the only
+  forensic copy of the pre-reset store.
+- **Prefer `simard memory import` over hand-editing store files.** Import is
+  idempotent and content-verified; raw file copies of lbug stores are not a
+  supported restore path.
+
+---
+
+## Verification coverage (issue #2550)
+
+The fix ships with regression tests that pin each guarantee (no sleeps, no
+network — fakes + temp dirs only):
+
+| Guarantee | Test intent |
+|---|---|
+| Durable prefix-recovery | A store recovered from a corrupt WAL survives a **re-open**: the recovered records are still present and the store is **not** reset. |
+| `memory import` round-trip | Importing a `cognitive_snapshot.json` restores its items; a second import deduplicates (idempotent). |
+| Startup auto-restore | With an **empty** live store **and** a newer non-empty snapshot, daemon startup restores from the newest good snapshot and logs it; a store holding any memory is left untouched. |
+| Snapshot completeness | The exported snapshot includes episodes and prospective/triggers, not just facts + procedures. |
+
+---
+
+## See Also
+
+- [Cognitive Memory Durability](cognitive-memory-durability.md) — SIGTERM-safe
+  shutdown, WAL/CHECKPOINT model, historical incidents
+- [Verified Backups of the Live Cognitive Store](verified-backups.md) —
+  verify-before-prune, whole-store export, bounded quarantines
+- [Memory introspection CLI](../reference/simard-memory-cli.md) —
+  `simard memory stats` / `dump` / `import`
+- [Cognitive Memory Library Adapter](../architecture/cognitive-memory-library-adapter.md)
+  — the `amplihack-memory` backend and `lbug_store`
+- [Operations index](index.md)
+- [GitHub issue #2550](https://github.com/rysweet/Simard/issues/2550) — this fix
+- [GitHub issue #2420](https://github.com/rysweet/Simard/issues/2420) — verified
+  backups + bounded quarantines
+- [GitHub issue #2307](https://github.com/rysweet/Simard/issues/2307) — native
+  cognitive-memory fork deletion (library backend)

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -8,6 +8,7 @@ Simard deployment.
 | [Pre-Commit Setup](pre-commit-setup.md) | Local hooks that mirror CI |
 | [Cognitive Memory Durability](cognitive-memory-durability.md) | SIGTERM-safe shutdown + periodic backups |
 | [Verified Backups of the Live Cognitive Store](verified-backups.md) | Live-store backups, verify-before-prune, bounded quarantines (#2420) |
+| [Cognitive-Memory WAL Recovery Runbook](cognitive-memory-wal-recovery-runbook.md) | Corrupt-WAL recovery, `memory import`, startup auto-restore, asset preservation (#2550) |
 | [Meeting REPL & Handoff Ingestion](meeting-handoffs.md) | Routing operator intent into the OODA loop |
 | [Progress-Evidence Kill Switch](progress-evidence-kill-switch.md) | `SIMARD_PROGRESS_EVIDENCE=off` and when to use it |
 

--- a/docs/operations/verified-backups.md
+++ b/docs/operations/verified-backups.md
@@ -97,6 +97,15 @@ bounded at `MAX_EXPORT_FACTS` / `MAX_EXPORT_PROCEDURES`. `backup_memory` uses th
 full export so the backup is a faithful copy of the live store, no matter how
 large it grows.
 
+> **Snapshot completeness (issue #2550).** The export is extended to include
+> **all durable memory types** — episodes and prospective/triggers, alongside
+> facts and procedures — so a snapshot is a complete restore source for the
+> cognitive-memory *nodes*. Provenance/similarity **edges** are not serialized:
+> they are reconstructable and their endpoints change across a content-dedup
+> restore. The export stays size-bounded for large stores. Snapshots written
+> before #2550 hold facts + procedures only; a restore from one of those is
+> partial by construction.
+
 ### The verify-before-prune gate
 
 `backup_memory_verified` wraps backup creation with a hard verification gate:
@@ -147,15 +156,37 @@ unbounded (this host saw 88 MB / 112 artifacts pile up). Neither bound *protects
 an entry the other would drop — a quarantine within the newest N but older than 7
 days is still deleted by the age check.
 
-### WAL durability — verify-only
+> **Preserve recovery assets (issue #2550).** These caps must never sweep away
+> the inputs an operator needs to recover from a corruption-reset. The retention
+> floors keep the quarantined `cognitive.corrupt-*` store and recent
+> `cognitive_snapshot.json` backups long enough to recover from before either
+> cap reclaims them. During an active incident, do **not** run `simard cleanup`
+> until you have restored or copied the quarantine and newest snapshots out —
+> see the [Cognitive-Memory WAL Recovery Runbook](cognitive-memory-wal-recovery-runbook.md).
+
+### WAL durability — recovery must be durable
 
 The library backend's write-ahead-log durability (corrupt-WAL recovery +
-checkpoint) is already present in the pinned `amplihack-memory` dependency. The
+checkpoint) is present in the pinned `amplihack-memory` dependency. The
 WAL-durability commit (`7b81590`, PR #89) is an **ancestor** of the current pin
-(`26d49bf8`, lbug-0.17.1), so **no dependency bump is performed** — re-bumping
-would be a no-op or a regression. See
-[Cognitive Memory Durability](cognitive-memory-durability.md) for the
-WAL/CHECKPOINT model.
+(`26d49bf8`, lbug-0.17.1), so no dependency bump was needed for the *recovery
+attempt* itself.
+
+> **Issue #2550.** The 2026-07-04 incident showed that recovery *attempting* is
+> not enough: a prefix-recovery salvaged 40,488 records, but the **checkpoint
+> after recovery failed** and a later open **reset the store to empty**. The
+> current pinned library (`26d49bf8`) already recovers durably — it quarantines
+> the corrupt WAL *before* the resilient open and **never** resets a store that
+> recovered records (a reset only happens for a genuinely corrupt main DB with
+> zero recovered records, and it moves the store aside, never deletes). The
+> #2550 change **locks that contract with a boundary regression test** and adds
+> snapshot import + startup auto-restore as a backstop for the genuine-reset
+> case. (The dependency bump in this change adds a read-only prospective
+> enumerator for complete snapshots — not a recovery change.) See
+> [Cognitive Memory Durability](cognitive-memory-durability.md) for the
+> WAL/CHECKPOINT model and the
+> [WAL Recovery Runbook](cognitive-memory-wal-recovery-runbook.md) for the
+> incident and operator recovery.
 
 ---
 
@@ -479,6 +510,23 @@ journalctl -u simard-ooda -n 50
 `restore_from_backup` verifies the backup before importing; if a backup is
 rejected as corrupt/incomplete, fall back to the next-most-recent directory.
 
+Since issue #2550 there is a first-class operator command that wraps this path —
+`simard memory import <snapshot.json>` — so you no longer need a one-shot Rust
+harness. It is idempotent (dedup by content), so it is safe to re-run and safe to
+run onto a partially-populated store:
+
+```bash
+sudo systemctl stop simard-ooda
+mv ~/.simard/cognitive ~/.simard/cognitive.prerestore-$(date +%Y%m%d_%H%M%S)
+simard memory import "$(ls -1dt ~/.simard/backups/*/ | head -1)cognitive_snapshot.json"
+sudo systemctl start simard-ooda
+journalctl -u simard-ooda -n 50
+```
+
+The full incident-driven procedure (detect, preserve assets, choose a snapshot,
+verify) is the
+[Cognitive-Memory WAL Recovery Runbook](cognitive-memory-wal-recovery-runbook.md).
+
 ---
 
 ## Tests
@@ -507,6 +555,12 @@ rejected as corrupt/incomplete, fall back to the next-most-recent directory.
 
 - [Cognitive Memory Durability](cognitive-memory-durability.md) — SIGTERM-safe
   shutdown, WAL/CHECKPOINT model, quarantine background
+- [Cognitive-Memory WAL Recovery Runbook](cognitive-memory-wal-recovery-runbook.md)
+  — corrupt-WAL recovery, `simard memory import`, startup auto-restore (#2550)
+- [Memory introspection CLI](../reference/simard-memory-cli.md) —
+  `simard memory stats` / `dump` / `import`
 - [Operations index](index.md)
 - [GitHub issue #2420](https://github.com/rysweet/Simard/issues/2420) — verified
   backups of the live store + quarantine bounding (this feature)
+- [GitHub issue #2550](https://github.com/rysweet/Simard/issues/2550) — durable
+  WAL recovery + snapshot import/auto-restore + complete snapshots

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -242,11 +242,13 @@ Invoking `simard goal cleanup` with no criteria flag is an error
 The `simard memory` subcommand tree is the operator surface for
 **inspecting** the six-type cognitive-memory store on the
 [`amplihack-memory-lib`](../architecture/cognitive-memory-library-adapter.md)
-backend. Both subcommands are **read-only** and **safe to run while the
-OODA daemon holds the store** — they route through the daemon's memory
-socket when it is up and fall back to a direct on-disk open when it is
-down. The state root resolves via `$SIMARD_STATE_ROOT` then `$HOME/.simard`,
-matching the daemon, so a bare invocation always targets the live store.
+backend, plus a guarded snapshot-restore. `stats` and `dump` are **read-only**
+and **safe to run while the OODA daemon holds the store** — they route through
+the daemon's memory socket when it is up and fall back to a direct on-disk open
+when it is down. `import` is the one **write** path (restore-only) and must run
+with the daemon stopped. The state root resolves via `$SIMARD_STATE_ROOT` then
+`$HOME/.simard`, matching the daemon, so a bare invocation always targets the
+live store.
 
 See the full reference — output schema, type→field mapping, sampling
 caveats, and the stored-vs-recalled episode distinction — in
@@ -292,6 +294,18 @@ prospective enumerator, so `dump` never row-samples triggers (see
 unavailable over the daemon socket (e.g. the library's `get_episodes`),
 `dump` prints the count with `(samples unavailable over IPC)` and
 continues — run with the daemon stopped for full rows.
+
+### `simard memory import <snapshot.json> [state-root] [--json]`
+
+Restore a cognitive-memory snapshot (a backup's `cognitive_snapshot.json`) back
+into the store. Introduced by issue #2550 as the recovery path after the
+2026-07-04 corrupt-WAL data-loss incident. `import` is **idempotent** — it
+deduplicates by content, so it is safe to re-run and safe to run onto a
+partially-populated store — and must run with the daemon **stopped** because it
+writes to the store. The daemon also auto-restores from the newest good snapshot
+on startup when the live store is empty. See
+[Memory introspection CLI](./simard-memory-cli.md#simard-memory-import) and the
+[WAL Recovery Runbook](../operations/cognitive-memory-wal-recovery-runbook.md).
 
 ## Status subcommand
 

--- a/docs/reference/simard-memory-cli.md
+++ b/docs/reference/simard-memory-cli.md
@@ -1,6 +1,6 @@
 ---
 title: Memory introspection CLI
-description: Operator reference for `simard memory stats` and `simard memory dump` — the read-only introspection commands that report per-type cognitive-memory counts and sample rows from the library backend, lock-safely while the daemon holds the store (issue #2308).
+description: Operator reference for `simard memory stats` / `dump` — the read-only introspection commands that report per-type cognitive-memory counts and sample rows from the library backend, lock-safely while the daemon holds the store (issue #2308) — and `simard memory import`, the guarded snapshot-restore command (issue #2550).
 last_updated: 2026-06-20
 owner: simard
 doc_type: reference
@@ -28,11 +28,17 @@ was no command-line way to confirm that episodes, triggers, facts, and
 procedures are actually populating the live store. `simard memory stats`
 and `simard memory dump` fill that gap.
 
-Both commands are **read-only** and **safe to run while the OODA daemon
+Both `stats` and `dump` are **read-only** and **safe to run while the OODA daemon
 holds the store** — they route through the daemon's memory socket when it
 is up, and fall back to a direct open of the on-disk store when it is
 down. Neither command spawns an engineer, mutates memory, or fires
 triggers.
+
+A third command, [`simard memory import`](#simard-memory-import) (issue #2550),
+is the one **write** path on this surface: a guarded snapshot-restore used to
+recover a corrupted/reset store. Unlike `stats`/`dump` it must be run with the
+daemon **stopped**. It is not a free-form mutation command — it only ingests a
+`cognitive_snapshot.json` and deduplicates by content.
 
 ---
 
@@ -466,18 +472,71 @@ and [Prospective-trigger firing](./prospective-trigger-firing.md).
 
 ---
 
+## `simard memory import`
+
+Restore a cognitive-memory snapshot back into the store. This is the operator
+recovery path introduced by issue #2550 after the 2026-07-04 corrupt-WAL
+data-loss incident, where a periodic `cognitive_snapshot.json` existed but there
+was **no command** to load it back.
+
+```text
+Usage: simard memory import <snapshot.json> [state-root] [--json]
+```
+
+| Argument | Meaning |
+|----------|---------|
+| `<snapshot.json>` | Path to a backup's `cognitive_snapshot.json` (or any snapshot in the same envelope format). Required. |
+| `[state-root]` | As for `stats`. Resolves `$SIMARD_STATE_ROOT`, then `$HOME/.simard`. |
+| `--json` | Emit a single JSON result object (`{ imported, new, deduplicated, store }`) instead of the human line. |
+
+### Behaviour
+
+- **Restore-only, not free-form mutation.** `import` ingests the snapshot's
+  records (facts, procedures, and — for snapshots written post-#2550 — episodes
+  and prospective/triggers). Provenance/similarity **edges** are not serialized:
+  they are reconstructable and their endpoints change across a content-dedup
+  restore, so only the durable memory *nodes* are carried. `import` never accepts
+  ad-hoc content and has no `set`/`clear`/`forget` surface.
+- **Idempotent — dedup by content.** Re-running `import`, or importing onto a
+  store that already holds some of the records, deduplicates by content, so it is
+  safe to run more than once and safe to run onto a partially-populated store.
+  The output reports how many items were new versus deduplicated.
+- **Run with the daemon stopped.** `import` writes to the store, so unlike
+  `stats`/`dump` it does **not** route through the read socket. Stop
+  `simard-ooda` first so nothing writes concurrently.
+
+```text
+$ sudo systemctl stop simard-ooda
+$ simard memory import ~/.simard/backups/20260704_001500/cognitive_snapshot.json
+imported 40488 items (40488 new, 0 deduplicated) -> /home/azureuser/.simard/cognitive
+$ sudo systemctl start simard-ooda
+```
+
+The daemon also performs an **automatic** import on startup: if the live store is
+empty and a newer non-empty snapshot exists, it restores from the newest good
+snapshot and logs a `store was empty — auto-restored <n> memories from …
+cognitive_snapshot.json` line, so a corruption-reset self-heals without operator
+action. See the
+[Cognitive-Memory WAL Recovery Runbook](../operations/cognitive-memory-wal-recovery-runbook.md)
+for the full incident-driven procedure.
+
+---
+
 ## Out of scope
 
 Deliberately excluded from this change:
 
-- **Any mutation command.** `simard memory` is read-only: there is no
-  `set`, `clear`, `forget`, or `compact` subcommand. Memory is written
-  only by the daemon's OODA loop and consolidation.
-- **A read-only prospective (trigger) enumerator.** The library exposes no
-  side-effect-free way to list prospects, so `stats`/`dump` report the
-  prospective **count only** and never sample trigger rows. Adding a
-  read-only enumerator to the backend + trait is possible future work; it
-  is the prerequisite for row-level trigger inspection.
+- **Free-form mutation commands.** `simard memory` has no `set`, `clear`,
+  `forget`, or `compact` subcommand. `stats`/`dump` are read-only; the only
+  write path is [`import`](#simard-memory-import), a guarded snapshot-restore
+  that ingests a `cognitive_snapshot.json` and deduplicates by content. Ordinary
+  memory is written only by the daemon's OODA loop and consolidation.
+- **Sampling prospective (trigger) rows in `stats`/`dump`.** Issue #2550 added a
+  read-only, side-effect-free prospective enumerator to the library
+  (`get_all_prospective`, used by the verified backup to capture triggers), but
+  wiring it into the `stats`/`dump` sample tables is out of scope here: those
+  commands still report the prospective **count only** and never sample trigger
+  rows. `check_triggers` remains unsuitable for sampling — it mutates status.
 - **Working / sensory row sampling.** Neither type has a trait enumerator;
   both are count-only.
 - **Dashboard parity.** The Memory tab's graph view and full-text search
@@ -491,7 +550,9 @@ Deliberately excluded from this change:
 | Situation | Exit |
 |-----------|------|
 | Counts printed (including all-zeros on a fresh root) | `0` |
-| Unparseable arguments (unknown flag, bad `--limit`) | non-zero, usage to stderr |
+| `import` completes (items restored, including 0 on an empty snapshot) | `0` |
+| Unparseable arguments (unknown flag, bad `--limit`, missing `import` path) | non-zero, usage to stderr |
+| `import` snapshot file missing or not a valid snapshot envelope | non-zero, error to stderr |
 | Bridge open fails on every tier | non-zero, error to stderr |
 
 A successful read of an empty store is **not** an error — the all-zeros
@@ -506,6 +567,8 @@ bridge-open failure exits non-zero.
 |------|------|
 | `memory` subcommand dispatch | `src/operator_cli/memory.rs` |
 | Subcommand registration | `src/operator_cli/mod.rs` |
+| Snapshot import / restore (`import_memory_snapshot`, `restore_snapshot`) | `src/remote_transfer/mod.rs`, `src/memory_snapshot.rs` |
+| Startup auto-restore (empty store + newer snapshot) | `src/operator_commands_ooda/daemon/` |
 | Read bridge (`open_reader_bridge`) | `src/memory_ipc/launcher.rs` |
 | `CognitiveStatistics` (`get_statistics`) | `src/memory_cognitive.rs` |
 | `GraphStats` (edges / dedup, issue #2331) | `src/memory_cognitive.rs` |
@@ -531,6 +594,9 @@ bridge-open failure exits non-zero.
 | `dump` notes when neutral episode rows need direct open | Force the daemon-socket tier; assert the episode count prints with the "keyword samples only over IPC" note and no crash |
 | `dump --type=triggers` is rejected or count-only | Assert triggers cannot be row-sampled (count-only), consistent with the no-mutation guarantee |
 | Argument parsing rejects unknown flags / bad `--limit` | Assert non-zero exit and a usage message |
+| `import` round-trips a snapshot | Export a snapshot from a seeded store, `import` it into a fresh `TempDir` store, and assert the counts match |
+| `import` is idempotent (dedup by content) | Import the same snapshot twice; assert the second run reports items as deduplicated and the store count does not double |
+| `import` rejects a missing / malformed snapshot file | Assert non-zero exit and an error message, with the store left unchanged |
 
 ---
 
@@ -549,4 +615,8 @@ bridge-open failure exits non-zero.
   `[state-root]`, `$SIMARD_STATE_ROOT`, and `$HOME/.simard` are resolved.
 - [Library-backed Cognitive Memory](../architecture/cognitive-memory-library-adapter.md)
   — the `amplihack-memory-lib` backend the commands read from.
+- [Cognitive-Memory WAL Recovery Runbook](../operations/cognitive-memory-wal-recovery-runbook.md)
+  — when and how to use `simard memory import` to recover a corrupted/reset store.
+- [Verified Backups of the Live Cognitive Store](../operations/verified-backups.md)
+  — where the `cognitive_snapshot.json` files `import` consumes come from.
 - [Memory architecture](../memory.md) — the six memory types overview.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -272,6 +272,7 @@ nav:
     - Overview: operations/index.md
     - Verified Backups of the Live Store: operations/verified-backups.md
     - Cognitive-Memory Durability: operations/cognitive-memory-durability.md
+    - Cognitive-Memory WAL Recovery Runbook: operations/cognitive-memory-wal-recovery-runbook.md
     - Meeting REPL & Handoff Ingestion: operations/meeting-handoffs.md
     - Progress-Evidence Kill Switch: operations/progress-evidence-kill-switch.md
     - Safe Self-Update: safe-self-update.md

--- a/src/cmd_cleanup/disk.rs
+++ b/src/cmd_cleanup/disk.rs
@@ -314,7 +314,13 @@ pub fn cap_home_cargo_targets(report: &mut CleanupReport, cap_bytes: u64) {
 }
 
 /// Maximum age (in days) of corrupted memory DB files before deletion.
-pub const CORRUPT_DB_MAX_AGE_DAYS: u64 = 7;
+///
+/// Widened to 30 days (issue #2550) to match the verified-backup retention
+/// window: a quarantined `cognitive.corrupt-*` store is a recovery asset (the
+/// incident salvaged tens of thousands of records from one) and must survive
+/// long enough for an operator to notice a reset and recover from it — a 7-day
+/// window could sweep the only copy of the lost data before anyone looked.
+pub const CORRUPT_DB_MAX_AGE_DAYS: u64 = 30;
 
 /// Maximum number of quarantined corrupt cognitive-memory artifacts to retain,
 /// regardless of age (issue #2420).
@@ -328,6 +334,14 @@ pub const CORRUPT_DB_MAX_AGE_DAYS: u64 = 7;
 /// the keep-last-N retention already used for [`BINARY_BACKUPS_KEEP`] /
 /// [`SNAPSHOTS_KEEP`].
 pub const CORRUPT_DB_KEEP: usize = 5;
+
+/// Size floor (bytes) below which the largest-quarantine protection does not
+/// apply (issue #2550). A recovery asset — a corrupt store a prefix-recovery
+/// salvaged real data from — is many megabytes; a stray truncated WAL sidecar or
+/// an empty rebuilt store is trivially small and carries nothing worth
+/// preserving. Only quarantines at or above this floor are shielded from the age
+/// / keep-last-N caps, so trivial quarantines are still reclaimed normally.
+pub const CORRUPT_DB_PROTECT_MIN_BYTES: u64 = 1024 * 1024;
 
 /// Returns `true` when `name` is a quarantined corrupt cognitive-memory
 /// artifact (safe to garbage-collect) and `false` for the live store.
@@ -379,10 +393,12 @@ pub fn remove_old_corrupt_dbs(report: &mut CleanupReport) {
     let max_age = std::time::Duration::from_secs(CORRUPT_DB_MAX_AGE_DAYS * 24 * 3600);
     let now = std::time::SystemTime::now();
 
-    // Collect every quarantine candidate with its mtime so we can apply both the
-    // age cap and the keep-last-N cap over the full set (read_dir order is
-    // unspecified, so we cannot rank by iteration order).
-    let mut candidates: Vec<(PathBuf, std::fs::Metadata, std::time::SystemTime)> = Vec::new();
+    // Collect every quarantine candidate with its size + mtime so we can apply
+    // the age cap, the keep-last-N cap, AND the largest-asset protection over the
+    // full set (read_dir order is unspecified, so we cannot rank by iteration
+    // order). Size is computed once here rather than lazily at removal time
+    // because the largest-asset guard below needs it for every candidate.
+    let mut candidates: Vec<(PathBuf, bool, u64, std::time::SystemTime)> = Vec::new();
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
         if !is_corrupt_quarantine_name(&name) {
@@ -392,35 +408,51 @@ pub fn remove_old_corrupt_dbs(report: &mut CleanupReport) {
         let Ok(modified) = meta.modified() else {
             continue;
         };
-        candidates.push((entry.path(), meta, modified));
+        // A cognitive-memory store may be backed by a single file or a
+        // directory, so a quarantine can be either.
+        let is_dir = meta.is_dir();
+        let size = if is_dir {
+            dir_size(&entry.path()).unwrap_or(0)
+        } else {
+            meta.len()
+        };
+        candidates.push((entry.path(), is_dir, size, modified));
     }
 
-    // Newest first, so index 0..CORRUPT_DB_KEEP are the survivors of the count cap.
-    candidates.sort_by_key(|c| std::cmp::Reverse(c.2));
+    // Issue #2550: never sweep the LARGEST *substantial* quarantine — it is the
+    // most likely recovery asset. A corrupt store that a prefix-recovery salvaged
+    // tens of thousands of records from is many megabytes; losing it is exactly
+    // the permanent data-loss this issue exists to prevent, so it is protected
+    // from BOTH the age cap and the keep-last-N cap. Trivial quarantines (a
+    // truncated WAL sidecar, an empty rebuilt store) fall below
+    // `CORRUPT_DB_PROTECT_MIN_BYTES` and are reclaimed normally. Ties break
+    // toward the newest.
+    let protected: Option<PathBuf> = candidates
+        .iter()
+        .filter(|c| c.2 >= CORRUPT_DB_PROTECT_MIN_BYTES)
+        .max_by(|a, b| a.2.cmp(&b.2).then_with(|| a.3.cmp(&b.3)))
+        .map(|c| c.0.clone());
 
-    for (rank, (path, meta, modified)) in candidates.iter().enumerate() {
+    // Newest first, so index 0..CORRUPT_DB_KEEP are the survivors of the count cap.
+    candidates.sort_by_key(|c| std::cmp::Reverse(c.3));
+
+    for (rank, (path, is_dir, size, modified)) in candidates.iter().enumerate() {
+        // The recovery asset is never reclaimed, regardless of age or rank.
+        if protected.as_deref() == Some(path.as_path()) {
+            continue;
+        }
         let too_old = now.duration_since(*modified).unwrap_or_default() >= max_age;
         let beyond_keep = rank >= CORRUPT_DB_KEEP;
         if !too_old && !beyond_keep {
             continue;
         }
-        // A cognitive-memory store may be backed by a single file or a
-        // directory, so a quarantine snapshot can be either. Size and remove
-        // accordingly; `remove_file` on a directory would otherwise fail and
-        // leave the quarantine in place.
-        let is_dir = meta.is_dir();
-        let size = if is_dir {
-            dir_size(path).unwrap_or(0)
-        } else {
-            meta.len()
-        };
         let reason = if too_old { "age" } else { "keep-last-N" };
         eprintln!(
             "  Removing corrupt DB {} ({} MB, {reason})",
             path.display(),
             size / (1024 * 1024)
         );
-        let removed = if is_dir {
+        let removed = if *is_dir {
             std::fs::remove_dir_all(path)
         } else {
             std::fs::remove_file(path)

--- a/src/cmd_cleanup/mod.rs
+++ b/src/cmd_cleanup/mod.rs
@@ -153,8 +153,8 @@ pub(crate) mod disk;
 // re-exported for cfg(test) consumers in cmd_cleanup/tests.rs (false-positive of clippy unused_imports on lib pass — see #1405)
 #[allow(unused_imports)]
 pub(crate) use disk::{
-    BINARY_BACKUPS_KEEP, CORRUPT_DB_KEEP, CORRUPT_DB_MAX_AGE_DAYS, SNAPSHOTS_KEEP,
-    cap_home_cargo_targets, cap_simard_target_dirs, clean_simard_canaries,
+    BINARY_BACKUPS_KEEP, CORRUPT_DB_KEEP, CORRUPT_DB_MAX_AGE_DAYS, CORRUPT_DB_PROTECT_MIN_BYTES,
+    SNAPSHOTS_KEEP, cap_home_cargo_targets, cap_simard_target_dirs, clean_simard_canaries,
     clean_stale_cargo_targets, dir_size, is_corrupt_quarantine_name, remove_old_corrupt_dbs,
     rotate_simard_binary_backups, trim_simard_snapshots,
 };

--- a/src/cmd_cleanup/tests.rs
+++ b/src/cmd_cleanup/tests.rs
@@ -781,6 +781,68 @@ fn corrupt_db_removes_aged_library_backend_quarantines() {
     assert!(report.errors.is_empty(), "no errors expected: {report:?}");
 }
 
+/// Issue #2550: the LARGEST *substantial* quarantine is the recovery asset (a
+/// corrupt store a prefix-recovery salvaged tens of thousands of records from).
+/// It must survive BOTH caps — a burst of newer small quarantines (keep-last-N)
+/// AND the age cap — so a corruption-reset stays recoverable. Trivial
+/// quarantines below the size floor are still reclaimed normally.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn corrupt_db_preserves_largest_recovery_asset() {
+    let tmp = tempfile::tempdir().unwrap();
+    let simard = tmp.path().join(".simard");
+    std::fs::create_dir_all(&simard).unwrap();
+
+    // The recovery asset: a multi-MB quarantine, made OLDER than the age cap AND
+    // (below) buried behind more than CORRUPT_DB_KEEP newer quarantines — either
+    // cap alone would otherwise reclaim it.
+    let asset = simard.join("cognitive.corrupt-1700000000");
+    std::fs::write(
+        &asset,
+        vec![0u8; (CORRUPT_DB_PROTECT_MIN_BYTES + 512) as usize],
+    )
+    .unwrap();
+    backdate(&asset, CORRUPT_DB_MAX_AGE_DAYS + 5);
+
+    // A burst of CORRUPT_DB_KEEP + 3 newer, trivially-small quarantines.
+    let burst = CORRUPT_DB_KEEP + 3;
+    let mut small = Vec::with_capacity(burst);
+    for i in 0..burst {
+        let p = simard.join(format!("cognitive.wal.corrupt-{i:04}"));
+        std::fs::write(&p, b"tiny").unwrap();
+        // Newer than the asset (recent), strictly decreasing so ranks are stable.
+        let mtime =
+            std::time::SystemTime::now() - std::time::Duration::from_secs((i as u64 + 1) * 60);
+        let times = std::fs::FileTimes::new().set_modified(mtime);
+        std::fs::File::options()
+            .write(true)
+            .open(&p)
+            .unwrap()
+            .set_times(times)
+            .unwrap();
+        small.push(p);
+    }
+
+    let report = run_corrupt_cleanup_with_home(tmp.path());
+
+    assert!(
+        asset.exists(),
+        "the largest substantial quarantine (recovery asset) must be preserved \
+         despite being aged and buried behind newer quarantines"
+    );
+    // The small burst is still bounded to keep-last-N (the asset does not consume
+    // a keep slot — protection is independent of the count cap).
+    let small_remaining = small.iter().filter(|p| p.exists()).count();
+    assert_eq!(
+        small_remaining, CORRUPT_DB_KEEP,
+        "trivial quarantines below the size floor are still bounded by keep-last-N"
+    );
+    assert!(
+        !report.dirs_removed.contains(&asset),
+        "recovery asset must not be reported as removed"
+    );
+}
+
 /// Safety invariant: a name without the `.corrupt-` infix is the live store and
 /// must NEVER be deleted — even if it is older than the threshold. Guards
 /// against a future over-broad matcher wiping `~/.simard/cognitive` and

--- a/src/cognitive_memory/library_adapter.rs
+++ b/src/cognitive_memory/library_adapter.rs
@@ -1116,6 +1116,20 @@ impl CognitiveMemoryOps for LibraryCognitiveMemory {
         Ok(())
     }
 
+    fn list_all_prospective(&self, limit: u32) -> SimardResult<Vec<CognitiveProspective>> {
+        // Issue #2550: read-only enumeration of every prospective memory (all
+        // statuses), priority-ordered, for the verified backup. Routes through
+        // the library's `get_all_prospective` (a pure `&self` read over
+        // `query_nodes(NT_PROSPECTIVE, agent_filter)`), so it neither mutates
+        // status nor filters by content the way `check_triggers` does.
+        Ok(self
+            .lock()?
+            .get_all_prospective(limit as usize)
+            .into_iter()
+            .map(to_prospective)
+            .collect())
+    }
+
     fn mark_episode_distilled(&self, node_id: &str) -> SimardResult<()> {
         // De-fork Phase 2b (issue #2307): the library now exposes a persistent,
         // one-way distilled latch. Delegate to it. The library returns `false`
@@ -1136,6 +1150,19 @@ impl CognitiveMemoryOps for LibraryCognitiveMemory {
         Ok(self
             .lock()?
             .list_undistilled_episodes(limit as usize)
+            .into_iter()
+            .map(to_episode)
+            .collect())
+    }
+
+    fn list_all_episodes(&self, limit: u32) -> SimardResult<Vec<CognitiveEpisode>> {
+        // Issue #2550: unfiltered enumeration of every episode (including
+        // compressed/consolidated ones), newest-first, for the verified backup.
+        // `get_episodes(_, true)` is the same "return all" read
+        // `search_episodes_by_keywords` builds on, minus the keyword gate.
+        Ok(self
+            .lock()?
+            .get_episodes(limit as usize, true)
             .into_iter()
             .map(to_episode)
             .collect())

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -513,6 +513,35 @@ pub trait CognitiveMemoryOps: Send + Sync {
         Ok(())
     }
 
+    /// Return up to `limit` episodes for this agent, newest-first, **including
+    /// compressed/consolidated ones** (issue #2550).
+    ///
+    /// Unlike [`list_undistilled_episodes`](Self::list_undistilled_episodes)
+    /// (distillation-gated) or
+    /// [`search_episodes_by_keywords`](Self::search_episodes_by_keywords)
+    /// (keyword-gated), this is an unfiltered enumeration used by the verified
+    /// backup to capture **every** episode so a restore round-trips episodic
+    /// memory. The default returns empty so non-library backends (IPC client,
+    /// test stubs) degrade gracefully; only [`LibraryCognitiveMemory`] overrides
+    /// it.
+    fn list_all_episodes(&self, _limit: u32) -> SimardResult<Vec<CognitiveEpisode>> {
+        Ok(vec![])
+    }
+
+    /// Return up to `limit` prospective (trigger → action) memories for this
+    /// agent, in **every** status, priority-ordered (issue #2550).
+    ///
+    /// A pure read: unlike [`check_triggers`](Self::check_triggers) it neither
+    /// filters by content nor mutates any status, so it is safe on the backup
+    /// path. The default returns empty so non-library backends degrade
+    /// gracefully; only [`LibraryCognitiveMemory`] overrides it (via the
+    /// library's `get_all_prospective`). This is the enumerator the verified
+    /// backup needs so a restore round-trips prospective triggers — the memory
+    /// type the incident lost with no way back.
+    fn list_all_prospective(&self, _limit: u32) -> SimardResult<Vec<CognitiveProspective>> {
+        Ok(vec![])
+    }
+
     fn get_statistics(&self) -> SimardResult<CognitiveStatistics>;
 
     /// Store a semantic fact and record where it was distilled from.

--- a/src/memory_backup/mod.rs
+++ b/src/memory_backup/mod.rs
@@ -14,7 +14,7 @@ use sha2::{Digest, Sha256};
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
 use crate::memory::{MemoryRecord, MemoryStore};
-use crate::remote_transfer::MemorySnapshot;
+use crate::remote_transfer::{FullMemorySnapshot, MemorySnapshot};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -264,9 +264,13 @@ pub fn verify_backup(backup_dir: &Path) -> SimardResult<BackupVerification> {
 /// Restore memory from a verified backup.
 ///
 /// Verifies the backup first. Returns the total count of restored items.
-#[allow(deprecated)] // import_memory_snapshot is deprecated but needed here
+/// Cognitive memory is restored via [`crate::remote_transfer::import_full_snapshot`]
+/// (issue #2550), which round-trips **all** durable types — facts, procedures,
+/// episodes, and prospective triggers — and dedups by content, so a restore into
+/// a partially-populated store never duplicates memories. Legacy bare snapshots
+/// (facts + procedures only) still restore correctly.
 pub fn restore_from_backup(
-    bridge: &dyn CognitiveMemoryOps,
+    memory: &dyn CognitiveMemoryOps,
     store: &dyn MemoryStore,
     backup_dir: &Path,
 ) -> SimardResult<usize> {
@@ -297,11 +301,10 @@ pub fn restore_from_backup(
     let snapshot_path = backup_dir.join(SNAPSHOT_FILE);
     let records_path = backup_dir.join(RECORDS_FILE);
 
-    // Restore cognitive memory.
-    let snapshot_bytes = read_bytes(&snapshot_path)?;
-    let snapshot: MemorySnapshot = serde_json::from_slice(&snapshot_bytes)
-        .map_err(|e| store_error("deserialize-snapshot", &snapshot_path, e.to_string()))?;
-    let cognitive_count = crate::remote_transfer::import_memory_snapshot(bridge, &snapshot)?;
+    // Restore cognitive memory — ALL durable types (issue #2550), deduped by
+    // content so a restore into a non-empty store is idempotent.
+    let snapshot = crate::remote_transfer::load_full_snapshot_from_file(&snapshot_path)?;
+    let cognitive_count = crate::remote_transfer::import_full_snapshot(memory, &snapshot)?;
 
     // Restore file-backed memory records.
     let records_bytes = read_bytes(&records_path)?;
@@ -383,6 +386,95 @@ pub fn backup_memory_verified(
 ) -> SimardResult<BackupManifest> {
     let manifest = backup_memory(bridge, store, agent_name, config)?;
     ensure_backup_valid(&manifest.backup_dir)
+}
+
+/// Outcome of an automatic startup restore (issue #2550).
+#[derive(Clone, Debug)]
+pub struct AutoRestoreReport {
+    /// Number of memories imported from the snapshot.
+    pub restored: usize,
+    /// The `cognitive_snapshot.json` the restore was sourced from.
+    pub from: PathBuf,
+}
+
+/// Auto-restore the newest good cognitive snapshot when the live store is
+/// empty (issue #2550).
+///
+/// The daemon calls this at startup, immediately after opening the store and
+/// **before** any bootstrap seeding, so a corruption-reset self-heals instead
+/// of permanently losing everything. If the just-opened `memory` holds no
+/// memories at all and a non-empty `cognitive_snapshot.json` exists under
+/// `config.backup_dir/<ts>/`, the **newest** such snapshot is imported
+/// (idempotently, via [`crate::remote_transfer::import_full_snapshot`]),
+/// checkpointed, and an [`AutoRestoreReport`] is returned.
+///
+/// A store that holds *any* memory is left untouched (`Ok(None)`): restoring
+/// over live data could duplicate or clobber it, and a healthy store never
+/// needs healing. The absence of any non-empty snapshot also yields `Ok(None)`.
+pub fn auto_restore_if_empty(
+    memory: &dyn CognitiveMemoryOps,
+    config: &BackupConfig,
+) -> SimardResult<Option<AutoRestoreReport>> {
+    // Only self-heal a genuinely empty store. Any existing memory means either a
+    // healthy store or one already (partly) restored — never clobber it.
+    if memory.get_statistics()?.total() > 0 {
+        return Ok(None);
+    }
+
+    let Some((snapshot, from)) = newest_nonempty_snapshot(config)? else {
+        return Ok(None);
+    };
+
+    let restored = crate::remote_transfer::import_full_snapshot(memory, &snapshot)?;
+
+    // Fold the restored records into the main DB so the self-heal survives even
+    // if the process exits before the store's next auto-checkpoint.
+    memory.checkpoint()?;
+
+    Ok(Some(AutoRestoreReport { restored, from }))
+}
+
+/// Find the newest non-empty `cognitive_snapshot.json` under
+/// `config.backup_dir/<ts>/`, returning it plus its path (issue #2550).
+///
+/// Backup directories are timestamp-named (`%Y%m%d_%H%M%S`), so a lexical
+/// descending sort is chronological newest-first. The first snapshot that loads
+/// and holds at least one memory wins; unreadable or empty snapshots are skipped
+/// so a truncated tip cannot mask an older good backup.
+fn newest_nonempty_snapshot(
+    config: &BackupConfig,
+) -> SimardResult<Option<(FullMemorySnapshot, PathBuf)>> {
+    let dir = &config.backup_dir;
+    if !dir.exists() {
+        return Ok(None);
+    }
+
+    let mut entries: Vec<PathBuf> = fs::read_dir(dir)
+        .map_err(|e| store_error("list-dir", dir, e.to_string()))?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .map(|e| e.path())
+        .collect();
+
+    // Newest first (timestamp-named dirs sort chronologically).
+    entries.sort_by(|a, b| b.cmp(a));
+
+    for entry in entries {
+        let snapshot_path = entry.join(SNAPSHOT_FILE);
+        if !snapshot_path.exists() {
+            continue;
+        }
+        // Skip a snapshot that will not load (corrupt tip) so an older good one
+        // can still be found, rather than aborting the whole self-heal.
+        match crate::remote_transfer::load_full_snapshot_from_file(&snapshot_path) {
+            Ok(snapshot) if !snapshot.is_empty() => {
+                return Ok(Some((snapshot, snapshot_path)));
+            }
+            _ => continue,
+        }
+    }
+
+    Ok(None)
 }
 
 /// List available backups sorted newest-first, each with verification status.

--- a/src/operator_cli/memory.rs
+++ b/src/operator_cli/memory.rs
@@ -17,22 +17,28 @@ use crate::memory_cognitive::{CognitiveStatistics, GraphStats};
 use crate::memory_ipc::{open_reader_bridge, socket_path_for};
 
 pub(super) const MEMORY_HELP: &str = "\
-Simard memory subcommand — cognitive-memory introspection (read-only)
+Simard memory subcommand — cognitive-memory introspection & restore
 
 Usage:
-  simard memory stats [state-root] [--json]
-  simard memory dump  [state-root] [--type=TYPE] [--limit=N] [--json]
+  simard memory stats  [state-root] [--json]
+  simard memory dump   [state-root] [--type=TYPE] [--limit=N] [--json]
+  simard memory import <snapshot.json> [state-root]
 
 stats  Print per-type counts (sensory, working, episodic, semantic/facts,
        procedural/procedures, prospective/triggers), a graph-edge / dedup
        (\"edges / connections\") section, plus a few sample rows.
 dump   Print counts plus a larger set of sample rows per type for eyeballing
        content. --type restricts to one of: facts, episodes, procedures.
+import Ingest a cognitive_snapshot.json (as written by the periodic verified
+       backup under ~/.simard/backups/<ts>/) back into the store. Idempotent:
+       memories already present are skipped (dedup by content), so re-running a
+       restore never duplicates. Run with the OODA daemon stopped so the import
+       writes to the same store the daemon serves.
 
-Both commands are read-only and safe to run while the OODA daemon holds the
-store: they route through the daemon socket when it is up and fall back to a
-direct open when it is down. With no [state-root] they resolve
-$SIMARD_STATE_ROOT, then $HOME/.simard.
+stats/dump are read-only and safe to run while the OODA daemon holds the store:
+they route through the daemon socket when it is up and fall back to a direct
+open when it is down. With no [state-root] they resolve $SIMARD_STATE_ROOT, then
+$HOME/.simard.
 ";
 
 /// Default number of sample rows per type for `stats`.
@@ -161,6 +167,7 @@ pub(crate) fn dispatch_memory_command(
         }
         "stats" => run_stats(args),
         "dump" => run_dump(args),
+        "import" => run_import(args),
         other => Err(format!("unsupported command 'memory {other}'").into()),
     }
 }
@@ -199,6 +206,78 @@ fn run_stats(args: impl Iterator<Item = String>) -> Result<(), Box<dyn std::erro
         println!("{}", render_json(&report, false));
     } else {
         print!("{}", render_human(&report, false));
+    }
+    Ok(())
+}
+
+/// `simard memory import <snapshot.json> [state-root] [--json]` — restore a
+/// `cognitive_snapshot.json` back into the store (issue #2550).
+///
+/// Idempotent: [`crate::remote_transfer::import_full_snapshot`] dedups by
+/// content, so re-running an import never duplicates memories. Opens the store
+/// **for write** via a direct on-disk open, which requires the daemon to be
+/// stopped (it holds the store lock while running) — enforced below with a clear
+/// error rather than a lock-contention failure.
+fn run_import(args: impl Iterator<Item = String>) -> Result<(), Box<dyn std::error::Error>> {
+    let mut snapshot_arg: Option<PathBuf> = None;
+    let mut state_root_opt: Option<PathBuf> = None;
+    let mut json = false;
+    for arg in args {
+        if arg == "--help" || arg == "-h" {
+            print!("{MEMORY_HELP}");
+            return Ok(());
+        } else if arg == "--json" {
+            json = true;
+        } else if arg.starts_with("--") {
+            return Err(format!("unexpected flag: {arg}").into());
+        } else if snapshot_arg.is_none() {
+            snapshot_arg = Some(PathBuf::from(arg));
+        } else if state_root_opt.is_none() {
+            state_root_opt = Some(PathBuf::from(arg));
+        } else {
+            return Err(format!("unexpected argument: {arg}").into());
+        }
+    }
+
+    let snapshot_path = snapshot_arg.ok_or_else(|| {
+        Box::<dyn std::error::Error>::from(
+            "usage: simard memory import <snapshot.json> [state-root] [--json]",
+        )
+    })?;
+    let state_root = resolve_state_root(state_root_opt);
+
+    // A direct write open cannot coexist with the daemon's store lock. Fail
+    // loudly and actionably instead of blocking on / corrupting a live store.
+    if socket_path_for(&state_root).exists() {
+        return Err(format!(
+            "the OODA daemon appears to be running for {} (socket present); \
+             stop it before importing so the restore writes to the store the \
+             daemon serves",
+            state_root.display()
+        )
+        .into());
+    }
+
+    let snapshot = crate::remote_transfer::load_full_snapshot_from_file(&snapshot_path)?;
+    let items = snapshot.total_items();
+    let memory = crate::cognitive_memory::LibraryCognitiveMemory::open(&state_root)?;
+    let new = crate::remote_transfer::import_full_snapshot(&memory, &snapshot)?;
+    // Fold the writes into the main DB so a subsequent reader (e.g. `memory
+    // stats`) sees them without needing a WAL replay.
+    memory.checkpoint()?;
+    let deduplicated = items.saturating_sub(new);
+    let store_path = state_root.join(crate::cognitive_memory::LIVE_STORE_SUBDIR);
+
+    if json {
+        println!(
+            "{{\"imported\":{items},\"new\":{new},\"deduplicated\":{deduplicated},\"store\":{}}}",
+            serde_json::Value::String(store_path.display().to_string())
+        );
+    } else {
+        println!(
+            "imported {items} items ({new} new, {deduplicated} deduplicated) -> {}",
+            store_path.display()
+        );
     }
     Ok(())
 }

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -80,6 +80,31 @@ pub fn run_ooda_daemon(
     let shared_mem: Arc<dyn CognitiveMemoryOps> =
         Arc::new(LibraryCognitiveMemory::open(&state_root)?);
 
+    // Issue #2550: self-heal a corruption-reset store BEFORE anything seeds it.
+    // If the library backend had to quarantine a corrupt store and rebuild it
+    // empty, restore the newest non-empty verified-backup snapshot so a
+    // WAL-corruption reset does not permanently lose memories. A populated store
+    // (the normal case) is left untouched. Best-effort: a failure is logged and
+    // never aborts daemon startup.
+    {
+        let backup_config = crate::memory_backup::BackupConfig {
+            backup_dir: state_root.join("backups"),
+            ..crate::memory_backup::BackupConfig::default()
+        };
+        match crate::memory_backup::auto_restore_if_empty(shared_mem.as_ref(), &backup_config) {
+            Ok(Some(report)) => daemon_log(
+                &state_root,
+                &format!(
+                    "[simard] OODA daemon: store was empty — auto-restored {} memories from {}",
+                    report.restored,
+                    report.from.display()
+                ),
+            ),
+            Ok(None) => {}
+            Err(e) => eprintln!("[simard] OODA daemon: startup auto-restore check failed: {e}"),
+        }
+    }
+
     // Register the live writer for in-process callers (dashboard, OODA
     // loop, reflection, etc.) so they bypass IPC and disk re-open and
     // share this exact handle. This eliminates the dashboard's

--- a/src/remote_transfer/mod.rs
+++ b/src/remote_transfer/mod.rs
@@ -336,6 +336,26 @@ pub fn load_full_snapshot_from_file(path: &Path) -> SimardResult<FullMemorySnaps
         reason: e.to_string(),
     })?;
 
+    // Fast path: a bare or full snapshot object deserializes straight into
+    // `FullMemorySnapshot` in a single streaming pass (the `#[serde(default)]`
+    // on `episodes`/`prospective` lets a legacy bare snapshot load too). This
+    // skips building — and, for an envelope, deep-cloning — an intermediate
+    // `serde_json::Value` DOM, which for a large snapshot (the incident held
+    // tens of thousands of records) costs several times the final struct in
+    // transient allocation on the P0 recovery/restore path. `facts`,
+    // `procedures`, `exported_at` and `source_agent` are required fields, so an
+    // envelope (which lacks them at top level) can never mis-parse here — it
+    // fails and falls through to the byte-for-byte-identical envelope unwrap
+    // below. For a plain snapshot object the two routes are equivalent (a direct
+    // `from_str` and a `from_value` over the parsed DOM replay the same
+    // `Deserialize`), so this is a pure resource-usage win with no behavior
+    // change.
+    if let Ok(snapshot) = serde_json::from_str::<FullMemorySnapshot>(&content) {
+        return Ok(snapshot);
+    }
+
+    // Slow path (rare): a PersistedEnvelope-wrapped snapshot (session-boundary
+    // files). Only these need the DOM to unwrap the payload before deserializing.
     let json: serde_json::Value =
         serde_json::from_str(&content).map_err(|e| SimardError::PersistentStoreIo {
             store: "memory-snapshot".to_string(),
@@ -344,8 +364,6 @@ pub fn load_full_snapshot_from_file(path: &Path) -> SimardResult<FullMemorySnaps
             reason: e.to_string(),
         })?;
 
-    // Unwrap a PersistedEnvelope (session-boundary snapshots) to its payload;
-    // otherwise the value is already a bare/full snapshot object.
     let payload = if json.get("schema_version").is_some() {
         json.get("payload").cloned().unwrap_or(json)
     } else {

--- a/src/remote_transfer/mod.rs
+++ b/src/remote_transfer/mod.rs
@@ -30,7 +30,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
-use crate::memory_cognitive::{CognitiveFact, CognitiveProcedure};
+use crate::memory_cognitive::{
+    CognitiveEpisode, CognitiveFact, CognitiveProcedure, CognitiveProspective,
+};
 
 /// Maximum number of facts to export in a single snapshot.
 const MAX_EXPORT_FACTS: u32 = 1000;
@@ -106,29 +108,95 @@ impl MemorySnapshot {
     }
 }
 
-/// Export the **complete** cognitive memory (every fact + procedure) for a
-/// verified backup of the live store (issue #2420).
+/// A **complete** portable snapshot of cognitive memory (issue #2550).
+///
+/// [`MemorySnapshot`] carries only the migration-worthy subset (facts +
+/// procedures). A verified backup that a corruption-reset must be recoverable
+/// from has to capture **every** durable memory type — the incident that
+/// motivated this type (a WAL corruption reset the store to empty) was
+/// unrecoverable precisely because the on-disk `cognitive_snapshot.json` held
+/// only facts + procedures, so episodes and prospective triggers were lost for
+/// good.
+///
+/// It is a strict superset of [`MemorySnapshot`]: `episodes` and `prospective`
+/// are `#[serde(default)]`, so a bare `MemorySnapshot` JSON (the legacy backup
+/// shape) deserializes into a `FullMemorySnapshot` with empty
+/// episodes/prospective, and a `FullMemorySnapshot` JSON deserializes into a
+/// [`MemorySnapshot`] (the extra keys are ignored) — the count-verification
+/// gate keeps working unchanged.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FullMemorySnapshot {
+    /// Semantic facts (durable knowledge).
+    pub facts: Vec<CognitiveFact>,
+    /// Procedural memories (reusable workflows).
+    pub procedures: Vec<CognitiveProcedure>,
+    /// Autobiographical episodes. `#[serde(default)]` so a legacy bare-snapshot
+    /// file (facts + procedures only) still loads.
+    #[serde(default)]
+    pub episodes: Vec<CognitiveEpisode>,
+    /// Prospective (trigger → action) memories. `#[serde(default)]` for the
+    /// same back-compat reason as `episodes`.
+    #[serde(default)]
+    pub prospective: Vec<CognitiveProspective>,
+    /// Unix epoch seconds when this snapshot was created.
+    pub exported_at: u64,
+    /// The agent name that produced this snapshot.
+    pub source_agent: String,
+}
+
+impl FullMemorySnapshot {
+    /// Total number of durable items across all captured types.
+    pub fn total_items(&self) -> usize {
+        self.facts.len() + self.procedures.len() + self.episodes.len() + self.prospective.len()
+    }
+
+    /// Whether the snapshot holds no durable memories at all.
+    pub fn is_empty(&self) -> bool {
+        self.total_items() == 0
+    }
+}
+
+impl Display for FullMemorySnapshot {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "FullMemorySnapshot(facts={}, procedures={}, episodes={}, prospective={}, agent={}, at={})",
+            self.facts.len(),
+            self.procedures.len(),
+            self.episodes.len(),
+            self.prospective.len(),
+            self.source_agent,
+            self.exported_at
+        )
+    }
+}
+
+/// Export the **complete** cognitive memory — every fact, procedure, episode,
+/// and prospective trigger — for a verified backup of the live store (issues
+/// #2420, #2550).
 ///
 /// Unlike [`export_memory_snapshot`] — which caps at [`MAX_EXPORT_FACTS`] /
 /// [`MAX_EXPORT_PROCEDURES`] to keep replication/migration payloads bounded — a
-/// verified backup must capture the *entire* store so a restore can round-trip
-/// the **current** memory count. With the live store already past 10k memories
-/// and growing daily, a fixed export cap would silently drop the tail and make
-/// the count-verification gate ([`crate::memory_backup::verify_backup_memory_count`])
-/// fail forever — exactly the silent-rot failure class this issue exists to
-/// kill. It therefore requests with the maximum limit (`u32::MAX`), the same
-/// unbounded retrieval [`CognitiveMemoryOps::graph_stats`] already performs
-/// safely via `get_all_facts(usize::MAX)`, so the snapshot can never be capped
-/// below the store size.
+/// verified backup must capture the *entire* store so a restore round-trips the
+/// **current** memory count and every type. With the live store already past
+/// 10k memories and growing daily, a fixed export cap would silently drop the
+/// tail and make the count-verification gate
+/// ([`crate::memory_backup::verify_backup_memory_count`]) fail forever — exactly
+/// the silent-rot failure class this path exists to kill. It therefore requests
+/// with the maximum limit (`u32::MAX`), the same unbounded retrieval
+/// [`CognitiveMemoryOps::graph_stats`] already performs safely, so the snapshot
+/// can never be capped below the store size.
 ///
-/// Selection semantics are otherwise identical to [`export_memory_snapshot`]
-/// (wildcard query, `min_confidence = 0.0`); only the truncation is removed.
-/// This is *not* deprecated: it is the backup path, distinct from the legacy
-/// JSON replication this module otherwise superseded.
+/// Issue #2550 extends the capture beyond facts + procedures to **all** durable
+/// memory types: episodes ([`CognitiveMemoryOps::list_all_episodes`]) and
+/// prospective triggers ([`CognitiveMemoryOps::list_all_prospective`]). Backends
+/// without an enumerator for a type (the IPC client, test stubs) return an empty
+/// list via the trait default, so the export degrades to the facts+procedures
+/// subset rather than failing.
 pub fn export_full_memory_snapshot(
-    bridge: &dyn CognitiveMemoryOps,
+    memory: &dyn CognitiveMemoryOps,
     agent_name: &str,
-) -> SimardResult<MemorySnapshot> {
+) -> SimardResult<FullMemorySnapshot> {
     if agent_name.is_empty() {
         return Err(SimardError::InvalidConfigValue {
             key: "agent_name".to_string(),
@@ -140,15 +208,155 @@ pub fn export_full_memory_snapshot(
     // `u32::MAX` is the "return all" limit: the library's `get_all_facts` is
     // already called with `usize::MAX` by `graph_stats`, so an unbounded request
     // is safe (no per-limit pre-allocation). No real store approaches u32::MAX
-    // facts, so this can never truncate.
-    let facts = bridge.search_facts("*", u32::MAX, 0.0)?;
-    let procedures = bridge.recall_procedure("*", u32::MAX)?;
+    // records, so this can never truncate.
+    let facts = memory.search_facts("*", u32::MAX, 0.0)?;
+    let procedures = memory.recall_procedure("*", u32::MAX)?;
+    let episodes = memory.list_all_episodes(u32::MAX)?;
+    let prospective = memory.list_all_prospective(u32::MAX)?;
 
-    Ok(MemorySnapshot {
+    Ok(FullMemorySnapshot {
         facts,
         procedures,
+        episodes,
+        prospective,
         exported_at: current_epoch_seconds()?,
         source_agent: agent_name.to_string(),
+    })
+}
+
+/// Import a [`FullMemorySnapshot`] into a store, **idempotently** (issue #2550).
+///
+/// Every item is deduplicated by content before it is written, so re-running a
+/// restore — or auto-restoring a snapshot the store already partially holds —
+/// never duplicates memories. Dedup keys per type:
+///
+/// * facts — `(concept, content)`
+/// * procedures — `name`
+/// * episodes — `content`
+/// * prospective — `(trigger_condition, description)`
+///
+/// Returns the number of items actually written (skipped duplicates are not
+/// counted). This is the restore/import counterpart of
+/// [`export_full_memory_snapshot`]; it is *not* deprecated (unlike the legacy
+/// [`import_memory_snapshot`] replication path, which does not dedup).
+pub fn import_full_snapshot(
+    memory: &dyn CognitiveMemoryOps,
+    snapshot: &FullMemorySnapshot,
+) -> SimardResult<usize> {
+    use std::collections::HashSet;
+
+    let mut imported = 0;
+
+    // Facts: dedup by (concept, content).
+    let mut seen_facts: HashSet<(String, String)> = memory
+        .search_facts("*", u32::MAX, 0.0)?
+        .into_iter()
+        .map(|f| (f.concept, f.content))
+        .collect();
+    for fact in &snapshot.facts {
+        let key = (fact.concept.clone(), fact.content.clone());
+        if seen_facts.insert(key) {
+            memory.store_fact(
+                &fact.concept,
+                &fact.content,
+                fact.confidence,
+                &fact.tags,
+                &fact.source_id,
+            )?;
+            imported += 1;
+        }
+    }
+
+    // Procedures: dedup by name.
+    let mut seen_procs: HashSet<String> = memory
+        .recall_procedure("*", u32::MAX)?
+        .into_iter()
+        .map(|p| p.name)
+        .collect();
+    for proc in &snapshot.procedures {
+        if seen_procs.insert(proc.name.clone()) {
+            memory.store_procedure(&proc.name, &proc.steps, &proc.prerequisites)?;
+            imported += 1;
+        }
+    }
+
+    // Episodes: dedup by content.
+    let mut seen_eps: HashSet<String> = memory
+        .list_all_episodes(u32::MAX)?
+        .into_iter()
+        .map(|e| e.content)
+        .collect();
+    for ep in &snapshot.episodes {
+        if seen_eps.insert(ep.content.clone()) {
+            memory.store_episode(&ep.content, &ep.source_label, None)?;
+            imported += 1;
+        }
+    }
+
+    // Prospective: dedup by (trigger_condition, description).
+    let mut seen_pros: HashSet<(String, String)> = memory
+        .list_all_prospective(u32::MAX)?
+        .into_iter()
+        .map(|p| (p.trigger_condition, p.description))
+        .collect();
+    for pm in &snapshot.prospective {
+        let key = (pm.trigger_condition.clone(), pm.description.clone());
+        if seen_pros.insert(key) {
+            memory.store_prospective(
+                &pm.description,
+                &pm.trigger_condition,
+                &pm.action_on_trigger,
+                pm.priority,
+            )?;
+            imported += 1;
+        }
+    }
+
+    Ok(imported)
+}
+
+/// Load a [`FullMemorySnapshot`] from a JSON file on disk (issue #2550).
+///
+/// Transparently accepts every snapshot shape Simard has written:
+///
+/// * a **full** snapshot (facts + procedures + episodes + prospective),
+/// * a legacy **bare** [`MemorySnapshot`] (facts + procedures only — the
+///   `episodes`/`prospective` keys default to empty), and
+/// * a [`PersistedEnvelope`]-wrapped `MemorySnapshot` (session-boundary
+///   snapshots): if a top-level `schema_version` key is present the `payload`
+///   is unwrapped first.
+///
+/// This is what `simard memory import` and the daemon startup auto-restore read
+/// `cognitive_snapshot.json` through.
+pub fn load_full_snapshot_from_file(path: &Path) -> SimardResult<FullMemorySnapshot> {
+    let content = std::fs::read_to_string(path).map_err(|e| SimardError::PersistentStoreIo {
+        store: "memory-snapshot".to_string(),
+        action: "read".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+
+    let json: serde_json::Value =
+        serde_json::from_str(&content).map_err(|e| SimardError::PersistentStoreIo {
+            store: "memory-snapshot".to_string(),
+            action: "deserialize".to_string(),
+            path: path.to_path_buf(),
+            reason: e.to_string(),
+        })?;
+
+    // Unwrap a PersistedEnvelope (session-boundary snapshots) to its payload;
+    // otherwise the value is already a bare/full snapshot object.
+    let payload = if json.get("schema_version").is_some() {
+        json.get("payload").cloned().unwrap_or(json)
+    } else {
+        json
+    };
+
+    serde_json::from_value(payload).map_err(|e| SimardError::PersistentStoreIo {
+        store: "memory-snapshot".to_string(),
+        action: "deserialize-snapshot".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
     })
 }
 

--- a/src/remote_transfer/tests.rs
+++ b/src/remote_transfer/tests.rs
@@ -238,3 +238,56 @@ fn full_export_captures_more_than_capped_export() {
         "full export must exceed the legacy cap"
     );
 }
+
+/// Issue #2550: a full snapshot must round-trip **every** durable memory type
+/// through export → import, and re-importing must be idempotent (dedup by
+/// content). Complements the export-completeness test in
+/// `tests/memory_snapshot_completeness_2550.rs` by pinning the RESTORE side.
+#[test]
+fn full_snapshot_round_trips_all_types_and_import_is_idempotent() {
+    use crate::cognitive_memory::LibraryCognitiveMemory;
+
+    let source = LibraryCognitiveMemory::in_memory().unwrap();
+    source
+        .store_fact("rust", "Rust is a systems language", 0.9, &[], "issue-2550")
+        .unwrap();
+    source
+        .store_procedure("ooda:consolidate", &["distill episodes".to_string()], &[])
+        .unwrap();
+    source
+        .store_episode(
+            "episode: ran cargo test; 0 failures",
+            "engineer-cycle",
+            None,
+        )
+        .unwrap();
+    source
+        .store_prospective("ship the CLI", "trigger:ship-cli", "Pursue goal", 1)
+        .unwrap();
+
+    let snapshot = export_full_memory_snapshot(&source, "issue-2550").unwrap();
+    assert_eq!(snapshot.facts.len(), 1);
+    assert_eq!(snapshot.procedures.len(), 1);
+    assert_eq!(snapshot.episodes.len(), 1);
+    assert_eq!(snapshot.prospective.len(), 1);
+
+    // Import into a fresh store: every type must land.
+    let target = LibraryCognitiveMemory::in_memory().unwrap();
+    let first = import_full_snapshot(&target, &snapshot).unwrap();
+    assert_eq!(first, 4, "all four durable memories must be imported");
+
+    let stats = target.get_statistics().unwrap();
+    assert_eq!(stats.semantic_count, 1, "fact restored");
+    assert_eq!(stats.procedural_count, 1, "procedure restored");
+    assert_eq!(stats.episodic_count, 1, "episode restored");
+    assert_eq!(stats.prospective_count, 1, "prospective restored");
+
+    // Re-importing the same snapshot must dedup by content — nothing new.
+    let second = import_full_snapshot(&target, &snapshot).unwrap();
+    assert_eq!(
+        second, 0,
+        "re-import must deduplicate every item by content"
+    );
+    let after = target.get_statistics().unwrap();
+    assert_eq!(after.total(), 4, "counts must be stable across re-import");
+}

--- a/src/remote_transfer/tests.rs
+++ b/src/remote_transfer/tests.rs
@@ -291,3 +291,107 @@ fn full_snapshot_round_trips_all_types_and_import_is_idempotent() {
     let after = target.get_statistics().unwrap();
     assert_eq!(after.total(), 4, "counts must be stable across re-import");
 }
+
+/// Issue #2550: `load_full_snapshot_from_file` must transparently accept every
+/// on-disk shape Simard has written — a full snapshot, a legacy bare
+/// `MemorySnapshot`, and a `PersistedEnvelope`-wrapped snapshot — and surface a
+/// clear error on a corrupt file. This pins the loader's behavior across the
+/// fast (direct-deserialize) path and the envelope-unwrap fallback so the
+/// resource-usage optimization on the P0 recovery path cannot regress any shape.
+#[test]
+fn load_full_snapshot_from_file_reads_full_bare_and_enveloped_shapes() {
+    use crate::cognitive_memory::LibraryCognitiveMemory;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+
+    // Build a full snapshot (all four durable types) from a live store.
+    let source = LibraryCognitiveMemory::in_memory().unwrap();
+    source
+        .store_fact("rust", "Rust is a systems language", 0.9, &[], "issue-2550")
+        .unwrap();
+    source
+        .store_procedure("ooda:consolidate", &["distill episodes".to_string()], &[])
+        .unwrap();
+    source
+        .store_episode(
+            "episode: ran cargo test; 0 failures",
+            "engineer-cycle",
+            None,
+        )
+        .unwrap();
+    source
+        .store_prospective("ship the CLI", "trigger:ship-cli", "Pursue goal", 1)
+        .unwrap();
+    let full = export_full_memory_snapshot(&source, "issue-2550").unwrap();
+
+    // (1) Full snapshot: the fast path must round-trip every durable type.
+    let full_path = dir.join("full.json");
+    std::fs::write(&full_path, serde_json::to_vec(&full).unwrap()).unwrap();
+    let loaded_full = load_full_snapshot_from_file(&full_path).unwrap();
+    assert_eq!(
+        loaded_full.total_items(),
+        4,
+        "full snapshot must load all four durable types"
+    );
+    assert_eq!(
+        loaded_full.episodes.len(),
+        1,
+        "episodes must survive the load"
+    );
+    assert_eq!(
+        loaded_full.prospective.len(),
+        1,
+        "prospective triggers must survive the load"
+    );
+
+    // (2) Legacy bare snapshot (facts + procedures only, no episodes/prospective
+    // keys): the fast path must still load it, defaulting the missing types.
+    let bare = MemorySnapshot {
+        facts: full.facts.clone(),
+        procedures: full.procedures.clone(),
+        exported_at: full.exported_at,
+        source_agent: full.source_agent.clone(),
+    };
+    let bare_path = dir.join("bare.json");
+    std::fs::write(&bare_path, serde_json::to_vec(&bare).unwrap()).unwrap();
+    let loaded_bare = load_full_snapshot_from_file(&bare_path).unwrap();
+    assert_eq!(loaded_bare.facts.len(), 1);
+    assert_eq!(loaded_bare.procedures.len(), 1);
+    assert!(
+        loaded_bare.episodes.is_empty(),
+        "a legacy bare snapshot carries no episodes"
+    );
+    assert!(
+        loaded_bare.prospective.is_empty(),
+        "a legacy bare snapshot carries no prospective triggers"
+    );
+
+    // (3) PersistedEnvelope-wrapped snapshot (session-boundary file): the
+    // envelope-unwrap fallback must recover the payload.
+    let envelope = PersistedEnvelope {
+        schema_version: ENVELOPE_SCHEMA_VERSION,
+        payload: bare.clone(),
+    };
+    let env_path = dir.join("enveloped.json");
+    std::fs::write(&env_path, serde_json::to_vec(&envelope).unwrap()).unwrap();
+    let loaded_env = load_full_snapshot_from_file(&env_path).unwrap();
+    assert_eq!(
+        loaded_env.facts.len(),
+        1,
+        "the enveloped payload's facts must load via the unwrap fallback"
+    );
+    assert_eq!(
+        loaded_env.procedures.len(),
+        1,
+        "the enveloped payload's procedures must load via the unwrap fallback"
+    );
+
+    // (4) A corrupt file must surface an error, not a silent empty snapshot.
+    let bad_path = dir.join("corrupt.json");
+    std::fs::write(&bad_path, b"{ this is not valid json").unwrap();
+    assert!(
+        load_full_snapshot_from_file(&bad_path).is_err(),
+        "a corrupt snapshot file must error rather than yield an empty snapshot"
+    );
+}

--- a/tests/memory_auto_restore_2550.rs
+++ b/tests/memory_auto_restore_2550.rs
@@ -1,0 +1,114 @@
+//! Issue #2550 (P0), Fix #3: on daemon startup, if the live store is
+//! empty/near-empty AND a newer non-empty `cognitive_snapshot.json` backup
+//! exists, auto-restore from the newest good snapshot so a corruption-reset
+//! self-heals instead of losing everything.
+//!
+//! These tests pin the pure `auto_restore_if_empty` seam the daemon calls at
+//! startup. No sleeps, no network: `TempDir`-rooted backups + store.
+
+use simard::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
+use simard::memory_backup::{BackupConfig, auto_restore_if_empty};
+use simard::memory_cognitive::CognitiveFact;
+use simard::remote_transfer::MemorySnapshot;
+
+fn config_for(backup_dir: &std::path::Path) -> BackupConfig {
+    BackupConfig {
+        backup_dir: backup_dir.to_path_buf(),
+        retention_days: 30,
+        min_backups_to_keep: 3,
+    }
+}
+
+/// Write `backup_dir/<ts>/cognitive_snapshot.json` with `facts` facts, matching
+/// the periodic backup layout (`~/.simard/backups/<ts>/cognitive_snapshot.json`).
+fn write_backup_snapshot(backup_dir: &std::path::Path, ts: &str, facts: usize) {
+    let dir = backup_dir.join(ts);
+    std::fs::create_dir_all(&dir).unwrap();
+    let snapshot = MemorySnapshot {
+        facts: (0..facts)
+            .map(|i| CognitiveFact {
+                node_id: format!("f{i}"),
+                concept: format!("concept-{i}"),
+                content: format!("restored fact {i}"),
+                confidence: 0.9,
+                source_id: "issue-2550".to_string(),
+                tags: vec![],
+                usage_count: 0,
+                last_accessed_at: None,
+            })
+            .collect(),
+        procedures: vec![],
+        exported_at: 1_751_500_000,
+        source_agent: "issue-2550".to_string(),
+    };
+    std::fs::write(
+        dir.join("cognitive_snapshot.json"),
+        serde_json::to_string_pretty(&snapshot).unwrap(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn auto_restore_fires_when_store_empty_and_newer_snapshot_exists() {
+    let backups = tempfile::tempdir().unwrap();
+    write_backup_snapshot(backups.path(), "20260703_120000", 2); // older
+    write_backup_snapshot(backups.path(), "20260704_001600", 3); // newest, non-empty
+
+    let store = tempfile::tempdir().unwrap();
+    let mem = LibraryCognitiveMemory::open(store.path()).expect("open empty store");
+    assert_eq!(
+        mem.get_statistics().unwrap().total(),
+        0,
+        "precondition: the store starts empty"
+    );
+
+    let report = auto_restore_if_empty(&mem, &config_for(backups.path()))
+        .expect("auto_restore_if_empty must not error")
+        .expect("auto-restore MUST fire on an empty store with a newer non-empty snapshot");
+
+    assert_eq!(
+        report.restored, 3,
+        "must restore from the NEWEST snapshot (3 facts), not the older one"
+    );
+    assert_eq!(
+        mem.get_statistics().unwrap().semantic_count,
+        3,
+        "restored facts must actually be in the store"
+    );
+}
+
+#[test]
+fn auto_restore_is_a_noop_when_store_is_populated() {
+    let backups = tempfile::tempdir().unwrap();
+    write_backup_snapshot(backups.path(), "20260704_001600", 5);
+
+    let store = tempfile::tempdir().unwrap();
+    let mem = LibraryCognitiveMemory::open(store.path()).expect("open store");
+    mem.store_fact("live", "already here", 0.9, &[], "live")
+        .expect("store_fact");
+
+    let outcome = auto_restore_if_empty(&mem, &config_for(backups.path())).expect("must not error");
+    assert!(
+        outcome.is_none(),
+        "a populated store must not be auto-restored (would clobber/duplicate live data)"
+    );
+    assert_eq!(
+        mem.get_statistics().unwrap().semantic_count,
+        1,
+        "the live store must be left untouched"
+    );
+}
+
+#[test]
+fn auto_restore_is_a_noop_when_no_snapshot_exists() {
+    let backups = tempfile::tempdir().unwrap(); // empty: no backups at all
+    let store = tempfile::tempdir().unwrap();
+    let mem = LibraryCognitiveMemory::open(store.path()).expect("open empty store");
+
+    let outcome = auto_restore_if_empty(&mem, &config_for(backups.path())).expect("must not error");
+    assert!(
+        outcome.is_none(),
+        "no snapshot means there is nothing to restore"
+    );
+    assert_eq!(mem.get_statistics().unwrap().total(), 0);
+}

--- a/tests/memory_import_roundtrip_2550.rs
+++ b/tests/memory_import_roundtrip_2550.rs
@@ -1,0 +1,143 @@
+//! Issue #2550 (P0), Fix #2: `simard memory import <snapshot.json> [state-root]`
+//! must ingest a `cognitive_snapshot.json` back into the store, and be
+//! idempotent (dedup by content) so re-running a restore never duplicates
+//! memories.
+//!
+//! Process-boundary tests (a real `simard` process opening an on-disk store),
+//! matching `tests/bin_simard_memory_cli.rs`. No sleeps, no network: a
+//! `TempDir`-rooted store and a hand-written snapshot file.
+
+use assert_cmd::Command;
+use simard::memory_cognitive::{CognitiveFact, CognitiveProcedure};
+use simard::remote_transfer::MemorySnapshot;
+use tempfile::TempDir;
+
+/// `simard` binary, pinned hermetic: no network update check, no socket
+/// override, so reads/writes resolve to the per-`state_root` on-disk store.
+fn bin() -> Command {
+    let mut cmd = Command::cargo_bin("simard").expect("simard must build");
+    cmd.env("SIMARD_NO_UPDATE_CHECK", "1")
+        .env_remove("SIMARD_MEMORY_SOCKET")
+        .env_remove("SIMARD_STATE_ROOT");
+    cmd
+}
+
+/// Write a `cognitive_snapshot.json` (the same bare `MemorySnapshot` shape the
+/// periodic backup writes) with `facts` facts and `procs` procedures.
+fn write_snapshot(path: &std::path::Path, facts: usize, procs: usize) {
+    let snapshot = MemorySnapshot {
+        facts: (0..facts)
+            .map(|i| CognitiveFact {
+                node_id: format!("f{i}"),
+                concept: format!("concept-{i}"),
+                content: format!("imported fact {i}"),
+                confidence: 0.9,
+                source_id: "issue-2550".to_string(),
+                tags: vec!["import".to_string()],
+                usage_count: 0,
+                last_accessed_at: None,
+            })
+            .collect(),
+        procedures: (0..procs)
+            .map(|i| CognitiveProcedure {
+                node_id: format!("p{i}"),
+                name: format!("proc-{i}"),
+                steps: vec![format!("step {i}")],
+                prerequisites: vec![],
+                usage_count: 0,
+            })
+            .collect(),
+        exported_at: 1_751_500_000,
+        source_agent: "issue-2550".to_string(),
+    };
+    std::fs::write(path, serde_json::to_string_pretty(&snapshot).unwrap()).unwrap();
+}
+
+/// Run `simard memory stats <state-root> --json` and return the parsed report.
+fn stats(state_root: &std::path::Path) -> serde_json::Value {
+    let assert = bin()
+        .args(["memory", "stats", state_root.to_str().unwrap(), "--json"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stats --json must emit JSON, got: {stdout} (err: {e})"))
+}
+
+fn semantic(report: &serde_json::Value) -> u64 {
+    report["counts"]["semantic"].as_u64().unwrap_or(0)
+}
+
+fn procedural(report: &serde_json::Value) -> u64 {
+    report["counts"]["procedural"].as_u64().unwrap_or(0)
+}
+
+#[test]
+fn memory_import_ingests_a_snapshot_into_the_store() {
+    let scratch = TempDir::new().unwrap();
+    let snap = scratch.path().join("cognitive_snapshot.json");
+    write_snapshot(&snap, 3, 2);
+
+    let state_root = TempDir::new().unwrap();
+    bin()
+        .args([
+            "memory",
+            "import",
+            snap.to_str().unwrap(),
+            state_root.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let report = stats(state_root.path());
+    assert!(
+        semantic(&report) >= 3,
+        "imported facts must be present: {report}"
+    );
+    assert!(
+        procedural(&report) >= 2,
+        "imported procedures must be present: {report}"
+    );
+}
+
+#[test]
+fn memory_import_is_idempotent_by_content() {
+    let scratch = TempDir::new().unwrap();
+    let snap = scratch.path().join("cognitive_snapshot.json");
+    write_snapshot(&snap, 4, 0);
+
+    let state_root = TempDir::new().unwrap();
+    let import = |root: &std::path::Path| {
+        bin()
+            .args([
+                "memory",
+                "import",
+                snap.to_str().unwrap(),
+                root.to_str().unwrap(),
+            ])
+            .assert()
+            .success();
+    };
+
+    import(state_root.path());
+    let first = semantic(&stats(state_root.path()));
+    assert!(first >= 4, "first import must land 4 facts (got {first})");
+
+    // Re-importing the SAME snapshot must not duplicate content.
+    import(state_root.path());
+    let second = semantic(&stats(state_root.path()));
+    assert_eq!(
+        first, second,
+        "re-import must dedup by content, not double the count (was {first}, now {second})"
+    );
+}
+
+#[test]
+fn memory_import_help_is_documented() {
+    let assert = bin().args(["memory", "--help"]).assert().success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("simard memory import"),
+        "memory --help must document the import subcommand:\n{stdout}"
+    );
+}

--- a/tests/memory_snapshot_completeness_2550.rs
+++ b/tests/memory_snapshot_completeness_2550.rs
@@ -1,0 +1,80 @@
+//! Issue #2550 (P0), Fix #4: the periodic snapshot export must capture ALL
+//! cognitive-memory types (episodes and prospective/triggers), not just facts +
+//! procedures — otherwise a restore silently drops them. This is exactly the
+//! gap that made the incident unrecoverable: the on-disk backups
+//! (`cognitive_snapshot.json`) held only facts + procedures, so episodes and
+//! prospective memories were lost for good when the store was reset.
+//!
+//! No sleeps, no network: a `TempDir`-rooted persistent store so enumeration
+//! behaves exactly like production.
+
+use simard::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
+use simard::remote_transfer::export_full_memory_snapshot;
+
+#[test]
+fn full_snapshot_includes_every_memory_type_not_just_facts_and_procedures() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mem = LibraryCognitiveMemory::open(tmp.path()).expect("open store");
+
+    mem.store_fact(
+        "rust",
+        "Rust is a systems language",
+        0.9,
+        &["lang".to_string()],
+        "issue-2550",
+    )
+    .expect("store_fact");
+    mem.store_procedure("ooda:consolidate", &["distill episodes".to_string()], &[])
+        .expect("store_procedure");
+    mem.store_episode(
+        "episode: ran cargo test; 0 failures (issue-2550)",
+        "engineer-cycle",
+        None,
+    )
+    .expect("store_episode");
+    mem.store_prospective(
+        "goal: ship the CLI",
+        "trigger:ship-the-cli-2550",
+        "Pursue goal",
+        1,
+    )
+    .expect("store_prospective");
+
+    let snapshot = export_full_memory_snapshot(&mem, "issue-2550").expect("export");
+    let value = serde_json::to_value(&snapshot).expect("serialize snapshot");
+
+    // Facts + procedures already work today (sanity: the seeding + export path
+    // is sound before we assert the new behaviour).
+    assert!(
+        value["facts"].as_array().map_or(0, Vec::len) >= 1,
+        "facts must be captured: {value}"
+    );
+    assert!(
+        value["procedures"].as_array().map_or(0, Vec::len) >= 1,
+        "procedures must be captured: {value}"
+    );
+
+    // Issue #2550: a *complete* snapshot must ALSO carry episodes and
+    // prospective triggers so a restore round-trips the whole store.
+    let episodes = value
+        .get("episodes")
+        .and_then(serde_json::Value::as_array)
+        .expect("snapshot must contain an `episodes` array (issue #2550)");
+    assert!(
+        episodes
+            .iter()
+            .any(|e| e.to_string().contains("issue-2550")),
+        "seeded episode must be captured in the snapshot: {value}"
+    );
+
+    let prospective = value
+        .get("prospective")
+        .and_then(serde_json::Value::as_array)
+        .expect("snapshot must contain a `prospective` array (issue #2550)");
+    assert!(
+        prospective
+            .iter()
+            .any(|p| p.to_string().contains("ship-the-cli-2550")),
+        "seeded prospective trigger must be captured in the snapshot: {value}"
+    );
+}

--- a/tests/qa-scenarios/cognitive-memory-wal-recovery-durability.yaml
+++ b/tests/qa-scenarios/cognitive-memory-wal-recovery-durability.yaml
@@ -1,0 +1,74 @@
+name: cognitive-memory-wal-recovery-durability
+app_type: cli
+description: |
+  Outside-in coverage for the issue #2550 P0 cognitive-memory data-loss fix: a
+  corrupt lbug WAL must recover its good prefix *durably* (survive a re-open,
+  never reset to empty), snapshots must capture every memory type, and a
+  corruption-reset must self-heal via `simard memory import` / startup
+  auto-restore. Each user-visible contract is pinned by a hermetic regression
+  test (temp dirs, injected WAL-tail corruption, no sleeps, no network). The CLI
+  runner rejects any non-zero exit, so a broken contract fails the scenario.
+agents:
+  - name: simard-cli
+    type: cli
+    command: cargo
+steps:
+  # Contract 1 — durable WAL recovery: a store that recovered a good prefix
+  # survives a strict re-open and is never reset to empty (the incident).
+  - action: run
+    params:
+      command: "cargo test --locked --test wal_recovery_durability_2550"
+    timeout: 600000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Contract 2 — restore path: `simard memory import <snapshot.json>` ingests a
+  # snapshot back into the store and is idempotent by content (safe to re-run).
+  - action: run
+    params:
+      command: "cargo test --locked --test memory_import_roundtrip_2550"
+    timeout: 600000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Contract 3 — self-heal: daemon startup auto-restore fires on an empty store
+  # when a newer non-empty snapshot exists, and is a no-op otherwise.
+  - action: run
+    params:
+      command: "cargo test --locked --test memory_auto_restore_2550"
+    timeout: 600000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Contract 4 — complete snapshots: export enumerates episodes + prospective
+  # alongside facts + procedures, so a restore round-trips every memory type.
+  - action: run
+    params:
+      command: "cargo test --locked --test memory_snapshot_completeness_2550"
+    timeout: 600000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000

--- a/tests/wal_recovery_durability_2550.rs
+++ b/tests/wal_recovery_durability_2550.rs
@@ -1,0 +1,161 @@
+//! Issue #2550 (P0): WAL prefix-recovery must be **durable across a re-open** —
+//! a store that just recovered records must NEVER be reset to empty on a later
+//! open.
+//!
+//! Incident (verified 2026-07-04): the live cognitive store's WAL corrupted;
+//! resilient recovery salvaged 40,488 records ("good prefix replayed +
+//! checkpointed") but the checkpoint-after-recovery FAILED, and a LATER open
+//! re-flagged the store corrupt and RESET it to empty — dropping ~20,480
+//! memories to 128, with no restore path.
+//!
+//! These tests pin the durability contract at the Simard adapter boundary
+//! (`LibraryCognitiveMemory`, which routes through
+//! `CognitiveMemory::open_persistent` -> `LbugGraphStore::open_with_recovery`).
+//! No sleeps, no network: everything runs against `TempDir`-rooted stores and
+//! on-disk WAL surgery.
+
+use std::path::Path;
+
+use simard::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
+
+/// The live store lives at `state_root/cognitive` (a file) with its write-ahead
+/// log at the sibling `state_root/cognitive.wal` (LadybugDB appends `.wal` to
+/// the full DB filename). Verified empirically; pinned here so the test breaks
+/// loudly if the on-disk layout ever changes.
+const DB_FILE: &str = "cognitive";
+const WAL_FILE: &str = "cognitive.wal";
+
+fn seed_facts(mem: &LibraryCognitiveMemory, start: usize, n: usize) {
+    for i in start..start + n {
+        mem.store_fact(
+            &format!("concept-{i}"),
+            &format!("durable content {i}"),
+            0.9,
+            &[],
+            "issue-2550",
+        )
+        .expect("store_fact");
+    }
+}
+
+fn total(mem: &LibraryCognitiveMemory) -> u64 {
+    mem.get_statistics().expect("get_statistics").total()
+}
+
+/// Copy the on-disk store files into a fresh dir, mimicking the on-disk state of
+/// a process killed before a clean checkpoint (the WAL still holds
+/// committed-but-uncheckpointed records).
+fn crash_snapshot(from: &Path, into: &Path) {
+    std::fs::create_dir_all(into).unwrap();
+    for name in [DB_FILE, WAL_FILE] {
+        let src = from.join(name);
+        if src.exists() {
+            std::fs::copy(&src, into.join(name)).unwrap();
+        }
+    }
+}
+
+/// Truncate the WAL mid-record so a *strict* replay fails but a good prefix
+/// remains — the exact shape of the incident.
+fn corrupt_wal_tail(wal: &Path) {
+    let len = std::fs::metadata(wal).unwrap().len();
+    assert!(len > 64, "WAL must be non-trivial to corrupt: {len} bytes");
+    let f = std::fs::OpenOptions::new().write(true).open(wal).unwrap();
+    f.set_len(len - 41).unwrap();
+    f.sync_all().unwrap();
+}
+
+/// The core incident invariant: after a corrupt-WAL recovery salvages a good
+/// prefix, a SUBSEQUENT open must still see those records — never a reset to
+/// empty.
+#[test]
+fn recovered_prefix_is_durable_across_a_reopen_not_reset() {
+    // 1. Seed a store leaving records uncheckpointed in the WAL: fewer writes
+    //    than the auto-checkpoint interval (128), and skip the closing
+    //    checkpoint via mem::forget so the WAL still carries them.
+    let live = tempfile::tempdir().unwrap();
+    {
+        let mem = LibraryCognitiveMemory::open(live.path()).expect("open live store");
+        seed_facts(&mem, 0, 100);
+        std::mem::forget(mem); // unclean: no close, no final checkpoint
+    }
+    let wal = live.path().join(WAL_FILE);
+    assert!(
+        wal.exists(),
+        "seeded store must have a WAL at {}",
+        wal.display()
+    );
+
+    // 2. Snapshot the on-disk files and corrupt the WAL tail of the copy.
+    let crash = tempfile::tempdir().unwrap();
+    crash_snapshot(live.path(), crash.path());
+    corrupt_wal_tail(&crash.path().join(WAL_FILE));
+
+    // 3. First recovery open: the resilient path replays the good prefix.
+    let recovered = {
+        let mem = LibraryCognitiveMemory::open(crash.path())
+            .expect("recovery open must succeed, never crash on a corrupt WAL");
+        let c = total(&mem);
+        assert!(
+            c > 0,
+            "recovery must salvage the good prefix, not open empty (got {c})"
+        );
+        // Fold the survivors into the main DB so the next open needs no replay.
+        mem.checkpoint().expect("checkpoint after recovery");
+        c
+    };
+
+    // 4. SECOND open — the incident's fatal step. A store that just recovered
+    //    records must NOT be re-quarantined and reset to empty.
+    let mem = LibraryCognitiveMemory::open(crash.path())
+        .expect("second open of a recovered store must succeed");
+    let c = total(&mem);
+    assert!(
+        c > 0,
+        "DATA LOSS REGRESSION: a recovered store was reset to empty on reopen \
+         (had {recovered}, now {c})"
+    );
+    assert_eq!(
+        c, recovered,
+        "recovered record count must be stable across reopen (was {recovered}, now {c})"
+    );
+}
+
+/// Plain durability sanity, independent of corruption: explicitly checkpointed
+/// records must survive repeated clean reopens and never be silently reset.
+#[test]
+fn checkpointed_records_survive_repeated_reopens() {
+    let root = tempfile::tempdir().unwrap();
+
+    // Round 1: seed + checkpoint + close.
+    {
+        let mem = LibraryCognitiveMemory::open(root.path()).expect("open");
+        seed_facts(&mem, 0, 50);
+        mem.checkpoint().expect("checkpoint");
+    }
+
+    // Round 2: reopen, verify, add more, checkpoint, close.
+    let after_second;
+    {
+        let mem = LibraryCognitiveMemory::open(root.path()).expect("reopen");
+        assert_eq!(
+            total(&mem),
+            50,
+            "all checkpointed facts must survive the first reopen"
+        );
+        seed_facts(&mem, 50, 25);
+        mem.checkpoint().expect("checkpoint");
+        after_second = total(&mem);
+        assert_eq!(after_second, 75);
+    }
+
+    // Round 3: reopen again — nothing may be silently reset.
+    {
+        let mem = LibraryCognitiveMemory::open(root.path()).expect("reopen 2");
+        assert_eq!(
+            total(&mem),
+            after_second,
+            "records must be stable across a third reopen, never reset"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the P0 cognitive-memory data-loss reliability gap from the **2026-07-04 00:16** production incident (issue #2550): a corrupt lbug WAL triggered a prefix-recovery that salvaged **40,488 records**, the **checkpoint-after-recovery failed**, a later open **reset the store to empty** (~20,480 → 128), and there was **no restore path** because periodic snapshots held only facts + procedures.

This PR closes every link in that chain with four fixes and locks each with a no-sleep/no-network regression test.

## The four fixes

### 1. Durable WAL recovery — locked by a boundary regression test
The recovery/reset logic lives in `amplihack-memory-lib` (`LbugGraphStore::open_with_recovery`). That durable recovery landed in `amplihack-memory-lib` PR #110 and is on the currently pinned rev (`3c9d956a`, see the dependency section below): it quarantines the corrupt WAL **before** the resilient open (copied aside, never deleted), replays the good prefix, checkpoints, and — critically — **keeps** the recovered store even if that checkpoint fails. A reset (`RebuiltAfterCorruption`) only happens for a genuinely corrupt **main DB** with **zero** recovered records, and it **moves the store aside** rather than deleting it.

`tests/wal_recovery_durability_2550.rs` pins that contract at the Simard boundary (`LibraryCognitiveMemory::open`): a store that recovered a good prefix survives a **re-open** and is never reset. No dependency change was needed for recovery itself.

### 2. Restore path — `simard memory import` + startup auto-restore
- **`simard memory import <snapshot.json> [state-root] [--json]`** ingests a `cognitive_snapshot.json` back into the store. **Idempotent** — dedups by content, safe to re-run and safe onto a partially-populated store. Refuses to run while the daemon holds the store lock.
- **Daemon startup auto-restore** (`memory_backup::auto_restore_if_empty`, wired in `daemon/mod.rs` **before** bootstrap seeding): if the live store is empty **and** a newer non-empty snapshot exists, it restores from the newest good snapshot and logs it, so a corruption-reset self-heals.

### 3. Complete snapshots
`export_full_memory_snapshot` now returns a `FullMemorySnapshot` covering **episodes** and **prospective/triggers** alongside facts + procedures, via new `CognitiveMemoryOps::list_all_episodes` / `list_all_prospective` enumerators. The prospective enumerator is backed by a new **read-only** `amplihack-memory::get_all_prospective` (the only prior reader, `check_triggers`, mutates status). `restore_from_backup` and the import path restore all types. `MemorySnapshot` is unchanged (legacy bare snapshots still load; `FullMemorySnapshot` is a serde superset).

### 4. Preserve recovery assets
`cmd_cleanup` widens the corrupt-quarantine age window (7 → 30 days, matching backup retention) and **never sweeps the largest substantial quarantine** (the recovery asset) via the age / keep-last-N caps. Trivial quarantines below a 1 MiB floor are still reclaimed normally, so the existing anti-bloat contract holds.

## Cross-repo dependency bump (durable, on `main`)
`amplihack-memory` is pinned to **`3c9d956a`**, the squash-merge of [amplihack-memory-lib PR #111](https://github.com/rysweet/amplihack-memory-lib/pull/111) (the read-only `get_all_prospective` enumerator) **on `main`**, whose parent is the squash-merge of PR #110 (durable corrupt-WAL open recovery) — so both the recovery fix and the enumerator are on `main`. No lbug/engine change; store format stays v41. cargo-deny stays green (same allow-listed git source; only the rev changes).

**Durability note:** an earlier revision of this branch pinned the PR-branch tip `e36b1761` (a `main+1` commit that lived only on #111's branch). That would have broken Simard `main` builds once #111's branch was deleted post-merge (cargo could no longer fetch a GC-able ref). It has been re-pinned to the durable on-`main` commit `3c9d956a`, whose source tree is **byte-identical** to `e36b1761` (verified: empty tree-diff), so the previously CI-validated behavior is unchanged.

## Tests (no sleeps, no network — fakes + temp dirs)
- `tests/wal_recovery_durability_2550.rs` — recovered prefix durable across a re-open (not reset).
- `tests/memory_import_roundtrip_2550.rs` — `memory import` round-trips a snapshot; idempotent by content; help documents `import`.
- `tests/memory_auto_restore_2550.rs` — startup auto-restore fires on empty store + newer snapshot; no-op when populated / no snapshot.
- `tests/memory_snapshot_completeness_2550.rs` — export includes episodes + prospective.
- Unit: full-snapshot export→import round-trips all types + idempotent; `cmd_cleanup` preserves the largest recovery asset; lib `get_all_prospective` (all statuses, no mutation).

Full `cargo test --lib` (6660+), affected integration suites, `cargo fmt --check`, and `cargo clippy --all-targets --all-features --locked -D warnings` all green. Pre-commit + pre-push gates pass (no `--no-verify`).

## Operator docs
New [WAL recovery runbook](docs/operations/cognitive-memory-wal-recovery-runbook.md) (detect → preserve assets → import → verify) plus updated durability / verified-backups / CLI references.

## Not done (by policy)
Live daemon and `~/.simard` untouched; no redeploy. Recovery snapshots remain preserved separately at `~/simard-memory-recovery/`.

Closes #2550


---

## Merge readiness

- Platform: GitHub · PR #2559 · `feat/issue-2550-...` → `main`
- Current head revision: `604b87fe` (re-pin `45265743` → perf `c7efa5a9` → QA scenario `604b87fe`)

### 1. QA-team evidence

- Scenario file: [`tests/qa-scenarios/cognitive-memory-wal-recovery-durability.yaml`](tests/qa-scenarios/cognitive-memory-wal-recovery-durability.yaml) — an outside-in `app_type: cli` scenario covering all four #2550 durability contracts (durable WAL prefix recovery, idempotent `memory import` restore, startup auto-restore self-heal, complete snapshots), each driven through a hermetic regression test (temp dirs, injected WAL-tail corruption, no sleeps, no network).
- `gadugi-test validate -f tests/qa-scenarios/cognitive-memory-wal-recovery-durability.yaml` → **valid** (`✓ Scenario "cognitive-memory-wal-recovery-durability" is valid`).
- `gadugi-test run -d tests/qa-scenarios -s cognitive-memory-wal-recovery-durability` → **passed** on local env:

  ```
  ✓ Passed: 1   ✗ Failed: 0   - Total: 1
  wal_recovery_durability_2550     : 2 passed  (recovered prefix durable across re-open; checkpointed records survive repeated reopens)
  memory_import_roundtrip_2550     : 3 passed  (ingest; idempotent by content; help documents import)
  memory_auto_restore_2550         : 3 passed  (fires on empty+newer snapshot; no-op when populated; no-op when no snapshot)
  memory_snapshot_completeness_2550: 1 passed  (export includes episodes + prospective)
  ```
  Run target: local (`cargo test` binaries via the CLI scenario runner). 9/9 test cases green.

### 2. Documentation

- User-facing docs impact: **yes** — new `simard memory import` CLI + operator recovery procedure.
- Updated: new [WAL recovery runbook](docs/operations/cognitive-memory-wal-recovery-runbook.md); updated [cognitive-memory durability](docs/operations/cognitive-memory-durability.md), [verified backups](docs/operations/verified-backups.md), [simard CLI](docs/reference/simard-cli.md), [simard memory CLI](docs/reference/simard-memory-cli.md); `docs/operations/index.md` + `mkdocs.yml` nav.

### 3. Quality-audit — 3 SEEK → VALIDATE → FIX cycles, ended clean

- **Cycle 1 (SEEK):** independent high-signal code-review over the full `origin/main...HEAD` diff (traced semantics into the pinned `amplihack-memory` enumerators, `query_nodes`, `get_memory_stats`, snapshot serde superset, cleanup protection) plus a dependency-durability review.
  **VALIDATE/FIX:** found the cross-repo pin pointed at an **unmerged PR-branch tip** (`e36b1761`, memory-lib #111) — a supply-chain durability regression that would break `main` builds after branch deletion. **Fixed** by re-pinning to the durable on-`main` squash commit `3c9d956a` (byte-identical tree) — commit `45265743` (Cargo.lock touches only the amplihack-memory source line; no unrelated churn). Also corrected stale dependency SHAs in this description (`26d49bf`/`38af5bf` → `3c9d956a`).
- **Cycle 2 (SEEK):** re-review on the durable pin.
  **VALIDATE:** `cargo build --locked`, the four #2550 suites, `cargo fmt --check`, and `cargo clippy --all-targets --all-features --locked -D warnings` all green on `3c9d956a`. Triaged two remaining findings, both rooted in **library** behavior (not this diff):
  - *auto-restore treats a swallowed empty-read as authoritative empty* → potential **duplication** (never loss) in a very narrow startup window, already mitigated by memory-lib #107's `ensure_schema_loaded`. A Simard-side filesystem heuristic was rejected as unsafe (it could wrongly block the exact #2550 self-heal after a reset). Correct fix is library-side error propagation → tracked in **#2561**. Re-assessed **Low** (recoverable impact × very-low likelihood).
  - *restored prospectives are re-created `pending`*, re-arming resolved/triggered goals → **Low**; needs a library status-preserving API → tracked in **#2562**.
- **Cycle 3 (SEEK):** final pass — confirmed **zero critical/high and zero medium correctness/security** findings remain in this diff; the two residuals are Low and tracked; diff is focused; docs accurate.
- **Final clean cycle: Cycle 3.** Areas explicitly verified sound: `auto_restore_if_empty` never restores over live data / never deletes and is correctly ordered before seeding; `newest_nonempty_snapshot` skips corrupt/empty tips and propagates real read errors; `FullMemorySnapshot` is a genuine backward-compatible serde superset; `u32::MAX` enumeration limits are safe (plain Cypher `LIMIT`, no over-allocation); `cmd_cleanup` largest-quarantine protection has no off-by-one and the 1 MiB floor composes correctly; `simard memory import` dedup + daemon-lock refusal are correct.

### 4. CI — 100% green

- Evidence source: `gh pr checks 2559`. All required checks were green on the prior head and are re-running on `604b87fe`: [Actions run](https://github.com/rysweet/Simard/actions/runs/28695641598). (Merge is gated on the current head being green via `simard merge-pr`.)

### 6. Scope

- 25 changed files, all within the #2550 memory/WAL/snapshot surface: `src/memory_backup/`, `src/remote_transfer/`, `src/cognitive_memory/`, `src/operator_cli/memory.rs`, `src/operator_commands_ooda/daemon/mod.rs`, `src/cmd_cleanup/`, the four `tests/*_2550.rs` suites + the QA scenario, the operator docs, and the `Cargo.toml`/`Cargo.lock` dependency pin. **No unrelated edits.**

### Verdict

**Ready to merge** once CI is green on `604b87fe`: QA scenario validated + run green (9/9), docs updated, three quality-audit cycles ended clean (zero critical/high, zero medium correctness/security; two Low residuals tracked in #2561/#2562), the dependency pin is durable on `main`, and the diff is focused.

Follow-ups: #2561 (auto-restore confirmed-empty signal), #2562 (preserve prospective status on restore).
