### PR TITLE
docs(engineer-prompt): encode operator naming + merge rules (no Bridge, one-Brain/reasoner, no admin-merge)

### DIFF
--- a/prompt_assets/simard/engineer_system.md
+++ b/prompt_assets/simard/engineer_system.md
@@ -449,6 +449,16 @@ You hold all code — yours and the ecosystem's — to the amplihack philosophy:
   ```
   The `test:` commit appears BEFORE the `feat:` commit in history (bottom = oldest). Bundling tests and implementation in a single commit violates this rule. This discipline is enforced through this prompt — not through CI scripts or git history parsing.
 
+- **Never merge with `--admin`**: PR merges must never bypass required CI checks. `gh pr merge --admin` is forbidden. A PR merges only when all required checks are GREEN. If checks fail, fix the cause — do not force the merge.
+
+## Naming and Logging Conventions (operator rules — MANDATORY)
+
+These are hard operator requirements. Violating them fails review:
+
+- **Never name anything "Bridge".** No type, struct, trait, module, file, field, or doc may contain the word `Bridge`/`bridge`. Use accurate, intuitive names instead — e.g. `Adapter`, `Client`, `Transport`, `Ingest`, `Gateway`, `Connector` — chosen for what the thing actually does. (A pack->memory ingestion module is `ingest`, not `bridge`.)
+- **The "brain" is the whole cognition** — the cognitive-thread scheduler/process abstraction + all threads + the cognitive-memory model. The per-OODA-phase LLM components are **reasoners** (`OrientReasoner`, `DecideReasoner`, `ActReasoner`), **not** separate "brains". Do not introduce new `*Brain` types for individual phases.
+- **No `print!`/`println!`/`eprintln!` in daemon/library code.** Use structured `tracing` events + spans and OTel metrics. Genuine operator-facing CLI output (command/gym renderers writing to stdout for a human) is the only exception and must go through the designated output path in a `src/bin/` binary — never scattered through library modules.
+
 ## Prompt-First Improvements (highest priority for self-modifying work)
 
 When the target repository is **Simard itself**, your default tool for changing


### PR DESCRIPTION
## Problem
Simard's engineer autonomously created `src/rust_expertise/bridge.rs` in #2567 — violating the operator's hard rule *never name anything 'Bridge'*. Root cause: the engineer system prompt never stated the rule, so engineers can't follow it.

## Fix
Add a **Naming and Logging Conventions (MANDATORY)** section to `engineer_system.md`:
- **No `Bridge` naming** anywhere — use accurate names (`Adapter`/`Client`/`Transport`/`Ingest`/…).
- **One 'brain' = the whole cognition**; per-phase LLM parts are **reasoners** (Orient/Decide/Act), not `*Brain` types.
- **No stray `print!`/`println!`/`eprintln!`** in library/daemon code — structured `tracing` + OTel; CLI stdout only via `src/bin/` renderers.
- Also adds the **no `--admin` merge** rule beside the existing no-`--no-verify` rule.

Prompt hot-reloads from `~/.simard/prompt_assets/simard/`, so it takes effect without a rebuild once synced. Prevents recurrence of the #2567-class violation.