### PR TITLE
docs(signal,audit): scrub stale "opt-in / off by default" comments left after #2576

### DIFF
--- a/docs/howto/set-up-the-signal-channel.md
+++ b/docs/howto/set-up-the-signal-channel.md
@@ -41,8 +41,9 @@ For the full contract (config keys, commands, guardrails), see the
 - [ ] A phone number for Simard's Signal identity: either an existing Signal
       account you will **link** as a device, or a **dedicated** number to register.
 
-> The Signal channel is **optional and off by default.** If you skip this guide,
-> Simard's daemon runs exactly as before with no Signal code compiled in.
+> The Signal channel is **built by default but dormant until configured.** If you
+> skip this guide, the Signal code is still compiled in, but with no `[signal]`
+> config Simard's daemon runs exactly as before — the channel never starts.
 
 ## 1. Install signal-cli
 

--- a/src/bin/simard_audit_dashboard.rs
+++ b/src/bin/simard_audit_dashboard.rs
@@ -6,7 +6,10 @@
 //! - Runs a jargon scan across every captured DOM dump.
 //! - Emits a consolidated `out/REPORT.md` ready to paste into an epic body.
 //!
-//! Build: `cargo build --features dashboard-audit --bin simard-audit-dashboard`
+//! Build: `cargo build --bin simard-audit-dashboard` (the `dashboard-audit`
+//!        feature is on by default since #2576; `--features dashboard-audit` is
+//!        now redundant). Needs a real Chrome binary at runtime, so the bin
+//!        keeps its `required-features` marker and stays out of the release tarball.
 //! Run:   `target/debug/simard-audit-dashboard`
 //!
 //! Prerequisites: same as `simard-audit-pass01` (daemon on :8080, dashkey, Chrome).

--- a/src/bin/simard_audit_pass01.rs
+++ b/src/bin/simard_audit_pass01.rs
@@ -7,7 +7,10 @@
 //!    dump (`out/NN-<slug>.txt`).
 //! 4. Writes `out/_index.json` summarising the capture.
 //!
-//! Build: `cargo build --features dashboard-audit --bin simard-audit-pass01`
+//! Build: `cargo build --bin simard-audit-pass01` (the `dashboard-audit`
+//!        feature is on by default since #2576; `--features dashboard-audit` is
+//!        now redundant). Needs a real Chrome binary at runtime, so the bin
+//!        keeps its `required-features` marker and stays out of the release tarball.
 //! Run:   `target/debug/simard-audit-pass01`
 //!
 //! Prerequisites:


### PR DESCRIPTION
## Summary

Follow-up to **#2576** (the "build Simard's runtime cargo features by default" work that landed via **#2579**). That change made `signal` + `dashboard-audit` part of the `[features] default` set, but left a few comments/docs still describing the old opt-in world. This PR scrubs the remaining contradictions so the tree is internally consistent.

Net delta vs `main` is **3 files, +11/-4** — purely docs/comments.

## What changed

- **`docs/howto/set-up-the-signal-channel.md`** — the *Prerequisites* callout still claimed the Signal channel is "**optional and off by default … no Signal code compiled in.**" That is now false: the code ships in every default build. Reworded to the accurate framing already used elsewhere in the same doc — *built by default, dormant until a `[signal]` config table exists; skipping setup just means the channel never starts.*
- **`src/bin/simard_audit_dashboard.rs`** & **`src/bin/simard_audit_pass01.rs`** — module docs still printed `Build: cargo build --features dashboard-audit --bin …`. Since `dashboard-audit` is now default, that flag is redundant; a plain `cargo build --bin …` works. Noted that the bins keep their `required-features` marker and stay out of the release tarball (they need a real Chrome binary at runtime).

## Why not part of #2579

#2579 was squash-merged while this branch was in flight. Rebasing onto latest `main` collapsed all the duplicate core work (Cargo.toml `default` set, `signal_default_build` contract test, `verify.yml` no-default-features step, `deny.toml`, `release.yml`) — those are already on `main`. What remained unique was this comment/doc consistency scrub, which #2579 did not include.

## Verification

- `cargo fmt --all -- --check` — clean (pre-commit).
- `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean (pre-push).
- `mkdocs build --strict` — 0 broken links / anchors; touched-page front-matter valid (`scripts/verify-docs.sh` T3/T7 pass).
- `cargo test --test signal_default_build` — green under both default features and `--no-default-features` (unchanged by this PR; the minimal `simard signal run` still degrades gracefully with a clear error, exit 1, no panic).

Comment/doc-only; no functional change. Branch is a single commit fast-forward on top of latest `main`.