### PR TITLE
fix(memory): fail closed on read-failure in cognitive-memory auto-restore (#2561)

### DIFF
--- a/docs/architecture/cognitive-memory-library-adapter.md
+++ b/docs/architecture/cognitive-memory-library-adapter.md
@@ -351,6 +351,45 @@ The library returns `HashMap<String, usize>` keyed by `MemoryCategory::as_str()`
 the adapter folds it into the typed `CognitiveStatistics`. Keys the library does
 not emit default to `0`.
 
+> **Caveat (issue #2561).** At the pinned commit the library counts via reads
+> (`query_nodes(...).len()`) that **swallow a query failure as an empty result**
+> (`Err(_) => Vec::new()`). A transient read failure at daemon startup therefore
+> surfaces to the adapter as a legitimate all-zeros `Ok(..)` rather than an
+> `Err` — an "empty" reading that may be a *read failure*, not a *confirmed-empty
+> store*. Any consumer that acts on emptiness (below) must treat this as a
+> fail-closed decision, not a bare count.
+
+### Fail-closed emptiness probe & auto-restore (`probe_emptiness`, #2561)
+
+`CognitiveMemoryOps::probe_emptiness()` is the single seam that decides whether a
+store is *confirmed empty* — the precondition the snapshot auto-restore path
+(`memory_snapshot::auto_restore_if_empty`) uses to self-heal a fresh or
+corruption-reset (#2550) store from its newest on-disk snapshot. It returns a
+three-way answer via `Result<StoreEmptiness>`:
+
+| Outcome | Meaning | Auto-restore action |
+|---|---|---|
+| `Ok(ConfirmedEmpty)` | read succeeded, zero memories | hydrate from snapshot |
+| `Ok(NonEmpty)` | read succeeded, ≥1 memory | skip (re-import would duplicate) |
+| `Err(..)` | read **failed** | **propagate; import nothing** |
+
+The `Err` arm is the crux: a read failure is never coerced into "empty", so a
+snapshot can never be layered on top of still-present-but-unreadable durable
+memory (which would duplicate every memory once reads recover). The default trait
+implementation derives the answer from `get_statistics()?`, so every backend that
+*surfaces* its read/transport errors (the bridge and IPC clients, test mocks)
+fails closed automatically.
+
+**Residual gap.** For the direct library backend the last gap stays open until
+the pinned `amplihack-memory-lib` propagates the read error it currently swallows
+(see the `get_statistics` caveat above) — the complete fix is upstream, as issue
+#2561 records. Until then this seam guarantees the *decision path* is fail-closed
+for every backend that can surface the error and centralises the one place the
+upstream error-propagating count will plug in. A Simard-side filesystem "is the
+store file large?" heuristic is deliberately **not** used: after the #2550
+corruption-reset this feature is meant to heal, a large-but-reset file could
+wrongly block a legitimate self-heal.
+
 ### Fact recency ordering (sequence stamping)
 
 Several Simard call sites select "the most recent fact for concept X" by taking

--- a/docs/architecture/cognitive-memory-library-adapter.md
+++ b/docs/architecture/cognitive-memory-library-adapter.md
@@ -363,9 +363,9 @@ not emit default to `0`.
 
 `CognitiveMemoryOps::probe_emptiness()` is the single seam that decides whether a
 store is *confirmed empty* — the precondition the snapshot auto-restore path
-(`memory_snapshot::auto_restore_if_empty`) uses to self-heal a fresh or
-corruption-reset (#2550) store from its newest on-disk snapshot. It returns a
-three-way answer via `Result<StoreEmptiness>`:
+(`memory_snapshot::auto_restore_if_empty`) is **intended** to use to self-heal a
+fresh or corruption-reset (#2550) store from its newest on-disk snapshot. It
+returns a three-way answer via `Result<StoreEmptiness>`:
 
 | Outcome | Meaning | Auto-restore action |
 |---|---|---|
@@ -389,6 +389,13 @@ upstream error-propagating count will plug in. A Simard-side filesystem "is the
 store file large?" heuristic is deliberately **not** used: after the #2550
 corruption-reset this feature is meant to heal, a large-but-reset file could
 wrongly block a legitimate self-heal.
+
+**Not yet wired.** `auto_restore_if_empty` / `auto_restore_latest_if_empty` /
+`probe_emptiness` are the correctly-gated primitives only — no session/daemon
+startup path invokes them yet. Activating snapshot auto-restore at startup is
+deferred (the on-disk snapshot API is `#[deprecated]` in favour of hive-mind
+replication), so no production restore path exists to be made unsafe in the
+interim.
 
 ### Fact recency ordering (sequence stamping)
 

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -80,6 +80,27 @@ pub enum MemoryKind {
     Procedure,
 }
 
+/// Outcome of a **fail-closed** emptiness probe over a cognitive store (issue
+/// #2561).
+///
+/// This deliberately has only two variants: a store that was *read
+/// successfully* is either [`ConfirmedEmpty`](StoreEmptiness::ConfirmedEmpty)
+/// or [`NonEmpty`](StoreEmptiness::NonEmpty). A read *failure* is **never**
+/// represented here — it is surfaced as `Err` by
+/// [`CognitiveMemoryOps::probe_emptiness`] so the auto-restore gate
+/// ([`crate::memory_snapshot::auto_restore_if_empty`]) can fail closed instead
+/// of mistaking an unreadable store for an empty one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoreEmptiness {
+    /// The store was read successfully and holds zero memories across every
+    /// cognitive type. Safe to hydrate from a snapshot.
+    ConfirmedEmpty,
+    /// The store was read successfully and holds at least one memory. The
+    /// auto-restore gate must NOT hydrate — re-importing a snapshot would
+    /// duplicate memories.
+    NonEmpty,
+}
+
 /// Forgetting threshold for [`CognitiveMemoryOps::forget_low_value_facts`]
 /// (issue #2434): live facts whose value falls below this fade during the
 /// controlled-forgetting hygiene pass.
@@ -543,6 +564,43 @@ pub trait CognitiveMemoryOps: Send + Sync {
     }
 
     fn get_statistics(&self) -> SimardResult<CognitiveStatistics>;
+
+    /// Probe whether the store is *confirmed* empty, **failing closed** on a
+    /// read error (issue #2561).
+    ///
+    /// The auto-restore gate
+    /// ([`crate::memory_snapshot::auto_restore_if_empty`]) hydrates a store from
+    /// an on-disk snapshot only when it is genuinely empty (e.g. a fresh install
+    /// or a corruption-reset self-heal, issue #2550). Deciding "empty" purely
+    /// from a count is unsafe when the underlying read can *fail silently*: if a
+    /// transient read error is coerced into an all-zeros count, the gate would
+    /// re-import a snapshot on top of still-present-but-unreadable durable data
+    /// and duplicate every memory once reads recover.
+    ///
+    /// This method therefore returns a `Result` so a surfaced read error is
+    /// **propagated as `Err`**, never mapped to
+    /// [`StoreEmptiness::ConfirmedEmpty`]. The default implementation derives the
+    /// answer from [`get_statistics`](Self::get_statistics) — which already
+    /// returns a `Result`, so any backend that surfaces its read/transport
+    /// errors (the bridge and IPC clients, test mocks) fails closed for free, and
+    /// this is the single seam a future error-propagating count plugs into.
+    ///
+    /// # Backend note
+    ///
+    /// The direct library backend ([`LibraryCognitiveMemory`]) cannot yet
+    /// observe a read error that the pinned `amplihack-memory-lib` swallows
+    /// internally (`Err(_) => Vec::new()`); closing that last gap needs the
+    /// upstream library to propagate the error (issue #2561). Until then this
+    /// seam guarantees the *decision path* is fail-closed for every backend that
+    /// can surface the error and centralises where the fix lands.
+    fn probe_emptiness(&self) -> SimardResult<StoreEmptiness> {
+        let stats = self.get_statistics()?;
+        Ok(if stats.total() == 0 {
+            StoreEmptiness::ConfirmedEmpty
+        } else {
+            StoreEmptiness::NonEmpty
+        })
+    }
 
     /// Store a semantic fact and record where it was distilled from.
     ///

--- a/src/memory_snapshot.rs
+++ b/src/memory_snapshot.rs
@@ -199,9 +199,13 @@ pub fn restore_snapshot(
 /// Hydrate `bridge` from `snapshot` **only when the store is confirmed empty**,
 /// failing closed on a read error (issue #2561).
 ///
-/// This is the guarded entry point a session/daemon startup uses to self-heal a
-/// freshly-initialised — or corruption-reset (issue #2550) — cognitive store
-/// from its most recent on-disk snapshot. The guard is the crux of #2561: the
+/// This is the **intended** guarded entry point for a session/daemon startup to
+/// self-heal a freshly-initialised — or corruption-reset (issue #2550) —
+/// cognitive store from its most recent on-disk snapshot. It is **not yet wired
+/// into any startup path**: this change ships the correctly-gated primitive, and
+/// activating it at startup is deliberately deferred (the on-disk snapshot API is
+/// `#[deprecated]` in favour of hive-mind replication). The guard is the crux of
+/// #2561: the
 /// decision to hydrate is taken from [`CognitiveMemoryOps::probe_emptiness`],
 /// which distinguishes a *confirmed-empty* store from one whose reads are
 /// *failing*, rather than from a bare count that a swallowed read error can
@@ -244,7 +248,11 @@ pub fn auto_restore_if_empty(
 ///
 /// * store confirmed empty and a snapshot exists → `Ok(Some(count))`.
 /// * store confirmed empty but no loadable snapshot in `dir` → `Ok(None)`
-///   (nothing to restore; the fresh store is left as-is).
+///   (nothing to restore; the fresh store is left as-is). Note: a *corrupt or
+///   unreadable* newest snapshot is currently treated the same as *absent* here
+///   — [`load_latest_snapshot`] logs and returns `None`, so this wrapper returns
+///   `Ok(None)` rather than surfacing the load error. Surfacing that as `Err`
+///   (fail-closed on the snapshot *source*) is deferred to the activation work.
 /// * store non-empty → `Ok(None)` (skip; re-importing would duplicate).
 /// * probe read failure → `Err(..)`, nothing imported (fail closed).
 pub fn auto_restore_latest_if_empty(
@@ -669,6 +677,84 @@ mod tests {
             writes.load(Ordering::SeqCst),
             0,
             "no writes on the fail-closed path (durable memory intact)",
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn auto_restore_latest_skips_a_non_empty_store() {
+        // Wrapper ordering guard: a non-empty store returns `Ok(None)` from the
+        // emptiness check BEFORE any snapshot is read off disk. The tempdir holds
+        // a valid snapshot precisely to prove it is never consulted.
+        let dir = std::env::temp_dir().join(format!(
+            "simard-test-autorestore-latest-nonempty-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create test dir");
+
+        let envelope = crate::remote_transfer::PersistedEnvelope {
+            schema_version: crate::remote_transfer::ENVELOPE_SCHEMA_VERSION,
+            payload: two_item_snapshot(),
+        };
+        std::fs::write(
+            dir.join("test-agent-0000000001.json"),
+            serde_json::to_vec_pretty(&envelope).expect("serialize snapshot"),
+        )
+        .expect("write snapshot file");
+
+        let (bridge, writes) = dest_bridge(|| {
+            Ok(json!({
+                "sensory_count": 0,
+                "working_count": 0,
+                "episodic_count": 0,
+                "semantic_count": 5,
+                "procedural_count": 0,
+                "prospective_count": 0
+            }))
+        });
+        let restored =
+            auto_restore_latest_if_empty(&bridge, &dir).expect("non-empty latest skip is Ok");
+
+        assert_eq!(
+            restored, None,
+            "a non-empty store must be left untouched even when a snapshot exists",
+        );
+        assert_eq!(
+            writes.load(Ordering::SeqCst),
+            0,
+            "no snapshot items should be written into a non-empty store",
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn auto_restore_latest_returns_none_when_confirmed_empty_but_no_snapshot() {
+        // Confirmed-empty store with an empty snapshot dir: nothing to restore, so
+        // the fresh store is left as-is (`Ok(None)`, zero writes). This exercises
+        // the "no loadable snapshot" branch — an absent (or corrupt/unreadable)
+        // newest snapshot both surface here as `None`.
+        let dir = std::env::temp_dir().join(format!(
+            "simard-test-autorestore-latest-nosnapshot-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create test dir");
+
+        let (bridge, writes) = dest_bridge(|| Ok(zero_stats()));
+        let restored = auto_restore_latest_if_empty(&bridge, &dir)
+            .expect("confirmed-empty with no snapshot is Ok");
+
+        assert_eq!(
+            restored, None,
+            "a confirmed-empty store with no loadable snapshot restores nothing",
+        );
+        assert_eq!(
+            writes.load(Ordering::SeqCst),
+            0,
+            "no writes when there is no snapshot to restore",
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/src/memory_snapshot.rs
+++ b/src/memory_snapshot.rs
@@ -205,11 +205,10 @@ pub fn restore_snapshot(
 /// into any startup path**: this change ships the correctly-gated primitive, and
 /// activating it at startup is deliberately deferred (the on-disk snapshot API is
 /// `#[deprecated]` in favour of hive-mind replication). The guard is the crux of
-/// #2561: the
-/// decision to hydrate is taken from [`CognitiveMemoryOps::probe_emptiness`],
-/// which distinguishes a *confirmed-empty* store from one whose reads are
-/// *failing*, rather than from a bare count that a swallowed read error can
-/// silently zero out.
+/// #2561: the decision to hydrate is taken from
+/// [`CognitiveMemoryOps::probe_emptiness`], which distinguishes a
+/// *confirmed-empty* store from one whose reads are *failing*, rather than from a
+/// bare count that a swallowed read error can silently zero out.
 ///
 /// Behaviour:
 ///
@@ -223,9 +222,26 @@ pub fn restore_snapshot(
 ///   never be mistaken for an empty store and cause a snapshot to be layered on
 ///   top of still-present-but-unreadable durable memory.
 ///
-/// The order matters: emptiness is confirmed *before* any write, so the import
-/// side effect is unreachable on the error path.
-#[allow(deprecated)] // restore_snapshot wraps the legacy snapshot API
+/// The order matters: emptiness is confirmed *before* any write, so a **probe**
+/// error can never trigger an import. The import itself, however, is **not
+/// transactional**: `restore_snapshot` → `import_memory_snapshot` writes each
+/// fact/procedure individually, so an `Err` returned *after the probe succeeded*
+/// (a mid-import write failure) can leave the store **partially** hydrated.
+/// Because that only happens on a store already confirmed empty, it can never
+/// duplicate or overwrite pre-existing durable memory (the #2561 invariant
+/// holds); but a subsequent startup then observes `NonEmpty` and skips, so the
+/// partial restore is not retried. "Nothing is imported" therefore applies to
+/// the *probe*-error path specifically; an atomic/idempotent import is a
+/// prerequisite for the deferred startup-activation work.
+///
+/// # Concurrency
+///
+/// The probe→import sequence is **not atomic** and this primitive is not
+/// internally synchronized. The caller must run it as the sole writer for the
+/// duration of the call (the single-writer startup precondition): a concurrent
+/// writer landing between the emptiness probe and the import could duplicate
+/// memories. Activation outside a single-writer context must wrap the call in the
+/// store's cross-process lock (cf. `goal_board_store`'s advisory `flock`, #2514).
 pub fn auto_restore_if_empty(
     bridge: &dyn CognitiveMemoryOps,
     snapshot: &MemorySnapshot,
@@ -248,11 +264,12 @@ pub fn auto_restore_if_empty(
 ///
 /// * store confirmed empty and a snapshot exists → `Ok(Some(count))`.
 /// * store confirmed empty but no loadable snapshot in `dir` → `Ok(None)`
-///   (nothing to restore; the fresh store is left as-is). Note: a *corrupt or
-///   unreadable* newest snapshot is currently treated the same as *absent* here
-///   — [`load_latest_snapshot`] logs and returns `None`, so this wrapper returns
-///   `Ok(None)` rather than surfacing the load error. Surfacing that as `Err`
-///   (fail-closed on the snapshot *source*) is deferred to the activation work.
+///   (nothing to restore; the fresh store is left as-is). [`load_latest_snapshot`]
+///   walks newest → oldest and returns the most recent *valid* snapshot, so a
+///   *corrupt or unreadable newest* snapshot degrades to an older valid one
+///   (`Ok(Some(..))`) rather than aborting the self-heal; `Ok(None)` results only
+///   when the directory holds no snapshot or **every** retained snapshot is
+///   unreadable.
 /// * store non-empty → `Ok(None)` (skip; re-importing would duplicate).
 /// * probe read failure → `Err(..)`, nothing imported (fail closed).
 pub fn auto_restore_latest_if_empty(
@@ -734,8 +751,10 @@ mod tests {
     fn auto_restore_latest_returns_none_when_confirmed_empty_but_no_snapshot() {
         // Confirmed-empty store with an empty snapshot dir: nothing to restore, so
         // the fresh store is left as-is (`Ok(None)`, zero writes). This exercises
-        // the "no loadable snapshot" branch — an absent (or corrupt/unreadable)
-        // newest snapshot both surface here as `None`.
+        // the "no loadable snapshot" branch, reached when the directory holds no
+        // snapshot (or, with the newest→oldest loader, when every retained
+        // snapshot is unreadable — a corrupt *newest* alone would instead recover
+        // an older valid snapshot).
         let dir = std::env::temp_dir().join(format!(
             "simard-test-autorestore-latest-nosnapshot-{}",
             std::process::id()

--- a/src/memory_snapshot.rs
+++ b/src/memory_snapshot.rs
@@ -6,7 +6,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::cognitive_memory::{CognitiveMemoryOps, StoreEmptiness};
 use crate::error::SimardResult;
 use crate::remote_transfer::MemorySnapshot;
 
@@ -196,6 +196,74 @@ pub fn restore_snapshot(
     crate::remote_transfer::import_memory_snapshot(bridge, snapshot)
 }
 
+/// Hydrate `bridge` from `snapshot` **only when the store is confirmed empty**,
+/// failing closed on a read error (issue #2561).
+///
+/// This is the guarded entry point a session/daemon startup uses to self-heal a
+/// freshly-initialised — or corruption-reset (issue #2550) — cognitive store
+/// from its most recent on-disk snapshot. The guard is the crux of #2561: the
+/// decision to hydrate is taken from [`CognitiveMemoryOps::probe_emptiness`],
+/// which distinguishes a *confirmed-empty* store from one whose reads are
+/// *failing*, rather than from a bare count that a swallowed read error can
+/// silently zero out.
+///
+/// Behaviour:
+///
+/// * [`StoreEmptiness::ConfirmedEmpty`] — the store was read successfully and is
+///   genuinely empty → import the snapshot and return `Ok(Some(count))` where
+///   `count` is the number of restored items.
+/// * [`StoreEmptiness::NonEmpty`] — the store already holds memories → do
+///   nothing and return `Ok(None)`. Re-importing would duplicate memories.
+/// * `Err(..)` from the probe — a read *failed*. We **fail closed**: the error
+///   is propagated and nothing is imported, so a transient read failure can
+///   never be mistaken for an empty store and cause a snapshot to be layered on
+///   top of still-present-but-unreadable durable memory.
+///
+/// The order matters: emptiness is confirmed *before* any write, so the import
+/// side effect is unreachable on the error path.
+#[allow(deprecated)] // restore_snapshot wraps the legacy snapshot API
+pub fn auto_restore_if_empty(
+    bridge: &dyn CognitiveMemoryOps,
+    snapshot: &MemorySnapshot,
+) -> SimardResult<Option<usize>> {
+    // `?` propagates a read failure BEFORE `restore_snapshot` runs — the
+    // fail-closed guarantee that protects durable memory (issue #2561).
+    match bridge.probe_emptiness()? {
+        StoreEmptiness::ConfirmedEmpty => Ok(Some(restore_snapshot(bridge, snapshot)?)),
+        StoreEmptiness::NonEmpty => Ok(None),
+    }
+}
+
+/// Load the most recent snapshot from `dir` and hydrate `bridge` from it **only
+/// when the store is confirmed empty**, failing closed on a read error (issue
+/// #2561).
+///
+/// A convenience wrapper over [`auto_restore_if_empty`] that sources the
+/// snapshot with [`load_latest_snapshot`]. Emptiness is confirmed *first*, so a
+/// non-empty (or unreadable) store never even reads a snapshot off disk:
+///
+/// * store confirmed empty and a snapshot exists → `Ok(Some(count))`.
+/// * store confirmed empty but no loadable snapshot in `dir` → `Ok(None)`
+///   (nothing to restore; the fresh store is left as-is).
+/// * store non-empty → `Ok(None)` (skip; re-importing would duplicate).
+/// * probe read failure → `Err(..)`, nothing imported (fail closed).
+pub fn auto_restore_latest_if_empty(
+    bridge: &dyn CognitiveMemoryOps,
+    dir: &Path,
+) -> SimardResult<Option<usize>> {
+    // Fail closed BEFORE touching a snapshot: only a confirmed-empty store is
+    // eligible for hydration.
+    match bridge.probe_emptiness()? {
+        StoreEmptiness::NonEmpty => return Ok(None),
+        StoreEmptiness::ConfirmedEmpty => {}
+    }
+    match load_latest_snapshot(dir) {
+        // Emptiness is already confirmed above, so restore directly.
+        Some(snapshot) => Ok(Some(restore_snapshot(bridge, &snapshot)?)),
+        None => Ok(None),
+    }
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Tests
 // ────────────────────────────────────────────────────────────────────────────
@@ -378,6 +446,230 @@ mod tests {
             let path = dir.join(format!("agent-{i:010}.json"));
             assert!(path.exists(), "recent snapshot {i} should still exist");
         }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Auto-restore fail-closed regression tests (issue #2561)
+    //
+    // These are fully hermetic: they drive an in-memory bridge transport and
+    // (for the disk-sourced path) a per-test tempdir. Nothing touches
+    // `$HOME/.simard` or any real cognitive store.
+    // ────────────────────────────────────────────────────────────────────
+
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::bridge::BridgeErrorPayload;
+    use crate::bridge_subprocess::InMemoryBridgeTransport;
+    use crate::memory_bridge::CognitiveMemoryBridge;
+    use serde_json::json;
+
+    /// A one-fact, one-procedure snapshot. Restoring it issues exactly two
+    /// writes (`store_fact` + `store_procedure`), so an import-side-effect
+    /// counter of 2 means the whole snapshot was applied and 0 means nothing
+    /// was written.
+    fn two_item_snapshot() -> MemorySnapshot {
+        serde_json::from_value(json!({
+            "facts": [{
+                "node_id": "f1",
+                "concept": "restore-guard",
+                "content": "durable knowledge",
+                "confidence": 0.9,
+                "source_id": "test",
+                "tags": []
+            }],
+            "procedures": [{
+                "node_id": "p1",
+                "name": "rebuild",
+                "steps": ["compile", "test"],
+                "prerequisites": [],
+                "usage_count": 0
+            }],
+            "exported_at": 0,
+            "source_agent": "test-agent"
+        }))
+        .expect("construct snapshot")
+    }
+
+    /// Build a destination bridge whose `memory.get_statistics` response is
+    /// produced by `stats`, and whose write ops (`store_fact` /
+    /// `store_procedure`) bump the returned counter. The counter is the
+    /// "durable memory touched" probe: a fail-closed restore must leave it at 0.
+    fn dest_bridge(
+        stats: impl Fn() -> Result<serde_json::Value, BridgeErrorPayload> + Send + Sync + 'static,
+    ) -> (CognitiveMemoryBridge, Arc<AtomicUsize>) {
+        let writes = Arc::new(AtomicUsize::new(0));
+        let writes_h = Arc::clone(&writes);
+        let transport =
+            InMemoryBridgeTransport::new("test-dest", move |method, _params| match method {
+                "memory.get_statistics" => stats(),
+                "memory.store_fact" => {
+                    writes_h.fetch_add(1, Ordering::SeqCst);
+                    Ok(json!({"id": "imported-fact"}))
+                }
+                "memory.store_procedure" => {
+                    writes_h.fetch_add(1, Ordering::SeqCst);
+                    Ok(json!({"id": "imported-proc"}))
+                }
+                _ => Err(BridgeErrorPayload {
+                    code: -32601,
+                    message: format!("unexpected method: {method}"),
+                }),
+            });
+        (CognitiveMemoryBridge::new(Box::new(transport)), writes)
+    }
+
+    fn zero_stats() -> serde_json::Value {
+        json!({
+            "sensory_count": 0,
+            "working_count": 0,
+            "episodic_count": 0,
+            "semantic_count": 0,
+            "procedural_count": 0,
+            "prospective_count": 0
+        })
+    }
+
+    #[test]
+    fn auto_restore_hydrates_a_confirmed_empty_store() {
+        // Path (a): a store that reads cleanly as all-zeros is genuinely empty,
+        // so the snapshot is applied in full.
+        let (bridge, writes) = dest_bridge(|| Ok(zero_stats()));
+        let snapshot = two_item_snapshot();
+
+        let restored = auto_restore_if_empty(&bridge, &snapshot).expect("confirmed-empty restore");
+
+        assert_eq!(restored, Some(2), "both snapshot items should be restored");
+        assert_eq!(
+            writes.load(Ordering::SeqCst),
+            2,
+            "restore should have written the fact and the procedure",
+        );
+    }
+
+    #[test]
+    fn auto_restore_fails_closed_on_read_error_without_wiping_memory() {
+        // Path (b): the emptiness probe FAILS (a swallowed read-failure surfaced
+        // as an error). The gate must propagate the error and perform NO writes,
+        // so still-present-but-unreadable durable memory is never overwritten or
+        // duplicated. This is the core #2561 regression guard.
+        let (bridge, writes) = dest_bridge(|| {
+            Err(BridgeErrorPayload {
+                code: -32000,
+                message: "transient read failure at startup".to_string(),
+            })
+        });
+        let snapshot = two_item_snapshot();
+
+        let result = auto_restore_if_empty(&bridge, &snapshot);
+
+        assert!(
+            result.is_err(),
+            "a read failure must be surfaced as Err, never coerced to empty",
+        );
+        assert_eq!(
+            writes.load(Ordering::SeqCst),
+            0,
+            "fail-closed restore must not write anything (durable memory intact)",
+        );
+    }
+
+    #[test]
+    fn auto_restore_skips_a_non_empty_store() {
+        // Path (c): a store that already holds memories must not be re-imported —
+        // doing so would duplicate every memory.
+        let (bridge, writes) = dest_bridge(|| {
+            Ok(json!({
+                "sensory_count": 0,
+                "working_count": 0,
+                "episodic_count": 0,
+                "semantic_count": 5,
+                "procedural_count": 0,
+                "prospective_count": 0
+            }))
+        });
+        let snapshot = two_item_snapshot();
+
+        let restored = auto_restore_if_empty(&bridge, &snapshot).expect("non-empty skip is Ok");
+
+        assert_eq!(restored, None, "a non-empty store must be left untouched");
+        assert_eq!(
+            writes.load(Ordering::SeqCst),
+            0,
+            "no snapshot items should be written into a non-empty store",
+        );
+    }
+
+    #[test]
+    fn auto_restore_latest_loads_and_hydrates_when_confirmed_empty() {
+        // End-to-end over the disk-sourced convenience wrapper, hermetic via a
+        // per-test tempdir: a confirmed-empty store hydrates from the newest
+        // on-disk snapshot.
+        let dir = std::env::temp_dir().join(format!(
+            "simard-test-autorestore-empty-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create test dir");
+
+        let snapshot = two_item_snapshot();
+        let envelope = crate::remote_transfer::PersistedEnvelope {
+            schema_version: crate::remote_transfer::ENVELOPE_SCHEMA_VERSION,
+            payload: snapshot,
+        };
+        std::fs::write(
+            dir.join("test-agent-0000000001.json"),
+            serde_json::to_vec_pretty(&envelope).expect("serialize snapshot"),
+        )
+        .expect("write snapshot file");
+
+        let (bridge, writes) = dest_bridge(|| Ok(zero_stats()));
+        let restored =
+            auto_restore_latest_if_empty(&bridge, &dir).expect("confirmed-empty latest restore");
+
+        assert_eq!(restored, Some(2), "the latest snapshot should be restored");
+        assert_eq!(writes.load(Ordering::SeqCst), 2, "both items written");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn auto_restore_latest_fails_closed_on_read_error() {
+        // The disk-sourced wrapper must also fail closed: a probe error aborts
+        // BEFORE any snapshot is read or applied.
+        let dir = std::env::temp_dir().join(format!(
+            "simard-test-autorestore-failclosed-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create test dir");
+
+        let envelope = crate::remote_transfer::PersistedEnvelope {
+            schema_version: crate::remote_transfer::ENVELOPE_SCHEMA_VERSION,
+            payload: two_item_snapshot(),
+        };
+        std::fs::write(
+            dir.join("test-agent-0000000001.json"),
+            serde_json::to_vec_pretty(&envelope).expect("serialize snapshot"),
+        )
+        .expect("write snapshot file");
+
+        let (bridge, writes) = dest_bridge(|| {
+            Err(BridgeErrorPayload {
+                code: -32000,
+                message: "transient read failure at startup".to_string(),
+            })
+        });
+        let result = auto_restore_latest_if_empty(&bridge, &dir);
+
+        assert!(result.is_err(), "probe error must abort the restore");
+        assert_eq!(
+            writes.load(Ordering::SeqCst),
+            0,
+            "no writes on the fail-closed path (durable memory intact)",
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/tests/qa-scenarios/cognitive-memory-auto-restore-fail-closed.yaml
+++ b/tests/qa-scenarios/cognitive-memory-auto-restore-fail-closed.yaml
@@ -1,0 +1,81 @@
+name: cognitive-memory-auto-restore-fail-closed
+app_type: cli
+description: |
+  Verify the cognitive-memory auto-restore path distinguishes a *confirmed-empty*
+  store from a *swallowed read-failure* (issue #2561, follow-up to #2550/#2559).
+
+  `memory_snapshot::auto_restore_if_empty` hydrates a store from an on-disk
+  snapshot only when `CognitiveMemoryOps::probe_emptiness` reports
+  `ConfirmedEmpty`. A read *failure* is surfaced as `Err` (never coerced to
+  "empty"), so a transient read error at daemon startup can never cause a
+  snapshot to be layered on top of still-present-but-unreadable durable memory
+  and duplicate it once reads recover.
+
+  Behaviour is proven by the hermetic unit tests this scenario drives (in-memory
+  bridge + tempdir; no `$HOME/.simard`, no live store — no destructive action
+  against the host). The CLI runner rejects any non-zero exit, so a failing test
+  fails the scenario.
+agents:
+  - name: simard-cli
+    type: cli
+    command: cargo
+steps:
+  # Path (a): a confirmed-empty store (reads cleanly as all-zeros) restores the
+  # whole snapshot. First invocation may compile the test binary; later filters
+  # reuse it.
+  - action: run
+    params:
+      command: "cargo test --locked --lib memory_snapshot::tests::auto_restore_hydrates_a_confirmed_empty_store"
+    timeout: 600000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Path (b) — the core #2561 guard: an injected read-failure is surfaced as an
+  # error AND performs zero writes, so existing durable memory is neither wiped
+  # nor duplicated.
+  - action: run
+    params:
+      command: "cargo test --locked --lib memory_snapshot::tests::auto_restore_fails_closed_on_read_error_without_wiping_memory"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Non-empty store is left untouched (re-importing would duplicate memories).
+  - action: run
+    params:
+      command: "cargo test --locked --lib memory_snapshot::tests::auto_restore_skips_a_non_empty_store"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Disk-sourced convenience wrapper also fails closed before reading a snapshot.
+  - action: run
+    params:
+      command: "cargo test --locked --lib memory_snapshot::tests::auto_restore_latest_fails_closed_on_read_error"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000

--- a/tests/qa-scenarios/cognitive-memory-auto-restore-fail-closed.yaml
+++ b/tests/qa-scenarios/cognitive-memory-auto-restore-fail-closed.yaml
@@ -14,7 +14,11 @@ description: |
   Behaviour is proven by the hermetic unit tests this scenario drives (in-memory
   bridge + tempdir; no `$HOME/.simard`, no live store — no destructive action
   against the host). The CLI runner rejects any non-zero exit, so a failing test
-  fails the scenario.
+  fails the scenario. Each step asserts `. 1 passed;` (a positive pass count),
+  not just `test result: ok`: a `cargo test` filter matching zero tests also
+  prints `test result: ok` and exits 0, so a renamed/removed test would pass the
+  scenario vacuously — the pass-count assertion closes that hollow-verification
+  gap.
 agents:
   - name: simard-cli
     type: cli
@@ -29,7 +33,7 @@ steps:
     timeout: 600000
   - action: wait_for_output
     params:
-      value: "test result: ok"
+      value: ". 1 passed;"
     timeout: 8000
   - action: validate_exit_code
     params:
@@ -45,7 +49,7 @@ steps:
     timeout: 300000
   - action: wait_for_output
     params:
-      value: "test result: ok"
+      value: ". 1 passed;"
     timeout: 8000
   - action: validate_exit_code
     params:
@@ -59,7 +63,7 @@ steps:
     timeout: 300000
   - action: wait_for_output
     params:
-      value: "test result: ok"
+      value: ". 1 passed;"
     timeout: 8000
   - action: validate_exit_code
     params:
@@ -73,7 +77,7 @@ steps:
     timeout: 300000
   - action: wait_for_output
     params:
-      value: "test result: ok"
+      value: ". 1 passed;"
     timeout: 8000
   - action: validate_exit_code
     params:


### PR DESCRIPTION
## Summary

Follow-up hardening from the quality-audit of PR #2559 (issue #2550). The
cognitive-memory auto-restore decision treated "store is empty" purely as a
count (`get_statistics().total() == 0`). Because the pinned
`amplihack-memory-lib` swallows read failures as empty results
(`Err(_) => Vec::new()`), a **transient read failure at daemon startup could be
mistaken for a genuinely empty store**. Re-importing a snapshot on top of
still-present-but-unreadable durable memory would then duplicate every memory
once reads recover.

This PR introduces a **fail-closed decision seam** so the restore path
distinguishes a *confirmed-empty* store from a *swallowed read-failure*.

## Changes

- **`src/cognitive_memory/mod.rs`**
  - `pub enum StoreEmptiness { ConfirmedEmpty, NonEmpty }` — a store that was
    *read successfully* is one of these two; a read *failure* is never
    represented here.
  - `CognitiveMemoryOps::probe_emptiness() -> SimardResult<StoreEmptiness>` —
    default impl derives the answer from `get_statistics()?`, so a surfaced
    read/transport error is **propagated as `Err`**, never coerced to
    `ConfirmedEmpty`. Every backend that surfaces its errors (bridge, IPC,
    mocks) fails closed for free; this is the single seam a future
    error-propagating count plugs into.
- **`src/memory_snapshot.rs`**
  - `auto_restore_if_empty(bridge, snapshot)` and
    `auto_restore_latest_if_empty(bridge, dir)`:
    - `ConfirmedEmpty` → import snapshot, `Ok(Some(count))`.
    - `NonEmpty` → `Ok(None)` (skip; re-import would duplicate).
    - probe `Err` → propagate, **import nothing** (emptiness is confirmed
      *before* any write, so no durable memory is touched on the error path).
- **`docs/architecture/cognitive-memory-library-adapter.md`** — documents the
  seam, the `get_statistics` swallow-to-empty caveat, and the residual
  upstream-lib limitation.

## Scope note (why the complete fix is partly upstream)

As the issue records, the *last* gap for the **direct library backend** stays
open until `amplihack-memory-lib` propagates the read error it currently
swallows — that lib is a git-pinned dependency and the fix is upstream. This PR
makes the **decision path fail-closed for every backend that can surface the
error** and centralises the one place the upstream error-propagating count will
plug in. A Simard-side "is the store file large?" filesystem heuristic is
deliberately **not** used: after the #2550 corruption-reset this feature heals,
a large-but-reset file could wrongly block a legitimate self-heal.

## Merge-ready evidence

### 1. qa-team scenarios (gadugi)
Added `tests/qa-scenarios/cognitive-memory-auto-restore-fail-closed.yaml` driving
the hermetic regression tests below.
- `gadugi-test validate -f ... --strict` → `✓ Scenario "cognitive-memory-auto-restore-fail-closed" is valid`
- `gadugi-test run -d tests/qa-scenarios -s cognitive-memory-auto-restore-fail-closed` → `✓ Passed: 1  ✗ Failed: 0` (re-validated `--strict` and re-run at the merge-ready gate, post-rebase)

Underlying hermetic tests (in-memory bridge + tempdir; **no `$HOME/.simard`**):

| Test | Path | Asserts |
|---|---|---|
| `auto_restore_hydrates_a_confirmed_empty_store` | (a) confirmed-empty | restores all items, 2 writes |
| `auto_restore_fails_closed_on_read_error_without_wiping_memory` | (b) injected read-failure | `Err` propagated **and 0 writes** (durable memory intact) |
| `auto_restore_skips_a_non_empty_store` | non-empty | `Ok(None)`, 0 writes |
| `auto_restore_latest_loads_and_hydrates_when_confirmed_empty` | disk-sourced happy path | restores latest snapshot |
| `auto_restore_latest_fails_closed_on_read_error` | disk-sourced fail-closed | `Err`, 0 writes |
| `auto_restore_latest_skips_a_non_empty_store` | disk-sourced non-empty | `Ok(None)`, 0 writes (snapshot never read) |
| `auto_restore_latest_returns_none_when_confirmed_empty_but_no_snapshot` | confirmed-empty, empty dir | `Ok(None)`, 0 writes |

```
test result: ok. 16 passed; 0 failed  (memory_snapshot::tests, incl. the 3 upstream
                                        load_latest_snapshot recovery tests)
test result: ok. 106 passed; 0 failed (cognitive_memory)
```
(`cargo test --release --lib memory_snapshot` / `... cognitive_memory`, post-rebase.)

### 2. Docs
`docs/architecture/cognitive-memory-library-adapter.md` updated for the new
`probe_emptiness` seam and fail-closed auto-restore behavior (the only
user/architecture-facing surface changed).

### 3. quality-audit (≥3 SEEK→VALIDATE→FIX cycles, clean final cycle)
Ran a 3-cycle quality audit (SEEK → multi-agent VALIDATE with ≥2/3 agreement → FIX)
scoped to this PR's diff:

- **Cycle 1** — SEEK (code-review + security + reliability), VALIDATE (architect +
  analyzer). Confirmed & fixed: misleading present-tense docs (the seam is **not yet
  wired** into startup); a hollow-verification gap in the gadugi scenario (a
  `cargo test` filter matching zero tests still prints `test result: ok` and exits 0,
  so a renamed/removed test would pass vacuously — steps now assert `. 1 passed;`); a
  corrupt-vs-absent doc caveat; and two missing wrapper tests. Security review found
  no data-integrity issue.
- **Cycle 2** — deeper SEEK. Confirmed & fixed (doc-only): the "nothing imported on
  error" guarantee holds for the *probe*-error path only (`import_memory_snapshot` is
  non-transactional, so a mid-import write failure can leave a *confirmed-empty* store
  partially hydrated — never duplicating durable memory); an undocumented
  single-writer/TOCTOU precondition (added a `# Concurrency` note). Also found the
  branch was 26 commits behind `main`, whose `load_latest_snapshot` now recovers the
  most-recent *valid* snapshot → **rebased onto `origin/main`** and corrected the
  caveat/test comment to match.
- **Cycle 3 (final, clean)** — fresh-eyes code-review + reliability on the rebased
  state: fail-closed probe→import ordering correct, docs verified accurate against the
  *pinned* `amplihack-memory` source, QA scenario non-vacuous, all 6 tests assert both
  the return value and a zero/expected write-count, diff focused, no error-swallowing →
  **MERGE READY**. Only a LOW cosmetic nit (a superfluous `#[allow(deprecated)]`),
  removed; `clippy -D warnings` stays clean. **Zero critical/high/medium residual
  findings.**

Audit commits: `a7c18e02` (fix), `a0ae0178` (gadugi scenario), `d71661b8` (cycle-1
hardening: docs + QA assertion + 2 tests), `ffec28c3` (cycle-2/3 doc-accuracy +
attribute cleanup). Branch rebased onto current `origin/main` (0 commits behind).

### 4. CI 100% green (0 failures)
GitHub Actions CI on the PR head commit `ffec28c3` — **all required checks green, 0 failures** ([all checks](https://github.com/rysweet/Simard/pull/2572/checks)):

| Check | Conclusion | Link |
|---|---|---|
| `build` | SUCCESS | [run](https://github.com/rysweet/Simard/actions/runs/28708511230/job/85138049279) |
| `pre-commit` | SUCCESS | [run](https://github.com/rysweet/Simard/actions/runs/28708511221/job/85138049295) |
| `coverage` | SUCCESS | [run](https://github.com/rysweet/Simard/actions/runs/28708511224/job/85138049226) |
| `install-real` | SUCCESS | [run](https://github.com/rysweet/Simard/actions/runs/28708511221/job/85138440307) |
| `e2e-dashboard` | SUCCESS | [run](https://github.com/rysweet/Simard/actions/runs/28708511221/job/85138440326) |
| `cargo-audit` | SUCCESS | [run](https://github.com/rysweet/Simard/actions/runs/28708511221/job/85138049308) |
| `cargo-deny` | SUCCESS | [run](https://github.com/rysweet/Simard/actions/runs/28708511221/job/85138049287) |
| `cargo-vet` | SUCCESS | [run](https://github.com/rysweet/Simard/actions/runs/28708511221/job/85138049306) |
| `npm-audit` | SUCCESS | [run](https://github.com/rysweet/Simard/actions/runs/28708511221/job/85138049310) |
| `GitGuardian Security Checks` | SUCCESS | [run](https://dashboard.gitguardian.com) |

Local pre-commit / pre-push gates (also green) that back these: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features --locked -- -D warnings`, `cargo clippy --release --no-deps -- -D warnings` (pre-commit), and `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)` (pre-push race subset).

### 6. Focused diff
4 files, +587/-1: two source modules (`src/cognitive_memory/mod.rs`,
`src/memory_snapshot.rs`), one architecture doc, and one gadugi qa-scenario. No
unrelated edits; no changes under `prompt_assets/`. Branch is rebased onto current
`origin/main` (0 commits behind) so the squash merge applies cleanly.

All six merge-ready criteria are now satisfied (see sections 1–4 and 6 above): the
quality-audit ran 3 cycles ending on a clean final cycle, and the gadugi scenario was
validated (`--strict`) and run (`✓ Passed: 1  ✗ Failed: 0`) at the gate.

Closes #2561



## Activation / scope note

This PR delivers the **fail-closed decision seam** (`probe_emptiness`) and the
correctly-gated `auto_restore_if_empty` consumer the issue names — the piece
that was unsafe. It intentionally does **not** wire snapshot auto-restore into
session/daemon startup:

- There is no pre-existing naive count-based auto-restore path in the tree, so
  nothing unsafe is being left unfixed — the reusable primitive is the fix.
- The on-disk snapshot API (`export/import/load_snapshot_*`) is `#[deprecated]`
  in favour of hive-mind distributed replication, so activating a deprecated
  restore-at-startup is deliberately out of scope for this hardening.
- The remaining "close the last gap for the direct library backend" step is
  upstream in `amplihack-memory-lib` (propagate the swallowed read error), as
  the issue records. `probe_emptiness` is the single seam that upstream count
  plugs into once the pin is bumped.

Verified by `Task(code-review)`: fail-closed ordering holds (probe `?` precedes
any import), the write-counter tests would fail if swallow-to-empty-then-import
were reintroduced, and no data-loss/duplication edge case was found.


