### PR TITLE
feat(build): build Simard's runtime cargo features by default (#2576)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,11 +84,16 @@ jobs:
           #
           # CRITICAL: only ship targets the release build actually produces. The
           # "Build release binary" step runs `cargo build --release` with the
-          # DEFAULT feature set, so bin targets gated behind a non-default
-          # `required-features` (e.g. the `dashboard-audit` audit tools
-          # simard-audit-pass01 / simard-audit-dashboard) are NOT compiled. They
-          # must be filtered out here; otherwise `tar` aborts trying to stat a
-          # binary that was never built (exit 2, every release).
+          # DEFAULT feature set. Since issue #2576 that set includes
+          # `dashboard-audit`, so the audit tools (simard-audit-pass01 /
+          # simard-audit-dashboard) now DO compile — but they still carry a
+          # `required-features` marker and are intentionally kept OUT of the
+          # shipped tarball: they need a real Chrome binary at runtime and are
+          # dev/ops tooling, not part of the deployed daemon payload. Filtering on
+          # a non-empty `required-features` still excludes exactly those targets.
+          # If a target's `required-features` ever left the default set again, it
+          # would (correctly) both stop building here and stay filtered, so `tar`
+          # never aborts trying to stat a binary that was never built.
           mapfile -t BIN_TARGETS < <(
             cargo metadata --no-deps --format-version 1 \
               | jq -r '

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -156,6 +156,15 @@ jobs:
         # run first.
         run: python -m pre_commit run --all-files --show-diff-on-failure --hook-stage pre-push cargo-clippy
 
+      - name: Build minimal binary (--no-default-features contract, issue #2576)
+        # Issue #2576 made every runtime feature (signal, dashboard-audit) part
+        # of the default set, so the default `cargo build` below already exercises
+        # the fully-capable path. This step locks the OTHER edge: that the crate
+        # still compiles and links with NO features, i.e. the deliberately minimal
+        # binary keeps building (the signal channel drops to its feature-off stub).
+        # `--locked` guards against Cargo.lock churn on the feature-off resolution.
+        run: cargo build --release --bin simard --no-default-features --locked
+
       - name: Build simard binary for downstream jobs
         # cargo test above already compiles the simard library + bins for the
         # test profile. Producing the dev-profile binary here is incremental

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "simard"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "amplihack-agent-eval",
  "amplihack-memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simard"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2024"
 default-run = "simard"
 
@@ -117,12 +117,27 @@ url = { version = "=2.5.8", optional = true }
 libc = "=0.2.185"
 
 [features]
+# Issue #2576: every FUNCTIONAL/runtime capability ships in a plain `cargo build`
+# — no shippable feature is opt-in. `default` therefore enables `signal` (the
+# operator Signal conversation channel) and `dashboard-audit` (the headless
+# dashboard audit tools), so a stock binary is fully capable and `simard signal
+# run` reaches its real config path instead of a "not compiled in" stub. Build a
+# deliberately minimal binary with `--no-default-features`.
+default = ["signal", "dashboard-audit"]
+
+# THE ONE INTENTIONAL EXCEPTION to the "features are default" rule (issue #2576):
+# `slow-tests` is NOT a shippable product capability — it is a TEST-SELECTION gate
+# that turns on the slow, long-running `#[cfg(feature = "slow-tests")]` tests.
+# Defaulting it would force those slow tests into every `cargo test` / CI run and
+# blow up CI time for zero runtime benefit, so it stays opt-in. Enable explicitly
+# with `cargo test --features slow-tests` when you want the slow suite.
 slow-tests = []
 dashboard-audit = ["dep:headless_chrome", "dep:regex", "dep:url"]
 # Issue #2527: the Signal conversation channel (`src/signal_conversation/`).
-# Default OFF so the daemon builds and runs with no signal-cli installed. The
-# transport reuses tokio `net` (already a dependency), so enabling this adds no
-# new mandatory dependency.
+# Built by DEFAULT since issue #2576 (see `default` above) so the daemon ships
+# signal-capable with no opt-in flag. The transport reuses tokio `net` (already a
+# dependency), so enabling this adds no new mandatory dependency. Drop it only via
+# an explicit `--no-default-features` minimal build.
 signal = []
 
 [dev-dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -15,8 +15,10 @@
 # Only Linux x86_64 ships today; scope the check to the target the release
 # binary is built for so platform-specific crates elsewhere don't skew bans.
 # Default features only — this mirrors the shipped `cargo build --release`
-# binary; the optional `dashboard-audit` feature (headless_chrome) is opt-in
-# and not part of the released artifact.
+# binary. Since issue #2576 the default set includes `dashboard-audit`
+# (headless_chrome), but the audit binaries that use it carry a
+# `required-features` marker and are filtered OUT of the released tarball, so
+# headless_chrome is still absent from the shipped `simard` artifact.
 targets = [{ triple = "x86_64-unknown-linux-gnu" }]
 
 # ── Advisories (RUSTSEC) ─────────────────────────────────────────────────────

--- a/deny.toml
+++ b/deny.toml
@@ -86,6 +86,33 @@ confidence-threshold = 0.8
 crate = "html2md"
 allow = ["GPL-3.0-or-later"]
 
+# webpki-roots ships Mozilla's CA certificate bundle under CDLA-Permissive-2.0
+# (Community Data License Agreement – Permissive 2.0), a *permissive* data
+# license (no copyleft). It enters the graph transitively through the
+# now-default `dashboard-audit` feature (issue #2576):
+# webpki-roots -> ureq -> auto_generate_cdp (build) -> headless_chrome -> simard.
+# Because it is a data license rather than a standard OSI *software* license, it
+# is allowed by an explicit, justified per-crate exception rather than by
+# widening the strictly-permissive global allowlist above. See the licensing
+# note in docs/reference/supply-chain-audit.md.
+[[licenses.exceptions]]
+crate = "webpki-roots"
+allow = ["CDLA-Permissive-2.0"]
+
+# auto_generate_cdp is GPL-3.0-or-later (copyleft). It is a BUILD-DEPENDENCY only:
+# a code generator that emits the Chrome DevTools Protocol Rust bindings at build
+# time for headless_chrome. It reaches the graph through the now-default
+# `dashboard-audit` feature (issue #2576):
+# auto_generate_cdp (build) -> headless_chrome -> simard. As a build-time tool it
+# is neither linked into nor distributed with the Simard binary, so its copyleft
+# does not extend to Simard (the GPL does not propagate through build tooling that
+# is not part of the distributed work — the same reasoning that lets GPL compilers
+# build non-GPL programs). Allowed by an explicit, justified per-crate exception,
+# analogous to the html2md exception above. See docs/reference/supply-chain-audit.md.
+[[licenses.exceptions]]
+crate = "auto_generate_cdp"
+allow = ["GPL-3.0-or-later"]
+
 # ── Bans (duplicate / wildcard / explicitly-blocked crates) ──────────────────
 [bans]
 # Duplicate versions of a crate bloat the tree; surface (warn) without blocking

--- a/docs/howto/set-up-the-signal-channel.md
+++ b/docs/howto/set-up-the-signal-channel.md
@@ -1,11 +1,11 @@
 ---
 title: How to set up the Signal channel
-description: Connect Simard to Signal so an allowlisted operator can command her and receive notifications, using a locally-run signal-cli JSON-RPC daemon. Covers the signal feature build, linking a device (or using a dedicated number), the Note-to-Self flow for single-number linked-device setups, loop prevention, configuration, the allowlist, and verification.
+description: Connect Simard to Signal so an allowlisted operator can command her and receive notifications, using a locally-run signal-cli JSON-RPC daemon. Covers linking a device (or using a dedicated number), the Note-to-Self flow for single-number linked-device setups, loop prevention, configuration, the allowlist, and verification. The signal feature is built by default, so a plain build is signal-capable.
 last_updated: 2026-07-04
 review_schedule: as-needed
 owner: simard
 doc_type: howto
-issues: ["#2527", "#2575"]
+issues: ["#2527", "#2575", "#2576"]
 related:
   - ../index.md
   - ../reference/signal-conversation.md
@@ -23,8 +23,10 @@ and receive notifications (PR merge-ready, stalls, high-risk sign-off requests).
 
 Simard does not implement Signal herself. She connects to a locally-run
 [`signal-cli`](https://github.com/AsamK/signal-cli) daemon over JSON-RPC. This
-guide installs signal-cli, links or registers an account, builds Simard with the
-`signal` feature, configures the `[signal]` table, and verifies the round trip.
+guide installs signal-cli, links or registers an account, configures the
+`[signal]` table, and verifies the round trip. The `signal` feature is **built by
+default** (issue #2576), so a plain `cargo build` already ships the channel — no
+`--features signal` needed.
 
 For the full contract (config keys, commands, guardrails), see the
 [Signal channel reference](../reference/signal-conversation.md).
@@ -119,8 +121,9 @@ Add a `[signal]` table to the runtime config file at `<state_root>/config.toml`
 (the same file Simard uses for the LLM provider; `<state_root>` is
 `$SIMARD_STATE_ROOT` or, by default, `~/.simard`, so `~/.simard/config.toml` out of
 the box). Environment variables still win over the file; there is no silent default.
-The `[signal]` table is only parsed and applied in a `--features signal` build
-(step 5) — a default build ignores it.
+The `[signal]` table is parsed and applied by any default build (the `signal`
+feature is on by default since issue #2576). Only a deliberately minimal
+`--no-default-features` build ignores it.
 
 ```toml
 [signal]
@@ -156,15 +159,16 @@ read_only_unknown = false        # keep unknown senders fully ignored (default)
 - Set `read_only_unknown = true` only if you want non-allowlisted senders to be
   able to read `status`; they can never trigger a mutation.
 
-## 5. Build and run Simard with the `signal` feature
+## 5. Build and run Simard
 
-The Signal channel compiles only with the `signal` feature:
+The Signal channel is compiled into a stock build (the `signal` feature is a
+default), so the plain build command already includes it:
 
 ```bash
-cargo build --features signal
+cargo build
 ```
 
-Then launch the Signal channel with the `signal run` subcommand from that build:
+Then launch the Signal channel with the `signal run` subcommand:
 
 ```bash
 simard signal run
@@ -174,9 +178,9 @@ On startup Simard reads the `[signal]` table, connects to the signal-cli endpoin
 and begins receiving inbound messages from allowlisted senders and sending
 notifications out. Leave it running (systemd unit, tmux, or a supervisor) alongside
 the signal-cli daemon from step 3. `simard signal run` exits when the signal-cli
-socket closes; supervise it if you want it to reconnect. A build **without**
-`--features signal` still recognizes `simard signal run` but tells you to rebuild
-with the feature — no Signal code is compiled into a default build.
+socket closes; supervise it if you want it to reconnect. Only a deliberately
+minimal `--no-default-features` build omits the Signal code; it still recognizes
+`simard signal run` but tells you to rebuild with the feature.
 
 ## 6. Verify the round trip
 
@@ -291,8 +295,9 @@ for a dedicated number.
    the `account` number itself (they are the same).
 2. **Is the daemon reachable?** Confirm `signal-cli -a … daemon --tcp 127.0.0.1:7583`
    is running and `endpoint` matches host:port exactly.
-3. **Built with the feature?** A default build has no Signal code. Rebuild with
-   `cargo build --features signal`.
+3. **Built with the feature?** A default build already includes the Signal
+   channel. You would only be missing it in a deliberately minimal
+   `--no-default-features` build — rebuild with a plain `cargo build`.
 
 ### My Note-to-Self messages are ignored (single-number setup)
 
@@ -320,9 +325,11 @@ authorize; the action then runs through its existing gated authority.
 
 ### The daemon runs but I never wanted Signal
 
-Nothing to do — the Signal channel is off unless you build with `--features signal`
-*and* provide a `[signal]` table. A plain `cargo build` has no Signal code and needs
-no signal-cli.
+The Signal channel is built by default, but it stays dormant until you provide a
+`[signal]` table (with a fail-closed, empty-by-default allowlist) — without it,
+`simard signal run` simply reports missing config and Simard never touches
+signal-cli. If you want a binary with no Signal code at all, build with
+`--no-default-features`.
 
 ## Related reading
 

--- a/docs/reference/multi-binary-self-update.md
+++ b/docs/reference/multi-binary-self-update.md
@@ -116,13 +116,14 @@ At the time of writing the producer packages these Cargo `bin` targets:
 | `simard_operator_probe` | Operator self-probe helper (note: underscore-named) | Auxiliary — best-effort |
 
 > **Feature-gated targets are NOT shipped.** Cargo `bin` targets carrying a
-> non-default `required-features` (for example `simard-audit-pass01` and
+> `required-features` marker (for example `simard-audit-pass01` and
 > `simard-audit-dashboard`, gated behind the `dashboard-audit` feature) are
-> **excluded** from the release tarball, because the release job builds with the
-> default feature set and never compiles them. The producer filter drops any
-> target whose `required-features` is non-empty (see
-> [Release packaging contract](#release-packaging-contract)). To ship such a
-> tool, the release build must first enable its feature.
+> **excluded** from the release tarball. Since issue #2576 `dashboard-audit` is a
+> default feature, so the release build DOES compile them — but they need a real
+> Chrome binary at runtime and are dev/ops tooling, not part of the deployed
+> daemon payload. The producer filter drops any target whose `required-features`
+> is non-empty (see [Release packaging contract](#release-packaging-contract)),
+> which keeps them out of the shipped set regardless.
 
 The table is **illustrative, not authoritative**. The authoritative set is
 whatever `cargo metadata` reports as `bin` targets *buildable with the release
@@ -388,10 +389,12 @@ set** into each platform tarball, instead of only `simard`. Without this, the
 consumer refactor installs nothing extra.
 
 The "Package binary" step enumerates Cargo `bin` targets dynamically rather than
-naming a literal `simard`. It also filters out targets gated behind a non-default
-`required-features` (such as the `dashboard-audit` audit tools), because the
-release build uses the default feature set and never compiles them — packaging a
-never-built target would make `tar` fail:
+naming a literal `simard`. It also filters out targets carrying a
+`required-features` marker (such as the `dashboard-audit` audit tools). Since
+issue #2576 the default feature set includes `dashboard-audit`, so the release
+build now compiles those tools — but they need a real Chrome binary at runtime,
+so they are intentionally kept out of the shipped tarball; the filter also keeps
+`tar` from failing should a target's feature ever leave the default set:
 
 ```bash
 set -euo pipefail

--- a/docs/reference/signal-conversation.md
+++ b/docs/reference/signal-conversation.md
@@ -36,32 +36,34 @@ installation and linking.
 
 ## Feature gate
 
-The Signal channel is compiled only when the `signal` Cargo feature is enabled; it
-is **off by default**. The default build has no Signal code and needs no signal-cli
-installed.
+The Signal channel lives behind the `signal` Cargo feature, which is **on by
+default** (issue #2576): a stock `cargo build` compiles the channel in. Only a
+deliberately minimal `--no-default-features` build omits the Signal code and needs
+no signal-cli installed.
 
 ```toml
 # Cargo.toml
 [features]
-signal = []  # default-OFF; adds no new dependency
+default = ["signal", "dashboard-audit"]  # signal is built in by default
+signal = []                              # adds no new dependency
 ```
 
 ```bash
-# Default build — no Signal, no signal-cli needed:
+# Default build — Signal channel included:
 cargo build
 cargo test
 
-# With the Signal channel:
-cargo build --features signal
-cargo test  --features signal
+# Minimal build — no Signal code:
+cargo build --no-default-features
+cargo test  --no-default-features
 ```
 
-The transport uses tokio `net` (already a dependency), so enabling `signal` pulls in
+The transport uses tokio `net` (already a dependency), so the `signal` feature pulls in
 no new crate — there is no HTTP client and no `async-trait`.
 
 ## Launching
 
-Start the channel with the operator subcommand from a `--features signal` build:
+Start the channel with the operator subcommand from any default build:
 
 ```bash
 simard signal run
@@ -71,9 +73,9 @@ simard signal run
 builds a tokio runtime, and calls `signal_conversation::run`
 (`src/signal_conversation/channel.rs`), which connects to the signal-cli endpoint
 and drives the operator conversation to completion. It exits when the signal-cli
-socket closes; supervise it (systemd/tmux) to reconnect. A default build (no
-`signal` feature) still recognizes `simard signal run` but returns a clear error
-telling the operator to rebuild with `--features signal`.
+socket closes; supervise it (systemd/tmux) to reconnect. A minimal
+`--no-default-features` build still recognizes `simard signal run` but returns a
+clear error telling the operator to rebuild with the feature.
 
 ## Transport
 
@@ -415,7 +417,8 @@ handoff under `default_handoff_dir()` (`$SIMARD_HANDOFF_DIR`, else
 
 ## Testing
 
-All Signal tests run under `cargo test --features signal` against a **mock JSON-RPC
+All Signal tests run under the default `cargo test` (the `signal` feature is on by
+default; explicit `--features signal` is redundant) against a **mock JSON-RPC
 transport** and a spy command handler — no live signal-cli or network is required:
 
 - **Allowlist enforcement** — an unknown E.164 is dropped (no dispatch, no reply);

--- a/docs/reference/supply-chain-audit.md
+++ b/docs/reference/supply-chain-audit.md
@@ -115,10 +115,16 @@ allow = [
 ]
 confidence-threshold = 0.8
 # Per-crate exceptions. The global allowlist stays strictly permissive; a
-# non-permissive crate is allowed ONLY by an explicit, justified per-crate
-# exception so it stays visible in every CI run.
+# non-permissive (or non-standard-software) license is allowed ONLY by an
+# explicit, justified per-crate exception so it stays visible in every CI run.
 [[licenses.exceptions]]
 crate = "html2md"          # GPL-3.0-or-later (copyleft) — see the note below
+allow = ["GPL-3.0-or-later"]
+[[licenses.exceptions]]
+crate = "webpki-roots"     # CDLA-Permissive-2.0 (permissive data license)
+allow = ["CDLA-Permissive-2.0"]
+[[licenses.exceptions]]
+crate = "auto_generate_cdp" # GPL-3.0-or-later, BUILD-ONLY code generator
 allow = ["GPL-3.0-or-later"]
 ```
 
@@ -136,6 +142,26 @@ all — fails `cargo deny check licenses`.
 > and reviewable. Removing it is upstream (`rustyclawd-tools`) work; until then
 > the exception is the sanctioned, tracked path — the licensing analogue of the
 > `rsa` advisory `ignore`.
+
+> **Flagged findings — the `dashboard-audit` default chain (issue #2576).**
+> Making `dashboard-audit` a **default** feature brought its `headless_chrome`
+> subtree into the default-feature license graph, surfacing two crates that were
+> previously outside the checked set:
+>
+> - [`webpki-roots`](https://crates.io/crates/webpki-roots) ships Mozilla's CA
+>   certificate bundle under **CDLA-Permissive-2.0** — a *permissive* data
+>   license (no copyleft), not a standard OSI *software* license. Chain:
+>   `webpki-roots -> ureq -> auto_generate_cdp (build) -> headless_chrome`.
+> - [`auto_generate_cdp`](https://crates.io/crates/auto_generate_cdp) is
+>   **GPL-3.0-or-later** but is a **build-dependency only** — a code generator
+>   that emits the Chrome DevTools Protocol bindings at build time. It is neither
+>   linked into nor distributed with the Simard binary, so its copyleft does not
+>   extend to Simard (the same reasoning that lets a GPL compiler build a
+>   non-GPL program).
+>
+> Both are allowed by explicit, justified `[[licenses.exceptions]]` entries
+> rather than by widening the global permissive allowlist, keeping them visible
+> and reviewable in every CI run.
 
 ### `[bans]`
 

--- a/scripts/dashboard_audit/README.md
+++ b/scripts/dashboard_audit/README.md
@@ -12,8 +12,9 @@ complaints.
 
 ## Binaries
 
-The audit tools are compiled as Rust binaries gated behind the `dashboard-audit`
-Cargo feature. Source lives in `src/bin/`:
+The audit tools are compiled as Rust binaries. They live behind the
+`dashboard-audit` Cargo feature, which is **on by default** (issue #2576), so a
+stock build compiles them. Source lives in `src/bin/`:
 
 | Binary                    | Source                               | Former Python          |
 | ------------------------- | ------------------------------------ | ---------------------- |
@@ -73,14 +74,20 @@ should be regenerated per audit pass against the live daemon.
 
 ## How to build
 
+The `dashboard-audit` feature is on by default, so a plain build produces the
+audit binaries:
+
 ```bash
-cargo build --features dashboard-audit \
+cargo build \
   --bin simard-audit-pass01 \
   --bin simard-audit-dashboard
 ```
 
-The `dashboard-audit` feature gates the `headless_chrome`, `regex`, and `url`
-dependencies so normal builds are unaffected.
+The `dashboard-audit` feature carries the `headless_chrome`, `regex`, and `url`
+dependencies; drop them from a build with `--no-default-features` if you need a
+minimal binary. The `headless_chrome` crate is a build-time dependency only — the
+actual Chrome/Chromium binary is a **runtime** concern, so these tools compile
+anywhere and only require Chrome when you actually run an audit pass.
 
 ## How to re-run an audit pass
 
@@ -95,10 +102,10 @@ Run a pass:
 
 ```bash
 # raw captures
-cargo run --features dashboard-audit --bin simard-audit-pass01
+cargo run --bin simard-audit-pass01
 
 # structured audit with REPORT.md
-cargo run --features dashboard-audit --bin simard-audit-dashboard
+cargo run --bin simard-audit-dashboard
 ```
 
 Or use the pre-built binaries:

--- a/src/operator_cli/mod.rs
+++ b/src/operator_cli/mod.rs
@@ -104,8 +104,8 @@ Product modes:
   dashboard serve [--port=8080]
   signal run             — connect to the configured signal-cli JSON-RPC daemon
                            and run the operator Signal conversation channel
-                           (requires a build with --features signal + a [signal]
-                           config table; see docs/howto/set-up-the-signal-channel.md)
+                           (built by default; needs a [signal] config table; see
+                           docs/howto/set-up-the-signal-channel.md)
   memory stats [state-root] [--json]
                          — read-only per-type cognitive-memory counts +
                            graph-edge / dedup section + sample rows

--- a/src/operator_cli/signal.rs
+++ b/src/operator_cli/signal.rs
@@ -9,10 +9,10 @@
 //! until the socket closes.
 //!
 //! The subcommand is **always recognized** so the operator gets a clear message
-//! either way; the Signal implementation itself compiles only under the `signal`
-//! Cargo feature (default off). A default build recognizes `simard signal` and
-//! tells the operator to rebuild with `--features signal` instead of failing
-//! with a bare "unsupported command".
+//! either way. The Signal implementation is compiled in by DEFAULT (issue #2576);
+//! only a deliberately minimal `--no-default-features` build omits it, and even
+//! then `simard signal` is recognized and tells the operator to rebuild with the
+//! feature instead of failing with a bare "unsupported command".
 //!
 //! # Naming
 //!
@@ -30,12 +30,13 @@ Usage: simard signal <command>
 Commands:
   run               Connect to the configured signal-cli JSON-RPC daemon and run
                     the operator Signal conversation channel until the socket
-                    closes. Requires a build with `--features signal` and a
-                    [signal] config table (endpoint, account, allowlist).
+                    closes. Built in by default; needs a [signal] config table
+                    (endpoint, account, allowlist).
   help, -h, --help  Show this help message and exit.
 
-The Signal channel is OPTIONAL and OFF by default; a plain build has no Signal
-code compiled in. See docs/howto/set-up-the-signal-channel.md for full setup.
+The Signal channel is built by DEFAULT (issue #2576) and stays dormant until a
+[signal] config table is present. Only a `--no-default-features` build omits the
+Signal code. See docs/howto/set-up-the-signal-channel.md for full setup.
 ";
 
 pub fn dispatch_signal_command(

--- a/src/signal_conversation/tests.rs
+++ b/src/signal_conversation/tests.rs
@@ -5,8 +5,8 @@
 //! required security behavior — a fail-closed sender allowlist and high-risk
 //! gating that never auto-executes a mutating command from a text.
 //!
-//! These run under `cargo test --features signal`; no live signal-cli or network
-//! is involved.
+//! These run under the default `cargo test` (the `signal` feature is on by
+//! default since issue #2576); no live signal-cli or network is involved.
 
 use super::allowlist::{Allowlist, AuthDecision};
 use super::config::SignalConfig;

--- a/tests/signal_default_build.rs
+++ b/tests/signal_default_build.rs
@@ -1,0 +1,271 @@
+//! Issue #2576 — TDD contract: Simard's runtime cargo features must build BY
+//! DEFAULT so no shippable capability is opt-in.
+//!
+//! Operator directive: "none of the features need to be opt-in in the future."
+//! Concretely, a plain `cargo build` / `cargo test` (no `--features`) must yield
+//! a fully-capable `simard` binary with the Signal conversation channel
+//! (`src/signal_conversation/`) compiled in, so `simard signal run` reaches its
+//! real config-loading path instead of the feature-off stub that prints
+//! "not compiled into this build".
+//!
+//! This file encodes the acceptance criteria as two layers of contract:
+//!
+//! 1. [`default_feature_set_includes_all_runtime_features`] — a manifest-level
+//!    assertion that ALWAYS runs, independent of the compiled feature set. It
+//!    reads `Cargo.toml` and requires the `[features] default` set to include
+//!    every functional/runtime feature (`signal`, `dashboard-audit`) and to
+//!    EXCLUDE `slow-tests` (the one intentional opt-in: a slow-test *selection*
+//!    gate, not a shippable capability — defaulting it would force slow tests
+//!    into every `cargo test` / CI run and blow up CI time). This is the genuine
+//!    TDD red: it FAILS on `main` (which declares no `default` set) and passes
+//!    once the change lands. It also passes harmlessly under
+//!    `--no-default-features`, because it inspects the manifest text rather than
+//!    the active compile features.
+//!
+//! 2. The behavioral `signal_*` tests in the [`signal_present`] module, gated
+//!    `#[cfg(feature = "signal")]` so they run under a default `cargo test` and
+//!    under `--all-features`, but AUTO-SKIP under `--no-default-features` (where
+//!    the Signal channel is legitimately absent and there is nothing to prove).
+//!    They drive the real binary via `assert_cmd` and assert the default build's
+//!    `simard signal` subcommand is fully wired: `--help` lists `run`, and
+//!    `run` (with no `[signal]` config) reaches the real missing-config error
+//!    path — never the feature-off "not compiled into this build" stub.
+//!
+//! Isolation: the behavioral tests point `SIMARD_STATE_ROOT` at a unique
+//! directory under the OS temp dir and clear the `SIMARD_SIGNAL_*` env vars, so
+//! they never read or write the operator's live `~/.simard` state and never
+//! depend on ambient signal configuration.
+//!
+//! Naming: nothing here is a "bridge"; this exercises the first-class Signal
+//! conversation channel and the one-Brain / reasoner terminology only.
+
+use std::path::PathBuf;
+
+/// Read the crate manifest that this test is compiled from.
+fn cargo_manifest() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("Cargo.toml must be readable at {}: {e}", path.display()))
+}
+
+/// Return the text of the `[features]` table (from its header to the next
+/// top-level table header), so key lookups cannot be confused by `default-run`
+/// in `[package]` or `default`-named keys in other tables.
+fn features_section(manifest: &str) -> &str {
+    let header = "[features]";
+    let start = if manifest.starts_with(header) {
+        0
+    } else {
+        manifest
+            .find(&format!("\n{header}"))
+            .map(|i| i + 1)
+            .expect("Cargo.toml must declare a [features] table")
+    };
+    let body = &manifest[start + header.len()..];
+    let end = body
+        .find("\n[")
+        .map(|i| header.len() + i)
+        .unwrap_or(body.len() + header.len());
+    &manifest[start..start + end]
+}
+
+/// Parse the `default = [ ... ]` array from the `[features]` table. Returns an
+/// empty vector when no `default` key is declared (the pre-change state on
+/// `main`), which is exactly what drives this test red until the fix lands.
+fn default_feature_set() -> Vec<String> {
+    let manifest = cargo_manifest();
+    let features = features_section(&manifest);
+
+    let mut offset = 0usize;
+    let mut key_pos: Option<usize> = None;
+    for line in features.lines() {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with('#') && trimmed.starts_with("default") {
+            let after_key = trimmed["default".len()..].trim_start();
+            if after_key.starts_with('=') {
+                key_pos = Some(offset);
+                break;
+            }
+        }
+        offset += line.len() + 1; // +1 for the '\n' consumed by `lines()`
+    }
+
+    let key_pos = match key_pos {
+        Some(pos) => pos,
+        None => return Vec::new(),
+    };
+
+    let tail = &features[key_pos..];
+    let open = tail
+        .find('[')
+        .expect("`default` feature set must be declared as an array");
+    let close = open
+        + tail[open..]
+            .find(']')
+            .expect("`default` feature array must be closed with ']'");
+
+    tail[open + 1..close]
+        .split(',')
+        .map(|token| {
+            token
+                .trim()
+                .trim_matches(|c| c == '"' || c == '\'')
+                .to_string()
+        })
+        .filter(|token| !token.is_empty())
+        .collect()
+}
+
+/// The core issue #2576 contract: every functional/runtime feature is built by
+/// default, and only the slow-test *selector* stays opt-in.
+#[test]
+fn default_feature_set_includes_all_runtime_features() {
+    let defaults = default_feature_set();
+
+    for feature in ["signal", "dashboard-audit"] {
+        assert!(
+            defaults.iter().any(|f| f == feature),
+            "Cargo.toml `[features] default` must include the runtime feature \
+             `{feature}` so a plain `cargo build` yields a fully-capable binary \
+             (issue #2576: no shippable capability may be opt-in). \
+             Current default set: {defaults:?}"
+        );
+    }
+
+    assert!(
+        !defaults.iter().any(|f| f == "slow-tests"),
+        "`slow-tests` must stay OUT of the default set — it is a slow-test \
+         *selection* gate, not a shippable capability; defaulting it would force \
+         slow tests into every `cargo test` / CI run and blow up CI time. \
+         Current default set: {defaults:?}"
+    );
+}
+
+/// Behavioral proof that the *default build* has the Signal channel compiled in.
+///
+/// Gated on `feature = "signal"`: `assert_cmd` builds `simard` with the same
+/// feature set as this test invocation, so whenever this module compiles the
+/// binary under test is guaranteed to carry the Signal channel. Under
+/// `--no-default-features` the module (and the binary's Signal code) drop out
+/// together, so these tests correctly auto-skip instead of failing on a build
+/// that legitimately omits Signal.
+#[cfg(feature = "signal")]
+mod signal_present {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::Output;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use assert_cmd::Command;
+
+    /// A unique, self-cleaning state root under the OS temp dir. Honors the
+    /// directive to never touch the operator's live `~/.simard`.
+    struct TempStateRoot {
+        path: PathBuf,
+    }
+
+    impl TempStateRoot {
+        fn new() -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be after the unix epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "simard-signal-default-{}-{unique}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).expect("temp state root should be creatable");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempStateRoot {
+        fn drop(&mut self) {
+            if self.path.exists() {
+                let _ = fs::remove_dir_all(&self.path);
+            }
+        }
+    }
+
+    /// Build a `simard` command isolated to `state_root`, with the update check
+    /// disabled and every `SIMARD_SIGNAL_*` override cleared so `signal run`
+    /// deterministically reaches the missing-config path rather than the
+    /// operator's ambient configuration.
+    fn simard(state_root: &Path) -> Command {
+        let mut cmd = Command::cargo_bin("simard").expect("the `simard` binary must build");
+        cmd.env("SIMARD_STATE_ROOT", state_root)
+            .env("SIMARD_NO_UPDATE_CHECK", "1")
+            .env_remove("SIMARD_SIGNAL_ENDPOINT")
+            .env_remove("SIMARD_SIGNAL_ACCOUNT")
+            .env_remove("SIMARD_SIGNAL_ALLOWLIST")
+            .env_remove("SIMARD_SIGNAL_READ_ONLY_UNKNOWN");
+        cmd
+    }
+
+    fn rendered(output: &Output) -> String {
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    }
+
+    const NOT_COMPILED: &str = "not compiled into this build";
+
+    #[test]
+    fn signal_help_succeeds_and_lists_run() {
+        let state = TempStateRoot::new();
+        let output = simard(state.path())
+            .args(["signal", "--help"])
+            .output()
+            .expect("`simard signal --help` should spawn");
+        let rendered = rendered(&output);
+
+        assert!(
+            output.status.success(),
+            "`simard signal --help` must exit 0 in a default build; got {:?}\n{rendered}",
+            output.status.code()
+        );
+        assert!(
+            rendered.contains("run"),
+            "`simard signal --help` must document the `run` subcommand; got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains(NOT_COMPILED),
+            "a default build must have the Signal channel compiled in, so \
+             `simard signal --help` must not mention the feature-off stub; got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn signal_run_reaches_real_config_path_not_feature_stub() {
+        let state = TempStateRoot::new();
+        let output = simard(state.path())
+            .args(["signal", "run"])
+            .output()
+            .expect("`simard signal run` should spawn");
+        let rendered = rendered(&output);
+
+        assert!(
+            !output.status.success(),
+            "`simard signal run` must fail when no `[signal]` config is present; \
+             got success.\n{rendered}"
+        );
+        assert!(
+            !rendered.contains(NOT_COMPILED),
+            "REGRESSION (issue #2576): the default build is MISSING the Signal \
+             channel — `simard signal run` fell through to the feature-off stub. \
+             A plain `cargo build` must compile the `signal` feature in.\n{rendered}"
+        );
+        assert!(
+            rendered.contains("missing required configuration 'signal."),
+            "in a default build with no `[signal]` config, `simard signal run` \
+             must reach the real config loader and fail with its \
+             missing-config error; got:\n{rendered}"
+        );
+    }
+}


### PR DESCRIPTION
## Why

Operator directive (issue #2576): **"none of the features need to be opt-in in the future."** The Signal conversation channel (`src/signal_conversation/`) was OFF by default, so the shipped daemon binary had no Signal code and `simard signal run` errored with *"not compiled into this build"* — this just bit the operator. This PR makes every **functional/runtime** cargo feature build by default so a plain `cargo build` yields a fully-capable binary.

## What changed

- **`Cargo.toml`** — add `default = ["signal", "dashboard-audit"]`. A stock build now compiles the Signal channel in and links `dashboard-audit` (headless_chrome). Version bumped **0.25.0 → 0.26.0** so the post-merge redeploy publishes a signal-capable release. Cargo.lock churn is the version line only (headless_chrome / regex / url were already locked, so `--locked` stays green).
- **`slow-tests` stays opt-in — the one intentional exception**, with a comment in `Cargo.toml` explaining why: it is a *test-selection gate*, not a shippable capability. Defaulting it would force the slow suite into every `cargo test` / CI run and blow up CI time.
- **`dashboard-audit` is now default** — the default build compiles and links it (headless_chrome is a build-time dep; the Chrome binary is a runtime concern). The audit binaries carry a `required-features` marker and remain **filtered out of the released tarball** (they need a real Chrome binary at runtime); when Chrome is absent they already degrade gracefully with a clear error (no panic).
- **CI (`verify.yml`)** — added a `cargo build --release --bin simard --no-default-features --locked` step to lock the deliberately-minimal (signal-absent) path. The existing default `cargo build --bin simard --locked` now covers the signal + dashboard-audit default path.
- **Docs + CLI help** — `docs/howto/set-up-the-signal-channel.md`, `docs/reference/signal-conversation.md`, `scripts/dashboard_audit/README.md`, `docs/reference/multi-binary-self-update.md`, `deny.toml`, and `simard signal --help` now state the Signal feature is built by default (no `--features signal` needed); minimal builds use `--no-default-features`.

## Tests

`tests/signal_default_build.rs` (added RED in the prior commit `0e5d5d67`) is now **GREEN**:
- `default_feature_set_includes_all_runtime_features` — manifest assertion (always runs): `default` must include `signal` + `dashboard-audit` and exclude `slow-tests`.
- `signal_present::signal_help_succeeds_and_lists_run` and `signal_present::signal_run_reaches_real_config_path_not_feature_stub` — drive the real binary via `assert_cmd`, gated on `feature = "signal"` so they run under default `cargo test` / `--all-features` and auto-skip under `--no-default-features`. Isolated to a unique `SIMARD_STATE_ROOT` under the OS temp dir — never touch `~/.simard`.

## Local verification

- `cargo build --bin simard` (default) → `simard signal --help` lists `run`, no "not compiled" stub; `simard signal run` reaches the real `missing required configuration 'signal.endpoint'` path.
- `cargo build --release --bin simard --no-default-features --locked` → compiles/links; OFF-path `signal run` degrades gracefully.
- `cargo test --test signal_default_build` (default + `--no-default-features`), `cargo fmt --check`, `cargo clippy --release --no-deps -D warnings`, `cargo clippy --all-targets --all-features --locked -D warnings`, and `mkdocs build --strict` all green.

## Policy / notes

- No `git --no-verify`, no `gh pr merge --admin`. Green pre-commit + pre-push locally; relying on required CI to gate merge.
- The live daemon and `~/.simard` were **not** touched. **After merge the operator will redeploy** so the daemon binary is signal-capable by default.
- Naming: first-class Signal conversation channel / one-Brain reasoner terminology only — nothing here is a "bridge".

Closes #2576
