### PR TITLE
fix(deps): bump amplihack-memory to durable corrupt-WAL recovery fix (#2550)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=26d49bf864ac2c03b80c4ab075c4a907c51f82a8#26d49bf864ac2c03b80c4ab075c4a907c51f82a8"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=88893a93c897541abbccfb24ced224c5e28f3121#88893a93c897541abbccfb24ced224c5e28f3121"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,10 +51,14 @@ path = "src/bin/simard_tui/main.rs"
 # `lbug = "=0.17.1"` crate.
 #
 # Pinned to the amplihack-memory-lib commit that carries the lbug 0.15.4 -> 0.17.1
-# engine migration AND the issue #107 silent-empty-read fix (the `_deleted`
-# tombstone read-path fix + the empty-read safety gate). This rev is the
-# squash-merge commit of amplihack-memory-lib PR #108 on `main`.
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "26d49bf864ac2c03b80c4ab075c4a907c51f82a8", features = ["persistent"] }
+# engine migration, the issue #107 silent-empty-read fix (the `_deleted`
+# tombstone read-path fix + the empty-read safety gate), AND the issue #2550
+# durable corrupt-WAL open recovery fix — a failed checkpoint-after-recovery now
+# salvages the recovered graph into a fresh, strict-reopen-verified database
+# instead of leaving records only in the quarantined WAL (which a later open reset
+# to empty, permanently dropping tens of thousands of memories). This rev is the
+# squash-merge commit of amplihack-memory-lib PR #110 on `main`.
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "88893a93c897541abbccfb24ced224c5e28f3121", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream


### PR DESCRIPTION
## Summary

Bumps Simard's pinned `amplihack-memory` git rev from `26d49bf` → **`88893a9`** (squash-merge of [amplihack-memory-lib PR #110](https://github.com/rysweet/amplihack-memory-lib/pull/110)) so the cognitive-memory store links the **durable corrupt-WAL open recovery** fix for the verified P0 data-loss incident (#2550).

The recovery/data-loss code lives in `amplihack-memory-lib` (`LbugGraphStore`), which Simard consumes as a pinned git dependency; this PR is the required dependency-pin bump that lands the fix in Simard's build.

## What the bumped commit fixes (#2550)

Verified production incident: the cognitive store's WAL corrupted on open (`Assertion failed … wal/wal_record.cpp:76`). Recovery replayed the good prefix and attempted a `CHECKPOINT` to fold it into the main DB file — but the **checkpoint-after-recovery failed** and the error was swallowed, so the recovered records lived only in the now-quarantined WAL. A later open read the pre-recovery (near-empty) main file and **reset the store to empty**, permanently dropping ~20,480 memories to 128 with no restore path.

The bumped `amplihack-memory` makes recovery **durable-or-salvaged**:
- On a failed checkpoint-after-recovery, the recovered graph is dumped from the still-open resilient store and **salvaged into a fresh, clean database whose durability is verified by a strict reopen** (quarantine the un-checkpointable original → reload nodes+edges → checkpoint → strict-reopen-verify). The pre-corruption prefix survives.
- `rebuild_after_corruption` performs a sealed **read-only salvage** of any still-readable records before resetting to empty — a store that still holds recoverable records is never reset.
- Partial reloads are surfaced at error level with node+edge counts; `recovered_records` is the strict-reopen-verified count.

Full detail, tests, and the blocking CI data-loss gate are in amplihack-memory-lib PR #110.

## Verification

- **`cargo build --locked` green** with the new rev (`amplihack-memory v0.4.0 … #88893a93`).
- Diff is **focused**: only the `amplihack-memory` pin in `Cargo.toml` (+ its comment) and the single corresponding `source` line in `Cargo.lock` — no unrelated lockfile churn.
- Pre-commit (Rust-only gate, `cargo fmt --check`, `cargo clippy --release -- -D warnings`) and the pre-push race-catching test subset pass locally.

Closes #2550.