### PR TITLE
test(merge-judge): pin real recipe-runner wire format for verdict capture (#2501, #2555)

### DIFF
--- a/docs/howto/diagnose-merge-pr-verdict-parse-failures.md
+++ b/docs/howto/diagnose-merge-pr-verdict-parse-failures.md
@@ -1,7 +1,7 @@
 ---
 title: Diagnose simard merge-pr verdict-parse failures
 description: Operator runbook for the gated merge path. simard merge-pr now surfaces a real verdict via the JSON envelope and fails closed to unclear (refused) when no verdict parses. Explains how to tell a real not_ready/unclear verdict from an infra error or a genuine not-ready PR, and why never to coerce unclear/empty into ready.
-last_updated: 2026-06-28
+last_updated: 2026-07-04
 review_schedule: as-needed
 owner: simard
 doc_type: howto
@@ -30,7 +30,9 @@ the PR and returns one verdict: `ready`, `not_ready`, or `unclear`.
 > [#2430](https://github.com/rysweet/Simard/issues/2430) /
 > [#2435](https://github.com/rysweet/Simard/issues/2435) /
 > [#2462](https://github.com/rysweet/Simard/issues/2462) /
-> [#2463](https://github.com/rysweet/Simard/issues/2463)).** `RecipeMergeJudge::judge`
+> [#2463](https://github.com/rysweet/Simard/issues/2463) /
+> [#2501](https://github.com/rysweet/Simard/issues/2501) /
+> [#2555](https://github.com/rysweet/Simard/issues/2555)).** `RecipeMergeJudge::judge`
 > (`src/stewardship/recipe_merge_judge.rs`) invokes `recipe-runner-rs` with
 > `--output-format json`, extracts the agent verdict from the envelope, runs the
 > shared escalation ladder on a parse-miss, and **fails closed to `unclear`**
@@ -40,6 +42,17 @@ the PR and returns one verdict: `ready`, `not_ready`, or `unclear`.
 > verdict (or a fail-closed `unclear`, or an explicit infra error) on every run.
 > See
 > [Recipe-brain verdict/decision parsing](../reference/recipe-brain-verdict-parsing.md#merge-judge-phase-2462).
+>
+> **The real agent wire format is regression-pinned** ([#2501](https://github.com/rysweet/Simard/issues/2501)
+> / [#2555](https://github.com/rysweet/Simard/issues/2555), duplicates of the
+> above). `recipe-runner-rs 0.3.6 --output-format json --agent-binary copilot`
+> captures the agent's stdout into `step_results[].output` with the GitHub
+> Copilot CLI launcher preamble line (`ℹ … NODE_OPTIONS=… (saved preference)…`)
+> **prepended** to the verdict. The shared noise stripper drops that preamble
+> and the balanced-JSON scan reads past it, so the verdict still parses. The
+> `issue_2501_2555_real_envelope_tests` module and step (d)/(e) of
+> `tests/gadugi/merge-judge-verdict.sh` pin this end-to-end against the exact
+> live envelope so a regression cannot silently reintroduce the abort.
 
 ## Step 1: Read the verdict
 

--- a/src/stewardship/recipe_merge_judge.rs
+++ b/src/stewardship/recipe_merge_judge.rs
@@ -802,3 +802,185 @@ mod issue_2428_production_tests {
         );
     }
 }
+
+// =====================================================================
+// issue_2501_2555_real_envelope_tests — the REAL recipe-runner wire format.
+//
+// #2501 and #2555 are duplicates of the #2428/#2496 verdict-capture family:
+// `simard merge-pr` aborted with
+//   `no verdict keyword (ready/not_ready/unclear) found in recipe output;
+//    raw="Recipe: merge-readiness-judge … SUCCESS …"`
+// The root cause (agent-step stdout not surfaced to the verdict extractor —
+// only the text-mode SUCCESS banner) was fixed by the `--output-format json`
+// transport (#2486) and the shared launcher-preamble strip (#2496/#2504); the
+// residual sightings were a STALE deployed binary.
+//
+// The modules above pin the parse composition with an INLINE envelope mirror
+// (`extract_final_step_output`) and synthetic clean step outputs. This module
+// closes the remaining gap: it drives the PRODUCTION
+// `extract_recipe_decision_output` on the EXACT `recipe-runner-rs 0.3.6
+// --output-format json --agent-binary copilot` envelope — where the GitHub
+// Copilot CLI launcher preamble line (`ℹ … NODE_OPTIONS=… (saved preference)…`)
+// is PREPENDED to the verdict inside the agent step's `output` — and then runs
+// the production `parse_merge_outcome`, so the whole capture → strip → parse
+// path is validated end-to-end against the real wire format that produced the
+// bug reports. Captured live: see `tests/gadugi/merge-judge-verdict.sh` step (d).
+// =====================================================================
+#[cfg(test)]
+mod issue_2501_2555_real_envelope_tests {
+    use super::*;
+    use crate::ooda_brain::LifecycleParseOutcome;
+
+    /// The GitHub Copilot CLI launcher preamble line the agent binary prints to
+    /// stdout *before* its real answer. Captured verbatim from a live
+    /// `recipe-runner-rs --output-format json --agent-binary copilot` run; it
+    /// lands inside the agent step's `output` field, ahead of the verdict.
+    const LAUNCHER_PREAMBLE: &str = "ℹ NODE_OPTIONS=--max-old-space-size=32768 (saved preference). \
+         To change: /home/azureuser/.amplihack/config";
+
+    /// Build a real `recipe-runner-rs 0.3.6` JSON envelope whose single agent
+    /// step's `output` is `agent_stdout` (the launcher preamble + whatever the
+    /// judge emitted). Mirrors the exact shape observed live.
+    fn real_envelope(agent_stdout: &str) -> Vec<u8> {
+        let envelope = serde_json::json!({
+            "recipe_name": "merge-readiness-judge",
+            "success": true,
+            "step_results": [{
+                "step_id": "judge-merge-readiness",
+                "status": "completed",
+                "output": agent_stdout,
+                "error": "",
+                "duration": 32.0
+            }],
+            "context": { "judge_result": agent_stdout },
+            "duration": 32.0
+        });
+        serde_json::to_vec(&envelope).expect("envelope serialises")
+    }
+
+    #[test]
+    fn real_copilot_envelope_recovers_ready_verdict() {
+        // The exact #2501/#2555 scenario, now proven to recover a verdict: the
+        // launcher preamble is prepended to a bare `{"verdict":"ready",…}` JSON
+        // inside the agent step output. The production extractor must surface
+        // that output and `parse_merge_outcome` must recover a REAL `ready`
+        // (Parsed) — NOT the fail-closed `unclear`, and NEVER the old
+        // "no verdict keyword" abort.
+        let agent_stdout = format!(
+            "{LAUNCHER_PREAMBLE}\n\
+             {{\"verdict\": \"ready\", \"rationale\": \"All six skill criteria present and substantive.\"}}"
+        );
+        let stdout = real_envelope(&agent_stdout);
+
+        let extracted = extract_recipe_decision_output(&stdout, ADAPTER_TAG)
+            .expect("production extractor must decode the real 0.3.6 envelope");
+        assert!(
+            extracted.contains("\"verdict\""),
+            "extracted agent output must carry the verdict JSON, not the banner: {extracted:?}"
+        );
+
+        let (outcome, parse) = parse_merge_outcome(&extracted);
+        assert_eq!(
+            outcome.verdict,
+            Verdict::Ready,
+            "the preamble-prefixed verdict JSON must parse as ready"
+        );
+        assert_eq!(parse, LifecycleParseOutcome::Parsed);
+        assert!(
+            !parse.is_parse_failure(),
+            "a real verdict was recovered — this must NOT count as a parse failure"
+        );
+    }
+
+    #[test]
+    fn real_copilot_envelope_recovers_not_ready_with_blockers() {
+        // Same wire format, `not_ready` with a structured blocker: the blocker
+        // must survive extraction + parse (operators act on it).
+        let agent_stdout = format!(
+            "{LAUNCHER_PREAMBLE}\n\
+             {{\"verdict\": \"not_ready\", \"rationale\": \"Quality-audit section is one line.\", \
+             \"blockers\": [{{\"section\": \"Quality-audit\", \"severity\": \"high\", \
+             \"observation\": \"No SEEK/VALIDATE/FIX cycle counts.\", \"fix\": \"Run three cycles.\"}}]}}"
+        );
+        let stdout = real_envelope(&agent_stdout);
+
+        let extracted = extract_recipe_decision_output(&stdout, ADAPTER_TAG).unwrap();
+        let (outcome, parse) = parse_merge_outcome(&extracted);
+        assert_eq!(outcome.verdict, Verdict::NotReady);
+        assert_eq!(
+            outcome.blockers.len(),
+            1,
+            "blocker must survive the real wire format"
+        );
+        assert_eq!(outcome.blockers[0].section, "Quality-audit");
+        assert_eq!(parse, LifecycleParseOutcome::Parsed);
+    }
+
+    #[test]
+    fn real_copilot_envelope_prose_verdict_falls_back_to_keyword() {
+        // The judge sometimes answers in prose. The launcher preamble must be
+        // stripped (it is not a verdict) and the keyword fallback must surface
+        // the real `ready` — proving the preamble never masks a prose verdict.
+        let agent_stdout = format!(
+            "{LAUNCHER_PREAMBLE}\n\
+             After reviewing all six sections I find this PR ready to merge."
+        );
+        let stdout = real_envelope(&agent_stdout);
+
+        let extracted = extract_recipe_decision_output(&stdout, ADAPTER_TAG).unwrap();
+        let (outcome, parse) = parse_merge_outcome(&extracted);
+        assert_eq!(outcome.verdict, Verdict::Ready);
+        assert_eq!(parse, LifecycleParseOutcome::Parsed);
+        assert!(
+            !outcome.rationale.contains("NODE_OPTIONS"),
+            "the launcher preamble must be stripped from the rationale: {}",
+            outcome.rationale
+        );
+    }
+
+    #[test]
+    fn real_copilot_envelope_preamble_only_fails_closed_never_ready() {
+        // Defence-in-depth: if the agent emits ONLY the launcher preamble (no
+        // verdict at all), the preamble must NOT be mined as a `ready` — the
+        // judge must fail CLOSED to `unclear` (a parse failure), so a stripped
+        // banner can never fabricate a merge authorisation.
+        let stdout = real_envelope(LAUNCHER_PREAMBLE);
+
+        let extracted = extract_recipe_decision_output(&stdout, ADAPTER_TAG).unwrap();
+        let (outcome, parse) = parse_merge_outcome(&extracted);
+        assert_eq!(
+            outcome.verdict,
+            Verdict::Unclear,
+            "preamble-only output must fail closed to unclear, never a false ready"
+        );
+        assert!(
+            parse.is_parse_failure(),
+            "preamble-only is a parse-miss (fail-closed), not a real verdict"
+        );
+        assert!(
+            outcome.rationale.contains("failing closed"),
+            "fail-closed rationale must name the miss: {}",
+            outcome.rationale
+        );
+    }
+
+    #[test]
+    fn text_mode_banner_bytes_are_a_loud_infra_error_not_a_silent_default() {
+        // If a STALE runner (or a missing `--output-format json`) ever feeds the
+        // text-mode SUCCESS banner in as the envelope bytes, the production
+        // extractor must fail LOUDLY (the banner is not a JSON envelope) rather
+        // than silently returning it for the keyword scanner — which is exactly
+        // how the original `no verdict keyword; raw="Recipe: … SUCCESS"` abort
+        // arose. This keeps a stale-binary environment diagnosable as infra.
+        let banner = b"Recipe: merge-readiness-judge (v1.0.0)\nSteps: 1\n\n\
+                       Recipe 'merge-readiness-judge': SUCCESS (32.0s)\n  \
+                       [completed] judge-merge-readiness (32.0s)\n\n";
+        let err = extract_recipe_decision_output(banner, ADAPTER_TAG)
+            .expect_err("the text-mode banner is not a decodable JSON envelope");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("deserialize") || msg.contains("recipe-merge-judge"),
+            "a stale-runner text banner must surface as a loud decode error: {msg}"
+        );
+    }
+}

--- a/tests/gadugi/merge-judge-verdict.sh
+++ b/tests/gadugi/merge-judge-verdict.sh
@@ -22,6 +22,16 @@
 # via `cargo test` (issue_2428_tests) so the JSON-envelope verdict extraction,
 # prose keyword fallback, and the empty-output fail-closed contract are all
 # validated end-to-end.
+#
+# Steps (d)/(e) extend this to the REAL agent wire format reported in
+# #2501 / #2555 (duplicates of the above): the GitHub Copilot CLI launcher
+# prints a preamble line (`ℹ … NODE_OPTIONS=… (saved preference)…`) to stdout
+# BEFORE the agent answer, so recipe-runner captures it into
+# step_results[].output PREPENDED to the verdict JSON. (d) reproduces that exact
+# shape deterministically (no LLM) and proves json mode still surfaces a
+# parseable `ready`; (e) runs the in-tree production-path regression module
+# (issue_2501_2555_real_envelope_tests) that drives the real
+# `extract_recipe_decision_output` on the same preamble-bearing envelope.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -104,4 +114,57 @@ grep -qF 'issue_2428_tests::empty_final_step_output_fails_closed' "$TEST_LOG" \
   || { echo "FAIL: the fail-closed contract test did not run" >&2; exit 1; }
 echo "OK: JSON-envelope verdict extraction + fail-closed contract pass (${PASSED} tests)."
 
-echo "PASS: merge-judge-verdict scenario (#2428/#2430/#2435/#2462/#2463)"
+# --- (d) REAL agent wire format (#2501/#2555): launcher preamble + verdict -----
+# recipe-runner captures the Copilot launcher preamble into step_results[].output
+# ahead of the verdict JSON. Reproduce that exact shape (no LLM) and prove the
+# verdict is still surfaced and parses to `ready` — the preamble must not shadow
+# the real answer, and the merge must NOT abort with "no verdict keyword".
+echo "== (d) real agent wire format: launcher preamble + verdict JSON =="
+PREAMBLE='ℹ NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: /home/azureuser/.amplihack/config'
+RECIPE_D="$WORK/merge-judge-preamble.yaml"
+cat > "$RECIPE_D" <<EOF
+name: "merge-judge-preamble-2501"
+description: "deterministic real-wire-format fixture: launcher preamble + verdict (no LLM)"
+version: "1.0.0"
+context: {}
+steps:
+  - id: "judge-merge-readiness"
+    type: "bash"
+    command: |
+      printf '%s\n%s\n' '${PREAMBLE}' '${VERDICT_JSON}'
+    output: "judge_result"
+EOF
+JSON_OUT_D="$(recipe-runner-rs "$RECIPE_D" --output-format json 2>/dev/null)"
+printf '%s' "$JSON_OUT_D" | jq -e '.success == true' >/dev/null \
+  || { echo "FAIL: preamble fixture did not report success in json mode" >&2; exit 1; }
+STEP_OUTPUT_D="$(printf '%s' "$JSON_OUT_D" | jq -r '.step_results | last | .output')"
+echo "json-mode final step output (with preamble):"
+printf '%s\n' "$STEP_OUTPUT_D"
+# The captured output must carry BOTH the launcher preamble AND the verdict JSON.
+printf '%s' "$STEP_OUTPUT_D" | grep -qF 'NODE_OPTIONS=' \
+  || { echo "FAIL: expected the launcher preamble in the captured step output" >&2; exit 1; }
+printf '%s' "$STEP_OUTPUT_D" | grep -qF '"verdict"' \
+  || { echo "FAIL: verdict JSON missing from the preamble-prefixed step output" >&2; exit 1; }
+# The verdict (last line) must still parse to `ready` despite the leading preamble.
+VERDICT_D="$(printf '%s\n' "$STEP_OUTPUT_D" | tail -1 | jq -r '.verdict')"
+echo "parsed verdict (past preamble): ${VERDICT_D}"
+[ "$VERDICT_D" = "ready" ] \
+  || { echo "FAIL: verdict past the launcher preamble is not the expected 'ready'" >&2; exit 1; }
+echo "OK: json mode surfaces a parseable verdict even behind the launcher preamble."
+
+# --- (e) in-tree production-path regression on the real 0.3.6 envelope ---------
+echo "== (e) production extractor on the real 0.3.6 envelope (#2501/#2555) =="
+TEST_LOG_E="$WORK/issue-2501-cargo-test.log"
+cargo test --lib --locked issue_2501_2555_real_envelope_tests -- --nocapture >"$TEST_LOG_E" 2>&1
+PASSED_E="$(grep -oE 'test result: ok\. [0-9]+ passed' "$TEST_LOG_E" | grep -oE '[0-9]+' | head -1)"
+PASSED_E="${PASSED_E:-0}"
+echo "issue_2501/2555 real-envelope tests passed: ${PASSED_E}"
+[ "$PASSED_E" -ge 1 ] \
+  || { echo "FAIL: issue_2501_2555_real_envelope_tests matched zero tests (module renamed?)" >&2; cat "$TEST_LOG_E" >&2; exit 1; }
+grep -qF 'real_copilot_envelope_recovers_ready_verdict' "$TEST_LOG_E" \
+  || { echo "FAIL: the real-envelope ready-verdict test did not run" >&2; exit 1; }
+grep -qF 'real_copilot_envelope_preamble_only_fails_closed_never_ready' "$TEST_LOG_E" \
+  || { echo "FAIL: the preamble-only fail-closed test did not run" >&2; exit 1; }
+echo "OK: production extractor recovers a verdict from the real preamble-bearing envelope."
+
+echo "PASS: merge-judge-verdict scenario (#2428/#2430/#2435/#2462/#2463, #2501/#2555)"

--- a/tests/gadugi/merge-judge-verdict.yaml
+++ b/tests/gadugi/merge-judge-verdict.yaml
@@ -1,5 +1,5 @@
-name: "Merge-Judge Verdict Parse (#2428/#2430/#2435/#2462/#2463)"
-description: "Outside-in proof that simard merge-pr's recipe-backed merge-readiness judge surfaces a real structured verdict from recipe-runner-rs JSON output instead of parsing the text-mode SUCCESS banner (which carries no verdict keyword and blocks every gated merge). Reproduces the text-mode banner bug and validates the json-mode fix at the recipe-runner boundary (no LLM), then runs the in-tree verdict-extraction + fail-closed unit tests."
+name: "Merge-Judge Verdict Parse (#2428/#2430/#2435/#2462/#2463, #2501/#2555)"
+description: "Outside-in proof that simard merge-pr's recipe-backed merge-readiness judge surfaces a real structured verdict from recipe-runner-rs JSON output instead of parsing the text-mode SUCCESS banner (which carries no verdict keyword and blocks every gated merge). Reproduces the text-mode banner bug and validates the json-mode fix at the recipe-runner boundary (no LLM), reproduces the real Copilot-launcher-preamble agent wire format from #2501/#2555, then runs the in-tree verdict-extraction + fail-closed unit tests."
 version: "1.0.0"
 
 config:
@@ -52,6 +52,8 @@ metadata:
     - "issue-2428"
     - "issue-2462"
     - "issue-2463"
+    - "issue-2501"
+    - "issue-2555"
   priority: "high"
   author: "copilot"
   test_type: "outside-in"


### PR DESCRIPTION
## Summary

`simard merge-pr` was reported (**#2555**, **#2501** — duplicates) to abort at the
infrastructure level with:

```
recipe-merge-judge: no verdict keyword (ready/not_ready/unclear) found in recipe output;
raw="Recipe: merge-readiness-judge (v1.0.0)\nSteps: 1\n\nRecipe 'merge-readiness-judge': SUCCESS (32.0s)\n  [completed] judge-merge-readiness (32.0s)\n\n"
```

**Root cause** — the agent step's stdout was never surfaced to the verdict
extractor; only the recipe-runner **text-mode SUCCESS banner** was parsed, which
contains `readiness` (not `ready`), so no verdict keyword matched and every gated
merge aborted. This was **already fixed** on `main` by:

- **#2486** — `RecipeMergeJudge::judge` now invokes `recipe-runner-rs --output-format json`
  and pulls the agent verdict from the JSON envelope (`extract_recipe_decision_output`).
- **#2496 / #2504** — the shared noise stripper drops the GitHub Copilot CLI launcher
  preamble line so it can't shadow the verdict.

The residual failures came from a **stale deployed binary** (`simard 0.22.0` vs repo
`0.24.0`); the diagnose runbook already predicts this "pre-fix binary" symptom.

### What this PR does

This PR is a **regression lock + dedupe** for the real wire format (no production
code change — the capture fix already shipped):

1. **Ground-truthed** the live wire format:
   `recipe-runner-rs 0.3.6 --output-format json --agent-binary copilot` captures the
   agent stdout into `step_results[].output` with the launcher preamble
   (`ℹ … NODE_OPTIONS=… (saved preference)…`) **prepended** to the verdict JSON.
2. Added `issue_2501_2555_real_envelope_tests` driving the **production**
   `extract_recipe_decision_output` + `parse_merge_outcome` on that exact envelope.
3. Extended the outside-in gadugi scenario to reproduce the preamble wire format
   deterministically (no LLM) and run the new module.
4. Documented the handling + regression pin in the diagnose howto.
5. Dedupes the two reports.

Closes #2501. #2555 is closed separately as a duplicate.

---

## Merge-ready evidence

### 1. qa-team scenarios (`gadugi-test`)

Extended `tests/gadugi/merge-judge-verdict.yaml` / `.sh` with steps **(d)** and **(e)**.

- **Validate:** `gadugi-test validate -f tests/gadugi/merge-judge-verdict.yaml`
  → `✓ Scenario "Merge-Judge Verdict Parse (#2428/#2430/#2435/#2462/#2463, #2501/#2555)" is valid`
- **Run:** `bash tests/gadugi/merge-judge-verdict.sh` →
  ```
  == (d) real agent wire format: launcher preamble + verdict JSON ==
  parsed verdict (past preamble): ready
  OK: json mode surfaces a parseable verdict even behind the launcher preamble.
  == (e) production extractor on the real 0.3.6 envelope (#2501/#2555) ==
  issue_2501/2555 real-envelope tests passed: 5
  PASS: merge-judge-verdict scenario (#2428/#2430/#2435/#2462/#2463, #2501/#2555)
  ```

### 2. Documentation

`docs/howto/diagnose-merge-pr-verdict-parse-failures.md` updated: the #2501/#2555
duplicates are added to the fixed-issue list, and a new callout documents the real
Copilot launcher-preamble wire format and the regression pin. No user-facing CLI
surface changed.

### 3. Quality-audit (SEEK → VALIDATE → FIX)

- **Cycle 1 — SEEK:** confirmed the fix landed (#2486/#2496) and the reports are
  stale-binary sightings. **VALIDATE:** installed `simard` is `0.22.0` (< repo
  `0.24.0`); the text-banner error is unreachable from current code (it passes
  `--output-format json`). **FIX:** none needed in production; identified the real
  gap = no test exercises the *production* extractor on the *real* preamble-bearing
  envelope.
- **Cycle 2 — SEEK:** could the current code still mis-handle the real envelope?
  **VALIDATE:** captured the live 0.3.6 envelope; added tests through the production
  path — all green (ready / not_ready+blockers / prose-fallback / preamble-only
  fail-closed / banner-is-infra-error). **FIX:** added the 5-test module.
- **Cycle 3 — SEEK:** could the preamble fabricate a false `ready` or mask a prose
  verdict? **VALIDATE:** `preamble-only → unclear` (fail-closed) and
  `preamble+prose → ready with preamble stripped from rationale` both asserted.
  **FIX:** none. **Final cycle clean:** zero critical/high; zero medium
  correctness/security findings.

### 4. CI

Local mirrors of the CI gates, all green:
- `cargo fmt --all -- --check` → clean
- `cargo clippy --all-targets --all-features --locked -- -D warnings` → clean
- `cargo clippy --release --no-deps -- -D warnings` (pre-commit) → clean
- pre-push race subset `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)` → Passed
- `cargo test --lib recipe_merge_judge` → `36 passed; 0 failed`

### 6. Scope

Focused diff, 4 files (test + docs only), `+265 / -5`:
- `src/stewardship/recipe_merge_judge.rs` (new test module)
- `tests/gadugi/merge-judge-verdict.sh` / `.yaml` (steps d/e)
- `docs/howto/diagnose-merge-pr-verdict-parse-failures.md`

No unrelated edits; no production code change.
