### PR TITLE
fix(distill): preserve pretty-printed fact content quoting a launcher substring (#2570)

### DIFF
--- a/docs/concepts/copilot-launcher-preamble-stripping.md
+++ b/docs/concepts/copilot-launcher-preamble-stripping.md
@@ -111,8 +111,19 @@ is therefore deliberately conservative:
 
 - It matches **anchored launcher shapes only** (literal `starts_with`/`contains`
   on known launcher prefixes), never a generic heuristic.
-- It never matches a line that begins with `{` (JSON payload), an action
-  keyword, a bare decimal, or a verdict keyword.
+- It never matches a line that begins (after trimming) with a JSON **structural
+  token** — `{` (a whole object), `"` (a pretty-printed object member such as a
+  fact `"content": …` line), or `[` (an array element). This structural-token
+  guard is an **absolute, code-enforced** exemption
+  ([#2570](https://github.com/rysweet/Simard/issues/2570)): without it the
+  `contains`-based `launching copilot binary=` / `version="GitHub Copilot CLI`
+  arms would drop a pretty-printed fact `"content"` line that legitimately quotes
+  one of those launcher substrings, silently emptying the fact and letting the
+  distill reliability gate quarantine it. (The `launching…` / `version=…` arms
+  match by **containment**, so the payload-safety guarantee is precisely that a
+  line *leading with* a structural token is preserved; a first-word action
+  keyword, bare decimal, or verdict keyword is likewise not one of the anchored
+  launcher shapes.)
 - ANSI is stripped **before** matching, so colour control bytes cannot smuggle a
   launcher line past the anchors or a payload line into a launcher match.
 - Processing is single-pass and bounded; the

--- a/docs/reference/text-parsing-wire-formats.md
+++ b/docs/reference/text-parsing-wire-formats.md
@@ -68,7 +68,7 @@ Used by: **every** recipe-backed parser below, before it runs.
 |---|---|
 | `strip_ansi(&str) -> Cow` | Single ANSI (CSI/OSC/two-char) stripper. `Cow::Borrowed` on the clean path (no `ESC` byte). |
 | `strip_recipe_noise(&str) -> Cow` | `strip_ansi` + drop ISO-8601 tracing lines, runner-banner lines, **and Copilot launch-log preamble lines** (via `is_noise_line`). `Cow::Borrowed` on the clean path. |
-| `is_noise_line(&str) -> bool` *(private)* | Per-line predicate: `true` for an ISO-timestamp tracing line, a runner summary-banner line, **or** a Copilot launcher line (`is_copilot_launcher_line`). A JSON payload (`{`-leading), action keyword, bare decimal, or verdict keyword never matches, so dropping such a line never discards the answer. |
+| `is_noise_line(&str) -> bool` *(private)* | Per-line predicate: `true` for an ISO-timestamp tracing line, a runner summary-banner line, **or** a Copilot launcher line (`is_copilot_launcher_line`). A JSON payload line beginning (after `trim_start`) with a structural token (`{`, `"`, `[`), an action keyword, a bare decimal, or a verdict keyword never matches, so dropping such a line never discards the answer. |
 | `is_copilot_launcher_line(&str) -> bool` *(private)* | The launcher-only arm (#2496). Anchored `starts_with`/`contains` matches on the four launcher shapes below; matches **no** payload line. ANSI is stripped before it runs. |
 | `balanced_objects` / `last_balanced_object` / `extract_json_payload` | String-literal-aware balanced `{…}` scan. JSON extraction is **dual-pass** (line-dropped **and** ANSI-only) so the payload survives both an interleaved log line inside a pretty body and a same-line log prefix. |
 | `extract_verdict(raw, keywords)` | Precedence keyword scan over cleaned text. |
@@ -87,10 +87,14 @@ no decision token, JSON payload, decimal, or verdict keyword is ever eaten:
 | contains `launching copilot binary=` / `version="GitHub Copilot CLI` | `… INFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot version="GitHub Copilot CLI 1.0.66-2."` |
 | leading `INFO`/`WARN` launcher line with **no** ISO-8601 timestamp | `INFO using cached login`, `WARN extension not pinned` |
 
-A line that begins with `{`, a known action keyword, a bare decimal, or a
-verdict keyword is **never** classified as a launcher line. ANSI escapes are
-stripped first, so an ANSI-coloured `INFO`/`WARN` launcher line still matches and
-a coloured payload line still survives. See
+A line that begins (after `trim_start`) with a JSON **structural token** — `{`,
+`"`, or `[` — a known action keyword, a bare decimal, or a verdict keyword is
+**never** classified as a launcher line. The structural-token guard is explicit
+([#2570](https://github.com/rysweet/Simard/issues/2570)) so the `contains`-based
+`launching copilot binary=` / `version="GitHub Copilot CLI` arms above cannot
+drop a pretty-printed fact `"content"` line that quotes one of those substrings.
+ANSI escapes are stripped first, so an ANSI-coloured `INFO`/`WARN` launcher line
+still matches and a coloured payload line still survives. See
 [Concept: Copilot launch-log preamble stripping § correctness as safety](../concepts/copilot-launcher-preamble-stripping.md#correctness-as-safety-never-eat-the-payload).
 
 #### Example: launcher preamble + ANSI around a decide decision

--- a/src/goal_curation/recipe_progress_checker.rs
+++ b/src/goal_curation/recipe_progress_checker.rs
@@ -433,3 +433,60 @@ mod tests {
         assert!(matched_reject, "a real verdict must report matched=true");
     }
 }
+
+/// Issue #2570: `is_copilot_launcher_line` / `strip_recipe_noise` is a shared
+/// chokepoint. The distillation fact-yield fix exempts JSON structural-token
+/// lines (`{`, `"`, `[`) from launcher-noise classification; this
+/// progress-checker consumer must keep stripping the REAL launcher preamble
+/// (which never begins with a JSON token) so a noise-obscured verdict is still
+/// read. This is the progress-checker slice of the cross-consumer regression
+/// coverage.
+#[cfg(test)]
+mod issue_2570_cross_consumer_tests {
+    use super::*;
+
+    fn launcher_preamble() -> String {
+        "\u{2139} NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: cfg\n\
+         INFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot \
+         version=\"GitHub Copilot CLI 1.0.66-2.\"\n\
+         Run 'copilot update' to check for updates.\n"
+            .to_string()
+    }
+
+    #[test]
+    fn progress_checker_still_strips_real_launcher_preamble() {
+        let raw = format!(
+            "{}reject — no measurable progress this cycle",
+            launcher_preamble()
+        );
+        let (decision, matched) = parse_verdict_outcome(&raw);
+        assert!(
+            matched,
+            "the real reject must be read, not silently defaulted"
+        );
+        match decision {
+            EvidenceDecision::Reject { reason } => {
+                assert!(reason.contains("reject"), "got: {reason}");
+                assert!(
+                    !reason.contains("launching copilot"),
+                    "launcher preamble must be dropped from the rationale: {reason}"
+                );
+            }
+            EvidenceDecision::Accept { .. } => {
+                panic!("noise-obscured reject must be recovered after the #2570 guard")
+            }
+        }
+    }
+
+    #[test]
+    fn shared_cleaner_preserves_pretty_fact_content_line_quoting_launcher_substring() {
+        let content_line =
+            "\"content\": \"the agent logged launching copilot binary=/x before answering\"";
+        let cleaned = crate::recipe_output::strip_recipe_noise(content_line);
+        assert_eq!(
+            cleaned.as_ref(),
+            content_line,
+            "a JSON payload line must survive the shared cleaner"
+        );
+    }
+}

--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -1282,6 +1282,13 @@ pub(crate) fn parse_recipe_output_full(raw: &str) -> SimardResult<DistillOutput>
 /// intact envelope recovers the payload; preferring the populated candidate
 /// stops the gutted view from shadowing it.
 ///
+/// Post-#2570: the shared `is_copilot_launcher_line` guard now exempts any
+/// `{`/`"`/`[`-leading JSON line, so `strip_recipe_noise` no longer drops that
+/// `"output": …` member line — the line-dropping view recovers this pretty
+/// shape on its own. Candidate selection remains as defence-in-depth for shapes
+/// the line-dropping view can still gut (e.g. a compact envelope sharing a
+/// physical line with a leading banner token, which is dropped wholesale).
+///
 /// Selection precedence:
 /// 1. the first candidate whose `into_distill_output()` is `Ok` **and** carries
 ///    facts or procedures — the intact, populated recovery;
@@ -1335,10 +1342,13 @@ fn recover_distill_output(trimmed: &str) -> Option<SimardResult<DistillOutput>> 
 /// one that yields a populated [`DistillOutput`] (see [`recover_distill_output`]).
 ///
 /// Unlike a first-match scan, ALL candidates are returned: the line-dropping
-/// [`strip_recipe_noise`](crate::recipe_output::strip_recipe_noise) view can gut
-/// a pretty-printed envelope's escaped `output` line to `null` (#2517), so the
-/// line-preserving [`strip_ansi`](crate::recipe_output::strip_ansi) view's
-/// intact envelope must remain available and must not be shadowed.
+/// [`strip_recipe_noise`](crate::recipe_output::strip_recipe_noise) view could
+/// gut a pretty-printed envelope's escaped `output` line to `null` (#2517; since
+/// #2570's structural-token guard that specific `"`-leading member line is
+/// preserved), and it still drops a compact envelope that shares a physical line
+/// with a leading banner token — so the line-preserving
+/// [`strip_ansi`](crate::recipe_output::strip_ansi) view's intact envelope must
+/// remain available and must not be shadowed.
 ///
 /// Two cleaned views are tried, mirroring [`scan_for_facts_object`]:
 ///
@@ -2549,6 +2559,12 @@ mod issue_2512_outer_envelope_banner_tests {
 /// evaluates BOTH cleaned views and commits to the candidate that actually
 /// yields a populated [`DistillOutput`], so the intact line-preserving view wins
 /// over the gutted line-dropping view.
+///
+/// Post-#2570: the structural-token guard now preserves that `"output": …` line,
+/// so the line-dropping view no longer guts THIS pretty shape on its own (see
+/// the renamed `line_dropping_view_preserves_pretty_envelope_output_after_2570_guard`);
+/// the two-view candidate selection stays as defence-in-depth for other shapes
+/// that view can still gut.
 #[cfg(test)]
 mod issue_2517_pretty_envelope_launch_banner_tests {
     use super::*;
@@ -2650,22 +2666,40 @@ mod issue_2517_pretty_envelope_launch_banner_tests {
         assert!(facts.iter().any(|f| f.concept == "lesson-learned"));
     }
 
-    /// Root-cause pin: the line-dropping [`strip_recipe_noise`] view ALONE, on
-    /// this exact fixture, still yields a *structurally valid* envelope but with
-    /// its `output` gutted to `null` — so committing to it (the pre-fix bug)
-    /// fails to yield facts. This documents precisely the trap the fix routes
-    /// around by preferring the populated candidate.
+    /// Post-#2570 interaction pin (was `line_dropping_view_alone_guts_…`): the
+    /// line-dropping [`strip_recipe_noise`] view used to GUT this fixture — it
+    /// matched the pretty envelope's escaped `"output": …` line (which quotes
+    /// `launching copilot binary=`) as launcher noise and dropped it, leaving a
+    /// structurally valid envelope whose `output` was absent, so committing to
+    /// that view (the original #2517 bug) failed to yield facts. The #2570
+    /// structural-token guard now exempts that `"`-leading JSON payload line, so
+    /// the line-dropping view PRESERVES the `output` and recovers the facts on
+    /// its own. The #2517 "prefer the populated candidate" logic
+    /// ([`candidate_runner_envelopes`]) remains as defence-in-depth for a view
+    /// that could still be gutted (e.g. an envelope sharing a physical line with
+    /// a leading banner token); this test pins that #2570 has eliminated the
+    /// specific gutting trap for the real pretty-envelope shape.
     #[test]
-    fn line_dropping_view_alone_guts_the_pretty_envelope_output() {
+    fn line_dropping_view_preserves_pretty_envelope_output_after_2570_guard() {
         let raw = raw_capture();
-        let gutted_view = crate::recipe_output::strip_recipe_noise(raw.trim());
-        let gutted: RecipeRunnerEnvelope = serde_json::from_str(gutted_view.trim()).expect(
-            "the line-dropping view still yields a *structurally valid* envelope (only the \
-             `output` line is dropped)",
+        let recovered_view = crate::recipe_output::strip_recipe_noise(raw.trim());
+        let envelope: RecipeRunnerEnvelope = serde_json::from_str(recovered_view.trim()).expect(
+            "the line-dropping view yields a structurally valid envelope; after the #2570 guard \
+             its escaped `output` JSON line is preserved rather than dropped",
+        );
+        let out = envelope.into_distill_output().expect(
+            "after the #2570 structural-token guard the line-dropping view preserves the \
+             `\"output\"` line, so the envelope yields facts on its own",
+        );
+        assert_eq!(
+            out.facts.len(),
+            2,
+            "both grounded facts are recovered by the line-dropping view post-#2570: {:?}",
+            out.facts
         );
         assert!(
-            gutted.into_distill_output().is_err(),
-            "the gutted view's envelope must fail to yield facts — the trap the #2517 fix avoids"
+            out.facts.iter().all(|f| f.source_episode_id == "epi_2517"),
+            "fact provenance must survive the line-dropping recovery"
         );
     }
 
@@ -2937,5 +2971,121 @@ mod issue_t9664_field_tolerance_tests {
         // Empty content → reliability hard gate quarantines it (score 0.0).
         let score = assess_fact_reliability(&facts[0], &[], &facts);
         assert_eq!(score, 0.0, "empty-content fact must score 0.0");
+    }
+}
+
+/// Issue #2570: a **pretty-printed** inner facts JSON whose legitimate fact
+/// `"content"` line literally quotes the `launching copilot binary=` launcher
+/// substring must not have that line dropped by the shared
+/// `is_copilot_launcher_line` / `strip_recipe_noise` chokepoint.
+///
+/// Mechanism (pre-fix): `is_copilot_launcher_line` matched any physical line
+/// *containing* `launching copilot binary=`. When the distill agent emitted its
+/// `{ "facts": [...] }` object pretty-printed AND a fact's `content` value quoted
+/// that substring, the `strip_recipe_noise` view (tried first in
+/// [`scan_for_facts_object`]) dropped the whole `"content": …` line. The
+/// remaining object still parsed (`content` defaulted to `""` via
+/// [`de_lenient_string`]) and, because its `source_episode_id` was non-empty,
+/// [`scan_cleaned_for_facts`] returned it as a "grounded-capable" answer *before*
+/// the line-preserving `strip_ansi` view was tried — so the fact's real content
+/// was silently lost and the reliability hard gate then quarantined the
+/// now-empty fact. The fix guards `is_copilot_launcher_line` so a line beginning
+/// with a JSON structural token (`{`, `"`, `[`) is never classified as launcher
+/// noise, honouring the module's documented "a JSON payload line is never
+/// launcher noise" contract.
+#[cfg(test)]
+mod issue_2570_pretty_fact_launcher_substring_tests {
+    use super::*;
+
+    /// A single fact whose `content` quotes the launcher substring, emitted
+    /// pretty-printed inside the runner envelope's `distill` step `output`.
+    /// The content is >= 3 words and grounded, so if it survives it is a fully
+    /// promotable fact; if the `"content"` line is dropped it collapses to
+    /// empty and the reliability gate quarantines it.
+    fn pretty_inner_output() -> String {
+        // Hand-written pretty JSON so the `"content"` line begins (after
+        // indentation) with a `"` — the JSON structural token the fix guards on.
+        "{\n  \"facts\": [\n    {\n      \"concept\": \"lesson-learned\",\n      \
+         \"content\": \"the runner printed INFO launching copilot binary=/usr/bin/copilot \
+         before the answer\",\n      \"source_episode_id\": \"epi_2570\"\n    }\n  ]\n}"
+            .to_string()
+    }
+
+    fn envelope(inner: &str) -> String {
+        serde_json::json!({
+            "recipe_name": "distill-episodes",
+            "success": true,
+            "step_results": [{
+                "step_id": "distill",
+                "status": "completed",
+                "output": inner,
+                "error": ""
+            }]
+        })
+        .to_string()
+    }
+
+    /// The headline regression: the pretty-printed fact's full `content`
+    /// (including the launcher substring it quotes) must be preserved, not
+    /// line-dropped to an empty string.
+    #[test]
+    fn pretty_printed_fact_content_quoting_launcher_substring_is_preserved() {
+        let out = parse_recipe_output_full(&envelope(&pretty_inner_output()))
+            .expect("issue #2570 pretty inner facts object must parse");
+        assert_eq!(
+            out.facts.len(),
+            1,
+            "exactly one fact recovered: {:?}",
+            out.facts
+        );
+        let fact = &out.facts[0];
+        assert_eq!(fact.concept, "lesson-learned");
+        assert_eq!(fact.source_episode_id, "epi_2570");
+        assert_eq!(
+            fact.content,
+            "the runner printed INFO launching copilot binary=/usr/bin/copilot before the answer",
+            "the fact content quoting the launcher substring must survive intact, not be \
+             line-dropped to empty"
+        );
+    }
+
+    /// The preserved fact must clear the reliability gate — proving the fix
+    /// actually restores fact-yield (not merely non-empty text). Grounded
+    /// (source in batch) + >= 3 words + known concept clears 0.5.
+    #[test]
+    fn preserved_fact_clears_the_reliability_gate() {
+        let out = parse_recipe_output_full(&envelope(&pretty_inner_output()))
+            .expect("issue #2570 pretty inner facts object must parse");
+        let fact = &out.facts[0];
+        let episode = CognitiveEpisode {
+            node_id: "epi_2570".to_string(),
+            content: "the source episode".to_string(),
+            source_label: "distill-test".to_string(),
+            temporal_index: 1,
+            compressed: false,
+        };
+        let score = assess_fact_reliability(fact, std::slice::from_ref(&episode), &out.facts);
+        assert!(
+            score >= DISTILL_RELIABILITY_THRESHOLD,
+            "preserved grounded fact must clear the promotion threshold, got {score}"
+        );
+    }
+
+    /// Compact (single-line) inner JSON quoting the same substring already
+    /// worked via the line-preserving `strip_ansi` view; pin it so the fix does
+    /// not regress the pre-existing recovery path.
+    #[test]
+    fn compact_fact_content_quoting_launcher_substring_still_recovers() {
+        let inner = "{\"facts\":[{\"concept\":\"bug-pattern\",\
+             \"content\":\"agent logged INFO launching copilot binary=/usr/bin/copilot here\",\
+             \"source_episode_id\":\"epi_2570c\"}]}";
+        let out = parse_recipe_output_full(&envelope(inner))
+            .expect("compact inner facts object must parse");
+        assert_eq!(out.facts.len(), 1);
+        assert_eq!(
+            out.facts[0].content,
+            "agent logged INFO launching copilot binary=/usr/bin/copilot here"
+        );
+        assert_eq!(out.facts[0].source_episode_id, "epi_2570c");
     }
 }

--- a/src/ooda_brain/recipe_brain.rs
+++ b/src/ooda_brain/recipe_brain.rs
@@ -4248,3 +4248,82 @@ mod issue_2496_decide_orient_launcher_tests {
         assert_eq!(v3["cause"], "ok");
     }
 }
+
+/// Issue #2570: the distillation fact-yield fix tightened the shared
+/// `is_copilot_launcher_line` predicate so a JSON structural-token line (`{`,
+/// `"`, `[`) is never launcher noise. `is_copilot_launcher_line` /
+/// `strip_recipe_noise` is a shared chokepoint, so these decide/orient/lifecycle
+/// consumers must keep stripping the REAL launcher preamble (the property they
+/// depend on) — the guard only exempts JSON payload lines, which real launcher
+/// lines never are. This module is the decide/orient/lifecycle third of the
+/// cross-consumer regression coverage the issue asks for.
+#[cfg(test)]
+mod issue_2570_cross_consumer_launcher_guard_tests {
+    use super::*;
+
+    /// The real Copilot CLI 1.0.66-2 launch preamble the consumers must still
+    /// strip. None of these lines begins with a JSON structural token, so the
+    /// #2570 guard leaves them classified as launcher noise.
+    fn launcher_preamble() -> String {
+        "\u{2139} NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: cfg\n\
+         INFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot \
+         version=\"GitHub Copilot CLI 1.0.66-2.\"\n\
+         Run 'copilot update' to check for updates.\n"
+            .to_string()
+    }
+
+    #[test]
+    fn decide_still_strips_real_launcher_preamble() {
+        let raw = format!("{}run_improvement fix the flaky test", launcher_preamble());
+        let (decision, outcome) = parse_action_outcome(&raw);
+        assert_eq!(
+            outcome,
+            LifecycleParseOutcome::Parsed,
+            "decide must still strip the real launcher preamble after the #2570 guard"
+        );
+        assert!(
+            matches!(decision, DecideJudgment::RunImprovement { .. }),
+            "the model's real action must be read, not launcher noise"
+        );
+    }
+
+    #[test]
+    fn orient_still_strips_real_launcher_preamble() {
+        // The version string 1.0.66-2 sits on a launcher line that must still be
+        // dropped, so the model's real 0.37 is the first float read.
+        let raw = format!("{}0.37 demote after one failure", launcher_preamble());
+        let (judgment, outcome) = parse_orient_outcome(&raw, 0.80, 1);
+        assert_eq!(outcome, LifecycleParseOutcome::Parsed);
+        assert!(
+            (judgment.adjusted_urgency - 0.37).abs() < 1e-9,
+            "must read the model's 0.37, not the version string; got {}",
+            judgment.adjusted_urgency
+        );
+    }
+
+    #[test]
+    fn lifecycle_still_strips_real_launcher_preamble() {
+        let raw = format!("{}deprioritize the goal is stalled", launcher_preamble());
+        let (decision, outcome) = parse_lifecycle_outcome(&raw);
+        assert_eq!(outcome, LifecycleParseOutcome::Parsed);
+        assert!(
+            matches!(decision, EngineerLifecycleDecision::Deprioritize { .. }),
+            "the model's real lifecycle decision must be read, not launcher noise"
+        );
+    }
+
+    #[test]
+    fn shared_cleaner_preserves_pretty_fact_content_line_quoting_launcher_substring() {
+        // The other half of the #2570 contract on the exact shared chokepoint
+        // these consumers call: a `"`-leading fact content line that quotes the
+        // launcher substring is preserved, not dropped.
+        let content_line =
+            "\"content\": \"the agent logged launching copilot binary=/x before answering\"";
+        let cleaned = crate::recipe_output::strip_recipe_noise(content_line);
+        assert_eq!(
+            cleaned.as_ref(),
+            content_line,
+            "a JSON payload line must survive the shared cleaner"
+        );
+    }
+}

--- a/src/recipe_output/extract.rs
+++ b/src/recipe_output/extract.rs
@@ -125,15 +125,34 @@ fn starts_with_iso_timestamp(s: &str) -> bool {
 /// - a `… launching copilot binary=… version="GitHub Copilot CLI …"` line,
 /// - a leading `INFO`/`WARN` launcher line that carries no ISO-8601 timestamp.
 ///
-/// A line beginning with `{` (JSON payload), an action keyword, a bare decimal,
-/// or a verdict keyword is **never** classified as launcher noise, so dropping a
-/// launcher line can never discard a decision token or a JSON answer. ANSI
-/// escapes are stripped before this runs (see [`strip_recipe_noise`]), so a
+/// A line beginning with a JSON structural token (`{`, `"`, `[`) — a JSON
+/// payload, a pretty-printed object member (`"key": …`), or an array element —
+/// an action keyword, a bare decimal, or a verdict keyword is **never**
+/// classified as launcher noise, so dropping a launcher line can never discard a
+/// decision token or a JSON answer. The structural-token guard is explicit
+/// (issue #2570): without it the `contains`-based `launching copilot binary=` /
+/// `version="GitHub Copilot CLI` arms would drop a pretty-printed fact
+/// `"content"` line that legitimately quotes one of those launcher substrings.
+/// ANSI escapes are stripped before this runs (see [`strip_recipe_noise`]), so a
 /// colour-coded launcher line still matches and a coloured payload line still
 /// survives. This is correctness-as-safety: the predicate consumes untrusted
 /// agent stdout, so it errs toward keeping a line rather than eating a payload.
 fn is_copilot_launcher_line(line: &str) -> bool {
     let t = line.trim_start();
+
+    // A line that begins with a JSON structural token (`{`, `"`, `[`) is a JSON
+    // payload line — a whole object, a pretty-printed object member (`"key": …`),
+    // or an array element — never a launcher-log preamble line. Every real
+    // launcher shape begins with `\u{2139}` (info marker), `Run`, or an `INFO`/
+    // `WARN` level token, so guarding here loses no launcher line while honouring
+    // the module's documented contract that "a `{`-leading JSON payload line is
+    // never launcher noise". This closes the lossy edge (issue #2570) where the
+    // `contains`-based `launching copilot binary=` / `version="GitHub Copilot CLI`
+    // arms below would otherwise drop a pretty-printed fact `"content"` line that
+    // legitimately quotes a launcher substring, silently emptying that fact.
+    if matches!(t.as_bytes().first(), Some(b'{') | Some(b'"') | Some(b'[')) {
+        return false;
+    }
 
     // An ISO-timestamped line is a tracing line owned by the timestamp arm of
     // `is_noise_line`; never treat it as a launcher line here (keeps this
@@ -728,5 +747,108 @@ mod issue_2496_launcher_tests {
             "clean path must not allocate"
         );
         assert_eq!(out, s);
+    }
+}
+
+/// Issue #2570: a line beginning with a JSON structural token (`{`, `"`, `[`) is
+/// a JSON payload line and must NEVER be classified as launcher noise, even when
+/// it literally quotes a launcher substring (`launching copilot binary=` /
+/// `version="GitHub Copilot CLI`). This is the shared-chokepoint half of the fix
+/// for the distillation fact-yield edge — a pretty-printed fact `"content"` line
+/// that quotes such a substring was being line-dropped, silently emptying the
+/// fact. These tests pin BOTH halves of the contract at the shared predicate the
+/// six consumers (decide, orient, engineer-lifecycle, merge-judge,
+/// progress-checker, distill) all route through: real launcher lines are still
+/// stripped, and structural-token payload lines are preserved.
+#[cfg(test)]
+mod issue_2570_structural_token_guard_tests {
+    use super::*;
+
+    // The real Copilot CLI 1.0.66-2 launcher shapes (ANSI already stripped), the
+    // lines the consumers RELY ON being dropped.
+    const INFO_MARKER: &str = "\u{2139} NODE_OPTIONS=--max-old-space-size=32768 \
+         (saved preference). To change: /home/azureuser/.amplihack/config";
+    const LAUNCHING: &str = "INFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot \
+         version=\"GitHub Copilot CLI 1.0.66-2.\"";
+    const UPDATE_NAG: &str = "Run 'copilot update' to check for updates.";
+
+    #[test]
+    fn structural_token_leading_lines_quoting_launcher_substring_are_never_noise() {
+        // A pretty-printed fact `"content"` member line quoting the substring.
+        let content_line =
+            "\"content\": \"the agent logged launching copilot binary=/x before answering\",";
+        // A whole compact object line quoting the substring.
+        let object_line = "{\"content\":\"see launching copilot binary=/x\"}";
+        // An array-element line quoting the launcher substring. Uses the raw
+        // needle (not a JSON-escaped one) so that WITHOUT the guard the
+        // `contains("launching copilot binary=")` arm would match and drop it —
+        // this input actually exercises the `[` arm of the structural-token guard.
+        let array_line = "[\"the agent logged launching copilot binary=/x here\"]";
+        // Pretty (indented) content line — `trim_start` must apply before the guard.
+        let indented_content = "      \"content\": \"launching copilot binary=/x\"";
+        for line in [content_line, object_line, array_line, indented_content] {
+            assert!(
+                !is_copilot_launcher_line(line),
+                "a JSON structural-token line is never launcher noise: {line:?}"
+            );
+            assert!(
+                !is_noise_line(line),
+                "a JSON structural-token line is never noise: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn real_launcher_shapes_are_still_classified_after_the_guard() {
+        // The structural-token guard must not stop any real launcher shape from
+        // being dropped — the property every text consumer depends on.
+        for line in [
+            INFO_MARKER,
+            LAUNCHING,
+            UPDATE_NAG,
+            "INFO using cached login",
+            "WARN extension not pinned",
+        ] {
+            assert!(
+                is_copilot_launcher_line(line),
+                "real launcher line must still be classified: {line:?}"
+            );
+            assert!(
+                is_noise_line(line),
+                "real launcher line must still be dropped: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn strip_recipe_noise_drops_launcher_lines_but_keeps_pretty_content_line() {
+        // The end-to-end shared-chokepoint behaviour: real launcher preamble
+        // lines are dropped, while the `"`-leading fact content line that quotes
+        // the launcher substring survives.
+        let content_line =
+            "\"content\": \"the agent logged launching copilot binary=/x before answering\"";
+        let raw = format!("{LAUNCHING}\n{UPDATE_NAG}\n{INFO_MARKER}\n{content_line}");
+        let cleaned = strip_recipe_noise(&raw);
+        assert_eq!(
+            cleaned.trim(),
+            content_line,
+            "launcher lines dropped; the quoted-substring content line preserved"
+        );
+    }
+
+    #[test]
+    fn pretty_json_object_quoting_launcher_substring_survives_unchanged() {
+        // A full pretty-printed object whose content quotes the substring passes
+        // through the cleaner unchanged (no line is noise) and remains valid JSON.
+        let pretty = "{\n  \"facts\": [\n    {\n      \
+             \"content\": \"see launching copilot binary=/x\"\n    }\n  ]\n}";
+        let cleaned = strip_recipe_noise(pretty);
+        assert_eq!(
+            cleaned.as_ref(),
+            pretty,
+            "no line of a pretty JSON object is launcher noise"
+        );
+        serde_json::from_str::<serde_json::Value>(cleaned.as_ref())
+            .expect("the cleaned view must still be valid JSON");
     }
 }

--- a/src/stewardship/recipe_merge_judge.rs
+++ b/src/stewardship/recipe_merge_judge.rs
@@ -984,3 +984,54 @@ mod issue_2501_2555_real_envelope_tests {
         );
     }
 }
+
+/// Issue #2570: `is_copilot_launcher_line` / `strip_recipe_noise` is a shared
+/// chokepoint. The distillation fact-yield fix exempts JSON structural-token
+/// lines (`{`, `"`, `[`) from launcher-noise classification; this merge-judge
+/// consumer must keep stripping the REAL launcher preamble (which never begins
+/// with a JSON token) so a noise-obscured verdict is still read. This is the
+/// merge-judge slice of the cross-consumer regression coverage.
+#[cfg(test)]
+mod issue_2570_cross_consumer_tests {
+    use super::*;
+    use crate::ooda_brain::LifecycleParseOutcome;
+
+    fn launcher_preamble() -> String {
+        "\u{2139} NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: cfg\n\
+         INFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot \
+         version=\"GitHub Copilot CLI 1.0.66-2.\"\n\
+         Run 'copilot update' to check for updates.\n"
+            .to_string()
+    }
+
+    #[test]
+    fn merge_judge_still_strips_real_launcher_preamble() {
+        let raw = format!(
+            "{}not_ready the quality audit is incomplete",
+            launcher_preamble()
+        );
+        let (out, outcome) = parse_merge_outcome(&raw);
+        assert_eq!(
+            outcome,
+            LifecycleParseOutcome::Parsed,
+            "merge-judge must still strip the launcher preamble after the #2570 guard"
+        );
+        assert_eq!(
+            out.verdict,
+            Verdict::NotReady,
+            "the model's real verdict must be read, not launcher noise"
+        );
+    }
+
+    #[test]
+    fn shared_cleaner_preserves_pretty_fact_content_line_quoting_launcher_substring() {
+        let content_line =
+            "\"content\": \"the agent logged launching copilot binary=/x before answering\"";
+        let cleaned = crate::recipe_output::strip_recipe_noise(content_line);
+        assert_eq!(
+            cleaned.as_ref(),
+            content_line,
+            "a JSON payload line must survive the shared cleaner"
+        );
+    }
+}

--- a/tests/gadugi/distill-parser-launch-banner-pretty-envelope.yaml
+++ b/tests/gadugi/distill-parser-launch-banner-pretty-envelope.yaml
@@ -20,9 +20,12 @@ description: >
   The fix (`recover_distill_output` + `candidate_runner_envelopes`) evaluates
   BOTH cleaned views and commits to the candidate that actually yields a
   populated `DistillOutput`, so the intact `strip_ansi` view wins over the
-  gutted `strip_recipe_noise` view. This scenario pins the full ANSI-wrapped
-  multi-line `1.0.66-2` banner + pretty envelope + inner-banner `output` shape
-  end-to-end (facts AND procedures recovered), preserves the
+  gutted `strip_recipe_noise` view. (Post-#2570: the shared structural-token
+  guard now preserves that `"output": …` line, so the line-dropping view
+  recovers this pretty shape on its own; the two-view selection remains as
+  defence-in-depth for shapes it can still gut.) This scenario pins the full
+  ANSI-wrapped multi-line `1.0.66-2` banner + pretty envelope + inner-banner
+  `output` shape end-to-end (facts AND procedures recovered), preserves the
   `success == false` -> RecipeReportedFailure contract, and keeps a genuinely
   empty "nothing to distill" answer an empty Ok (no burned retry) so the
   `distill_parse_success_rate` metric path stays green.
@@ -67,7 +70,7 @@ steps:
       outputContains:
         - "full_1_0_66_2_launch_banner_with_ansi_and_envelope_recovers_facts_and_procedures ... ok"
         - "facts_only_wrapper_recovers_facts_from_pretty_envelope ... ok"
-        - "line_dropping_view_alone_guts_the_pretty_envelope_output ... ok"
+        - "line_dropping_view_preserves_pretty_envelope_output_after_2570_guard ... ok"
         - "banner_prefixed_failed_pretty_envelope_reports_recipe_failure ... ok"
         - "banner_prefixed_pretty_envelope_with_nothing_to_distill_returns_empty_ok ... ok"
         - "test result: ok"

--- a/tests/qa-scenarios/distill-pretty-fact-launcher-substring-parse.yaml
+++ b/tests/qa-scenarios/distill-pretty-fact-launcher-substring-parse.yaml
@@ -1,0 +1,83 @@
+name: distill-pretty-fact-launcher-substring-parse
+app_type: cli
+description: |
+  Verify episode→fact distillation preserves a fact's `content` when the distill
+  agent emits its `{ "facts": [...] }` answer PRETTY-PRINTED and a legitimate
+  fact `"content"` line literally quotes the `launching copilot binary=` launcher
+  substring (issue #2570).
+
+  Before the fix, the shared `is_copilot_launcher_line` predicate matched any
+  physical line *containing* that substring, so the line-dropping
+  `strip_recipe_noise` view (tried first in `scan_for_facts_object`) discarded
+  the whole `"content": …` line. The remaining object still parsed with an
+  empty, defaulted `content`; because its `source_episode_id` was non-empty it
+  was returned as a "grounded-capable" answer before the line-preserving
+  `strip_ansi` view was tried, so the fact's real content was silently lost and
+  the reliability hard gate then quarantined the now-empty fact — a fact-yield
+  regression.
+
+  The fix guards `is_copilot_launcher_line` so a line beginning (after trimming)
+  with a JSON structural token (`{`, `"`, `[`) is never launcher noise, honouring
+  the module's documented "a JSON payload line is never launcher noise" contract.
+  Because that predicate / `strip_recipe_noise` is a shared chokepoint used by
+  decide, orient, engineer-lifecycle, merge-judge, progress-checker AND distill,
+  this scenario also drives the cross-consumer regression tests proving those
+  consumers still strip real launcher-noise lines.
+
+  Proven by the hermetic in-process unit tests this scenario drives (no network,
+  no live host mutation). The CLI runner rejects any non-zero exit, so a failing
+  test fails the scenario.
+agents:
+  - name: simard-cli
+    type: cli
+    command: cargo
+steps:
+  # Headline distill regression: the pretty-printed fact content quoting the
+  # launcher substring is preserved (not line-dropped to empty), and the
+  # preserved grounded fact clears the reliability promotion gate. First
+  # invocation may compile the test binary.
+  - action: run
+    params:
+      command: "cargo test --locked --lib -- memory_consolidation::distillation::issue_2570_pretty_fact_launcher_substring_tests"
+    timeout: 600000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Shared chokepoint: a JSON structural-token line (`{`, `"`, `[`) quoting the
+  # launcher substring is never classified as launcher noise, while every real
+  # launcher shape is still stripped by `strip_recipe_noise`.
+  - action: run
+    params:
+      command: "cargo test --locked --lib -- recipe_output::extract::issue_2570_structural_token_guard_tests"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Cross-consumer safety: decide, orient, engineer-lifecycle, merge-judge and
+  # progress-checker still strip the real launcher preamble after the guard,
+  # while the shared cleaner preserves a `"`-leading fact content line quoting
+  # the substring. A single filter runs every `issue_2570` regression test.
+  - action: run
+    params:
+      command: "cargo test --locked --lib -- issue_2570_cross_consumer"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000


### PR DESCRIPTION
## Summary

Fixes the distillation **fact-yield** edge in issue #2570: a fact's real
`content` was silently lost when the distill agent emitted its
`{ "facts": [...] }` answer **pretty-printed** AND a legitimate fact
`"content"` line literally quoted the launcher substring
`launching copilot binary=`.

**Root cause.** The shared `is_copilot_launcher_line` predicate
(`src/recipe_output/extract.rs`) matched any physical line *containing* that
substring. In `scan_for_facts_object` the line-dropping `strip_recipe_noise`
view (tried first) discarded the `"content": …` line; the remaining object
still parsed with `content` defaulted to `""` (`de_lenient_string`), and because
`source_episode_id` was non-empty it was returned as a "grounded-capable" answer
*before* the line-preserving `strip_ansi` view was tried. The fact's real
content was lost and the reliability hard gate then quarantined the now-empty
fact.

**Fix (1 production line).** Guard `is_copilot_launcher_line` so a line
beginning (after `trim_start`) with a JSON structural token (`{`, `"`, `[`) is
**never** classified as launcher noise — honouring the module's documented
"a JSON payload line is never launcher noise" contract:

```rust
if matches!(t.as_bytes().first(), Some(b'{') | Some(b'"') | Some(b'[')) {
    return false;
}
```

Every real Copilot CLI launcher shape begins with `ℹ`, `Run`, or an
`INFO`/`WARN` level token, so **no real launcher line stops being stripped**;
runner banners (`[completed]`/`[failed]`/…) are still dropped by `is_noise_line`'s
own arm. The change is O(1) per line and byte/char-safe (ASCII bytes never
collide with a UTF-8 continuation byte).

Because `is_copilot_launcher_line` / `strip_recipe_noise` is a **shared
chokepoint** used by decide, orient, engineer-lifecycle, merge-judge,
progress-checker and distill, the PR adds cross-consumer regression tests
proving those consumers still strip the real launcher preamble while the
pretty-printed fact `"content"` line is preserved.

Closes #2570

---

## Rebase / conflict resolution (this revision)

Rebased onto current `origin/main` (which had merged #2571 for issue #2517 and
#2530). Two coupled items were handled and re-verified:

1. **Conflict in `src/stewardship/recipe_merge_judge.rs`** — two additive,
   non-overlapping test modules were both kept: `issue_2501_2555_real_envelope_tests`
   (from main) and `issue_2570_cross_consumer_tests` (this PR). Both compile and
   pass (verified: 38/38 in the module).
2. **Tightly-coupled #2517 test** — the #2570 structural-token guard also
   preserves a pretty envelope's `"output": …` line (it starts with `"`), so the
   line-dropping view no longer *guts* that envelope. The #2517 test
   `line_dropping_view_alone_guts_the_pretty_envelope_output` was renamed to
   `line_dropping_view_preserves_pretty_envelope_output_after_2570_guard` and now
   asserts the envelope yields its 2 facts. The pinned test name in
   `tests/gadugi/distill-parser-launch-banner-pretty-envelope.yaml` and the
   related #2517 doc comments were updated to match (post-#2570 behavior).
   The #2517 production recovery path (`candidate_runner_envelopes` /
   `parse_recipe_output_full`) is **not** weakened — the guard only makes
   `strip_recipe_noise` preserve *more* valid JSON, so recovery strictly improves;
   two-view candidate selection remains as defence-in-depth.

---

## Merge-ready evidence

### 1. QA scenarios (written, validated, run)
- New gadugi scenario: `tests/qa-scenarios/distill-pretty-fact-launcher-substring-parse.yaml`.
- `gadugi-test validate --strict -f …` → `✓ Scenario … is valid` (1 valid, 0 invalid).
- `gadugi-test run -s distill-pretty-fact-launcher-substring-parse` → **✓ Passed: 1 / Total: 1**,
  driving 15 hermetic tests across 3 steps (3 distill + 4 shared-chokepoint +
  8 cross-consumer), all `test result: ok`.

### 2. Docs updated
Shared-predicate reference/concept surfaces updated for the structural-token
guarantee; internal #2517/#2570 interaction comments corrected to state
post-#2570 behavior (no overstated claims):
- `docs/concepts/copilot-launcher-preamble-stripping.md`
- `docs/reference/text-parsing-wire-formats.md`
- `src/memory_consolidation/distillation.rs` doc comments (`recover_distill_output`,
  `candidate_runner_envelopes`, `issue_2517_*` test module) + the #2517 gadugi
  scenario description.

### 3. quality-audit (3 SEEK→VALIDATE→FIX cycles, clean final)
- **Cycle 1** (code-review): found a Medium — the #2517 gadugi scenario still
  pinned the OLD test name via `outputContains`, unsatisfiable after the rename.
  **FIX:** updated the pinned string to the new test name. Verified the core
  guard is UTF-8/O(1)-safe, both reconstructed merge-judge test modules complete,
  and the distillation rename is correct (not a masked regression).
- **Cycle 2** (fresh, skeptical rubber-duck): **zero blocking issues.** Confirmed
  no real launcher line begins with `{`/`"`/`[`, `[completed]`/`[failed]` banners
  still dropped by `is_noise_line`, guard ordering safe. One non-blocking
  doc-staleness note → **FIX:** corrected the #2517 comments to post-#2570 wording.
- **Cycle 3** (security-review): **no vulnerabilities.** The guard makes
  `strip_recipe_noise` *less* aggressive (keep-rather-than-drop on untrusted
  stdout); it cannot flip a merge verdict to `ready` (fail-closed `unclear` on
  parse miss is untouched; preserving lines can only add keyword matches, never
  delete a `not_ready`), cannot bypass the distillation reliability gate
  (`assess_fact_reliability` grounding via `source_episode_id` match is
  independent of line-stripping), and adds no injection/ReDoS/DoS path.

Final cycle ended clean (zero critical/high; zero medium correctness/security).

### 4. CI green
All checks green on the merge commit (`95fe4337`): `build` (full
`cargo test --all-features --locked`), `pre-commit`, `coverage`, `install-real`,
`e2e-dashboard`, `cargo-audit`, `cargo-deny`, `cargo-vet`, `npm-audit`,
GitGuardian. Green run links for the required checks:
- build: https://github.com/rysweet/Simard/actions/runs/28707761009/job/85136165535
- pre-commit: https://github.com/rysweet/Simard/actions/runs/28707761012/job/85136165643
- coverage: https://github.com/rysweet/Simard/actions/runs/28707761031/job/85136165433
- install-real: https://github.com/rysweet/Simard/actions/runs/28707761012/job/85136598730
- e2e-dashboard: https://github.com/rysweet/Simard/actions/runs/28707761012/job/85136598732

Local pre-push gates (mirror CI): `cargo fmt --check`,
`cargo clippy --all-targets --all-features --locked -D warnings`, and
`cargo test --release --lib (…|memory_consolidation)` all pass.

### 5. Verdict — ready to merge
**Verdict: READY TO MERGE.** All six merge-ready criteria are satisfied with
concrete evidence above: the qa-scenario is written, `gadugi-test validate`d and
`run` (1/1, 15 hermetic tests); user-facing and internal doc surfaces are updated
with file paths; three quality-audit SEEK→VALIDATE→FIX cycles ran and ended clean
(zero critical/high, zero medium correctness/security); all 17 CI checks are green
on the merge commit `95fe4337` (links above); and the diff is focused (1 production
line + regression tests, docs, and the rebase-coupled #2517 test rename). No open
blockers remain.

### 6. Focused diff
1-line production change (the guard in `extract.rs`); everything else is
`#[cfg(test)]` regression tests, doc-comment/reference accuracy, one qa-scenario,
and the rebase-coupled #2517 test rename + its pinned-name/doc updates. No
unrelated edits.

---

🤖 Generated with [GitHub Copilot CLI](https://github.com/features/copilot)
