### PR TITLE
feat(signal): accept Note-to-Self commands on linked-device setups (#2575)

### DIFF
--- a/docs/howto/set-up-the-signal-channel.md
+++ b/docs/howto/set-up-the-signal-channel.md
@@ -1,11 +1,11 @@
 ---
 title: How to set up the Signal channel
-description: Connect Simard to Signal so an allowlisted operator can command her and receive notifications, using a locally-run signal-cli JSON-RPC daemon. Covers the signal feature build, linking a device (or using a dedicated number), configuration, the allowlist, and verification.
-last_updated: 2026-07-03
+description: Connect Simard to Signal so an allowlisted operator can command her and receive notifications, using a locally-run signal-cli JSON-RPC daemon. Covers the signal feature build, linking a device (or using a dedicated number), the Note-to-Self flow for single-number linked-device setups, loop prevention, configuration, the allowlist, and verification.
+last_updated: 2026-07-04
 review_schedule: as-needed
 owner: simard
 doc_type: howto
-issues: ["#2527"]
+issues: ["#2527", "#2575"]
 related:
   - ../index.md
   - ../reference/signal-conversation.md
@@ -69,6 +69,25 @@ signal-cli prints a `sgnl://linkdevice?...` URI (and a QR code). On your phone:
 the URI). When linking finishes, note the account number (your own E.164, e.g.
 `+15551234567`) — that is the `account` value below.
 
+> **Single number? You chat with Simard via _Note to Self._** When signal-cli is a
+> linked device on your *own* account, the number you message Simard **from** and the
+> `account` she receives **on** are the **same** number. There is no separate number
+> to text, so the operator commands Simard by messaging **themselves** — Signal's
+> **Note to Self** conversation. signal-cli delivers those to Simard as *sync-sent*
+> messages, and she accepts a Note-to-Self message from your **primary phone** as an
+> operator command. See [Chatting via Note to Self](#chatting-via-note-to-self-single-number-setups)
+> below for the trust boundary and how this stays loop-free.
+
+While you are linked, record signal-cli's own **device id** — you will use it for
+defence-in-depth loop prevention (`own_device_id`, step 4):
+
+```bash
+signal-cli -a +15551234567 listDevices
+```
+
+Your phone is **always device 1**; the `simard-daemon` device you just linked has a
+higher id (e.g. `2`). Note that number.
+
 ### Option B — Register a dedicated number
 
 Register a separate number that Simard owns:
@@ -105,17 +124,33 @@ The `[signal]` table is only parsed and applied in a `--features signal` build
 
 ```toml
 [signal]
-endpoint = "127.0.0.1:7583"     # the signal-cli daemon from step 3
+endpoint = "127.0.0.1:7583"      # the signal-cli daemon from step 3
 account  = "+15551234567"        # the linked/dedicated account from step 2
 allowlist = ["+15559876543"]     # YOUR operator number(s) — who may command Simard
 read_only_unknown = false        # keep unknown senders fully ignored (default)
+# own_device_id = 2              # single-number setups only: signal-cli's OWN linked
+                                 # device id from `listDevices` — defence-in-depth
+                                 # loop prevention. Omit it for a dedicated number.
 ```
 
 - **`allowlist` is the security boundary.** Only the E.164 numbers listed here may
   command Simard. It is **fail-closed**: an empty or missing allowlist means
   *nobody* may command her. Put the operator's own phone number here — the number
-  you message Simard *from*, which is different from `account` (the number Simard
-  receives *on*).
+  you message Simard *from*.
+    - **Dedicated number (Option B):** the operator number is **different** from
+      `account` (the number Simard receives *on*).
+    - **Single-number linked device (Option A):** the operator number **is** the
+      `account` number, so `account` and `allowlist` hold the **same** E.164. This is
+      correct and required — a Note-to-Self command's sender *is* the account. It does
+      **not** weaken fail-closed behavior: an unknown sender is still ignored, and a
+      Note-to-Self message is accepted only when it comes from your **primary phone**
+      (device 1) — see [Chatting via Note to Self](#chatting-via-note-to-self-single-number-setups).
+- **`own_device_id` (optional, single-number setups).** signal-cli's own linked
+  device id (from `signal-cli … listDevices`, e.g. `2`). It is defence-in-depth: even
+  without it Simard already rejects her own echoes (only device 1 may command), but
+  setting it makes the own-device rejection explicit. Resolve it env-first with
+  `SIMARD_SIGNAL_OWN_DEVICE_ID`. Omit it for a dedicated number. A present-but-unparseable
+  value is a hard error (like the other keys) — never a silent default.
 - Set `read_only_unknown = true` only if you want non-allowlisted senders to be
   able to read `status`; they can never trigger a mutation.
 
@@ -143,8 +178,12 @@ with the feature — no Signal code is compiled into a default build.
 
 ## 6. Verify the round trip
 
-From your **operator** phone (an allowlisted number), message Simard's Signal
-account:
+Message Simard from your **operator** phone (an allowlisted number):
+
+- **Dedicated number (Option B):** open the conversation with Simard's Signal
+  `account` and send to it.
+- **Single-number linked device (Option A):** open **Note to Self** (you are the
+  account) and send there — that is the only way to reach Simard on a single number.
 
 ```text
 status
@@ -170,6 +209,58 @@ merge then proceeds through the gated
 [operational autonomy model](../concepts/operational-autonomy-model.md) for the full
 HIGH-RISK boundary.
 
+## Chatting via Note to Self (single-number setups)
+
+When signal-cli is a **linked device on your own account** (Option A), you and Simard
+share one number, so you command her from **Note to Self**. This section explains how
+that works and — critically — how Simard avoids an infinite self-reply loop.
+
+### Why Note to Self
+
+A linked device receives everything the account does. When you type into **Note to
+Self** on your phone, Signal syncs that to every linked device as a **sync-sent**
+message (`syncMessage.sentMessage`) — a transcript of a message the account sent to
+itself. signal-cli forwards it to Simard, who reads the body (`status`, a question,
+`merge #NNNN`, …) and treats the **account itself** as the sender. Because the account
+number is on the `allowlist`, the command is authorized and answered right back into
+Note to Self.
+
+> A dedicated-number setup (Option B) never uses this path: those are ordinary
+> `dataMessage`s from a separate operator number and behave exactly as before.
+
+### The loop problem — and the three guards
+
+A linked device **also** receives sync-sent transcripts of the messages **Simard
+herself** sends via signal-cli (her replies are sent *from* the account, so they sync
+back too). Naïvely, Simard would read her own reply as a new command and answer it
+forever. Three layered guards prevent this; a sync-sent message is accepted as a
+command **only if all of them pass**:
+
+1. **Primary-phone gate (device 1).** Signal guarantees the account owner's **phone is
+   always device 1**; every linked device (signal-cli, Signal Desktop, an iPad) has a
+   higher id. Simard accepts a Note-to-Self command **only** when the envelope's source
+   device is **device 1** — i.e. it was typed on your phone. Her own replies originate
+   from signal-cli's linked device (id ≥ 2) and are therefore rejected. This gate alone
+   closes the loop, even with no extra configuration.
+2. **Own-device rejection (defence-in-depth).** If you set `own_device_id` (step 4),
+   Simard *also* explicitly rejects any sync-sent message whose source device equals
+   signal-cli's own id. This is redundant with the device-1 gate by design.
+3. **Recent-outbound echo suppression (defence-in-depth).** Simard remembers the bodies
+   of the messages she just sent (a small, bounded, in-memory window — the last 64
+   messages, expiring after 5 minutes) and ignores a sync-sent message whose body
+   exactly matches one of them. This catches any echo the first two guards might miss.
+
+Only **your primary phone's** Note-to-Self messages are newly accepted. Commands from
+Signal Desktop or any other linked device are **not** honored — issue commands from
+your phone. And a genuinely unknown sender is still dropped, fail-closed, exactly as
+for a dedicated number.
+
+> **Third-party syncs are ignored too.** When you text *someone else* from your phone,
+> your linked device receives a sync-sent transcript of that message as well. Simard
+> only treats a sync-sent message as a command when it is a **true Note to Self** — its
+> destination is the account itself. Messages you send to other people never reach her
+> command surface.
+
 ## What you can do over Signal
 
 | You send | Simard does |
@@ -193,12 +284,25 @@ HIGH-RISK boundary.
 
 1. **Are you allowlisted?** Your sending number must be in `[signal].allowlist`
    (E.164, e.g. `+15559876543`). Unknown senders are dropped and logged at `debug`
-   — enable debug logging to see the drop. `allowlist` is *your* number, not
-   `account`.
+   — enable debug logging to see the drop. On a **dedicated number** the allowlist is
+   *your* number, not `account`; on a **single-number linked device** the allowlist is
+   the `account` number itself (they are the same).
 2. **Is the daemon reachable?** Confirm `signal-cli -a … daemon --tcp 127.0.0.1:7583`
    is running and `endpoint` matches host:port exactly.
 3. **Built with the feature?** A default build has no Signal code. Rebuild with
    `cargo build --features signal`.
+
+### My Note-to-Self messages are ignored (single-number setup)
+
+1. **Are you sending from your phone?** Simard accepts a Note-to-Self command **only**
+   from **device 1** (your primary phone). Messages typed in **Note to Self** on Signal
+   Desktop, a linked iPad, or any other linked device are rejected by the loop-prevention
+   gate. Send from your phone.
+2. **Is the account number allowlisted?** For a single-number linked device the sender
+   *is* the `account`, so `account` must appear in `allowlist`.
+3. **Is `own_device_id` set to the wrong id?** It must be signal-cli's **own** linked
+   device id (≥ 2) from `listDevices`, never `1`. Setting it to `1` would reject your
+   phone. When in doubt, omit it — the device-1 gate already prevents loops.
 
 ### Simard receives but never replies
 

--- a/docs/howto/set-up-the-signal-channel.md
+++ b/docs/howto/set-up-the-signal-channel.md
@@ -129,8 +129,9 @@ account  = "+15551234567"        # the linked/dedicated account from step 2
 allowlist = ["+15559876543"]     # YOUR operator number(s) — who may command Simard
 read_only_unknown = false        # keep unknown senders fully ignored (default)
 # own_device_id = 2              # single-number setups only: signal-cli's OWN linked
-                                 # device id from `listDevices` — defence-in-depth
-                                 # loop prevention. Omit it for a dedicated number.
+                                 # device id (>= 2) from `listDevices` — defence-in-depth
+                                 # loop prevention. A value < 2 is rejected at load. Omit
+                                 # it for a dedicated number.
 ```
 
 - **`allowlist` is the security boundary.** Only the E.164 numbers listed here may
@@ -146,11 +147,12 @@ read_only_unknown = false        # keep unknown senders fully ignored (default)
       Note-to-Self message is accepted only when it comes from your **primary phone**
       (device 1) — see [Chatting via Note to Self](#chatting-via-note-to-self-single-number-setups).
 - **`own_device_id` (optional, single-number setups).** signal-cli's own linked
-  device id (from `signal-cli … listDevices`, e.g. `2`). It is defence-in-depth: even
-  without it Simard already rejects her own echoes (only device 1 may command), but
-  setting it makes the own-device rejection explicit. Resolve it env-first with
-  `SIMARD_SIGNAL_OWN_DEVICE_ID`. Omit it for a dedicated number. A present-but-unparseable
-  value is a hard error (like the other keys) — never a silent default.
+  device id (from `signal-cli … listDevices`, an integer `>= 2`, e.g. `2`). It is
+  defence-in-depth: even without it Simard already rejects her own echoes (only device 1
+  may command), but setting it makes the own-device rejection explicit. Resolve it
+  env-first with `SIMARD_SIGNAL_OWN_DEVICE_ID`. Omit it for a dedicated number. A present
+  value that is unparseable **or `< 2`** is a hard config error (device 1 is your phone,
+  so `own_device_id = 1` would disable Note to Self) — never a silent default.
 - Set `read_only_unknown = true` only if you want non-allowlisted senders to be
   able to read `status`; they can never trigger a mutation.
 
@@ -301,8 +303,9 @@ for a dedicated number.
 2. **Is the account number allowlisted?** For a single-number linked device the sender
    *is* the `account`, so `account` must appear in `allowlist`.
 3. **Is `own_device_id` set to the wrong id?** It must be signal-cli's **own** linked
-   device id (≥ 2) from `listDevices`, never `1`. Setting it to `1` would reject your
-   phone. When in doubt, omit it — the device-1 gate already prevents loops.
+   device id (≥ 2) from `listDevices`. A value `< 2` (e.g. `1`, your phone) is rejected
+   at startup with a config error, because it would disable every Note-to-Self command.
+   When in doubt, omit it — the device-1 gate already prevents loops.
 
 ### Simard receives but never replies
 

--- a/docs/reference/signal-conversation.md
+++ b/docs/reference/signal-conversation.md
@@ -1,11 +1,11 @@
 ---
 title: Signal channel reference
-description: Reference for SignalConversation — the optional, feature-gated ConversationChannel that connects Simard to a locally-run signal-cli JSON-RPC daemon, with a sender allowlist, operator-identity binding, high-risk gating, inbound commands, and outbound notifications.
-last_updated: 2026-07-03
+description: Reference for SignalConversation — the optional, feature-gated ConversationChannel that connects Simard to a locally-run signal-cli JSON-RPC daemon, with a sender allowlist, operator-identity binding, high-risk gating, Note-to-Self (sync-sent) command handling with loop prevention, inbound commands, and outbound notifications.
+last_updated: 2026-07-04
 review_schedule: as-needed
 owner: simard
 doc_type: reference
-issues: ["#2527"]
+issues: ["#2527", "#2575"]
 related:
   - ../index.md
   - ../architecture/conversation-channel.md
@@ -86,13 +86,41 @@ signal-cli -a +15551234567 daemon --tcp 127.0.0.1:7583
 `src/signal_conversation/transport.rs` opens a tokio `TcpStream` to that endpoint
 and speaks **newline-delimited JSON-RPC 2.0**:
 
-- **inbound** — signal-cli `receive` notifications are mapped to
-  `Inbound { from: OperatorRef { id: <E.164>, authorized }, text }`.
+- **inbound** — signal-cli `receive` notifications are parsed by the pure
+  `parse_incoming` helper into a `ParsedInbound` (see below), which the channel maps
+  to `Inbound { from: OperatorRef { id: <E.164>, authorized }, text }`.
 - **outbound** — an `Outbound` is mapped to a JSON-RPC `send` request addressed to
   the operator number.
 
 `signal-cli-rest-api` and any HTTP-based transport are out of scope for this
 version; the JSON-RPC-over-TCP daemon is the supported transport.
+
+### Inbound parsing (`ParsedInbound`)
+
+`parse_incoming(line: &str) -> Option<ParsedInbound>` is pure, I/O-free, and total —
+every unrecognized shape resolves to `None` (dropped), never to a coerced default. It
+recognizes two envelope shapes and ignores everything else (JSON-RPC responses to our
+own `send` calls, receipts, typing indicators, unparseable lines):
+
+```rust
+pub struct ParsedInbound {
+    pub sender: String,               // E.164 the command is attributed to
+    pub body: String,                 // the message text
+    pub source_device: Option<u32>,   // envelope source device id (None if absent)
+    pub is_sync_sent: bool,           // true for a syncMessage.sentMessage
+    pub sync_destination: Option<String>, // sentMessage destination (sync only)
+}
+```
+
+| Envelope shape | `is_sync_sent` | `sender` | `body` | `source_device` | `sync_destination` |
+|----------------|----------------|----------|--------|-----------------|--------------------|
+| `dataMessage` (normal inbound) | `false` | `sourceNumber`, else `source` | `dataMessage.message` | envelope `sourceDevice` (if present) | `None` |
+| `syncMessage.sentMessage` (Note to Self / a message the account sent) | `true` | the **account**'s own number | `sentMessage.message` | envelope `sourceDevice` | `sentMessage.destinationNumber`, else `destination` |
+
+`dataMessage` is checked **first**, so the normal dedicated-number path is byte-for-byte
+unchanged. A missing or non-numeric `sourceDevice` becomes `None` — it is **never**
+coerced to `1`, so a malformed sync envelope fails the primary-phone gate and is
+rejected (fail-closed).
 
 ## Configuration
 
@@ -111,9 +139,12 @@ ignored.
 > via the already-present `serde` + `toml` crates — no new dependency. It keeps the
 > same env-wins → file → error resolution and no-silent-default guarantee. Each
 > field also has an environment override: `SIMARD_SIGNAL_ENDPOINT`,
-> `SIMARD_SIGNAL_ACCOUNT`, `SIMARD_SIGNAL_ALLOWLIST` (comma-separated), and
-> `SIMARD_SIGNAL_READ_ONLY_UNKNOWN`. `endpoint` and `account` are required;
-> `allowlist` defaults to empty (fail-closed) and `read_only_unknown` to false.
+> `SIMARD_SIGNAL_ACCOUNT`, `SIMARD_SIGNAL_ALLOWLIST` (comma-separated),
+> `SIMARD_SIGNAL_READ_ONLY_UNKNOWN`, and `SIMARD_SIGNAL_OWN_DEVICE_ID`. `endpoint`
+> and `account` are required; `allowlist` defaults to empty (fail-closed),
+> `read_only_unknown` to false, and `own_device_id` to `None` (absent). A
+> present-but-unparseable `own_device_id` is a hard error, consistent with the other
+> keys — never a silent default.
 
 ```toml
 [signal]
@@ -125,11 +156,17 @@ account = "+15551234567"
 
 # E.164 operator numbers permitted to COMMAND Simard. Everyone else is ignored
 # (or read-only, if read_only_unknown = true). Fail-closed: empty ⇒ nobody may command.
+# On a single-number linked device this is the `account` number itself (Note to Self).
 allowlist = ["+15557654321"]
 
 # Opt-in: allow non-allowlisted senders to receive READ-ONLY results (e.g. status).
 # They can never trigger a mutation. Default false (unknown senders fully ignored).
 read_only_unknown = false
+
+# Optional (single-number linked-device setups): signal-cli's OWN linked device id
+# (>= 2, from `signal-cli … listDevices`). Defence-in-depth loop prevention; the
+# device-1 gate already closes the loop without it. Omit for a dedicated number.
+# own_device_id = 2
 ```
 
 | Key | Type | Default | Meaning |
@@ -138,12 +175,16 @@ read_only_unknown = false
 | `account` | E.164 string | — (required) | the Signal account signal-cli operates |
 | `allowlist` | array of E.164 | `[]` | numbers permitted to issue commands |
 | `read_only_unknown` | bool | `false` | if true, unknown senders may read status only |
+| `own_device_id` | integer `>= 2` | `None` (absent) | signal-cli's own linked device id; defence-in-depth Note-to-Self loop prevention |
 
 ## Guardrails
 
 The Signal channel is a **remote command surface**, so it adds three guardrails on
 top of the shared abstraction. They are layered — a message must clear all three to
-cause any mutation.
+cause any mutation. On a single-number linked-device setup, a Note-to-Self (sync-sent)
+message must **additionally** pass the loop-prevention predicate in
+[Note to Self (sync-sent) and loop prevention](#note-to-self-sync-sent-and-loop-prevention)
+before it is treated as a command.
 
 ### (a) Sender allowlist — fail-closed
 
@@ -215,6 +256,68 @@ routing be unit-tested in isolation (a spy handler proves `execute_approved` is
 never called before an `approve`), and lets a deployment wire concrete
 status/pause/execution to its real subsystems.
 
+## Note to Self (sync-sent) and loop prevention
+
+When signal-cli is a **linked device on the operator's own account** (a single-number
+setup), the operator and Simard share one E.164. The operator commands Simard from
+Signal's **Note to Self** conversation, which the account "sends" to itself; signal-cli
+delivers it to Simard as a **sync-sent** message (`syncMessage.sentMessage`), not a
+`dataMessage`. The channel treats a qualifying Note-to-Self message as an operator
+command whose sender is the account itself.
+
+Because a linked device also receives sync-sent transcripts of the messages **Simard
+herself** sends (her replies are sent from the account and sync back), the channel
+must not process its own output as new commands. It applies a **conjunctive** acceptance
+predicate — a sync-sent message is accepted **only if every condition holds**:
+
+```text
+is_sync_sent
+  && sync_destination == account          // a TRUE Note to Self, not a message to a third party
+  && source_device == Some(1)             // typed on the operator's PRIMARY PHONE (device 1)
+  && source_device != own_device_id       // defence-in-depth: not signal-cli's own linked device
+  && !matches_recent_outbound(body)       // defence-in-depth: not an echo of something Simard just sent
+  && allowlist.authorize(account) == Authorized  // the account is allowlisted (fail-closed, unchanged)
+```
+
+The pure decision lives in `should_accept_sync_sent(source_device, own_device_id,
+destination, account, primary_device_id = 1)` and `matches_recent_outbound(body,
+&recent, now)` in `transport.rs`; the stateful window and the allowlist call live in
+`channel.rs`. The three loop guards are layered, not alternatives:
+
+1. **Primary-phone gate (`source_device == Some(1)`).** Signal guarantees the
+   account owner's **phone is always device 1**; every linked device (signal-cli,
+   Desktop, iPad) is `>= 2`. Simard's own replies originate from signal-cli's linked
+   device, so they are rejected. **This gate alone closes the loop**, even with
+   `own_device_id == None` and an empty recent-outbound window — the loop-free
+   guarantee does not depend on configuration.
+2. **Own-device rejection (`source_device != own_device_id`).** If `own_device_id`
+   is configured, a sync-sent message from signal-cli's own device id is explicitly
+   rejected. Redundant with (1) by design; it satisfies the literal "reject signal-cli's
+   own device" requirement as defence-in-depth.
+3. **Recent-outbound echo suppression (`!matches_recent_outbound(body)`).** The
+   channel records the body of each message it sends in a bounded
+   `VecDeque<(String, Instant)>` (cap **64**, TTL **300 s**, pruned on insert) and
+   rejects a sync-sent message whose body **exactly** matches a recent outbound. This
+   catches any echo the first two guards miss. The window is in-memory only — never
+   persisted, never logged.
+
+Two further properties keep the change **monotonic** — the sync path only ever *adds*
+gates, it never widens acceptance:
+
+- **True Note to Self only.** A linked device also receives sync-sent transcripts of
+  messages the operator sends to **other people**. `sync_destination == account`
+  admits only genuine Note-to-Self messages; syncs destined for a third party are
+  ignored, so Simard never reacts to the operator's unrelated conversations.
+- **Fail-closed everywhere.** The account still runs through `Allowlist::authorize`,
+  so an account that is not allowlisted is dropped. Any missing/malformed field
+  (absent `sourceDevice`, absent destination) resolves to a rejection. Only the
+  account's own **device-1** Note-to-Self is newly accepted; genuinely unknown senders
+  are dropped exactly as before.
+
+The **dedicated-number** path is untouched: a normal `dataMessage` from a separate
+operator number carries `is_sync_sent = false`, skips this predicate entirely, and is
+authorized and gated exactly as in the original channel.
+
 ## Commands in
 
 `src/signal_conversation/gating.rs` parses a small lightweight command vocabulary;
@@ -253,11 +356,20 @@ gated action then proceeds through its authority; a text alone never executes it
 **Inbound command:**
 
 ```text
-signal-cli ─▶ transport.recv_line ─▶ parse_incoming ─▶ allowlist gate ─▶ parse_inbound
+signal-cli ─▶ transport.recv_line ─▶ parse_incoming ─▶ ParsedInbound
+   ├─ dataMessage (is_sync_sent = false) ─────────────────────────────────┐
+   └─ syncMessage.sentMessage (is_sync_sent = true) ─▶ sync predicate ─────┤
+        (dest == account && source_device == 1 && != own_device_id         │
+         && !recent-outbound echo)  ── fail ▶ ignore (loop prevention)     │
+                                                                            ▼
+                                                      allowlist gate ─▶ parse_inbound
            ─▶ gate ┬─ AutoExecute    ─▶ handler (status/pause/approve) ─▶ reply
                    └─ PendingSignOff ─▶ record pending ─▶ reply "sign off?"
                                         (execute only after `approve`)
 ```
+
+A `reply` also records the outbound body in the bounded recent-outbound window used by
+the echo-suppression guard (guard 3 above).
 
 **Notification out:**
 
@@ -285,11 +397,28 @@ transport** and a spy command handler — no live signal-cli or network is requi
   explicit `approve`, and exactly once; `status`/`pause`/`approve` run immediately.
 - **Identity binding** — replies and the delivered conversation `Inbound` are bound
   to the sender's E.164.
-- **Wire helpers** — `parse_incoming` maps a signal-cli `receive` notification to
-  `(sender, text)` and ignores responses/receipts/unparseable lines;
+- **Wire helpers** — `parse_incoming` maps a signal-cli `receive` notification to a
+  `ParsedInbound`. It parses a normal `dataMessage` to `(sender, body)` with
+  `is_sync_sent = false` (byte-identical to the original behavior), parses a
+  `syncMessage.sentMessage` to a sync-sent `ParsedInbound` carrying `source_device`
+  and `sync_destination`, and ignores responses/receipts/typing/unparseable lines;
   `build_send_request` produces valid JSON-RPC.
-- **Config** — env-first resolution, the `[signal]` table from `config.toml`, and a
-  clear error for a missing required key.
+- **Note-to-Self acceptance + loop prevention** — driven by canned JSON-RPC envelope
+  lines (no network), the tests assert the acceptance predicate exactly:
+    - a sync-sent envelope from **device 1** (phone) with body `status`, destined for
+      the account → parsed as an operator command from the account number;
+    - a sync-sent envelope from signal-cli's **own device id** (`>= 2`) → **ignored**
+      (loop prevention);
+    - a sync-sent envelope whose body matches a **recent Simard outbound** → **ignored**
+      (echo suppression);
+    - a sync-sent envelope whose destination is a **third party** (not the account) →
+      **ignored**;
+    - a normal `dataMessage` from a separate allowlisted number → still parsed
+      (regression — the dedicated-number path is unchanged);
+    - a receipt / typing / unparseable line → still ignored.
+- **Config** — env-first resolution, the `[signal]` table from `config.toml`, a clear
+  error for a missing required key, and `own_device_id` resolving to `None` when absent
+  and a hard error when present-but-unparseable.
 
 ## Related reading
 

--- a/docs/reference/signal-conversation.md
+++ b/docs/reference/signal-conversation.md
@@ -87,8 +87,10 @@ signal-cli -a +15551234567 daemon --tcp 127.0.0.1:7583
 and speaks **newline-delimited JSON-RPC 2.0**:
 
 - **inbound** — signal-cli `receive` notifications are parsed by the pure
-  `parse_incoming` helper into a `ParsedInbound` (see below), which the channel maps
-  to `Inbound { from: OperatorRef { id: <E.164>, authorized }, text }`.
+  `parse_incoming` helper into a `ParsedInbound` (see below). The channel dispatches a
+  recognized command (`status`, `pause`, `approve`, `merge #NNNN`, …) internally; only
+  an ordinary conversation turn surfaces to the driver as
+  `Inbound { from: OperatorRef { id: <E.164>, authorized }, text }`.
 - **outbound** — an `Outbound` is mapped to a JSON-RPC `send` request addressed to
   the operator number.
 
@@ -122,6 +124,26 @@ unchanged. A missing or non-numeric `sourceDevice` becomes `None` — it is **ne
 coerced to `1`, so a malformed sync envelope fails the primary-phone gate and is
 rejected (fail-closed).
 
+> **Implementation assumption — verify against a captured envelope before building.**
+> This design commits to the JSON-RPC field name **`sourceDevice`** and to two semantics
+> that the issue #2575 production logs do **not** prove (they only show the inbound-phone
+> case, `sourceDevice: 1`):
+>
+> 1. a `syncMessage.sentMessage` envelope **carries `sourceDevice`**, and it is the id
+>    of the device that *originated* the message — so Simard's own replies, emitted from
+>    signal-cli's linked device, stamp `>= 2`; and
+> 2. a genuine Note to Self exposes the account's own E.164 via
+>    `sentMessage.destinationNumber` (or `destination`), so `sync_destination == account`
+>    can be evaluated.
+>
+> **Confirm both against a real signal-cli line** (capture the raw `jsonRpc` output for a
+> Note-to-Self message *and* for one of Simard's own replies) before implementing. If the
+> field is actually named differently (`sourceDeviceId`, …) or is absent, or if
+> `destination` is only a UUID with no E.164, `parse_incoming` yields `None` / the
+> acceptance predicate fails and **every Note-to-Self command is silently rejected — the
+> exact failure mode #2575 fixes.** The parser is fail-closed by construction, but these
+> field names must be validated for the feature to *work*, not merely to be safe.
+
 ## Configuration
 
 Signal settings live in the `[signal]` table of the runtime config file at
@@ -142,9 +164,11 @@ ignored.
 > `SIMARD_SIGNAL_ACCOUNT`, `SIMARD_SIGNAL_ALLOWLIST` (comma-separated),
 > `SIMARD_SIGNAL_READ_ONLY_UNKNOWN`, and `SIMARD_SIGNAL_OWN_DEVICE_ID`. `endpoint`
 > and `account` are required; `allowlist` defaults to empty (fail-closed),
-> `read_only_unknown` to false, and `own_device_id` to `None` (absent). A
-> present-but-unparseable `own_device_id` is a hard error, consistent with the other
-> keys — never a silent default.
+> `read_only_unknown` to false, and `own_device_id` to `None` (absent). A present
+> `own_device_id` that is unparseable **or `< 2`** is a hard error — never a silent
+> default. (Device 1 is always the operator's primary phone, so `own_device_id = 1`
+> would disable every Note-to-Self command; the loader rejects it at startup rather than
+> letting it fail closed at runtime.)
 
 ```toml
 [signal]
@@ -163,9 +187,10 @@ allowlist = ["+15557654321"]
 # They can never trigger a mutation. Default false (unknown senders fully ignored).
 read_only_unknown = false
 
-# Optional (single-number linked-device setups): signal-cli's OWN linked device id
-# (>= 2, from `signal-cli … listDevices`). Defence-in-depth loop prevention; the
-# device-1 gate already closes the loop without it. Omit for a dedicated number.
+# Optional (single-number linked-device setups): signal-cli's OWN linked device id,
+# an integer >= 2 from `signal-cli … listDevices`. A present value < 2 is rejected at
+# load (device 1 is your phone). Defence-in-depth loop prevention; the device-1 gate
+# already closes the loop without it. Omit for a dedicated number.
 # own_device_id = 2
 ```
 
@@ -175,7 +200,7 @@ read_only_unknown = false
 | `account` | E.164 string | — (required) | the Signal account signal-cli operates |
 | `allowlist` | array of E.164 | `[]` | numbers permitted to issue commands |
 | `read_only_unknown` | bool | `false` | if true, unknown senders may read status only |
-| `own_device_id` | integer `>= 2` | `None` (absent) | signal-cli's own linked device id; defence-in-depth Note-to-Self loop prevention |
+| `own_device_id` | integer `>= 2` (validated) | `None` (absent) | signal-cli's own linked device id; defence-in-depth Note-to-Self loop prevention. A present value `< 2` is a hard config error. |
 
 ## Guardrails
 
@@ -299,7 +324,11 @@ destination, account, primary_device_id = 1)` and `matches_recent_outbound(body,
    `VecDeque<(String, Instant)>` (cap **64**, TTL **300 s**, pruned on insert) and
    rejects a sync-sent message whose body **exactly** matches a recent outbound. This
    catches any echo the first two guards miss. The window is in-memory only — never
-   persisted, never logged.
+   persisted, never logged. Because `reply()` records **every** outbound — command
+   replies *and* notifications — an operator Note-to-Self whose body is byte-identical
+   to a message Simard sent within the TTL is transiently suppressed. That is a
+   deliberate fail-safe bias: guard (1) is the primary loop guard, so this rare
+   false-negative is preferred over risking an unbroken echo.
 
 Two further properties keep the change **monotonic** — the sync path only ever *adds*
 gates, it never widens acceptance:

--- a/src/signal_conversation/channel.rs
+++ b/src/signal_conversation/channel.rs
@@ -28,13 +28,19 @@
 //! conversation channel and does not implement the cognitive-memory
 //! `BridgeTransport`.
 
+use std::collections::VecDeque;
+use std::time::Instant;
+
 use crate::conversation_channel::{ConversationChannel, Inbound, OperatorRef, OutKind, Outbound};
 use crate::error::SimardResult;
 
 use super::allowlist::{Allowlist, AuthDecision};
 use super::config::SignalConfig;
 use super::gating::{GateDecision, InboundCommand, gate, parse_inbound};
-use super::transport::{SignalTransport, build_send_request};
+use super::transport::{
+    PRIMARY_DEVICE_ID, RECENT_OUTBOUND_CAP, RECENT_OUTBOUND_TTL, SignalTransport,
+    build_send_request, matches_recent_outbound, should_accept_sync_sent,
+};
 
 /// The integration seam for the effects a Signal command produces. Keeping this
 /// out of the channel lets the (security-critical) allowlist + gating routing be
@@ -114,6 +120,15 @@ pub struct SignalConversation<T: SignalTransport, H: SignalCommandHandler> {
     current_operator: Option<String>,
     /// A gated high-risk command awaiting `approve`: `(sender, command)`.
     pending: Option<(String, InboundCommand)>,
+    /// signal-cli's OWN linked-device id, if configured — defence-in-depth loop
+    /// guard for Note-to-Self setups (issue #2575). A sync-sent message from this
+    /// device is rejected. `None` is safe: the primary-phone (device 1) gate is
+    /// the primary loop guard.
+    own_device_id: Option<u32>,
+    /// Bodies of recently-sent outbound messages (with send time) used to suppress
+    /// a synced-back echo of Simard's own reply on a linked-device setup. Bounded
+    /// to [`RECENT_OUTBOUND_CAP`] entries, each expiring after [`RECENT_OUTBOUND_TTL`].
+    recent_outbound: VecDeque<(String, Instant)>,
     next_id: u64,
 }
 
@@ -129,6 +144,8 @@ impl<T: SignalTransport, H: SignalCommandHandler> SignalConversation<T, H> {
             operators: config.allowlist.clone(),
             current_operator: None,
             pending: None,
+            own_device_id: config.own_device_id,
+            recent_outbound: VecDeque::new(),
             next_id: 1,
         }
     }
@@ -138,7 +155,29 @@ impl<T: SignalTransport, H: SignalCommandHandler> SignalConversation<T, H> {
         let id = self.next_id;
         self.next_id += 1;
         let line = build_send_request(id, &self.account, recipient, text);
-        self.transport.send_line(line).await
+        self.transport.send_line(line).await?;
+        // Remember what we just sent so a synced-back echo of it (on a
+        // linked-device setup) is suppressed rather than reprocessed (#2575).
+        self.record_outbound(text);
+        Ok(())
+    }
+
+    /// Track an outbound body (with the current time) for echo suppression,
+    /// dropping expired and over-cap entries to keep the window small and bounded.
+    fn record_outbound(&mut self, text: &str) {
+        let now = Instant::now();
+        self.recent_outbound.push_back((text.to_string(), now));
+        // Entries are pushed in send order, so expired ones cluster at the front.
+        while self
+            .recent_outbound
+            .front()
+            .is_some_and(|(_, t)| now.saturating_duration_since(*t) > RECENT_OUTBOUND_TTL)
+        {
+            self.recent_outbound.pop_front();
+        }
+        while self.recent_outbound.len() > RECENT_OUTBOUND_CAP {
+            self.recent_outbound.pop_front();
+        }
     }
 
     /// Deliver an operator notification (PR merge-ready, stall/problem, high-risk
@@ -203,9 +242,39 @@ impl<T: SignalTransport + Send, H: SignalCommandHandler> ConversationChannel
             let Some(line) = self.transport.recv_line().await? else {
                 return Ok(None);
             };
-            let Some((sender, text)) = super::transport::parse_incoming(&line) else {
+            let Some(parsed) = super::transport::parse_incoming(&line) else {
                 continue; // JSON-RPC responses, receipts, unparseable lines.
             };
+
+            // Loop prevention for sync-sent (Note-to-Self) messages, issue #2575.
+            // A linked device receives sync-sent transcripts of BOTH the operator's
+            // Note-to-Self commands AND Simard's own replies; only the former (from
+            // the operator's primary phone, destined for the account) is a command.
+            if parsed.is_sync_sent {
+                if !should_accept_sync_sent(
+                    parsed.source_device,
+                    self.own_device_id,
+                    parsed.sync_destination.as_deref(),
+                    &self.account,
+                    PRIMARY_DEVICE_ID,
+                ) {
+                    tracing::debug!(
+                        target: "signal",
+                        "ignoring sync-sent message that is not a primary-phone Note to Self"
+                    );
+                    continue;
+                }
+                if matches_recent_outbound(&parsed.body, &self.recent_outbound, Instant::now()) {
+                    tracing::debug!(
+                        target: "signal",
+                        "ignoring sync-sent echo of a recently-sent outbound message"
+                    );
+                    continue;
+                }
+            }
+
+            let sender = parsed.sender;
+            let text = parsed.body;
 
             match self.allowlist.authorize(&sender) {
                 // Guardrail (a): fail-closed. Unknown senders are dropped.
@@ -335,6 +404,7 @@ mod tests {
     const OPERATOR: &str = "+15557654321";
     const STRANGER: &str = "+15550000000";
     const ACCOUNT: &str = "+15551230000";
+    const THIRD_PARTY: &str = "+15559990000";
 
     #[derive(Default)]
     struct SpyState {
@@ -394,6 +464,7 @@ mod tests {
             account: ACCOUNT.to_string(),
             allowlist: vec![OPERATOR.to_string()],
             read_only_unknown,
+            own_device_id: None,
         }
     }
 
@@ -521,5 +592,163 @@ mod tests {
         let (to, msg) = sent(ch.transport.sent.last().unwrap());
         assert_eq!(to, OPERATOR);
         assert_eq!(msg, "reply text");
+    }
+
+    // ── Note-to-Self acceptance + loop prevention (issue #2575) ──────────────
+    //
+    // On a single-number linked-device setup the operator and Simard share one
+    // E.164; the operator commands Simard from Signal's "Note to Self", which
+    // signal-cli delivers as a sync-sent message. These scenarios pin the
+    // conjunctive acceptance predicate and the three layered loop guards.
+
+    /// A signal-cli `receive` line for a Note-to-Self (sync-sent) message: the
+    /// account sent `body` to `destination` from device `source_device`.
+    fn sync_sent_line(source_device: u32, destination: &str, body: &str) -> String {
+        json!({
+            "jsonrpc": "2.0",
+            "method": "receive",
+            "params": {"envelope": {
+                "source": ACCOUNT,
+                "sourceNumber": ACCOUNT,
+                "sourceDevice": source_device,
+                "syncMessage": {"sentMessage": {"destinationNumber": destination, "message": body}}
+            }}
+        })
+        .to_string()
+    }
+
+    /// Config for the single-number linked-device setup: the account's own number
+    /// is the allowlisted operator, with an optional signal-cli own-device id.
+    fn note_config(own_device_id: Option<u32>) -> SignalConfig {
+        SignalConfig {
+            endpoint: "127.0.0.1:0".to_string(),
+            account: ACCOUNT.to_string(),
+            allowlist: vec![ACCOUNT.to_string()],
+            read_only_unknown: false,
+            own_device_id,
+        }
+    }
+
+    fn note_channel(
+        lines: Vec<String>,
+        own_device_id: Option<u32>,
+    ) -> (
+        SignalConversation<MockTransport, SpyHandler>,
+        Arc<Mutex<SpyState>>,
+    ) {
+        let state = Arc::new(Mutex::new(SpyState::default()));
+        let handler = SpyHandler {
+            state: Arc::clone(&state),
+        };
+        let transport = MockTransport::with_lines(lines);
+        let ch = SignalConversation::new(transport, handler, &note_config(own_device_id));
+        (ch, state)
+    }
+
+    #[test]
+    fn note_to_self_status_from_primary_phone_runs_as_command() {
+        // A sync-sent message from device 1, destined for the account, is a genuine
+        // Note to Self → treated as a `status` command from the (allowlisted) account.
+        let (mut ch, _state) = note_channel(vec![sync_sent_line(1, ACCOUNT, "status")], None);
+        assert!(block_on(ch.recv()).unwrap().is_none());
+        assert_eq!(ch.transport.sent.len(), 1, "one status reply");
+        let (to, msg) = sent(&ch.transport.sent[0]);
+        assert_eq!(
+            to, ACCOUNT,
+            "the reply goes back to the account (Note to Self)"
+        );
+        assert!(msg.contains("STATUS"), "got {msg}");
+    }
+
+    #[test]
+    fn note_to_self_conversation_turn_is_bound_to_the_account() {
+        let (mut ch, _state) = note_channel(
+            vec![sync_sent_line(1, ACCOUNT, "let's plan the release")],
+            None,
+        );
+        let inbound = block_on(ch.recv()).unwrap().expect("a conversation turn");
+        assert_eq!(inbound.text, "let's plan the release");
+        assert_eq!(inbound.from.id, ACCOUNT);
+        assert!(inbound.from.authorized);
+    }
+
+    #[test]
+    fn sync_sent_from_signal_cli_own_device_is_ignored() {
+        // A reply Simard emitted syncs back from signal-cli's linked device (>= 2).
+        // It must be ignored — never processed as a new command (loop prevention).
+        let (mut ch, state) = note_channel(vec![sync_sent_line(2, ACCOUNT, "status")], Some(2));
+        assert!(block_on(ch.recv()).unwrap().is_none());
+        assert!(
+            ch.transport.sent.is_empty(),
+            "no reply to our own synced-back message"
+        );
+        assert!(state.lock().unwrap().executed.is_empty());
+    }
+
+    #[test]
+    fn sync_sent_from_linked_device_ignored_without_own_device_id() {
+        // Even with own_device_id unset, the primary-phone gate rejects a device>=2
+        // sync-sent — the loop-free guarantee does not depend on configuration.
+        let (mut ch, _state) = note_channel(vec![sync_sent_line(3, ACCOUNT, "status")], None);
+        assert!(block_on(ch.recv()).unwrap().is_none());
+        assert!(ch.transport.sent.is_empty());
+    }
+
+    #[test]
+    fn sync_sent_echo_of_recent_outbound_is_ignored() {
+        // Simard sends a notification; the linked device syncs it back as a device-1
+        // sync-sent with an identical body. Echo suppression drops it even though it
+        // clears the primary-phone gate.
+        let echo = "PR #7 is merge-ready";
+        let (mut ch, _state) = note_channel(vec![sync_sent_line(1, ACCOUNT, echo)], None);
+        // Record the outbound first — this is what reply() tracks.
+        block_on(ch.notify(echo)).unwrap();
+        assert_eq!(ch.transport.sent.len(), 1, "just the notification");
+        // The synced-back echo is ignored: recv reaches EOF with no new send.
+        assert!(block_on(ch.recv()).unwrap().is_none());
+        assert_eq!(ch.transport.sent.len(), 1, "no reply to the echo");
+    }
+
+    #[test]
+    fn sync_sent_to_third_party_is_ignored() {
+        // The operator texts someone else from their phone; it syncs to the linked
+        // device but is NOT a Note to Self, so Simard ignores it.
+        let (mut ch, state) = note_channel(vec![sync_sent_line(1, THIRD_PARTY, "status")], None);
+        assert!(block_on(ch.recv()).unwrap().is_none());
+        assert!(ch.transport.sent.is_empty(), "not a command; no reply");
+        assert!(state.lock().unwrap().executed.is_empty());
+    }
+
+    #[test]
+    fn sync_sent_high_risk_from_primary_phone_is_still_gated() {
+        // Even a genuine Note-to-Self high-risk command must not auto-execute.
+        let (mut ch, state) = note_channel(vec![sync_sent_line(1, ACCOUNT, "merge #42")], None);
+        assert!(block_on(ch.recv()).unwrap().is_none());
+        assert!(
+            state.lock().unwrap().executed.is_empty(),
+            "no auto-execute from a text"
+        );
+        assert_eq!(ch.transport.sent.len(), 1);
+        let (_to, msg) = sent(&ch.transport.sent[0]);
+        assert!(msg.contains("HIGH-RISK"), "got {msg}");
+    }
+
+    #[test]
+    fn normal_data_message_from_separate_number_still_parsed() {
+        // Regression: the dedicated-number path is unchanged. A normal dataMessage
+        // from a separate allowlisted operator still yields a conversation turn.
+        let (mut ch, _state) = channel(vec![receive_line(OPERATOR, "let's chat")], false);
+        let inbound = block_on(ch.recv()).unwrap().expect("a conversation turn");
+        assert_eq!(inbound.text, "let's chat");
+        assert_eq!(inbound.from.id, OPERATOR);
+        assert!(inbound.from.authorized);
+    }
+
+    #[test]
+    fn receipt_and_unparseable_lines_are_skipped() {
+        let receipt = r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{"sourceNumber":"+15551230000","receiptMessage":{"isDelivery":true}}}}"#.to_string();
+        let (mut ch, _state) = note_channel(vec![receipt, "not json".to_string()], None);
+        assert!(block_on(ch.recv()).unwrap().is_none());
+        assert!(ch.transport.sent.is_empty());
     }
 }

--- a/src/signal_conversation/config.rs
+++ b/src/signal_conversation/config.rs
@@ -24,12 +24,25 @@ pub struct SignalConfig {
     /// If true, non-allowlisted senders may receive READ-ONLY results (e.g.
     /// `status`) but can never trigger a mutation. Default false.
     pub read_only_unknown: bool,
+    /// signal-cli's OWN linked-device id, for single-number linked-device setups
+    /// (issue #2575). Used as defence-in-depth loop prevention: a Note-to-Self
+    /// (sync-sent) message whose source device equals this id is rejected so
+    /// Simard never reprocesses her own synced-back replies. Optional — the
+    /// primary-phone (device 1) gate is the primary loop guard and needs no
+    /// configuration. When set it must be `>= 2` (device 1 is always the
+    /// operator's primary phone); a value `< 2` is a hard error at load.
+    pub own_device_id: Option<u32>,
 }
 
 pub const ENV_ENDPOINT: &str = "SIMARD_SIGNAL_ENDPOINT";
 pub const ENV_ACCOUNT: &str = "SIMARD_SIGNAL_ACCOUNT";
 pub const ENV_ALLOWLIST: &str = "SIMARD_SIGNAL_ALLOWLIST";
 pub const ENV_READ_ONLY_UNKNOWN: &str = "SIMARD_SIGNAL_READ_ONLY_UNKNOWN";
+pub const ENV_OWN_DEVICE_ID: &str = "SIMARD_SIGNAL_OWN_DEVICE_ID";
+
+/// The lowest valid `own_device_id`: signal-cli, as a linked device, is always
+/// `>= 2`. Device 1 is reserved for the account owner's primary phone.
+const MIN_OWN_DEVICE_ID: u32 = 2;
 
 /// The `[signal]` table as read from `config.toml` (every field optional so env
 /// can supply or override it).
@@ -39,6 +52,7 @@ struct SignalTable {
     account: Option<String>,
     allowlist: Option<Vec<String>>,
     read_only_unknown: Option<bool>,
+    own_device_id: Option<u32>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -77,11 +91,14 @@ impl SignalConfig {
             Err(_) => table.read_only_unknown.unwrap_or(false),
         };
 
+        let own_device_id = resolve_own_device_id(table.own_device_id)?;
+
         Ok(Self {
             endpoint,
             account,
             allowlist,
             read_only_unknown,
+            own_device_id,
         })
     }
 }
@@ -123,5 +140,49 @@ fn resolve_string(env_key: &str, file_value: Option<String>, field: &str) -> Sim
             key: format!("signal.{field}"),
             help: format!("set `{env_key}` or add `{field}` to the [signal] table of config.toml"),
         }),
+    }
+}
+
+/// Resolve the optional `own_device_id` env-first, then the config file.
+///
+/// Absent everywhere → `None` (fail-safe: the primary-phone/device-1 gate is the
+/// primary loop guard and needs no configuration). A present-but-unparseable env
+/// value, or any resolved value `< 2`, is a hard error — never a silent default —
+/// matching the fail-loud contract of the other `[signal]` fields.
+fn resolve_own_device_id(file_value: Option<u32>) -> SimardResult<Option<u32>> {
+    let resolved = match std::env::var(ENV_OWN_DEVICE_ID) {
+        Ok(v) => {
+            let v = v.trim();
+            if v.is_empty() {
+                file_value
+            } else {
+                let parsed = v
+                    .parse::<u32>()
+                    .map_err(|_| SimardError::InvalidConfigValue {
+                        key: "signal.own_device_id".to_string(),
+                        value: v.to_string(),
+                        help: format!(
+                            "own_device_id must be an integer >= {MIN_OWN_DEVICE_ID} \
+                         (signal-cli's own linked-device id; device 1 is always the \
+                         operator's primary phone)"
+                        ),
+                    })?;
+                Some(parsed)
+            }
+        }
+        Err(_) => file_value,
+    };
+
+    match resolved {
+        Some(id) if id < MIN_OWN_DEVICE_ID => Err(SimardError::InvalidConfigValue {
+            key: "signal.own_device_id".to_string(),
+            value: id.to_string(),
+            help: format!(
+                "own_device_id must be >= {MIN_OWN_DEVICE_ID}; device 1 is always the \
+                 operator's primary phone, so a value < {MIN_OWN_DEVICE_ID} would reject \
+                 genuine Note-to-Self commands"
+            ),
+        }),
+        other => Ok(other),
     }
 }

--- a/src/signal_conversation/tests.rs
+++ b/src/signal_conversation/tests.rs
@@ -56,6 +56,7 @@ fn allowlist_from_config_uses_config_fields() {
         account: "+15551234567".to_string(),
         allowlist: vec![OPERATOR.to_string()],
         read_only_unknown: false,
+        own_device_id: None,
     };
     let al = Allowlist::from_config(&cfg);
     assert_eq!(al.authorize(OPERATOR), AuthDecision::Authorized);
@@ -187,7 +188,8 @@ fn low_risk_commands_auto_execute() {
 
 mod config_loading {
     use super::super::config::{
-        ENV_ACCOUNT, ENV_ALLOWLIST, ENV_ENDPOINT, ENV_READ_ONLY_UNKNOWN, SignalConfig,
+        ENV_ACCOUNT, ENV_ALLOWLIST, ENV_ENDPOINT, ENV_OWN_DEVICE_ID, ENV_READ_ONLY_UNKNOWN,
+        SignalConfig,
     };
     use serial_test::serial;
 
@@ -198,6 +200,7 @@ mod config_loading {
             std::env::remove_var(ENV_ACCOUNT);
             std::env::remove_var(ENV_ALLOWLIST);
             std::env::remove_var(ENV_READ_ONLY_UNKNOWN);
+            std::env::remove_var(ENV_OWN_DEVICE_ID);
         }
     }
 
@@ -220,6 +223,9 @@ mod config_loading {
         assert_eq!(cfg.account, "+15551230000");
         assert_eq!(cfg.allowlist, vec!["+15557654321", "+15559990000"]);
         assert!(cfg.read_only_unknown);
+        // own_device_id is optional; unset resolves to None (fail-safe: the
+        // device-1 gate is the primary loop guard and needs no configuration).
+        assert_eq!(cfg.own_device_id, None);
     }
 
     #[test]
@@ -259,5 +265,98 @@ allowlist = ["+15557654321"]
         assert_eq!(cfg.allowlist, vec!["+15557654321"]);
         // Fail-closed default: unset read_only_unknown resolves to false.
         assert!(!cfg.read_only_unknown);
+    }
+
+    // ── own_device_id: optional loop-prevention defence-in-depth (issue #2575) ──
+
+    #[test]
+    #[serial(cognitive_memory)]
+    fn own_device_id_absent_resolves_to_none() {
+        clear_env();
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: serialized.
+        unsafe {
+            std::env::set_var(ENV_ENDPOINT, "127.0.0.1:7583");
+            std::env::set_var(ENV_ACCOUNT, "+15551230000");
+        }
+        let cfg = SignalConfig::load_from(tmp.path()).unwrap();
+        clear_env();
+        assert_eq!(cfg.own_device_id, None);
+    }
+
+    #[test]
+    #[serial(cognitive_memory)]
+    fn own_device_id_from_env_is_parsed() {
+        clear_env();
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: serialized.
+        unsafe {
+            std::env::set_var(ENV_ENDPOINT, "127.0.0.1:7583");
+            std::env::set_var(ENV_ACCOUNT, "+15551230000");
+            std::env::set_var(ENV_OWN_DEVICE_ID, "2");
+        }
+        let cfg = SignalConfig::load_from(tmp.path()).unwrap();
+        clear_env();
+        assert_eq!(cfg.own_device_id, Some(2));
+    }
+
+    #[test]
+    #[serial(cognitive_memory)]
+    fn own_device_id_reads_from_config_toml() {
+        clear_env();
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("config.toml"),
+            r#"
+[signal]
+endpoint = "127.0.0.1:9000"
+account = "+15551230000"
+own_device_id = 4
+"#,
+        )
+        .unwrap();
+        let cfg = SignalConfig::load_from(tmp.path()).unwrap();
+        assert_eq!(cfg.own_device_id, Some(4));
+    }
+
+    #[test]
+    #[serial(cognitive_memory)]
+    fn own_device_id_unparseable_is_a_hard_error() {
+        clear_env();
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: serialized.
+        unsafe {
+            std::env::set_var(ENV_ENDPOINT, "127.0.0.1:7583");
+            std::env::set_var(ENV_ACCOUNT, "+15551230000");
+            std::env::set_var(ENV_OWN_DEVICE_ID, "not-a-number");
+        }
+        let err = SignalConfig::load_from(tmp.path()).unwrap_err();
+        clear_env();
+        assert!(
+            format!("{err:?}").contains("own_device_id"),
+            "expected an InvalidConfigValue for signal.own_device_id, got {err:?}"
+        );
+    }
+
+    #[test]
+    #[serial(cognitive_memory)]
+    fn own_device_id_below_two_is_a_hard_error() {
+        // Device 1 is always the operator's primary phone; signal-cli's linked
+        // device is always >= 2. A configured own_device_id < 2 is a mistake, never
+        // a silent default.
+        clear_env();
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: serialized.
+        unsafe {
+            std::env::set_var(ENV_ENDPOINT, "127.0.0.1:7583");
+            std::env::set_var(ENV_ACCOUNT, "+15551230000");
+            std::env::set_var(ENV_OWN_DEVICE_ID, "1");
+        }
+        let err = SignalConfig::load_from(tmp.path()).unwrap_err();
+        clear_env();
+        assert!(
+            format!("{err:?}").contains("own_device_id"),
+            "expected a hard error for own_device_id < 2, got {err:?}"
+        );
     }
 }

--- a/src/signal_conversation/transport.rs
+++ b/src/signal_conversation/transport.rs
@@ -16,21 +16,67 @@
 //! Nothing here is named `bridge`/`Bridge`. This is the Signal conversation
 //! channel's transport; it is unrelated to the cognitive-memory `BridgeTransport`.
 
+use std::collections::VecDeque;
 use std::future::Future;
+use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
 
 use crate::error::{SimardError, SimardResult};
 
-/// Parse one newline-delimited JSON-RPC line from the signal-cli daemon into an
-/// inbound `(sender_e164, message_text)` pair.
+/// signal-cli always assigns the account owner's **primary phone** device id `1`;
+/// every linked device (signal-cli itself, Signal Desktop, an iPad) gets a
+/// distinct id `>= 2`. This is the anchor of Note-to-Self loop prevention.
+pub(crate) const PRIMARY_DEVICE_ID: u32 = 1;
+
+/// How long a just-sent outbound body suppresses an identical synced-back echo
+/// (defence-in-depth loop guard for Note-to-Self setups, issue #2575).
+pub(crate) const RECENT_OUTBOUND_TTL: Duration = Duration::from_secs(300);
+
+/// Upper bound on the echo-suppression window so it stays small and bounded.
+pub(crate) const RECENT_OUTBOUND_CAP: usize = 64;
+
+/// A parsed inbound Signal message: either a normal `dataMessage` from a separate
+/// sender, or a `syncMessage.sentMessage` — a sync of a message the account
+/// itself sent (e.g. **Note to Self** on a single-number linked-device setup,
+/// issue #2575).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParsedInbound {
+    /// The commanding party's E.164. For a sync-sent message this is the
+    /// account's own number, since the account sent the message.
+    pub sender: String,
+    /// The message body / command text.
+    pub body: String,
+    /// The originating device id from the envelope, if present. **Never coerced**:
+    /// `None` means the envelope carried no `sourceDevice` — it is not defaulted
+    /// to `1`, so a missing device can never masquerade as the primary phone.
+    pub source_device: Option<u32>,
+    /// True iff this came from `syncMessage.sentMessage` — a sync of a message the
+    /// account sent (Note to Self, or a message to a third party).
+    pub is_sync_sent: bool,
+    /// For a sync-sent message, the number the account sent to. Used to tell a
+    /// true Note to Self (destined for the account itself) from a sync of a
+    /// message to a third party. `None` for a normal `dataMessage`.
+    pub sync_destination: Option<String>,
+}
+
+/// Parse one newline-delimited JSON-RPC line from the signal-cli daemon into a
+/// [`ParsedInbound`].
 ///
-/// Returns `None` for anything that is not a delivered text message — JSON-RPC
-/// responses to our own `send` calls, receipts, typing indicators, sync
-/// messages, and unparseable lines are all ignored. signal-cli delivers an
-/// incoming message as a `"receive"` notification whose `params.envelope`
-/// carries the source number and a `dataMessage.message` body.
-pub fn parse_incoming(line: &str) -> Option<(String, String)> {
+/// Returns `None` for anything that is not an actionable inbound message —
+/// JSON-RPC responses to our own `send` calls, receipts, typing indicators, and
+/// unparseable lines are all ignored. signal-cli delivers an incoming message as
+/// a `"receive"` notification whose `params.envelope` carries either:
+/// - a `dataMessage.message` body (a normal message from a separate sender), or
+/// - a `syncMessage.sentMessage` (a sync of a message the **account** sent — the
+///   Note-to-Self path for single-number linked-device setups, issue #2575).
+///
+/// A normal `dataMessage` is parsed exactly as before (`is_sync_sent == false`),
+/// so the dedicated-number setup is unchanged. A sync-sent message is surfaced
+/// with `is_sync_sent == true`; the channel then applies the primary-phone gate
+/// and echo suppression (see [`should_accept_sync_sent`] and
+/// [`matches_recent_outbound`]) before treating it as an operator command.
+pub fn parse_incoming(line: &str) -> Option<ParsedInbound> {
     let value: Value = serde_json::from_str(line.trim()).ok()?;
     if value.get("method")?.as_str()? != "receive" {
         return None;
@@ -41,15 +87,91 @@ pub fn parse_incoming(line: &str) -> Option<(String, String)> {
         .and_then(Value::as_str)
         .or_else(|| envelope.get("source").and_then(Value::as_str))?
         .to_string();
-    let text = envelope
-        .get("dataMessage")?
-        .get("message")?
-        .as_str()?
-        .to_string();
-    if text.is_empty() {
-        return None;
+    let source_device = envelope
+        .get("sourceDevice")
+        .and_then(Value::as_u64)
+        .map(|d| d as u32);
+
+    // A normal delivered text message (dedicated-number path — unchanged).
+    if let Some(text) = envelope
+        .get("dataMessage")
+        .and_then(|m| m.get("message"))
+        .and_then(Value::as_str)
+    {
+        if text.is_empty() {
+            return None;
+        }
+        return Some(ParsedInbound {
+            sender,
+            body: text.to_string(),
+            source_device,
+            is_sync_sent: false,
+            sync_destination: None,
+        });
     }
-    Some((sender, text))
+
+    // A sync of a message the account sent (Note to Self on a linked device).
+    if let Some(sent) = envelope
+        .get("syncMessage")
+        .and_then(|m| m.get("sentMessage"))
+    {
+        let body = sent.get("message").and_then(Value::as_str).unwrap_or("");
+        if body.is_empty() {
+            return None;
+        }
+        let sync_destination = sent
+            .get("destinationNumber")
+            .and_then(Value::as_str)
+            .or_else(|| sent.get("destination").and_then(Value::as_str))
+            .map(str::to_string);
+        return Some(ParsedInbound {
+            sender,
+            body: body.to_string(),
+            source_device,
+            is_sync_sent: true,
+            sync_destination,
+        });
+    }
+
+    // Receipts, typing indicators, and everything else are ignored.
+    None
+}
+
+/// Decide whether a **sync-sent** (Note-to-Self) message may be accepted as an
+/// operator command. This is the pure loop-prevention predicate (issue #2575);
+/// all conditions must hold:
+///
+/// - **Primary-phone gate:** it originated on the operator's phone
+///   (`source_device == primary_device_id`, i.e. device 1). Simard's own replies
+///   sync back from signal-cli's linked device (id `>= 2`) and are rejected here,
+///   closing the loop even with no `own_device_id` configured.
+/// - **Own-device rejection (defence-in-depth):** its source device is not
+///   signal-cli's own linked-device id, when one is configured.
+/// - **True Note to Self:** it was destined for the account itself, not a third
+///   party the operator happened to text from their phone.
+pub(crate) fn should_accept_sync_sent(
+    source_device: Option<u32>,
+    own_device_id: Option<u32>,
+    destination: Option<&str>,
+    account: &str,
+    primary_device_id: u32,
+) -> bool {
+    source_device == Some(primary_device_id)
+        && source_device != own_device_id
+        && destination == Some(account)
+}
+
+/// Whether `body` exactly matches a still-fresh outbound Simard recently sent —
+/// used to suppress a synced-back echo of her own message (defence-in-depth loop
+/// guard, issue #2575). Entries older than [`RECENT_OUTBOUND_TTL`] never match.
+pub(crate) fn matches_recent_outbound(
+    body: &str,
+    recent: &VecDeque<(String, Instant)>,
+    now: Instant,
+) -> bool {
+    recent
+        .iter()
+        .any(|(b, t)| b == body && now.saturating_duration_since(*t) <= RECENT_OUTBOUND_TTL)
 }
 
 /// Build a newline-delimited JSON-RPC `send` request for the signal-cli daemon.
@@ -170,22 +292,110 @@ impl SignalTransport for MockTransport {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+    use std::time::{Duration, Instant};
+
     use super::*;
+
+    const ACCOUNT: &str = "+15551230000";
+    const THIRD_PARTY: &str = "+15559990000";
+
+    // ── parse_incoming: normal dataMessage (regression — unchanged behavior) ──
 
     #[test]
     fn parse_incoming_extracts_sender_and_text() {
         let line = r#"{"jsonrpc":"2.0","method":"receive","params":{"account":"+15551230000","envelope":{"source":"+15557654321","sourceNumber":"+15557654321","timestamp":1,"dataMessage":{"message":"status"}}}}"#;
-        let (sender, text) = parse_incoming(line).expect("a delivered text message");
-        assert_eq!(sender, "+15557654321");
-        assert_eq!(text, "status");
+        let msg = parse_incoming(line).expect("a delivered text message");
+        assert_eq!(msg.sender, "+15557654321");
+        assert_eq!(msg.body, "status");
+        assert!(
+            !msg.is_sync_sent,
+            "a dataMessage is not a sync-sent message"
+        );
+        assert_eq!(msg.sync_destination, None);
     }
 
     #[test]
     fn parse_incoming_prefers_source_number() {
         let line = r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{"source":"uuid-form","sourceNumber":"+15557654321","dataMessage":{"message":"hi"}}}}"#;
-        let (sender, _) = parse_incoming(line).unwrap();
-        assert_eq!(sender, "+15557654321");
+        let msg = parse_incoming(line).unwrap();
+        assert_eq!(msg.sender, "+15557654321");
+        assert!(!msg.is_sync_sent);
     }
+
+    #[test]
+    fn parse_incoming_reads_source_device_when_present() {
+        let line = r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{"sourceNumber":"+15557654321","sourceDevice":1,"dataMessage":{"message":"hi"}}}}"#;
+        let msg = parse_incoming(line).unwrap();
+        assert_eq!(msg.source_device, Some(1));
+    }
+
+    #[test]
+    fn parse_incoming_missing_source_device_is_none_never_coerced() {
+        // A dataMessage without sourceDevice must yield None — never coerced to 1.
+        let line = r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{"sourceNumber":"+15557654321","dataMessage":{"message":"hi"}}}}"#;
+        let msg = parse_incoming(line).unwrap();
+        assert_eq!(msg.source_device, None);
+    }
+
+    // ── parse_incoming: syncMessage.sentMessage (Note to Self, issue #2575) ──
+
+    #[test]
+    fn parse_incoming_parses_sync_sent_note_to_self() {
+        // The account sends "status" to itself from the primary phone (device 1);
+        // signal-cli delivers this as a sync-sent message, not a dataMessage.
+        let line = r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{"source":"+15551230000","sourceNumber":"+15551230000","sourceDevice":1,"syncMessage":{"sentMessage":{"destinationNumber":"+15551230000","message":"status"}}}}}"#;
+        let msg = parse_incoming(line).expect("a sync-sent Note-to-Self message");
+        assert!(
+            msg.is_sync_sent,
+            "a syncMessage.sentMessage is a sync-sent message"
+        );
+        assert_eq!(
+            msg.sender, ACCOUNT,
+            "the sender is the account's own number"
+        );
+        assert_eq!(msg.body, "status");
+        assert_eq!(
+            msg.source_device,
+            Some(1),
+            "originated on the primary phone"
+        );
+        assert_eq!(
+            msg.sync_destination.as_deref(),
+            Some(ACCOUNT),
+            "a true Note to Self is destined for the account itself"
+        );
+    }
+
+    #[test]
+    fn parse_incoming_sync_sent_falls_back_to_destination_field() {
+        // Some envelopes carry `destination` rather than `destinationNumber`.
+        let line = r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{"sourceNumber":"+15551230000","sourceDevice":1,"syncMessage":{"sentMessage":{"destination":"+15551230000","message":"pause"}}}}}"#;
+        let msg = parse_incoming(line).expect("sync-sent parsed");
+        assert!(msg.is_sync_sent);
+        assert_eq!(msg.body, "pause");
+        assert_eq!(msg.sync_destination.as_deref(), Some(ACCOUNT));
+    }
+
+    #[test]
+    fn parse_incoming_sync_sent_records_higher_source_device() {
+        // A reply Simard emitted from signal-cli's linked device syncs back with a
+        // device id >= 2. The parser must surface it faithfully (never coerce to 1).
+        let line = r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{"sourceNumber":"+15551230000","sourceDevice":3,"syncMessage":{"sentMessage":{"destinationNumber":"+15551230000","message":"echo"}}}}}"#;
+        let msg = parse_incoming(line).unwrap();
+        assert!(msg.is_sync_sent);
+        assert_eq!(msg.source_device, Some(3));
+    }
+
+    #[test]
+    fn parse_incoming_sync_sent_missing_source_device_is_none() {
+        let line = r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{"sourceNumber":"+15551230000","syncMessage":{"sentMessage":{"destinationNumber":"+15551230000","message":"hi"}}}}}"#;
+        let msg = parse_incoming(line).unwrap();
+        assert!(msg.is_sync_sent);
+        assert_eq!(msg.source_device, None);
+    }
+
+    // ── parse_incoming: everything else is ignored ──
 
     #[test]
     fn parse_incoming_ignores_non_receive_lines() {
@@ -201,10 +411,149 @@ mod tests {
     }
 
     #[test]
+    fn parse_incoming_ignores_typing_indicators() {
+        let typing = r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{"sourceNumber":"+15557654321","typingMessage":{"action":"STARTED"}}}}"#;
+        assert!(parse_incoming(typing).is_none());
+    }
+
+    #[test]
+    fn parse_incoming_ignores_empty_sync_sent_body() {
+        let line = r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{"sourceNumber":"+15551230000","sourceDevice":1,"syncMessage":{"sentMessage":{"destinationNumber":"+15551230000","message":""}}}}}"#;
+        assert!(
+            parse_incoming(line).is_none(),
+            "an empty body is not a command"
+        );
+    }
+
+    #[test]
     fn parse_incoming_ignores_unparseable_lines() {
         assert!(parse_incoming("not json").is_none());
         assert!(parse_incoming("").is_none());
     }
+
+    // ── should_accept_sync_sent: the pure acceptance predicate ──
+
+    #[test]
+    fn accept_sync_sent_from_primary_phone_to_account() {
+        // device 1 + destination == account + no own-device config → accepted.
+        assert!(should_accept_sync_sent(
+            Some(1),
+            None,
+            Some(ACCOUNT),
+            ACCOUNT,
+            1
+        ));
+    }
+
+    #[test]
+    fn reject_sync_sent_from_linked_device_even_without_own_device_id() {
+        // A linked device (>= 2) is rejected by the primary-phone gate alone, even
+        // with own_device_id == None — the loop-free guarantee needs no config.
+        assert!(!should_accept_sync_sent(
+            Some(2),
+            None,
+            Some(ACCOUNT),
+            ACCOUNT,
+            1
+        ));
+        assert!(!should_accept_sync_sent(
+            Some(3),
+            None,
+            Some(ACCOUNT),
+            ACCOUNT,
+            1
+        ));
+    }
+
+    #[test]
+    fn reject_sync_sent_from_signal_cli_own_device_id() {
+        // Defence-in-depth: an explicit own_device_id match is rejected even if it
+        // somehow presented as the primary device.
+        assert!(!should_accept_sync_sent(
+            Some(1),
+            Some(1),
+            Some(ACCOUNT),
+            ACCOUNT,
+            1
+        ));
+    }
+
+    #[test]
+    fn reject_sync_sent_to_third_party() {
+        // A sync of a message the operator sent to someone else is not a command.
+        assert!(!should_accept_sync_sent(
+            Some(1),
+            None,
+            Some(THIRD_PARTY),
+            ACCOUNT,
+            1
+        ));
+    }
+
+    #[test]
+    fn reject_sync_sent_without_destination() {
+        assert!(!should_accept_sync_sent(Some(1), None, None, ACCOUNT, 1));
+    }
+
+    #[test]
+    fn reject_sync_sent_without_source_device() {
+        // A missing source device fails the primary-phone gate (fail-closed).
+        assert!(!should_accept_sync_sent(
+            None,
+            None,
+            Some(ACCOUNT),
+            ACCOUNT,
+            1
+        ));
+    }
+
+    // ── matches_recent_outbound: echo-suppression window ──
+
+    #[test]
+    fn recent_outbound_matches_exact_fresh_body() {
+        let t0 = Instant::now();
+        let mut recent: VecDeque<(String, Instant)> = VecDeque::new();
+        recent.push_back(("PR #7 is merge-ready".to_string(), t0));
+        assert!(matches_recent_outbound(
+            "PR #7 is merge-ready",
+            &recent,
+            t0 + Duration::from_secs(1),
+        ));
+    }
+
+    #[test]
+    fn recent_outbound_ignores_expired_entries() {
+        let t0 = Instant::now();
+        let mut recent: VecDeque<(String, Instant)> = VecDeque::new();
+        recent.push_back(("stale".to_string(), t0));
+        // Past the TTL, an identical body is no longer suppressed.
+        let now = t0 + RECENT_OUTBOUND_TTL + Duration::from_secs(1);
+        assert!(!matches_recent_outbound("stale", &recent, now));
+    }
+
+    #[test]
+    fn recent_outbound_no_match_for_different_body() {
+        let t0 = Instant::now();
+        let mut recent: VecDeque<(String, Instant)> = VecDeque::new();
+        recent.push_back(("one".to_string(), t0));
+        assert!(!matches_recent_outbound(
+            "two",
+            &recent,
+            t0 + Duration::from_secs(1)
+        ));
+    }
+
+    #[test]
+    fn recent_outbound_empty_window_never_matches() {
+        let recent: VecDeque<(String, Instant)> = VecDeque::new();
+        assert!(!matches_recent_outbound(
+            "anything",
+            &recent,
+            Instant::now()
+        ));
+    }
+
+    // ── build_send_request (unchanged) ──
 
     #[test]
     fn build_send_request_is_valid_jsonrpc() {


### PR DESCRIPTION
## Problem

Fixes #2575. When `signal-cli` is linked as a **device on the operator's own Signal account**, "Note to Self" is the only way to message Simard. In production the operator linked signal-cli on `+12062591306` and messaged "Note to Self"; signal-cli received them as **sync-sent** messages (`Received sync sent message ... Body: status`). The transport parser ignored sync messages, so Note-to-Self commands were silently dropped and **Simard never responded**.

## Fix

Parse `syncMessage.sentMessage` (sync-sent) envelopes and accept a Note to Self as an operator command **only when every loop-prevention guard passes**:

1. **Primary-phone gate (device 1).** Signal guarantees the account owner's phone is always device 1; every linked device (signal-cli, Desktop) is `>= 2`. Simard's own replies sync back from signal-cli's linked device and are rejected here — this closes the loop even with no configuration.
2. **Own-device rejection (defence-in-depth).** Optional `own_device_id` (`SIMARD_SIGNAL_OWN_DEVICE_ID` / `[signal].own_device_id`, must be `>= 2`) explicitly rejects signal-cli's own device id.
3. **True Note to Self.** The sync destination must be the account itself, so syncs of messages the operator sent to third parties are ignored.
4. **Recent-outbound echo suppression.** A bounded 64-entry / 5-minute window drops a sync-sent whose body exactly matches a message Simard just sent.

Fail-closed behavior for genuinely unknown senders is unchanged; the account's own number must be on the `allowlist`. Normal `dataMessage`s from a dedicated operator number are parsed exactly as before (regression-safe).

## Changes

- `parse_incoming` now returns a `ParsedInbound` struct (`sender`, `body`, `source_device`, `is_sync_sent`, `sync_destination`) instead of a `(sender, text)` tuple. `source_device` is never coerced — a missing device id stays `None` and can't masquerade as the primary phone.
- New pure, unit-tested helpers `should_accept_sync_sent` and `matches_recent_outbound`.
- `SignalConfig.own_device_id: Option<u32>` with env-first resolution; unparseable or `< 2` is a hard error (never a silent default).
- Channel wires the sync-sent gates into `recv()` and records outbound bodies in `reply()` for echo suppression.
- Docs (`docs/howto/set-up-the-signal-channel.md`) explain the Note-to-Self flow and the three loop guards.

## Tests (no network — canned JSON-RPC envelope lines)

- sync-sent from device 1 (phone) with body `status` → parsed/dispatched as a command from the account number;
- sync-sent from signal-cli's own device id → ignored (loop prevention);
- sync-sent whose body matches a recent Simard outbound → ignored;
- sync-sent to a third party → ignored;
- normal `dataMessage` from a separate allowlisted number → still parsed (regression);
- receipt / typing / unparseable line → still ignored;
- config: `own_device_id` absent → `None`, env/file parsing, unparseable and `< 2` are hard errors.

64 signal tests pass. Feature stays behind the `signal` cargo feature.

## Policy

No `git --no-verify`, no `gh pr merge --admin`. Green pre-commit (fmt + release clippy) and pre-push (race-subset tests + `clippy --all-targets --all-features --locked -D warnings`) locally. Branch off latest `origin/main`. Live daemon / `~/.simard` untouched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>