### PR TITLE
feat(distill): canonicalize concept surface-forms to raise fact-yield (#2432)

### DIFF
--- a/docs/architecture/episode-distillation.md
+++ b/docs/architecture/episode-distillation.md
@@ -221,6 +221,27 @@ useful. Adding labels expands the search surface without immediately
 improving fact relevance; new labels should be added only when a
 clear retrieval pattern motivates them.
 
+#### Surface-form canonicalization
+
+The prompt constrains the label to those three strings, but an LLM
+routinely varies the *surface form* of a label it clearly intends —
+title/upper case (`PR-Pattern`, `BUG-PATTERN`), surrounding whitespace
+or quotes/sentence punctuation (`" bug-pattern "`, `pr-pattern.`), and
+`_`/space separators (`pr_pattern`, `lesson learned`). The parser's
+concept filter (`canonical_distill_concept`) folds these variants back
+to the canonical lower-hyphen label **before** the closed-set match, so
+a well-formed, grounded fact is not lost to cosmetics. Normalization is
+limited to case-folding, trimming, and `_`/space→`-` (with repeated
+hyphens collapsed); a concept that does not normalize to exactly one of
+the three labels — `made-up-label`, `pr-patterns`, `pull-request` — is
+still dropped. Recovered facts are stored under the canonical label, so
+the concept column is uniform for downstream dedup and recall regardless
+of how the model spelled it. This raises fact-yield (fewer legitimate
+facts dropped) without weakening precision (off-spec labels still
+dropped, and the reliability gate still quarantines ungrounded/empty
+facts). See the [fact-yield benchmark](#fact-yield-benchmark) for the
+recorded before/after numbers.
+
 ---
 
 ## Trait surface
@@ -397,6 +418,58 @@ measure different things and must not be summed or compared
 directly; they are emitted on separate log lines so an operator can
 tell which pass — textual or semantic — is doing the work on a given
 cycle.
+
+---
+
+## Fact-yield benchmark
+
+Fact-yield is the number of facts a pass promotes per unit of
+consolidation input (facts-per-episode-batch). Because the LLM recipe
+call is non-deterministic, the yield of the *deterministic* portion of a
+pass — the JSON parse + concept filter + reliability gate — is pinned by
+a fixed-corpus **regression benchmark**. This records a concrete baseline
+so a regression fails CI; it is **not** an estimate of real-world
+end-to-end LLM yield. The numbers are a property of the fixed corpus
+(which deliberately contains five recoverable surface-form-variant
+labels), not a global production delta.
+
+`src/memory_consolidation/distillation_fact_yield_bench.rs` runs a fixed
+batch of 25 episodes and a fixed recipe-output envelope of 13 candidate
+facts (canonical, surface-form-variant, off-spec, ungrounded, and
+empty-content cases) through the real production path
+(`parse_recipe_output_full` + `assess_fact_reliability`). It embeds an
+exact-match baseline oracle so the before/after comparison is
+self-contained: reverting the concept canonicalization collapses
+`improved` to `baseline` and fails the strict-improvement assertion.
+
+Recorded numbers (`cargo test --lib
+memory_consolidation::distillation_fact_yield_bench -- --nocapture`):
+
+```
+[fact-yield-bench] corpus_episodes=25 candidate_facts=13 \
+  baseline_promoted=3 improved_promoted=8 \
+  baseline_yield=0.120 improved_yield=0.320 \
+  baseline_structural_precision=1.000 improved_structural_precision=1.000
+```
+
+On this fixed corpus the canonicalization recovers the five
+surface-form-variant facts the exact-match filter dropped, raising the
+parse+gate fact-yield from **0.120 to 0.320** while **structural
+precision** stays at **1.000**. Precision here is *structural* — every
+promoted fact remains grounded, non-empty, and known-concept (the
+reliability gate's admission invariant); it is not a claim that the
+fact's content is semantically supported by the cited episode. No
+baseline-promoted fact is dropped.
+
+The benchmark is DB-free (parse + reliability gate only). Because the
+corpus is dedup-neutral against an empty store, its parse+gate survivor
+count equals a full pass's promoted count for a fresh memory — and that
+equality is *exercised*, not merely asserted, by
+`distillation_tests::full_pass_promotes_canonicalized_surface_variants_through_dedup`,
+which routes the same corpus through the real
+`distill_recent_episodes_with_runner` (parse → gate → **dedup guard** →
+store) and confirms all eight survive with the ungrounded and empty
+candidates quarantined.
 
 ---
 

--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -10,7 +10,10 @@
 //!    pass entirely — no LLM call, no markers.
 //! 3. Otherwise invokes a pluggable [`DistillRecipeRunner`] that
 //!    classifies each episode into one of three concept labels
-//!    (`pr-pattern`, `bug-pattern`, `lesson-learned`) or `skip`.
+//!    (`pr-pattern`, `bug-pattern`, `lesson-learned`) or `skip`. Surface-form
+//!    variants of those labels (case, whitespace, `_`↔`-`) are canonicalized by
+//!    [`canonical_distill_concept`] so a well-formed fact is not lost to
+//!    cosmetics; genuinely off-spec labels are still dropped.
 //! 4. Self-assesses each candidate fact's reliability (issue #2433,
 //!    BGML's ISAO) and GATES on `Fact.confidence`: low-reliability facts
 //!    are quarantined (not promoted) and a weaker new fact never clobbers
@@ -1557,23 +1560,80 @@ struct RecipeProcedure {
     source_episode_ids: Vec<String>,
 }
 
+/// Canonicalize a recipe-emitted concept label to one of the fixed
+/// [`KNOWN_DISTILL_CONCEPTS`], or `None` if it is genuinely off-spec.
+///
+/// The distillation recipe's prompt constrains the label to the closed set
+/// `{pr-pattern, bug-pattern, lesson-learned}`, but an LLM routinely varies the
+/// *surface form* of a label it clearly intends: title/upper case
+/// (`"PR-Pattern"`, `"BUG-PATTERN"`), surrounding whitespace or quotes/sentence
+/// punctuation (`" bug-pattern "`, `"pr-pattern."`), and space/underscore
+/// separators (`"pr_pattern"`, `"lesson learned"`). The legacy exact-match
+/// filter silently dropped every such fact — a well-formed, grounded fact lost
+/// purely to cosmetics, depressing distillation fact-yield.
+///
+/// Canonicalization recovers those facts (higher yield) **without weakening
+/// precision**: normalization only folds case, trims surrounding
+/// whitespace/quotes/sentence-punctuation, and unifies `_`/space→`-` (collapsing
+/// repeated hyphens) before an EXACT match against the three labels. A concept
+/// that does not normalize to one of them — `"made-up-label"`, `"skip"`,
+/// `"pr-patterns"`, `"pull-request"` — still returns `None` and is dropped. The
+/// three labels are lexically distinct, so no genuinely different concept can
+/// alias onto another. The returned value is the canonical lower-hyphen form,
+/// so the stored concept is uniform for downstream dedup/recall regardless of
+/// how the model spelled it.
+pub(crate) fn canonical_distill_concept(raw: &str) -> Option<&'static str> {
+    // Fold case, then strip surrounding whitespace and the quote/sentence
+    // punctuation a model sometimes wraps a label in.
+    let trimmed = raw
+        .trim()
+        .trim_matches(|c: char| {
+            c.is_whitespace() || matches!(c, '"' | '\'' | '`' | '.' | ',' | ':' | ';')
+        })
+        .to_ascii_lowercase();
+
+    // Unify separators (`_` and interior spaces behave as `-`) and collapse runs
+    // of hyphens, then trim any leading/trailing hyphens the folding produced.
+    let mut canon = String::with_capacity(trimmed.len());
+    let mut prev_hyphen = false;
+    for ch in trimmed.chars() {
+        let c = if ch == '_' || ch == ' ' { '-' } else { ch };
+        if c == '-' {
+            if !prev_hyphen {
+                canon.push('-');
+            }
+            prev_hyphen = true;
+        } else {
+            canon.push(c);
+            prev_hyphen = false;
+        }
+    }
+    let canon = canon.trim_matches('-');
+
+    match canon {
+        "pr-pattern" => Some("pr-pattern"),
+        "bug-pattern" => Some("bug-pattern"),
+        "lesson-learned" => Some("lesson-learned"),
+        _ => None,
+    }
+}
+
 impl RecipeEnvelope {
     fn into_facts(self) -> Vec<DistilledFact> {
-        // Keep only the three documented concepts so the recipe cannot
-        // sneak new labels past the contract. Everything else (incl.
-        // `skip` if it ever lands here) is dropped.
+        // Keep only facts whose concept canonicalizes to one of the three
+        // documented labels so the recipe cannot sneak new labels past the
+        // contract — but tolerate the LLM's surface-form variation (case /
+        // whitespace / `_`↔`-`) of a label it clearly intends. Off-spec
+        // concepts (incl. `skip` if it ever lands here) still return `None` and
+        // are dropped; recovered facts are stored under the canonical label.
         self.facts
             .into_iter()
-            .filter(|f| {
-                matches!(
-                    f.concept.as_str(),
-                    "pr-pattern" | "bug-pattern" | "lesson-learned"
-                )
-            })
-            .map(|f| DistilledFact {
-                concept: f.concept,
-                content: f.content,
-                source_episode_id: f.source_episode_id,
+            .filter_map(|f| {
+                canonical_distill_concept(&f.concept).map(|concept| DistilledFact {
+                    concept: concept.to_string(),
+                    content: f.content,
+                    source_episode_id: f.source_episode_id,
+                })
             })
             .collect()
     }
@@ -1698,6 +1758,77 @@ mod unit_tests {
         let facts = parse_recipe_output(raw).unwrap();
         assert_eq!(facts.len(), 1, "made-up-label must be filtered out");
         assert_eq!(facts[0].concept, "lesson-learned");
+    }
+
+    #[test]
+    fn canonical_concept_accepts_surface_form_variants() {
+        // Case, surrounding whitespace/quotes/punctuation, and `_`/space
+        // separators of a clearly-intended label all normalize to the canonical
+        // lower-hyphen form (higher fact-yield without lowering precision).
+        for (raw, want) in [
+            ("pr-pattern", "pr-pattern"),
+            ("PR-Pattern", "pr-pattern"),
+            ("BUG-PATTERN", "bug-pattern"),
+            (" bug-pattern ", "bug-pattern"),
+            ("Lesson-Learned", "lesson-learned"),
+            ("pr_pattern", "pr-pattern"),
+            ("lesson learned", "lesson-learned"),
+            ("pr--pattern", "pr-pattern"),
+            ("\"pr-pattern\"", "pr-pattern"),
+            ("bug-pattern.", "bug-pattern"),
+        ] {
+            assert_eq!(
+                canonical_distill_concept(raw),
+                Some(want),
+                "surface variant {raw:?} should canonicalize to {want:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_concept_rejects_offspec_labels() {
+        // Precision guard: anything that does not normalize to exactly one of the
+        // three labels is still dropped — the canonicalizer must not admit
+        // near-misses, plurals, or unrelated labels.
+        for raw in [
+            "made-up-label",
+            "skip",
+            "observation",
+            "pr-patterns",
+            "pull-request",
+            "bug",
+            "pattern",
+            "",
+            "   ",
+            "pr-pattern-v2",
+            "prpattern",
+        ] {
+            assert_eq!(
+                canonical_distill_concept(raw),
+                None,
+                "off-spec label {raw:?} must be dropped"
+            );
+        }
+    }
+
+    #[test]
+    fn into_facts_recovers_surface_variant_but_drops_offspec() {
+        // End-to-end through the production parser: a case/whitespace/underscore
+        // variant is recovered (and stored canonical); an off-spec label is
+        // dropped.
+        let raw = r#"{"facts":[
+            {"concept":"PR-Pattern","content":"squash fixups","source_episode_id":"epi_1"},
+            {"concept":" bug_pattern ","content":"off by one","source_episode_id":"epi_2"},
+            {"concept":"made-up-label","content":"nope","source_episode_id":"epi_3"}
+        ]}"#;
+        let facts = parse_recipe_output(raw).unwrap();
+        assert_eq!(
+            facts.len(),
+            2,
+            "two surface variants recovered, off-spec dropped"
+        );
+        assert_eq!(facts[0].concept, "pr-pattern");
+        assert_eq!(facts[1].concept, "bug-pattern");
     }
 
     #[test]

--- a/src/memory_consolidation/distillation_fact_yield_bench.rs
+++ b/src/memory_consolidation/distillation_fact_yield_bench.rs
@@ -1,0 +1,336 @@
+//! Deterministic **fact-yield benchmark** for episode distillation (perpetual
+//! cognition sub-goal: *raise distillation fact-yield*).
+//!
+//! ## What this measures — and what it does NOT claim
+//!
+//! This is a **deterministic regression benchmark**, not an estimate of
+//! real-world LLM yield. It measures the *parse + reliability-gate* fact-yield —
+//! surviving facts per input episode — over a **fixed, hand-authored sample
+//! corpus**. It exercises the deterministic portion of a distillation pass,
+//! everything downstream of the (non-deterministic) LLM recipe call:
+//!
+//! 1. `parse_recipe_output_full` — parses the recipe's JSON envelope and applies
+//!    the concept filter ([`RecipeEnvelope::into_facts`]).
+//! 2. the ISAO reliability gate — [`assess_fact_reliability`] against
+//!    [`DISTILL_RELIABILITY_THRESHOLD`].
+//!
+//! The numbers are a property of this corpus (which deliberately contains five
+//! recoverable surface-form-variant labels), NOT a measurement of how often
+//! concept-variant drops occur in production. Treat `baseline_yield=0.120 →
+//! improved_yield=0.320` as "the concept filter no longer drops these five
+//! legitimate facts", not as a global production-yield delta.
+//!
+//! The corpus is deliberately **dedup-neutral against an empty store** (every
+//! candidate has distinct `concept + content`), so the production dedup guard —
+//! which only blocks an equal-or-stronger *identical* prior — never fires. The
+//! parse+gate survivor count therefore equals the full-pass promoted count for a
+//! FRESH memory; that equality is not merely asserted here but *exercised* by
+//! [`distillation_tests::full_pass_promotes_canonicalized_surface_variants_through_dedup`],
+//! which routes this same corpus through the real
+//! `distill_recent_episodes_with_runner` (parse → gate → dedup guard → store)
+//! and confirms all eight survive.
+//!
+//! ## `structural_precision`, not semantic truth
+//!
+//! Precision here is **structural**: a promoted fact is "correct" iff it is
+//! grounded in the batch, non-empty, and carries a recognized concept — exactly
+//! the reliability gate's admission invariant. It does NOT assert the fact's
+//! content is semantically supported by the cited episode (the gate never claimed
+//! to). The point this benchmark proves is narrow but real: canonicalization does
+//! not *weaken* that structural invariant — it admits only facts the gate would
+//! already accept had the label been spelled canonically, and never an off-spec,
+//! ungrounded, or empty candidate.
+//!
+//! ## Baseline vs improved (self-contained before/after)
+//!
+//! The benchmark computes two numbers over the SAME corpus:
+//!
+//! * **baseline** — an in-test oracle that replicates the *legacy exact-match*
+//!   concept filter (`concept == "pr-pattern" | "bug-pattern" | "lesson-learned"`).
+//! * **improved** — the REAL production path (`parse_recipe_output_full`), which
+//!   now canonicalizes surface-form concept variants before the filter.
+//!
+//! It asserts the improved path promotes strictly more facts than the baseline
+//! (higher parse+gate yield) while keeping **structural_precision at 1.0** and
+//! never dropping a fact the baseline kept (superset). If the canonicalization is
+//! reverted, `improved` collapses to `baseline` and the strict-improvement
+//! assertion fails — the permanent regression guard.
+
+use crate::memory_cognitive::CognitiveEpisode;
+use crate::memory_consolidation::distillation::{
+    DISTILL_RELIABILITY_THRESHOLD, DistilledFact, KNOWN_DISTILL_CONCEPTS, assess_fact_reliability,
+    parse_recipe_output_full,
+};
+
+/// Number of episodes in the fixed consolidation-input batch.
+pub(crate) const CORPUS_EPISODE_COUNT: usize = 25;
+
+/// Parse+gate survivor count under the legacy exact-match concept filter. This
+/// is the **recorded baseline** the improvement is measured against.
+pub(crate) const BASELINE_PROMOTED: usize = 3;
+
+/// Parse+gate survivor count under the canonicalizing concept filter (the
+/// shipped change). Recovers the five surface-form-variant facts the exact-match
+/// filter silently dropped. The full-pass test
+/// `distillation_tests::full_pass_promotes_canonicalized_surface_variants_through_dedup`
+/// confirms all eight are actually promoted (survive the dedup guard + storage).
+pub(crate) const IMPROVED_PROMOTED: usize = 8;
+
+/// Build the fixed episode batch: ids `ep-000`..`ep-024`. Grounding is decided
+/// purely by whether a fact cites one of these ids.
+fn corpus_episodes() -> Vec<CognitiveEpisode> {
+    (0..CORPUS_EPISODE_COUNT)
+        .map(|i| CognitiveEpisode {
+            node_id: format!("ep-{i:03}"),
+            content: format!("episode {i} body"),
+            source_label: "distill-bench".to_string(),
+            temporal_index: i as i64,
+            compressed: false,
+        })
+        .collect()
+}
+
+/// The fixed recipe-output envelope (a stand-in for one LLM distillation
+/// response), shared with the full-pass test in `distillation_tests` so both
+/// measure the identical corpus. Thirteen candidate facts spanning every
+/// yield/precision case:
+///
+/// * 3 canonical, grounded, well-formed — kept by BOTH filters.
+/// * 5 surface-form variants (case / whitespace / underscore), grounded,
+///   well-formed — dropped by the exact-match filter, RECOVERED by
+///   canonicalization. This is the yield gain.
+/// * 3 genuinely off-spec concepts — dropped by BOTH (precision guard: the
+///   canonicalizer must NOT admit these).
+/// * 1 canonical concept but ungrounded provenance — passes both filters, then
+///   quarantined by the reliability gate (precision guard).
+/// * 1 canonical concept but empty content — passes both filters, then
+///   quarantined by the reliability hard gate (precision guard).
+pub(crate) const CORPUS_RECIPE_JSON: &str = r#"{"facts":[
+  {"concept":"pr-pattern","content":"rebase feature branches before merging to keep history linear","source_episode_id":"ep-000"},
+  {"concept":"bug-pattern","content":"null dereference when the input batch is empty","source_episode_id":"ep-001"},
+  {"concept":"lesson-learned","content":"write the failing parser test before touching the scanner","source_episode_id":"ep-002"},
+  {"concept":"PR-Pattern","content":"squash fixups so each commit builds green","source_episode_id":"ep-003"},
+  {"concept":" bug-pattern ","content":"off by one on the last chunk boundary","source_episode_id":"ep-004"},
+  {"concept":"Lesson-Learned","content":"measure before optimizing the hot path","source_episode_id":"ep-005"},
+  {"concept":"pr_pattern","content":"request review from the module owner","source_episode_id":"ep-006"},
+  {"concept":"BUG-PATTERN","content":"unbounded retry loop on transient network error","source_episode_id":"ep-007"},
+  {"concept":"made-up-label","content":"this concept is off spec and must be dropped","source_episode_id":"ep-008"},
+  {"concept":"skip","content":"no durable signal in this episode","source_episode_id":"ep-009"},
+  {"concept":"observation","content":"random unstructured note with no label","source_episode_id":"ep-010"},
+  {"concept":"pr-pattern","content":"cites an episode outside this batch so provenance is unverifiable","source_episode_id":"ep-999"},
+  {"concept":"bug-pattern","content":"   ","source_episode_id":"ep-011"}
+]}"#;
+
+/// A parsed candidate fact straight from the recipe JSON, BEFORE any concept
+/// filtering — the raw material the baseline oracle filters itself.
+struct RawCandidate {
+    concept: String,
+    content: String,
+    source_episode_id: String,
+}
+
+/// Parse `CORPUS_RECIPE_JSON` into raw candidates without applying any concept
+/// filter. Used only by the baseline oracle so it can replicate the *legacy*
+/// exact-match behaviour independently of the production parser.
+fn raw_candidates() -> Vec<RawCandidate> {
+    let v: serde_json::Value =
+        serde_json::from_str(CORPUS_RECIPE_JSON).expect("benchmark corpus JSON must be valid");
+    v["facts"]
+        .as_array()
+        .expect("corpus must have a facts array")
+        .iter()
+        .map(|f| RawCandidate {
+            concept: f["concept"].as_str().unwrap_or_default().to_string(),
+            content: f["content"].as_str().unwrap_or_default().to_string(),
+            source_episode_id: f["source_episode_id"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+        })
+        .collect()
+}
+
+/// The reliability gate: keep only facts whose self-assessed confidence clears
+/// [`DISTILL_RELIABILITY_THRESHOLD`]. This is the exact promotion predicate the
+/// production pass applies (minus the dedup guard, which the dedup-neutral
+/// corpus never triggers).
+fn gate_survivors(facts: &[DistilledFact], episodes: &[CognitiveEpisode]) -> Vec<DistilledFact> {
+    facts
+        .iter()
+        .filter(|f| assess_fact_reliability(f, episodes, facts) >= DISTILL_RELIABILITY_THRESHOLD)
+        .cloned()
+        .collect()
+}
+
+/// Legacy baseline oracle: replicate the *exact-match* concept filter that
+/// `into_facts` used before canonicalization, then gate. Independent of the
+/// production parser so the before/after comparison is honest.
+fn baseline_promoted(episodes: &[CognitiveEpisode]) -> Vec<DistilledFact> {
+    let filtered: Vec<DistilledFact> = raw_candidates()
+        .into_iter()
+        .filter(|c| {
+            matches!(
+                c.concept.as_str(),
+                "pr-pattern" | "bug-pattern" | "lesson-learned"
+            )
+        })
+        .map(|c| DistilledFact {
+            concept: c.concept,
+            content: c.content,
+            source_episode_id: c.source_episode_id,
+        })
+        .collect();
+    gate_survivors(&filtered, episodes)
+}
+
+/// Improved path: the REAL production parse+filter (`parse_recipe_output_full`,
+/// which now canonicalizes concepts), then the same gate.
+fn improved_promoted(episodes: &[CognitiveEpisode]) -> Vec<DistilledFact> {
+    let output = parse_recipe_output_full(CORPUS_RECIPE_JSON)
+        .expect("benchmark corpus must parse into a facts object");
+    gate_survivors(&output.facts, episodes)
+}
+
+/// A promoted fact is "structurally correct" iff it is grounded in the batch,
+/// has non-empty content, and carries a recognized concept label — exactly the
+/// reliability gate's admission invariant. This is a STRUCTURAL check, not a
+/// judgement that the fact's content is semantically supported by the cited
+/// episode; the point is that canonicalization does not weaken the invariant.
+fn is_correct(fact: &DistilledFact, episodes: &[CognitiveEpisode]) -> bool {
+    let grounded = episodes.iter().any(|e| e.node_id == fact.source_episode_id);
+    let non_empty = !fact.content.trim().is_empty();
+    let known_concept = KNOWN_DISTILL_CONCEPTS
+        .iter()
+        .any(|c| c.eq_ignore_ascii_case(fact.concept.trim()));
+    grounded && non_empty && known_concept
+}
+
+/// Structural precision: fraction of promoted facts that satisfy the gate's
+/// structural admission invariant (see [`is_correct`]). 1.0 means the promotion
+/// set contains no ungrounded, empty, or off-spec fact.
+fn structural_precision(promoted: &[DistilledFact], episodes: &[CognitiveEpisode]) -> f64 {
+    if promoted.is_empty() {
+        return 1.0;
+    }
+    let correct = promoted.iter().filter(|f| is_correct(f, episodes)).count();
+    correct as f64 / promoted.len() as f64
+}
+
+#[test]
+fn fact_yield_benchmark_records_baseline_and_proves_improvement() {
+    let episodes = corpus_episodes();
+
+    let baseline = baseline_promoted(&episodes);
+    let improved = improved_promoted(&episodes);
+
+    let baseline_yield = baseline.len() as f64 / episodes.len() as f64;
+    let improved_yield = improved.len() as f64 / episodes.len() as f64;
+    let baseline_structural_precision = structural_precision(&baseline, &episodes);
+    let improved_structural_precision = structural_precision(&improved, &episodes);
+
+    // Emit the recorded numbers so CI logs (`-- --nocapture`) show the baseline
+    // and the measured improvement on every run. These are parse+gate survivor
+    // counts over the FIXED corpus, not a real-world end-to-end LLM yield.
+    println!(
+        "[fact-yield-bench] corpus_episodes={} candidate_facts={} \
+         baseline_promoted={} improved_promoted={} \
+         baseline_yield={:.3} improved_yield={:.3} \
+         baseline_structural_precision={:.3} improved_structural_precision={:.3}",
+        episodes.len(),
+        raw_candidates().len(),
+        baseline.len(),
+        improved.len(),
+        baseline_yield,
+        improved_yield,
+        baseline_structural_precision,
+        improved_structural_precision,
+    );
+
+    // 1. Recorded baseline is stable.
+    assert_eq!(
+        baseline.len(),
+        BASELINE_PROMOTED,
+        "recorded baseline fact-yield drifted; corpus or exact-match oracle changed"
+    );
+
+    // 2. The shipped change raises measured yield to the recorded improved number.
+    assert_eq!(
+        improved.len(),
+        IMPROVED_PROMOTED,
+        "improved fact-yield drifted from the recorded number"
+    );
+
+    // 3. Yield strictly improved (the core acceptance signal). Reverting the
+    //    concept canonicalization makes `improved == baseline` and fails here.
+    assert!(
+        improved.len() > baseline.len(),
+        "fact-yield did not improve: improved={} baseline={}",
+        improved.len(),
+        baseline.len()
+    );
+
+    // 4. Structural precision is NOT lowered — both paths promote only facts that
+    //    satisfy the gate's grounded/non-empty/known-concept invariant.
+    assert_eq!(
+        baseline_structural_precision, 1.0,
+        "baseline structural precision must be 1.0"
+    );
+    assert_eq!(
+        improved_structural_precision, 1.0,
+        "improved structural precision regressed below 1.0 — canonicalization admitted an off-spec/ungrounded/empty fact"
+    );
+    assert!(
+        improved_structural_precision >= baseline_structural_precision,
+        "structural precision regressed: improved={improved_structural_precision} baseline={baseline_structural_precision}"
+    );
+
+    // 5. No regression: every fact the baseline promoted is still promoted.
+    for b in &baseline {
+        assert!(
+            improved
+                .iter()
+                .any(|i| i.content == b.content && i.source_episode_id == b.source_episode_id),
+            "improved path dropped a baseline-promoted fact: {b:?}"
+        );
+    }
+}
+
+#[test]
+fn fact_yield_benchmark_recovers_only_surface_variants_not_offspec() {
+    // The five recovered facts (improved − baseline) must all be the grounded,
+    // well-formed, surface-variant-concept facts — never an off-spec, ungrounded,
+    // or empty candidate. This pins that the yield gain is precision-safe.
+    let episodes = corpus_episodes();
+    let baseline = baseline_promoted(&episodes);
+    let improved = improved_promoted(&episodes);
+
+    let recovered: Vec<&DistilledFact> = improved
+        .iter()
+        .filter(|i| {
+            !baseline
+                .iter()
+                .any(|b| b.content == i.content && b.source_episode_id == i.source_episode_id)
+        })
+        .collect();
+
+    assert_eq!(
+        recovered.len(),
+        IMPROVED_PROMOTED - BASELINE_PROMOTED,
+        "unexpected number of recovered facts"
+    );
+    for r in recovered {
+        assert!(
+            is_correct(r, &episodes),
+            "a recovered fact is not a correct (grounded/non-empty/known-concept) fact: {r:?}"
+        );
+        // Every promoted concept is stored in canonical (lower-hyphen) form.
+        assert!(
+            matches!(
+                r.concept.as_str(),
+                "pr-pattern" | "bug-pattern" | "lesson-learned"
+            ),
+            "recovered fact concept was not canonicalized: {:?}",
+            r.concept
+        );
+    }
+}

--- a/src/memory_consolidation/distillation_tests.rs
+++ b/src/memory_consolidation/distillation_tests.rs
@@ -46,6 +46,11 @@ use crate::memory_consolidation::distillation::{
     DISTILL_RELIABILITY_THRESHOLD, DistillRecipeRunner, DistilledFact, KNOWN_DISTILL_CONCEPTS,
     assess_fact_reliability, distill_recent_episodes_with_runner,
 };
+// Fixed fact-yield corpus, shared with `distillation_fact_yield_bench` so the
+// full-pass test below measures the identical input the benchmark records.
+use crate::memory_consolidation::distillation_fact_yield_bench::{
+    BASELINE_PROMOTED, CORPUS_EPISODE_COUNT, CORPUS_RECIPE_JSON, IMPROVED_PROMOTED,
+};
 
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
@@ -1880,4 +1885,89 @@ fn surviving_parse_failure_writes_nothing_when_capture_disabled() {
         !created_any,
         "capture is default-off: no sample may be written when the toggle is falsy"
     );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Full-pass companion to the deterministic fact-yield benchmark
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Runner that parses a fixed raw recipe-output envelope through the REAL
+/// production parse path (`parse_recipe_output_full`), so the concept
+/// canonicalization in `RecipeEnvelope::into_facts` is exercised end-to-end via
+/// `distill_recent_episodes_with_runner` (parse → gate → dedup guard → store)
+/// rather than bypassed by a facts-returning stub.
+struct RawEnvelopeRunner {
+    raw: &'static str,
+    call_count: AtomicU32,
+}
+
+impl DistillRecipeRunner for RawEnvelopeRunner {
+    fn run(&self, _episodes: &[CognitiveEpisode]) -> SimardResult<Vec<DistilledFact>> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        parse_recipe_output_full(self.raw).map(|o| o.facts)
+    }
+}
+
+/// Full-pass companion to `distillation_fact_yield_bench`. Routes the SAME fixed
+/// corpus through the real `distill_recent_episodes_with_runner` — parse +
+/// concept canonicalization + reliability gate + the identity dedup guard +
+/// storage — against a FRESH (empty) memory, and confirms all `IMPROVED_PROMOTED`
+/// canonical / surface-variant grounded facts are actually stored while the
+/// ungrounded and empty candidates are quarantined. This upgrades the
+/// benchmark's "dedup-neutral corpus ⇒ parse+gate survivors == full-pass
+/// promoted" claim from *asserted* to *exercised*, closing the gap between the
+/// DB-free benchmark and a real production pass.
+#[test]
+fn full_pass_promotes_canonicalized_surface_variants_through_dedup() {
+    let rows: Vec<EpisodeRow> = (0..CORPUS_EPISODE_COUNT)
+        .map(|i| EpisodeRow {
+            node_id: format!("ep-{i:03}"),
+            content: format!("episode {i} body"),
+            source_label: "distill-bench".to_string(),
+            temporal_index: i as i64,
+            compressed: false,
+            distilled: false,
+        })
+        .collect();
+    let mock = EpisodeMock::with_episodes(rows);
+    let runner = RawEnvelopeRunner {
+        raw: CORPUS_RECIPE_JSON,
+        call_count: AtomicU32::new(0),
+    };
+
+    let report = distill_recent_episodes_with_runner(&mock, &runner).unwrap();
+
+    // The runner (and thus the LLM-side parse) ran exactly once — no transient
+    // retry, since the fixed corpus parses cleanly.
+    assert_eq!(runner.call_count.load(Ordering::SeqCst), 1);
+
+    // All eight canonical/surface-variant grounded facts are promoted through the
+    // FULL pipeline (dedup guard included), matching the benchmark's parse+gate
+    // survivor count. The two precision-guard candidates (ungrounded ep-999 and
+    // empty content) are quarantined by the reliability gate; the three off-spec
+    // concepts are dropped at the concept filter (not counted as quarantined).
+    assert_eq!(
+        report.fact_count, IMPROVED_PROMOTED as u32,
+        "full pass must promote all recovered surface-variant facts"
+    );
+    assert_eq!(
+        report.quarantined_count, 2,
+        "ungrounded + empty candidates must be quarantined by the reliability gate"
+    );
+    assert!(
+        report.fact_count > BASELINE_PROMOTED as u32,
+        "full-pass yield must exceed the exact-match baseline"
+    );
+
+    // Every stored fact carries a canonical lower-hyphen concept label, proving
+    // canonicalization normalized the surface variants before storage.
+    for (concept, _content) in mock.facts_stored() {
+        assert!(
+            matches!(
+                concept.as_str(),
+                "pr-pattern" | "bug-pattern" | "lesson-learned"
+            ),
+            "stored concept was not canonicalized: {concept:?}"
+        );
+    }
 }

--- a/src/memory_consolidation/mod.rs
+++ b/src/memory_consolidation/mod.rs
@@ -981,6 +981,14 @@ pub mod scheduler;
 #[cfg(test)]
 mod distillation_tests;
 
+// Perpetual-cognition sub-goal: raise distillation fact-yield. A deterministic,
+// DB-free benchmark that records a baseline facts-per-consolidation-input number
+// over a fixed sample corpus and proves the concept-canonicalization change
+// raises yield without lowering precision. See
+// `docs/architecture/episode-distillation.md` §"Fact-yield benchmark".
+#[cfg(test)]
+mod distillation_fact_yield_bench;
+
 // PR-C (issue #2281, problem 4): episodic recall tests for
 // `preparation_memory_operations`. Pins the tokenizer rules,
 // self-session noise filter, and no-tokens short-circuit

--- a/tests/gadugi/distill-fact-yield.yaml
+++ b/tests/gadugi/distill-fact-yield.yaml
@@ -1,0 +1,112 @@
+name: "Distillation Fact-Yield Canonicalization"
+description: >
+  qa-team outside-in gate for the perpetual-cognition sub-goal "raise
+  distillation fact-yield". Simard's episode distiller
+  (src/memory_consolidation/distillation.rs) previously dropped a candidate
+  fact whenever the LLM emitted a concept label in any surface form other than
+  the exact lower-hyphen string — title/upper case (PR-Pattern, BUG-PATTERN),
+  surrounding whitespace/quotes/punctuation (" bug-pattern ", pr-pattern.), or
+  underscore/space separators (pr_pattern, lesson learned). Those well-formed,
+  grounded facts were lost purely to cosmetics, depressing fact-yield. The
+  concept filter now canonicalizes surface-form variants back to the fixed
+  label set before the closed-set match, recovering the facts WITHOUT weakening
+  precision: genuinely off-spec labels are still dropped and the reliability
+  gate still quarantines ungrounded/empty facts. A deterministic fixed-corpus
+  benchmark records the before/after numbers (baseline promoted=3 yield=0.120 →
+  improved promoted=8 yield=0.320, precision held at 1.000) so a regression
+  fails CI. This scenario pins that behaviour end-to-end.
+version: "1.0.0"
+
+config:
+  timeout: 900000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "test-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 900000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Fact-yield benchmark records baseline and proves precision-safe improvement"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        memory_consolidation::distillation_fact_yield_bench
+        -- --nocapture
+    timeout: 900000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "baseline_promoted=3 improved_promoted=8"
+        - "baseline_yield=0.120 improved_yield=0.320"
+        - "improved_structural_precision=1.000"
+        - "fact_yield_benchmark_records_baseline_and_proves_improvement ... ok"
+        - "fact_yield_benchmark_recovers_only_surface_variants_not_offspec ... ok"
+        - "test result: ok"
+
+  - name: "Concept canonicalization recovers surface variants but rejects off-spec (precision guard)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        memory_consolidation::distillation::unit_tests
+        -- --nocapture
+    timeout: 900000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "canonical_concept_accepts_surface_form_variants ... ok"
+        - "canonical_concept_rejects_offspec_labels ... ok"
+        - "into_facts_recovers_surface_variant_but_drops_offspec ... ok"
+        - "test result: ok"
+
+  - name: "Full distillation parser + reliability-gate + dedup contract still green (no regression)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib memory_consolidation::distillation
+        -- --nocapture
+    timeout: 900000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "parse_recipe_output_drops_unknown_concepts ... ok"
+        - "full_pass_promotes_canonicalized_surface_variants_through_dedup ... ok"
+        - "test result: ok"
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "test-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "memory"
+    - "distillation"
+    - "fact-yield"
+    - "regression"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Sub-goal: raise distillation fact-yield (bounded, shippable cycle)

Perpetual-cognition slice of #2432: **raise distillation fact-yield** — one
bounded, measurable, code-shipping change on the most directly measurable
cognition axis (facts promoted per consolidation input on a fixed corpus).

### Where the distiller actually lives (and why no `amplihack-memory` rev bump)

The goal named `rysweet/amplihack-memory-lib`, but the episode **distiller** —
and every drop point it lists (concept/prompt filter, ISAO/confidence gate,
identity dedup guard) — lives in **Simard's** `src/memory_consolidation/distillation.rs`.
The `amplihack-memory` Rust crate is the *storage* engine; Simard calls
`store_fact_with_provenance` directly and does **not** use the library's
`SameConceptSimilarity` dedup, so the fact-yield lever is entirely in this repo.
No library change is required, so the `Cargo.toml` `amplihack-memory` rev is
unchanged and no bump PR is needed.

### The drop point and the fix

`RecipeEnvelope::into_facts` exact-matched the LLM concept string against
`{pr-pattern, bug-pattern, lesson-learned}`, silently dropping any well-formed,
grounded fact whose label differed only in **surface form** — case
(`PR-Pattern`), whitespace/quotes/punctuation (`" bug-pattern "`, `pr-pattern.`),
or `_`/space separators (`pr_pattern`, `lesson learned`). Legitimate facts were
lost to cosmetics.

New `canonical_distill_concept()` folds surface variants back to the fixed label
set **before** the closed-set match and stores the canonical form. This raises
yield **without lowering precision**: genuinely off-spec labels still drop, and
the ISAO reliability gate still quarantines ungrounded/empty facts.

### Before/after (recorded, deterministic)

```
[fact-yield-bench] corpus_episodes=25 candidate_facts=13 \
  baseline_promoted=3 improved_promoted=8 \
  baseline_yield=0.120 improved_yield=0.320 \
  baseline_structural_precision=1.000 improved_structural_precision=1.000
```

On the fixed sample corpus the concept filter no longer drops the five
surface-form-variant facts: **parse+gate yield 0.120 → 0.320**, structural
precision held at **1.000**. `structural_precision` is the gate's admission
invariant (grounded/non-empty/known-concept), not a semantic-truth claim; the
numbers are a property of the fixed corpus, not a real-world end-to-end LLM
yield estimate.

---

## Merge-ready evidence

### 1. qa-team scenario (validated + run)

`tests/gadugi/distill-fact-yield.yaml` — 3 steps pinning the benchmark numbers,
the canonicalization precision guard, and the full-pass/no-regression contract.

```
$ gadugi-test validate -f tests/gadugi/distill-fact-yield.yaml
✓ Scenario "Distillation Fact-Yield Canonicalization" is valid
$ gadugi-test run -d <scenario dir>
✓ Passed: 1  ✗ Failed: 0
```

### 2. Docs updated (user-facing surface)

`docs/architecture/episode-distillation.md`: new **Surface-form canonicalization**
subsection under Concept labels + a **Fact-yield benchmark** section with the
recorded numbers and honest scoping (deterministic regression benchmark, not a
real-world yield estimate).

### 3. quality-audit — 3 SEEK→VALIDATE→FIX cycles, ended clean

- **Cycle 1** (code-review): empirically verified all six focus areas
  (canonicalizer correctness/no false-admit, no regression vs exact-match,
  downstream safety, benchmark honesty/fails-if-reverted, no panics, gadugi
  assertions) — no issues.
- **Cycle 2** (rubber-duck + security-review): security clean. Logic pass raised
  2 medium honesty findings — benchmark overclaimed "real-world yield" and
  `precision` was structural not semantic — plus a non-blocking gap (dedup guard
  not exercised). **FIX:** reframed all claims as a fixed-corpus parse+gate
  regression benchmark; renamed the metric to `structural_precision` with an
  explicit disclaimer; added a full-pass test
  (`full_pass_promotes_canonicalized_surface_variants_through_dedup`) routing the
  same corpus through the real `distill_recent_episodes_with_runner`
  (parse → gate → **dedup guard** → store), asserting `fact_count==8`,
  `quarantined_count==2`.
- **Cycle 3** (code-review, VALIDATE): confirmed all three fixes correct/complete,
  the full-pass numbers pipeline-derived (hand-traced), `pub(crate)` test
  constants don't leak into non-test builds, diff focused — **clean final cycle,
  zero critical/high, zero medium correctness/security**.

### 4. CI green (mirrored locally)

- `cargo fmt --all -- --check` — clean
- `cargo clippy --release --no-deps -- -D warnings` — clean
- `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- `cargo test --lib` (clean env) — **6526 passed, 0 failed, 7 ignored**
- `cargo test --lib memory_consolidation::distillation` — **91 passed, 0 failed**
- `cargo test --release --lib` for cognitive_memory|bootstrap|memory_ipc|memory_consolidation
  (pre-push gate) — Passed
- All pre-commit + pre-push hooks Passed on push.

> Note: `ooda_loop::decide::tests::decide_respects_max_concurrent_actions` fails
> *only* when the shell exports `SIMARD_MAX_CONCURRENT_ACTIONS`/`SIMARD_SCALING`
> (adaptive scaling overrides the test's config). It is pre-existing
> environmental pollution in the engineer worktree, unrelated to this change, and
> passes in a clean env like CI.

### 6. Focused diff

Only the distiller (`distillation.rs`), its tests (`distillation_tests.rs`,
new `distillation_fact_yield_bench.rs`), the module declaration (`mod.rs`), the
architecture doc, and the qa scenario. No unrelated edits.
