### PR TITLE
fix(memory): preserve prospective status on snapshot restore (#2562)

### DIFF
--- a/docs/operations/cognitive-memory-durability.md
+++ b/docs/operations/cognitive-memory-durability.md
@@ -249,6 +249,13 @@ corruption-reset recoverable without a code harness:
   memories from … cognitive_snapshot.json` line, so a corruption-reset self-heals
   instead of losing everything.
 
+Both paths **preserve prospective status** across the restore (issue #2562): a
+trigger that was already `triggered` or `resolved` when the snapshot was taken is
+restored to a terminal, non-firing state rather than reset to `pending`, so an
+auto-restore or `simard memory import` can never re-fire a goal the daemon had
+already completed. Genuinely `pending` triggers restore as `pending` and stay
+eligible to fire.
+
 For a corruption incident (recover the pre-reset store, choose a snapshot, and
 run the import), follow the
 [Cognitive-Memory WAL Recovery Runbook](cognitive-memory-wal-recovery-runbook.md).

--- a/src/remote_transfer/mod.rs
+++ b/src/remote_transfer/mod.rs
@@ -239,11 +239,33 @@ pub fn export_full_memory_snapshot(
 /// counted). This is the restore/import counterpart of
 /// [`export_full_memory_snapshot`]; it is *not* deprecated (unlike the legacy
 /// [`import_memory_snapshot`] replication path, which does not dedup).
+///
+/// **Prospective status is preserved across the round-trip (issue #2562).**
+/// [`CognitiveMemoryOps::store_prospective`] always creates a fresh `"pending"`
+/// record, so a snapshot trigger that was already `"triggered"` or `"resolved"`
+/// would otherwise come back `"pending"` — and
+/// [`CognitiveMemoryOps::check_triggers`] would **re-fire a goal the daemon had
+/// already handled** after an auto-restore or `simard memory import`. To close
+/// that, any non-`pending` prospective is re-resolved to the terminal,
+/// non-firing `"resolved"` status immediately after it is written. Genuinely
+/// `pending` records restore as `pending` and stay eligible to fire. The
+/// library exposes no arbitrary status setter and `"resolved"` is the correct
+/// terminal state for both prior `"triggered"` and `"resolved"` records —
+/// neither should fire again on a recovery restore, where no in-flight action
+/// remains to resume.
+///
+/// Because the restore is idempotent, this also **self-heals** a store that a
+/// pre-#2562 restore left with a stale `"pending"` copy of an already-handled
+/// trigger: re-running the import resolves that pre-existing record when the
+/// snapshot marks the same `(trigger_condition, description)` as terminal.
+///
+/// [`CognitiveMemoryOps::store_prospective`]: crate::cognitive_memory::CognitiveMemoryOps::store_prospective
+/// [`CognitiveMemoryOps::check_triggers`]: crate::cognitive_memory::CognitiveMemoryOps::check_triggers
 pub fn import_full_snapshot(
     memory: &dyn CognitiveMemoryOps,
     snapshot: &FullMemorySnapshot,
 ) -> SimardResult<usize> {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     let mut imported = 0;
 
@@ -293,23 +315,63 @@ pub fn import_full_snapshot(
         }
     }
 
-    // Prospective: dedup by (trigger_condition, description).
-    let mut seen_pros: HashSet<(String, String)> = memory
+    // Prospective: dedup by (trigger_condition, description). Track each
+    // existing record's (node_id, status) — not just its key — so a snapshot
+    // record that is already terminal can also correct a *pre-existing* stale
+    // "pending" duplicate (e.g. a store left half-restored by the pre-#2562
+    // bug), keeping the restore idempotent with respect to status (issue #2562).
+    let mut seen_pros: HashMap<(String, String), (String, String)> = memory
         .list_all_prospective(u32::MAX)?
         .into_iter()
-        .map(|p| (p.trigger_condition, p.description))
+        .map(|p| ((p.trigger_condition, p.description), (p.node_id, p.status)))
         .collect();
     for pm in &snapshot.prospective {
         let key = (pm.trigger_condition.clone(), pm.description.clone());
-        if seen_pros.insert(key) {
-            memory.store_prospective(
-                &pm.description,
-                &pm.trigger_condition,
-                &pm.action_on_trigger,
-                pm.priority,
-            )?;
-            imported += 1;
+        // Any status other than "pending" is a trigger the daemon already
+        // handled; it must restore non-firing so `check_triggers` (which fires
+        // only "pending" records) cannot resurrect a completed goal.
+        let snapshot_is_terminal = !pm.status.eq_ignore_ascii_case("pending");
+
+        if let Some((existing_node_id, existing_status)) = seen_pros.get(&key) {
+            // Already present in the target. Only act on the stale-bug case:
+            // the snapshot marks this trigger as already-handled but the live
+            // record is still "pending". Resolve it so a re-run of the restore
+            // cannot leave a completed trigger eligible to re-fire. A live
+            // record that is already terminal is left untouched.
+            if snapshot_is_terminal && existing_status.eq_ignore_ascii_case("pending") {
+                memory.resolve_prospective(existing_node_id)?;
+            }
+            continue;
         }
+
+        let node_id = memory.store_prospective(
+            &pm.description,
+            &pm.trigger_condition,
+            &pm.action_on_trigger,
+            pm.priority,
+        )?;
+        // `store_prospective` always creates a "pending" record; re-resolve any
+        // non-pending snapshot record to the terminal, non-firing "resolved"
+        // status so a recovery restore cannot resurrect a completed trigger.
+        if snapshot_is_terminal {
+            memory.resolve_prospective(&node_id)?;
+        }
+        // Register the freshly written record so a later duplicate of this key
+        // within the same snapshot is treated as already-present (mirrors the
+        // dedup for the other memory types).
+        seen_pros.insert(
+            key,
+            (
+                node_id,
+                if snapshot_is_terminal {
+                    "resolved"
+                } else {
+                    "pending"
+                }
+                .to_string(),
+            ),
+        );
+        imported += 1;
     }
 
     Ok(imported)

--- a/src/remote_transfer/tests.rs
+++ b/src/remote_transfer/tests.rs
@@ -395,3 +395,214 @@ fn load_full_snapshot_from_file_reads_full_bare_and_enveloped_shapes() {
         "a corrupt snapshot file must error rather than yield an empty snapshot"
     );
 }
+
+/// Issue #2562: a prospective trigger that was already `resolved` when the
+/// snapshot was taken must restore as `resolved` — NOT `pending` — so an
+/// auto-restore / `simard memory import` can never re-fire a goal the daemon
+/// already completed via `check_triggers`. Pins the RESTORE side of the
+/// status-preservation contract documented on `import_full_snapshot`.
+#[test]
+fn restored_resolved_prospective_stays_resolved_so_completed_goal_does_not_refire() {
+    use crate::cognitive_memory::LibraryCognitiveMemory;
+
+    // Source store: create a prospective, then resolve it (a completed goal).
+    let source = LibraryCognitiveMemory::in_memory().unwrap();
+    let node_id = source
+        .store_prospective("ship the CLI", "deploy", "Pursue goal", 1)
+        .unwrap();
+    source.resolve_prospective(&node_id).unwrap();
+
+    // The snapshot must capture the terminal status verbatim (export side).
+    let snapshot = export_full_memory_snapshot(&source, "issue-2562").unwrap();
+    assert_eq!(snapshot.prospective.len(), 1);
+    assert_eq!(
+        snapshot.prospective[0].status, "resolved",
+        "export must capture the resolved status the source store holds"
+    );
+
+    // Restore into a fresh store.
+    let target = LibraryCognitiveMemory::in_memory().unwrap();
+    import_full_snapshot(&target, &snapshot).unwrap();
+
+    // The restored record must keep its resolved status (equals the snapshot),
+    // never regressing to pending.
+    let restored = target.list_all_prospective(u32::MAX).unwrap();
+    assert_eq!(restored.len(), 1, "the prospective must be restored");
+    assert_eq!(
+        restored[0].status, "resolved",
+        "restored status must equal the snapshotted status, not reset to pending"
+    );
+
+    // The behavioural guarantee: a completed trigger must not re-fire.
+    let fired = target
+        .check_triggers("please deploy the release now")
+        .unwrap();
+    assert!(
+        fired.is_empty(),
+        "a restored resolved trigger must not re-fire after restore (issue #2562)"
+    );
+}
+
+/// Issue #2562: a prospective captured as `triggered` (it fired but was not yet
+/// resolved) must not come back `pending` and re-fire on restore. It restores to
+/// a terminal, non-firing status so an auto-restore cannot resurrect an
+/// already-fired trigger.
+#[test]
+fn restored_triggered_prospective_does_not_come_back_pending_and_refire() {
+    use crate::cognitive_memory::LibraryCognitiveMemory;
+
+    let source = LibraryCognitiveMemory::in_memory().unwrap();
+    source
+        .store_prospective("ship the CLI", "deploy", "Pursue goal", 1)
+        .unwrap();
+    // Fire it: check_triggers moves the matched record to "triggered".
+    let fired = source.check_triggers("time to deploy").unwrap();
+    assert_eq!(fired.len(), 1, "the trigger must fire on the source store");
+
+    let snapshot = export_full_memory_snapshot(&source, "issue-2562").unwrap();
+    assert_eq!(snapshot.prospective.len(), 1);
+    assert_eq!(
+        snapshot.prospective[0].status, "triggered",
+        "export must capture the triggered status"
+    );
+
+    let target = LibraryCognitiveMemory::in_memory().unwrap();
+    import_full_snapshot(&target, &snapshot).unwrap();
+
+    let restored = target.list_all_prospective(u32::MAX).unwrap();
+    assert_eq!(restored.len(), 1);
+    assert_eq!(
+        restored[0].status, "resolved",
+        "a triggered trigger restores to the terminal, non-firing resolved \
+         status (the library has no arbitrary status setter) — never pending \
+         (issue #2562)"
+    );
+    let refired = target.check_triggers("time to deploy again").unwrap();
+    assert!(
+        refired.is_empty(),
+        "a restored already-fired trigger must not re-fire (issue #2562)"
+    );
+}
+
+/// Issue #2562 (guard): a genuinely `pending` prospective must still restore as
+/// `pending` and stay eligible to fire — the status-preservation fix must not
+/// blanket-resolve live triggers.
+#[test]
+fn restored_pending_prospective_stays_pending_and_can_still_fire() {
+    use crate::cognitive_memory::LibraryCognitiveMemory;
+
+    let source = LibraryCognitiveMemory::in_memory().unwrap();
+    source
+        .store_prospective("ship the CLI", "deploy", "Pursue goal", 1)
+        .unwrap();
+
+    let snapshot = export_full_memory_snapshot(&source, "issue-2562").unwrap();
+    assert_eq!(snapshot.prospective.len(), 1);
+    assert_eq!(
+        snapshot.prospective[0].status, "pending",
+        "a freshly stored trigger is pending"
+    );
+
+    let target = LibraryCognitiveMemory::in_memory().unwrap();
+    import_full_snapshot(&target, &snapshot).unwrap();
+
+    let restored = target.list_all_prospective(u32::MAX).unwrap();
+    assert_eq!(restored.len(), 1);
+    assert_eq!(
+        restored[0].status, "pending",
+        "a pending trigger must restore as pending"
+    );
+
+    let fired = target.check_triggers("please deploy now").unwrap();
+    assert_eq!(
+        fired.len(),
+        1,
+        "a restored pending trigger must still be able to fire"
+    );
+}
+
+/// Issue #2562 (idempotent self-heal): re-importing a snapshot must correct a
+/// store that a pre-fix restore left with a stale `pending` copy of an
+/// already-handled trigger. When the target already holds the same
+/// `(trigger_condition, description)` as `pending` but the snapshot marks it
+/// terminal, the import resolves the existing record so it can no longer fire.
+#[test]
+fn reimport_resolves_a_preexisting_stale_pending_duplicate() {
+    use crate::cognitive_memory::LibraryCognitiveMemory;
+
+    // Snapshot captured a resolved (already-handled) trigger.
+    let source = LibraryCognitiveMemory::in_memory().unwrap();
+    let src_node = source
+        .store_prospective("ship the CLI", "deploy", "Pursue goal", 1)
+        .unwrap();
+    source.resolve_prospective(&src_node).unwrap();
+    let snapshot = export_full_memory_snapshot(&source, "issue-2562").unwrap();
+    assert_eq!(snapshot.prospective[0].status, "resolved");
+
+    // Target already holds the SAME trigger as a stale `pending` record — the
+    // exact residue a pre-#2562 restore would have left behind.
+    let target = LibraryCognitiveMemory::in_memory().unwrap();
+    target
+        .store_prospective("ship the CLI", "deploy", "Pursue goal", 1)
+        .unwrap();
+    let before = target.list_all_prospective(u32::MAX).unwrap();
+    assert_eq!(before.len(), 1);
+    assert_eq!(
+        before[0].status, "pending",
+        "precondition: stale pending record"
+    );
+
+    // Re-import: dedup skips a fresh insert (0 new items) but must still resolve
+    // the pre-existing stale record.
+    let imported = import_full_snapshot(&target, &snapshot).unwrap();
+    assert_eq!(imported, 0, "the duplicate must not be inserted again");
+
+    let after = target.list_all_prospective(u32::MAX).unwrap();
+    assert_eq!(after.len(), 1, "no duplicate row is created");
+    assert_eq!(
+        after[0].status, "resolved",
+        "the stale pending duplicate must be resolved so it can no longer fire"
+    );
+    let fired = target.check_triggers("please deploy now").unwrap();
+    assert!(
+        fired.is_empty(),
+        "the self-healed trigger must not fire after re-import (issue #2562)"
+    );
+}
+
+/// Issue #2562 (guard against over-correction): a live `pending` trigger whose
+/// `(trigger_condition, description)` also appears as `pending` in the snapshot
+/// must stay `pending` and remain able to fire — the self-heal only resolves
+/// records the snapshot marks terminal.
+#[test]
+fn reimport_leaves_a_matching_pending_trigger_firable() {
+    use crate::cognitive_memory::LibraryCognitiveMemory;
+
+    let source = LibraryCognitiveMemory::in_memory().unwrap();
+    source
+        .store_prospective("ship the CLI", "deploy", "Pursue goal", 1)
+        .unwrap();
+    let snapshot = export_full_memory_snapshot(&source, "issue-2562").unwrap();
+    assert_eq!(snapshot.prospective[0].status, "pending");
+
+    let target = LibraryCognitiveMemory::in_memory().unwrap();
+    target
+        .store_prospective("ship the CLI", "deploy", "Pursue goal", 1)
+        .unwrap();
+
+    let imported = import_full_snapshot(&target, &snapshot).unwrap();
+    assert_eq!(imported, 0, "the duplicate must not be inserted again");
+
+    let after = target.list_all_prospective(u32::MAX).unwrap();
+    assert_eq!(after.len(), 1);
+    assert_eq!(
+        after[0].status, "pending",
+        "a pending trigger matching a pending snapshot record stays pending"
+    );
+    let fired = target.check_triggers("please deploy now").unwrap();
+    assert_eq!(
+        fired.len(),
+        1,
+        "the still-pending trigger must remain firable"
+    );
+}

--- a/tests/gadugi/prospective-status-restore-2562.yaml
+++ b/tests/gadugi/prospective-status-restore-2562.yaml
@@ -1,0 +1,126 @@
+name: "Cognitive Memory — Prospective Status Preserved on Restore (#2562)"
+description: >
+  Outside-in gate for issue #2562: the verified-snapshot restore path
+  (`remote_transfer::import_full_snapshot`, reached by `simard memory import` and
+  the daemon startup auto-restore) rebuilt every prospective via
+  `store_prospective`, which always creates a "pending" record — so a trigger
+  that was already "triggered"/"resolved" came back "pending" and
+  `check_triggers` could re-fire a goal the daemon had already completed. The fix
+  re-resolves any non-pending prospective to a terminal, non-firing status after
+  it is written, while genuinely pending triggers restore as pending. These steps
+  drive the RESTORE-side regression gates in `src/remote_transfer/tests.rs`.
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "test-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "#2562 — a restored resolved trigger stays resolved and does not re-fire"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        remote_transfer::tests::restored_resolved_prospective_stays_resolved_so_completed_goal_does_not_refire
+        -- --nocapture --test-threads=1
+    timeout: 300000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test remote_transfer::tests::restored_resolved_prospective_stays_resolved_so_completed_goal_does_not_refire ... ok"
+
+  - name: "#2562 — a restored triggered trigger does not regress to pending and re-fire"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        remote_transfer::tests::restored_triggered_prospective_does_not_come_back_pending_and_refire
+        -- --nocapture --test-threads=1
+    timeout: 300000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test remote_transfer::tests::restored_triggered_prospective_does_not_come_back_pending_and_refire ... ok"
+
+  - name: "#2562 — a genuinely pending trigger restores as pending and can still fire"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        remote_transfer::tests::restored_pending_prospective_stays_pending_and_can_still_fire
+        -- --nocapture --test-threads=1
+    timeout: 300000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test remote_transfer::tests::restored_pending_prospective_stays_pending_and_can_still_fire ... ok"
+
+  - name: "#2562 — re-import self-heals a pre-existing stale pending duplicate"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        remote_transfer::tests::reimport_resolves_a_preexisting_stale_pending_duplicate
+        -- --nocapture --test-threads=1
+    timeout: 300000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test remote_transfer::tests::reimport_resolves_a_preexisting_stale_pending_duplicate ... ok"
+
+  - name: "#2562 — re-import leaves a matching pending trigger firable (no over-correction)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        remote_transfer::tests::reimport_leaves_a_matching_pending_trigger_firable
+        -- --nocapture --test-threads=1
+    timeout: 300000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test remote_transfer::tests::reimport_leaves_a_matching_pending_trigger_firable ... ok"
+
+assertions: []
+
+cleanup:
+  - name: "Test agent cleanup"
+    agent: "test-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "cognitive-memory"
+    - "prospective-triggers"
+    - "snapshot-restore"
+    - "regression"
+    - "issue-2562"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Summary

Fixes #2562. The verified-snapshot **restore** path
`remote_transfer::import_full_snapshot` — reached by `simard memory import` and
the daemon startup **auto-restore** — rebuilt every prospective (trigger→action)
memory via the library `store_prospective(...)`, which **always** creates a
`status="pending"` record. A snapshot trigger that was already `triggered` or
`resolved` therefore came back `pending`, and `check_triggers` (which fires only
`pending` records) could **re-fire a goal the daemon had already completed** after
a recovery restore.

### The fix (self-contained in `rysweet/Simard` — no upstream lib change)

After storing each snapshot prospective, if its status is not `pending`
(case-insensitive) the record is re-resolved to the terminal, non-firing
`resolved` status. Genuinely `pending` records restore as `pending` and stay
eligible to fire.

- `CognitiveProspective` already carries `status`, and the **export** side
  (`export_full_memory_snapshot` → `list_all_prospective`) already captures it —
  the defect was purely on the import side.
- The library (`amplihack-memory-lib`, pinned rev `26d49bf…`) exposes only
  `store_prospective` (→`pending`), `check_triggers` (→`triggered`), and
  `resolve_prospective` (→`resolved`) — **no arbitrary status setter**. `resolved`
  is the correct terminal state for both prior `triggered` and `resolved` records
  (neither should fire again on a recovery restore, where no in-flight action
  remains to resume), so the whole fix stays inside Simard; no
  `amplihack-memory-lib` change or `Cargo.toml` rev-pin bump is required.

### Idempotent self-heal

Because the restore is idempotent, re-running it also **corrects a store that a
pre-#2562 restore left with a stale `pending` copy** of an already-handled
trigger: when the target already holds the same `(trigger_condition, description)`
as `pending` and the snapshot marks it terminal, the existing record is resolved.
A live record that is already terminal is left untouched (over-correction guard).

## Files changed
- `src/remote_transfer/mod.rs` — `import_full_snapshot` prospective loop + contract doc.
- `src/remote_transfer/tests.rs` — 5 new hermetic regression tests.
- `tests/gadugi/prospective-status-restore-2562.yaml` — outside-in QA scenario (5 steps).
- `docs/operations/cognitive-memory-durability.md` — documents the restore contract.

---

## Merge-ready evidence

### 1. QA scenarios (gadugi-test) — validated + run ✅
`tests/gadugi/prospective-status-restore-2562.yaml` drives the 5 restore-side gates.

- `gadugi-test validate -f … --strict` → `✓ Scenario … is valid` (1 valid, 0 invalid).
- `gadugi-test run -d tests/gadugi -s prospective-status-restore-2562` →
  `✓ Passed: 1  ✗ Failed: 0  ✓ All tests passed!` (all 5 steps `... ok`).

### 2. Docs ✅
User-facing surfaces = `simard memory import` + daemon auto-restore behaviour.
`docs/operations/cognitive-memory-durability.md` now states both paths preserve
prospective status (non-`pending` restores non-firing; `pending` stays firable).
The `import_full_snapshot` rustdoc documents the full contract, including the
intentional `triggered → resolved` collapse and the idempotent self-heal.

### 3. quality-audit — 3 SEEK→VALIDATE→FIX cycles, clean final ✅
- **Cycle 1 (correctness/security review):** no significant issues; verified
  node_id capture, error propagation, dedup, edge cases (empty/unknown/case) against
  the pinned library.
- **Cycle 2 (design/requirements audit):** confirmed collapsing non-pending →
  `resolved` satisfies the core no-refire requirement and the self-contained
  approach is justified (issue impact "low"); surfaced ONE non-blocking gap —
  a pre-existing stale `pending` duplicate was not corrected on re-import.
  **FIXED:** added the idempotent self-heal (HashMap tracks existing node_id+status)
  + 2 tests (self-heal + over-correction guard).
- **Cycle 3 (final review):** **PASS** — borrow-checker soundness, `imported`
  count semantics (duplicates not counted; existing idempotency test still returns 0),
  intra-snapshot duplicate handling, and the over-correction guard all verified.
  Zero critical/high, zero medium correctness/security findings. One informational
  low (multiple identical `pending` rows already in a target — an anomalous state
  the normal import path never creates; strictly better than before, out of scope).

### 4. CI / local gates — green ✅
- `cargo test --lib remote_transfer --locked` → **14 passed; 0 failed** (5 new + 9 existing).
- Integration sweep (no regressions): `memory_auto_restore_2550` (3), `memory_import_roundtrip_2550` (3),
  `memory_snapshot_completeness_2550` (1), `issue_2420_live_backup_e2e` (1),
  `prospective_triggers_outside_in` (2) → all passed.
- **Pre-commit** (`cargo fmt --check`, `cargo clippy --release -D warnings`) → Passed.
- **Pre-push** (race-catching `cargo test --release` subset, full
  `cargo clippy --all-targets --all-features --locked -D warnings`) → Passed.

### 5. Evidence
This description (criteria 1–4, 6).

### 6. Focused diff ✅
Only the restore prospective loop + its tests, one new QA scenario, and one doc
note. No unrelated edits.

## Test coverage (new, hermetic — `LibraryCognitiveMemory::in_memory`)
- `restored_resolved_prospective_stays_resolved_so_completed_goal_does_not_refire`
- `restored_triggered_prospective_does_not_come_back_pending_and_refire` (asserts restored status is `resolved`)
- `restored_pending_prospective_stays_pending_and_can_still_fire`
- `reimport_resolves_a_preexisting_stale_pending_duplicate`
- `reimport_leaves_a_matching_pending_trigger_firable`

Closes #2562
