### PR TITLE
fix(goals,dashboard): perpetual standing goals + honest Brain-Failures/Thinking tabs (#2580)

### DIFF
--- a/src/goal_curation/completion_gate.rs
+++ b/src/goal_curation/completion_gate.rs
@@ -469,7 +469,22 @@ pub fn completion_evidence_enabled() -> bool {
 
 /// True for goals whose status makes them archive candidates under the legacy
 /// rule (`Completed`, or `InProgress` at ≥ 100%).
+///
+/// Standing/perpetual goals (issue #2580) are never candidates: they have no
+/// terminal done-state, so the gate must not archive them regardless of status.
 fn is_complete_candidate(goal: &ActiveGoal) -> bool {
+    if goal.is_perpetual() {
+        return false;
+    }
+    matches!(goal.status, GoalProgress::Completed)
+        || matches!(goal.status, GoalProgress::InProgress { percent } if percent >= 100)
+}
+
+/// True when a goal's status *looks* terminal (`Completed`, or `InProgress` at
+/// ≥ 100%), independent of whether the goal is perpetual. Used to detect a
+/// standing goal whose unit of work finished so it can be rolled to a fresh
+/// cycle instead of stalling in a done-looking state.
+fn has_dominant_progress(goal: &ActiveGoal) -> bool {
     matches!(goal.status, GoalProgress::Completed)
         || matches!(goal.status, GoalProgress::InProgress { percent } if percent >= 100)
 }
@@ -487,6 +502,17 @@ pub fn archive_completed_with_evidence<E: EvidenceSource>(
     let mut retained = Vec::new();
 
     for goal in std::mem::take(&mut board.active) {
+        // Standing/perpetual goals never archive (issue #2580). If a unit of
+        // work drove one to a terminal-looking status, roll it to a fresh cycle
+        // in place instead of retaining it stuck as "done".
+        if goal.is_perpetual() {
+            let mut g = goal;
+            if has_dominant_progress(&g) {
+                g.roll_to_new_cycle();
+            }
+            retained.push(g);
+            continue;
+        }
         if !is_complete_candidate(&goal) {
             retained.push(goal);
             continue;

--- a/src/goal_curation/completion_gate/tests.rs
+++ b/src/goal_curation/completion_gate/tests.rs
@@ -597,3 +597,72 @@ fn error_class_from_missing_defaults_when_no_concrete_kind() {
     assert_eq!(class, "refuted_unknown");
     assert_eq!(error_class_from_missing(&[]), "refuted_unknown");
 }
+
+// --- standing / perpetual goals never archive (issue #2580) -----------------
+
+/// Build a standing/perpetual goal at the given status.
+fn standing_goal(id: &str, status: GoalProgress) -> ActiveGoal {
+    let mut g = simard_goal(id, status);
+    g.description = "Continuously research and improve cognition. STANDING PERPETUAL goal.".into();
+    assert!(g.is_perpetual(), "test fixture must read as perpetual");
+    g
+}
+
+#[test]
+fn gate_never_archives_a_perpetual_goal_even_with_full_evidence() {
+    let mut board = GoalBoard::new();
+    board
+        .active
+        .push(standing_goal("research", GoalProgress::Completed));
+    // Full evidence would archive a normal goal; a standing goal must not.
+    let gate = CompletionEvidenceGate::new(FakeEvidence::ok(true, true, true));
+    let (archived, blocked) = archive_completed_with_evidence(&mut board, &gate);
+    assert!(
+        archived.is_empty(),
+        "a standing goal must never be archived by the completion gate"
+    );
+    assert!(blocked.is_empty());
+    assert_eq!(board.active.len(), 1, "standing goal stays on the board");
+    // ...and it is rolled to a fresh, actionable cycle rather than left as done.
+    assert_eq!(board.active[0].status, GoalProgress::NotStarted);
+    assert!(board.active[0].is_perpetual());
+}
+
+#[test]
+fn archive_completed_rolls_perpetual_goal_instead_of_removing() {
+    let mut board = GoalBoard::new();
+    board
+        .active
+        .push(standing_goal("research", GoalProgress::Completed));
+    board
+        .active
+        .push(simard_goal("normal-done", GoalProgress::Completed));
+
+    let archived = archive_completed(&mut board);
+
+    // The normal goal archives; the standing goal is rolled and retained.
+    assert_eq!(archived.len(), 1);
+    assert_eq!(archived[0].id, "normal-done");
+    let research = board
+        .active
+        .iter()
+        .find(|g| g.id == "research")
+        .expect("standing goal must remain on the board");
+    assert_eq!(research.status, GoalProgress::NotStarted);
+    assert!(research.assigned_to.is_none());
+    assert!(research.is_perpetual());
+}
+
+#[test]
+fn is_complete_candidate_is_false_for_perpetual_goals() {
+    // Even at 100% progress, a standing goal is not a completion candidate.
+    let done = standing_goal("s", GoalProgress::Completed);
+    let full = standing_goal("s2", GoalProgress::InProgress { percent: 100 });
+    assert!(!super::is_complete_candidate(&done));
+    assert!(!super::is_complete_candidate(&full));
+    // A normal completed goal still is a candidate (regression guard).
+    assert!(super::is_complete_candidate(&simard_goal(
+        "n",
+        GoalProgress::Completed
+    )));
+}

--- a/src/goal_curation/mod.rs
+++ b/src/goal_curation/mod.rs
@@ -29,7 +29,8 @@ pub use operations::{
 };
 pub use types::{
     ActiveGoal, BacklogItem, CARRYOVER_CONCEPT, GoalBoard, GoalCarryoverRecord, GoalEdge,
-    GoalEdgeType, GoalNode, GoalProgress, MAX_ACTIVE_GOALS, WipRef,
+    GoalEdgeType, GoalNode, GoalProgress, MAX_ACTIVE_GOALS, STANDING_MARKER_PREFIX, WipRef,
+    description_marks_standing,
 };
 
 pub use decompose::{

--- a/src/goal_curation/operations.rs
+++ b/src/goal_curation/operations.rs
@@ -1107,16 +1107,26 @@ pub fn clear_goal_assignment(board: &mut GoalBoard, goal_id: &str) -> SimardResu
 }
 
 /// Remove completed goals from the active list. Returns the removed goals.
+///
+/// Standing/perpetual goals (issue #2580) are never removed: a standing goal
+/// that reached a terminal-looking status is rolled into a fresh cycle in place
+/// (see [`ActiveGoal::roll_to_new_cycle`]) and kept on the board, so perpetual
+/// research / stewardship work is never silently dropped.
 pub fn archive_completed(board: &mut GoalBoard) -> Vec<ActiveGoal> {
     let mut archived = Vec::new();
-    board.active.retain(|goal| {
+    board.active.retain_mut(|goal| {
         let dominated = matches!(goal.status, GoalProgress::Completed)
             || matches!(goal.status, GoalProgress::InProgress { percent } if percent >= 100);
-        if dominated {
+        if !dominated {
+            return true;
+        }
+        if goal.is_perpetual() {
+            // Never terminate a standing goal — roll it to a fresh cycle.
+            goal.roll_to_new_cycle();
+            true
+        } else {
             archived.push(goal.clone());
             false
-        } else {
-            true
         }
     });
     archived

--- a/src/goal_curation/types.rs
+++ b/src/goal_curation/types.rs
@@ -48,6 +48,65 @@ impl Display for GoalProgress {
     }
 }
 
+/// Canonical marker that `simard goal add --standing` prepends to a goal's
+/// description so the standing/perpetual nature is durable in the persisted
+/// board without adding a new field to every `ActiveGoal` construction site
+/// (issue #2580). Detection is by description marker rather than a bool field
+/// so pre-existing live standing goals — whose descriptions already read
+/// "STANDING PERPETUAL goal" / "Standing goal" — are reconciled automatically
+/// without touching `~/.simard`.
+pub const STANDING_MARKER_PREFIX: &str = "[standing] ";
+
+/// Whole-phrase, case-insensitive markers in a goal description that make it a
+/// standing/perpetual goal. Matched with a leading word boundary so ordinary
+/// words that merely *contain* one of these substrings (e.g. "understanding",
+/// "outstanding") never trigger a false positive.
+const STANDING_DESCRIPTION_MARKERS: &[&str] = &[
+    "standing perpetual",
+    "perpetual/standing",
+    "standing/perpetual",
+    "standing goal",
+    "perpetual goal",
+];
+
+/// The `[standing]` sentinel written by `--standing`. Detected verbatim
+/// (bracket-delimited, so no word-boundary check is needed).
+const STANDING_SENTINEL: &str = "[standing]";
+
+/// True when `description` durably marks the goal as standing/perpetual.
+///
+/// A standing goal has no terminal done-state: it is never marked
+/// `Completed` by goal-curation or the completion gate, is never tombstoned,
+/// and when its current unit of work finishes it rolls to a fresh cycle
+/// (see [`ActiveGoal::roll_to_new_cycle`]).
+pub fn description_marks_standing(description: &str) -> bool {
+    let lower = description.to_ascii_lowercase();
+    if lower.contains(STANDING_SENTINEL) {
+        return true;
+    }
+    STANDING_DESCRIPTION_MARKERS
+        .iter()
+        .any(|phrase| contains_phrase_on_word_boundary(&lower, phrase))
+}
+
+/// `haystack_lower.contains(phrase)` but only where the match begins on a word
+/// boundary (start-of-string or a non-alphanumeric char before it). Both
+/// arguments must already be lowercase. Keeps "understanding goal" from
+/// matching "standing goal".
+fn contains_phrase_on_word_boundary(haystack_lower: &str, phrase: &str) -> bool {
+    let bytes = haystack_lower.as_bytes();
+    let mut from = 0;
+    while let Some(rel) = haystack_lower[from..].find(phrase) {
+        let idx = from + rel;
+        let prev_is_word = idx > 0 && bytes[idx - 1].is_ascii_alphanumeric();
+        if !prev_is_word {
+            return true;
+        }
+        from = idx + 1;
+    }
+    false
+}
+
 /// A reference to work-in-progress associated with a goal.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct WipRef {
@@ -146,6 +205,44 @@ impl ActiveGoal {
     /// Short label for display.
     pub fn concise_label(&self) -> String {
         format!("p{} [{}] {}", self.priority, self.status, self.description)
+    }
+
+    /// True when this is a standing/perpetual goal — one with no terminal
+    /// done-state (issue #2580). Backed by a durable description marker so the
+    /// live research + CI-stewardship standing goals are recognised without a
+    /// data migration. A standing goal must never be marked `Completed` by
+    /// curation or the completion gate, and must never be tombstoned.
+    pub fn is_perpetual(&self) -> bool {
+        description_marks_standing(&self.description)
+    }
+
+    /// Builder: durably mark this goal as standing/perpetual by prepending the
+    /// [`STANDING_MARKER_PREFIX`] to its description (idempotent — a goal that
+    /// already reads as standing is returned unchanged). Set by
+    /// `simard goal add --standing`.
+    #[must_use]
+    pub fn mark_standing(mut self) -> Self {
+        if !self.is_perpetual() {
+            self.description = format!("{STANDING_MARKER_PREFIX}{}", self.description);
+        }
+        self
+    }
+
+    /// Roll a standing/perpetual goal into a fresh cycle after its current unit
+    /// of work finishes, instead of terminating it (issue #2580). Resets the
+    /// goal to an actionable, re-dispatchable state: status back to
+    /// `NotStarted`, assignment cleared, and stale work-in-progress refs
+    /// dropped so the next OODA cycle re-enters the spawn path. The
+    /// standing-goal description marker (and thus [`is_perpetual`]) is
+    /// preserved.
+    ///
+    /// [`is_perpetual`]: ActiveGoal::is_perpetual
+    pub fn roll_to_new_cycle(&mut self) {
+        self.status = GoalProgress::NotStarted;
+        self.assigned_to = None;
+        self.wip_refs.clear();
+        self.current_activity =
+            Some("standing goal — finished a unit of work; rolled to a fresh cycle".to_string());
     }
 }
 
@@ -491,6 +588,77 @@ mod tests {
         let json = serde_json::to_string(&g).unwrap();
         let g2: ActiveGoal = serde_json::from_str(&json).unwrap();
         assert_eq!(g2.assigned_to, None);
+    }
+
+    // ── Standing / perpetual goals (issue #2580) ────────────────────
+
+    #[test]
+    fn description_marks_standing_recognizes_live_markers() {
+        // The exact phrasings on the live board must be recognised so they are
+        // reconciled without a data migration or touching ~/.simard.
+        assert!(description_marks_standing("STANDING PERPETUAL goal"));
+        assert!(description_marks_standing("Standing goal"));
+        assert!(description_marks_standing(
+            "Continuously research and improve your own cognition. STANDING PERPETUAL goal."
+        ));
+        assert!(description_marks_standing(&format!(
+            "{STANDING_MARKER_PREFIX}watch CI health"
+        )));
+    }
+
+    #[test]
+    fn description_marks_standing_rejects_false_positives() {
+        // Ordinary words that merely contain "standing" must not match.
+        assert!(!description_marks_standing(
+            "Improve understanding of goals"
+        ));
+        assert!(!description_marks_standing(
+            "Fix an outstanding goal-board bug"
+        ));
+        assert!(!description_marks_standing("Ship the MVP"));
+        assert!(!description_marks_standing(""));
+    }
+
+    #[test]
+    fn is_perpetual_tracks_description() {
+        let normal = ActiveGoal::new("g", "Ship the MVP", 1);
+        assert!(!normal.is_perpetual());
+        let standing = ActiveGoal::new("g", "Steward CI health. Standing goal.", 1);
+        assert!(standing.is_perpetual());
+    }
+
+    #[test]
+    fn mark_standing_makes_goal_perpetual_and_is_idempotent() {
+        let g = ActiveGoal::new("g", "watch CI", 1).mark_standing();
+        assert!(g.is_perpetual());
+        assert!(g.description.starts_with(STANDING_MARKER_PREFIX));
+        // Idempotent: a goal already read as standing is not double-marked.
+        let again = g.clone().mark_standing();
+        assert_eq!(again.description, g.description);
+    }
+
+    #[test]
+    fn roll_to_new_cycle_resets_to_actionable_and_stays_perpetual() {
+        let mut g = sample_goal();
+        g.description = "Research cognition. STANDING PERPETUAL goal.".to_string();
+        g.status = GoalProgress::Completed;
+        g.assigned_to = Some("engineer-x".to_string());
+        g.wip_refs = vec![WipRef {
+            kind: "pr".to_string(),
+            ref_id: "1".to_string(),
+            label: "old".to_string(),
+            url: None,
+        }];
+        assert!(g.is_perpetual());
+
+        g.roll_to_new_cycle();
+        assert_eq!(g.status, GoalProgress::NotStarted);
+        assert_eq!(g.assigned_to, None);
+        assert!(g.wip_refs.is_empty());
+        assert!(
+            g.is_perpetual(),
+            "must remain a standing goal after rolling to a new cycle"
+        );
     }
 
     // ── BacklogItem ─────────────────────────────────────────────────

--- a/src/operator_cli/goal.rs
+++ b/src/operator_cli/goal.rs
@@ -18,7 +18,8 @@
 //!   - `goal remove <id>…` — variadic, idempotent. Surgically removes the ids
 //!     from the authoritative store under the shared flock and writes durable
 //!     tombstones (issue #1).
-//!   - `goal complete <id>` — mark a goal done, remove it, and tombstone it.
+//!   - `goal complete <id>` — mark a goal done, remove it, and tombstone it
+//!     (a standing/perpetual goal is refused and auto-reopened instead).
 //!   - `goal reprioritize <id> <p>` — alias of `set-priority`.
 //!   - `goal cleanup --placeholders` — defence-in-depth sweep that
 //!     removes every active or backlog goal whose description is exactly
@@ -48,12 +49,16 @@ Usage: simard goal <command> [args]
 
 Commands:
   list                        Print active + backlog goal snapshot.
-  add <priority> [--repo <slug>] <description>
+  add <priority> [--repo <slug>] [--standing] <description>
                               Add a new active goal at given priority (1-7).
                               `--repo <slug>` routes the goal's engineer to
                               ~/src/<slug> (default: the daemon's own repo).
+                              `--standing` marks the goal standing/perpetual —
+                              it never completes or tombstones and rolls to a
+                              fresh cycle when a unit of work finishes.
   complete <goal-id>          Mark a goal done, remove it, and tombstone it so
-                              nothing re-seeds it (idempotent).
+                              nothing re-seeds it (idempotent). A standing goal
+                              is refused and auto-reopened for a fresh cycle.
   reprioritize <goal-id> <p>  Change an active goal's priority (alias of
                               set-priority).
   demote <goal-id>            Move an active goal to the backlog.
@@ -99,14 +104,15 @@ pub(super) fn dispatch_goal_command(
         "add" => {
             let priority_str = next_required(&mut args, "priority (1-7)")?;
             let rest: Vec<String> = args.collect();
-            let (repo, desc_tokens) = extract_repo_flag(rest)?;
+            let (repo, standing, desc_tokens) = extract_add_flags(rest)?;
             let description = desc_tokens.join(" ");
             if description.is_empty() {
                 return Err(
-                    "usage: simard goal add <priority> [--repo <slug>] <description>".into(),
+                    "usage: simard goal add <priority> [--repo <slug>] [--standing] <description>"
+                        .into(),
                 );
             }
-            handle_add(&priority_str, &description, repo.as_deref())
+            handle_add(&priority_str, &description, repo.as_deref(), standing)
         }
         "demote" => {
             let goal_id = next_required(&mut args, "goal id")?;
@@ -304,11 +310,18 @@ fn handle_unblock_all() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-/// `simard goal add <priority> <description>` — add a new active goal.
+/// Parsed `goal add` flags: `(repo slug, is-standing, description tokens)`.
+type AddFlags = (Option<String>, bool, Vec<String>);
+
+/// `simard goal add <priority> [--standing] <description>` — add a new active
+/// goal. `--standing` marks the goal as standing/perpetual (issue #2580): it
+/// has no terminal done-state, is never tombstoned, and rolls to a fresh cycle
+/// when a unit of work finishes.
 fn handle_add(
     priority_str: &str,
     description: &str,
     repo: Option<&str>,
+    standing: bool,
 ) -> Result<(), Box<dyn Error>> {
     let priority: u32 = priority_str
         .parse()
@@ -322,11 +335,20 @@ fn handle_add(
         crate::ooda_actions::advance_goal::repo_resolver::validate_repo_slug(slug)
             .map_err(|e| -> Box<dyn Error> { e.to_string().into() })?;
     }
+    // Slug from the operator's original text so the id stays clean; the stored
+    // description carries the durable standing marker when `--standing` is set.
     let id = crate::goals::goal_slug(description);
+    let stored_description = if standing {
+        format!(
+            "{}{description}",
+            crate::goal_curation::STANDING_MARKER_PREFIX
+        )
+    } else {
+        description.to_string()
+    };
     let repo_owned = repo.map(str::to_string);
     {
         let id = id.clone();
-        let description = description.to_string();
         with_board(move |board| {
             if board.active.iter().any(|g| g.id == id) {
                 return Err(format!("goal '{id}' is already active").into());
@@ -341,7 +363,7 @@ fn handle_add(
             board.active.push(crate::goal_curation::ActiveGoal {
                 parent_goal_id: None,
                 id,
-                description,
+                description: stored_description,
                 priority,
                 status: GoalProgress::NotStarted,
                 assigned_to: None,
@@ -356,15 +378,22 @@ fn handle_add(
     let repo_note = repo
         .map(|r| format!(" -> repo '{r}'"))
         .unwrap_or_else(|| " -> repo Simard (daemon)".to_string());
-    eprintln!("[simard] goal add: '{id}' added at p{priority}{repo_note}");
+    let standing_note = if standing {
+        " [standing/perpetual]"
+    } else {
+        ""
+    };
+    eprintln!("[simard] goal add: '{id}' added at p{priority}{repo_note}{standing_note}");
     Ok(())
 }
 
-/// Extract an optional `--repo <slug>` / `--repo=<slug>` flag from the trailing
-/// `goal add` tokens, returning the slug (if any) and the remaining tokens that
-/// form the goal description.
-fn extract_repo_flag(tokens: Vec<String>) -> Result<(Option<String>, Vec<String>), Box<dyn Error>> {
+/// Extract the optional `--repo <slug>` / `--repo=<slug>` and `--standing`
+/// flags from the trailing `goal add` tokens, returning `(repo, standing,
+/// description_tokens)`. Flags may appear in any order relative to the
+/// description; remaining tokens form the goal description.
+fn extract_add_flags(tokens: Vec<String>) -> Result<AddFlags, Box<dyn Error>> {
     let mut repo: Option<String> = None;
+    let mut standing = false;
     let mut rest: Vec<String> = Vec::with_capacity(tokens.len());
     let mut iter = tokens.into_iter();
     while let Some(tok) = iter.next() {
@@ -375,11 +404,13 @@ fn extract_repo_flag(tokens: Vec<String>) -> Result<(Option<String>, Vec<String>
             repo = Some(slug);
         } else if let Some(slug) = tok.strip_prefix("--repo=") {
             repo = Some(slug.to_string());
+        } else if tok == "--standing" || tok == "--perpetual" {
+            standing = true;
         } else {
             rest.push(tok);
         }
     }
-    Ok((repo, rest))
+    Ok((repo, standing, rest))
 }
 
 /// `simard goal demote <goal-id>` — move an active goal to the backlog.
@@ -434,22 +465,57 @@ fn handle_set_priority(goal_id: &str, priority_str: &str) -> Result<(), Box<dyn 
 /// board, and write a durable tombstone so no path (default seeding, memory
 /// recall, a meeting handoff, or the daemon's cycle reconcile) can resurrect it.
 /// Idempotent: completing an absent goal still records the tombstone.
+///
+/// Standing/perpetual goals (issue #2580) are the exception: `complete` refuses
+/// to terminate one and instead **auto-reopens** it for a fresh cycle — no
+/// removal, no tombstone — because a standing goal has no terminal done-state.
 fn handle_complete(goal_id: &str) -> Result<(), Box<dyn Error>> {
-    let existed = with_board(|board| {
+    enum CompleteOutcome {
+        /// A standing goal — reopened for a fresh cycle instead of terminating.
+        Reopened,
+        /// A normal goal that existed and was removed.
+        Completed,
+        /// No matching goal on the board (still recorded as a tombstone).
+        Absent,
+    }
+
+    let outcome = with_board(|board| {
+        if let Some(goal) = board.active.iter_mut().find(|g| g.id == goal_id)
+            && goal.is_perpetual()
+        {
+            goal.roll_to_new_cycle();
+            return Ok(CompleteOutcome::Reopened);
+        }
         let before = board.active.len() + board.backlog.len();
         board.active.retain(|g| g.id != goal_id);
         board.backlog.retain(|b| b.id != goal_id);
-        Ok(before != board.active.len() + board.backlog.len())
+        let existed = before != board.active.len() + board.backlog.len();
+        Ok(if existed {
+            CompleteOutcome::Completed
+        } else {
+            CompleteOutcome::Absent
+        })
     })?;
-    tombstone(&[goal_id.to_string()])?;
-    if existed {
-        eprintln!(
-            "[simard] goal complete: '{goal_id}' marked done, removed from board, and tombstoned"
-        );
-    } else {
-        eprintln!(
-            "[simard] goal complete: '{goal_id}' not on board; recorded tombstone (idempotent)"
-        );
+
+    match outcome {
+        CompleteOutcome::Reopened => {
+            eprintln!(
+                "[simard] goal complete: '{goal_id}' is a standing goal — refused to terminate; \
+                 reopened it for a fresh cycle (no tombstone)"
+            );
+        }
+        CompleteOutcome::Completed => {
+            tombstone(&[goal_id.to_string()])?;
+            eprintln!(
+                "[simard] goal complete: '{goal_id}' marked done, removed from board, and tombstoned"
+            );
+        }
+        CompleteOutcome::Absent => {
+            tombstone(&[goal_id.to_string()])?;
+            eprintln!(
+                "[simard] goal complete: '{goal_id}' not on board; recorded tombstone (idempotent)"
+            );
+        }
     }
     Ok(())
 }
@@ -710,6 +776,50 @@ mod tests {
         assert!(!is_id_placeholder("abc", ""));
     }
 
+    // ---- extract_add_flags (issue #2580 --standing) -----------------------
+
+    fn toks(s: &[&str]) -> Vec<String> {
+        s.iter().map(|t| t.to_string()).collect()
+    }
+
+    #[test]
+    fn extract_add_flags_plain_description() {
+        let (repo, standing, rest) = extract_add_flags(toks(&["ship", "the", "mvp"])).unwrap();
+        assert_eq!(repo, None);
+        assert!(!standing);
+        assert_eq!(rest, toks(&["ship", "the", "mvp"]));
+    }
+
+    #[test]
+    fn extract_add_flags_parses_standing_anywhere() {
+        let (repo, standing, rest) =
+            extract_add_flags(toks(&["--standing", "watch", "CI"])).unwrap();
+        assert!(standing);
+        assert_eq!(repo, None);
+        assert_eq!(rest, toks(&["watch", "CI"]));
+
+        // Flag may trail the description too, and --perpetual is an alias.
+        let (_r, standing2, rest2) =
+            extract_add_flags(toks(&["watch", "CI", "--perpetual"])).unwrap();
+        assert!(standing2);
+        assert_eq!(rest2, toks(&["watch", "CI"]));
+    }
+
+    #[test]
+    fn extract_add_flags_combines_repo_and_standing() {
+        let (repo, standing, rest) = extract_add_flags(toks(&[
+            "--repo",
+            "amplihack-rs",
+            "--standing",
+            "steward",
+            "ci",
+        ]))
+        .unwrap();
+        assert_eq!(repo.as_deref(), Some("amplihack-rs"));
+        assert!(standing);
+        assert_eq!(rest, toks(&["steward", "ci"]));
+    }
+
     #[test]
     fn placeholder_with_empty_id_matches_goal_space() {
         // `format!("Goal {}", "")` produces `"Goal "`, so this matches.
@@ -873,21 +983,21 @@ mod tests {
 
     #[test]
     fn add_rejects_zero_priority() {
-        let result = handle_add("0", "test goal", None);
+        let result = handle_add("0", "test goal", None, false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("1-7"));
     }
 
     #[test]
     fn add_rejects_priority_above_7() {
-        let result = handle_add("8", "test goal", None);
+        let result = handle_add("8", "test goal", None, false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("1-7"));
     }
 
     #[test]
     fn add_rejects_non_numeric_priority() {
-        let result = handle_add("high", "test goal", None);
+        let result = handle_add("high", "test goal", None, false);
         assert!(result.is_err());
     }
 

--- a/src/operator_cli/tests_goal.rs
+++ b/src/operator_cli/tests_goal.rs
@@ -516,3 +516,112 @@ fn operator_reprioritize_via_cli_sticks_and_survives_restart() {
         "reprioritize of an unknown goal id must return a non-zero exit"
     );
 }
+
+// ─── standing / perpetual goals (issue #2580) ───────────────────────────────
+
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn simard_goal_add_standing_marks_goal_perpetual() {
+    let (_tmp, root) = isolated_state_root();
+
+    let result = dispatch_operator_cli(vec![
+        "goal".to_string(),
+        "add".to_string(),
+        "5".to_string(),
+        "--standing".to_string(),
+        "continuously research and improve cognition".to_string(),
+    ]);
+    assert!(
+        result.is_ok(),
+        "`goal add --standing` must exit 0; got: {:?}",
+        result.err().map(|e| e.to_string())
+    );
+
+    let board = load_board(&root);
+    let g = board
+        .active
+        .iter()
+        .find(|g| g.is_perpetual())
+        .expect("a standing goal must be on the board after --standing add");
+    assert!(
+        g.description.contains("continuously research"),
+        "operator description must be preserved: {}",
+        g.description
+    );
+}
+
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn simard_goal_complete_reopens_standing_goal_without_tombstone() {
+    let (_tmp, root) = isolated_state_root();
+    // A standing goal that a done-claim drove to Completed.
+    let mut standing = active_goal("research-loop", GoalProgress::Completed);
+    standing.description = "Research cognition. STANDING PERPETUAL goal.".to_string();
+    standing.assigned_to = Some("engineer-x".to_string());
+    seed_board(&root, vec![standing]);
+
+    let result = dispatch_operator_cli(vec![
+        "goal".to_string(),
+        "complete".to_string(),
+        "research-loop".to_string(),
+    ]);
+    assert!(
+        result.is_ok(),
+        "`goal complete` on a standing goal must exit 0; got: {:?}",
+        result.err().map(|e| e.to_string())
+    );
+
+    let board = load_board(&root);
+    let g = board
+        .active
+        .iter()
+        .find(|g| g.id == "research-loop")
+        .expect("a standing goal must NOT be removed by `goal complete`");
+    assert_eq!(
+        g.status,
+        GoalProgress::NotStarted,
+        "standing goal must be reopened (rolled to a fresh cycle)"
+    );
+    assert!(
+        g.assigned_to.is_none(),
+        "assignment must be cleared on reopen"
+    );
+    // Never tombstoned: a fresh add of the same id must succeed / not be filtered.
+    let tombstones = crate::ooda_loop::load_tombstones(&root);
+    assert!(
+        !tombstones.contains("research-loop"),
+        "a standing goal must never be tombstoned by `goal complete`"
+    );
+}
+
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn simard_goal_complete_still_removes_and_tombstones_normal_goal() {
+    // Regression guard: a normal goal completes as before.
+    let (_tmp, root) = isolated_state_root();
+    seed_board(
+        &root,
+        vec![active_goal("one-shot", GoalProgress::Completed)],
+    );
+
+    let result = dispatch_operator_cli(vec![
+        "goal".to_string(),
+        "complete".to_string(),
+        "one-shot".to_string(),
+    ]);
+    assert!(
+        result.is_ok(),
+        "`goal complete` on a normal goal must exit 0"
+    );
+
+    let board = load_board(&root);
+    assert!(
+        board.active.iter().all(|g| g.id != "one-shot"),
+        "a normal goal must be removed by `goal complete`"
+    );
+    let tombstones = crate::ooda_loop::load_tombstones(&root);
+    assert!(
+        tombstones.contains("one-shot"),
+        "a normal completed goal must be tombstoned"
+    );
+}

--- a/src/operator_commands_dashboard/brain_failures.rs
+++ b/src/operator_commands_dashboard/brain_failures.rs
@@ -17,6 +17,7 @@
 //!     are marked as escalated)
 
 use axum::Json;
+use chrono::{DateTime, Duration, Utc};
 use serde_json::{Value, json};
 
 use super::routes::resolve_state_root;
@@ -27,6 +28,19 @@ const MAX_CYCLES_TO_SCAN: usize = 50;
 /// Maximum number of failure entries to return.
 const MAX_FAILURES_RETURNED: usize = 200;
 
+/// Rolling window (minutes) for the *current* Brain-Failures rate. The tab
+/// headline reports failures in this window plus a per-hour rate, so a scary
+/// cumulative lifetime total can never masquerade as the current state
+/// (issue #2580). Zero failures in the window renders green.
+const RECENT_WINDOW_MINUTES: i64 = 60;
+
+/// Metric names that count as a genuine, post-sanitization brain parse failure.
+/// `brain_parse_error` is the companion workstream's explicit metric that fires
+/// only on a real parse failure after bounded retry; `brain_parse_failure` is
+/// the pre-existing name. Both are read so the recent count stays truthful
+/// across the transition.
+const BRAIN_PARSE_METRIC_NAMES: &[&str] = &["brain_parse_error", "brain_parse_failure"];
+
 pub(crate) async fn brain_failures() -> Json<Value> {
     let state_root = resolve_state_root();
     let cycle_dir = state_root.join("cycle_reports");
@@ -36,6 +50,10 @@ pub(crate) async fn brain_failures() -> Json<Value> {
     let mut total_fallback_count: u64 = 0;
     let mut total_parse_failure_count: u64 = 0;
     let mut cycles_scanned: u32 = 0;
+    // Timestamps of deterministic fallbacks seen in cycle reports, used to
+    // compute the *recent* (bounded-window) count. Parse failures are counted
+    // from the timestamped metric instead (authoritative, see below).
+    let mut fallback_instants: Vec<DateTime<Utc>> = Vec::new();
 
     // Scan cycle reports for brain judgment failures.
     if let Ok(entries) = std::fs::read_dir(&cycle_dir) {
@@ -91,6 +109,9 @@ pub(crate) async fn brain_failures() -> Json<Value> {
 
                 if is_fallback {
                     total_fallback_count += 1;
+                    if let Some(at) = parse_rfc3339(cycle_timestamp) {
+                        fallback_instants.push(at);
+                    }
                 }
                 if has_parse_failure {
                     total_parse_failure_count += 1;
@@ -192,16 +213,101 @@ pub(crate) async fn brain_failures() -> Json<Value> {
     // Quick count from metrics.jsonl for the summary stat.
     let metrics_parse_failure_count = count_brain_parse_failure_metrics(&metrics_path);
 
+    // ── Current (bounded-window) view (issue #2580) ─────────────────────────
+    // Show what is happening NOW, not an accumulated lifetime number. Parse
+    // failures are counted from the timestamped brain parse-error metric (the
+    // honest, post-sanitization signal); deterministic fallbacks from the
+    // cycle-report timestamps gathered above. Zero in the window ⇒ green.
+    let now = Utc::now();
+    let since = now - Duration::minutes(RECENT_WINDOW_MINUTES);
+    let recent_fallback = count_at_or_after(&fallback_instants, since);
+    let recent_parse_failure = recent_parse_failures_from_metrics(&metrics_path, since);
+    let recent_total = recent_fallback + recent_parse_failure;
+    let recent_rate_per_hour = rate_per_hour(recent_total, RECENT_WINDOW_MINUTES);
+    let recent_status = recent_status(recent_total, recent_parse_failure);
+
     Json(json!({
         "failures": failures,
+        // Current state: a bounded, honest window separate from any lifetime
+        // total. The dashboard headline reads from here.
+        "recent": {
+            "window_minutes": RECENT_WINDOW_MINUTES,
+            "total": recent_total,
+            "fallback": recent_fallback,
+            "parse_failure": recent_parse_failure,
+            "rate_per_hour": recent_rate_per_hour,
+            "status": recent_status,
+        },
+        // Lifetime cumulative counts — clearly labelled so they are never
+        // mistaken for the current rate.
+        "lifetime": {
+            "parse_failure_count": metrics_parse_failure_count,
+        },
         "summary": {
             "total_fallback_count": total_fallback_count,
             "total_parse_failure_count": total_parse_failure_count,
             "metrics_parse_failure_count": metrics_parse_failure_count,
             "cycles_scanned": cycles_scanned,
         },
-        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "timestamp": now.to_rfc3339(),
     }))
+}
+
+/// Parse an RFC3339 timestamp string into a UTC instant, returning `None` for
+/// an empty or unparseable value (so it is conservatively excluded from the
+/// recent-window count rather than inflating it).
+fn parse_rfc3339(ts: &str) -> Option<DateTime<Utc>> {
+    if ts.is_empty() {
+        return None;
+    }
+    DateTime::parse_from_rfc3339(ts)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+/// Count instants at or after `since`.
+fn count_at_or_after(instants: &[DateTime<Utc>], since: DateTime<Utc>) -> u64 {
+    instants.iter().filter(|t| **t >= since).count() as u64
+}
+
+/// Failures-per-hour for `count` events observed over a `window_minutes`
+/// window. Returns `0.0` for a zero or non-positive window.
+fn rate_per_hour(count: u64, window_minutes: i64) -> f64 {
+    if window_minutes <= 0 {
+        return 0.0;
+    }
+    count as f64 / (window_minutes as f64 / 60.0)
+}
+
+/// Traffic-light status for the current window: `ok` (green) when there are no
+/// failures at all, `err` (red) when any genuine parse failure occurred, and
+/// `warn` (amber) for deterministic fallbacks only. Zero ⇒ green, never a
+/// stale large number.
+fn recent_status(recent_total: u64, recent_parse_failure: u64) -> &'static str {
+    if recent_total == 0 {
+        "ok"
+    } else if recent_parse_failure > 0 {
+        "err"
+    } else {
+        "warn"
+    }
+}
+
+/// Count genuine brain parse failures recorded at or after `since`, read from
+/// the timestamped metric log ([`BRAIN_PARSE_METRIC_NAMES`]). This is the
+/// authoritative, honest recent signal — it never returns a lifetime total.
+fn recent_parse_failures_from_metrics(path: &std::path::Path, since: DateTime<Utc>) -> u64 {
+    use crate::self_metrics::MetricEntry;
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return 0,
+    };
+    content
+        .lines()
+        .filter_map(|line| serde_json::from_str::<MetricEntry>(line).ok())
+        .filter(|e| BRAIN_PARSE_METRIC_NAMES.contains(&e.metric_name.as_str()))
+        .filter(|e| e.timestamp >= since)
+        .count() as u64
 }
 
 /// Count `brain_parse_failure` metric entries in `metrics.jsonl`.
@@ -398,6 +504,78 @@ mod tests {
         assert!(
             !d.contains("It chose to"),
             "empty decision must omit the choice clause: {d}"
+        );
+    }
+
+    // ── recent (bounded-window) telemetry honesty (issue #2580) ─────────────
+
+    #[test]
+    fn rate_per_hour_scales_by_window() {
+        // 3 events in a 60-minute window ⇒ 3.0/hr.
+        assert_eq!(rate_per_hour(3, 60), 3.0);
+        // 3 events in a 30-minute window ⇒ 6.0/hr.
+        assert_eq!(rate_per_hour(3, 30), 6.0);
+        // Zero events ⇒ zero rate; degenerate window ⇒ zero (no divide-by-zero).
+        assert_eq!(rate_per_hour(0, 60), 0.0);
+        assert_eq!(rate_per_hour(5, 0), 0.0);
+    }
+
+    #[test]
+    fn recent_status_is_green_only_when_zero() {
+        // The core honesty property: zero current failures ⇒ green, never a
+        // large stale number.
+        assert_eq!(recent_status(0, 0), "ok");
+        assert_eq!(recent_status(2, 0), "warn"); // fallbacks only
+        assert_eq!(recent_status(2, 1), "err"); // a real parse failure
+    }
+
+    #[test]
+    fn count_at_or_after_windows_correctly() {
+        let now = Utc::now();
+        let instants = vec![
+            now - Duration::minutes(5),   // in window
+            now - Duration::minutes(59),  // in window
+            now - Duration::minutes(120), // out of window
+        ];
+        let since = now - Duration::minutes(60);
+        assert_eq!(count_at_or_after(&instants, since), 2);
+    }
+
+    #[test]
+    fn parse_rfc3339_rejects_empty_and_garbage() {
+        assert!(parse_rfc3339("").is_none());
+        assert!(parse_rfc3339("not-a-date").is_none());
+        assert!(parse_rfc3339("2026-07-04T16:24:11+00:00").is_some());
+    }
+
+    #[test]
+    fn recent_parse_failures_from_metrics_counts_only_recent_brain_parse_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("metrics.jsonl");
+        let now = Utc::now();
+        let recent = (now - Duration::minutes(10)).to_rfc3339();
+        let old = (now - Duration::hours(6)).to_rfc3339();
+        // Two recent genuine parse failures (both accepted metric names), one
+        // old parse failure (out of window), and an unrelated recent metric.
+        let body = format!(
+            "{}\n{}\n{}\n{}\n",
+            json!({"timestamp": recent, "metric_name": "brain_parse_error", "value": 1.0, "context": ""}),
+            json!({"timestamp": recent, "metric_name": "brain_parse_failure", "value": 1.0, "context": ""}),
+            json!({"timestamp": old, "metric_name": "brain_parse_failure", "value": 1.0, "context": ""}),
+            json!({"timestamp": recent, "metric_name": "ooda_cycle", "value": 1.0, "context": ""}),
+        );
+        std::fs::write(&path, body).unwrap();
+
+        let since = now - Duration::minutes(RECENT_WINDOW_MINUTES);
+        assert_eq!(recent_parse_failures_from_metrics(&path, since), 2);
+    }
+
+    #[test]
+    fn recent_parse_failures_from_metrics_missing_file_is_zero() {
+        let since = Utc::now() - Duration::minutes(RECENT_WINDOW_MINUTES);
+        assert_eq!(
+            recent_parse_failures_from_metrics(std::path::Path::new("/nonexistent/m.jsonl"), since),
+            0
         );
     }
 }

--- a/src/operator_commands_dashboard/index_html/part_00.rs
+++ b/src/operator_commands_dashboard/index_html/part_00.rs
@@ -355,7 +355,7 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
 
   <div class="tab-content" id="tab-thinking">
     <h1 class="page-h1">Thinking</h1>
-    <p class="page-lede">A live stream of the daemon's internal reasoning between actions, showing what it considered before deciding what to do next.</p>
+    <p class="page-lede">A live view of what the daemon decided each cycle - repeated deferring-to-an-active-engineer notes are collapsed with a count so genuine forward progress stands out from a stuck loop.</p>
     <div class="card" style="margin-bottom:1rem">
       <h2>Cycle History <button class="btn" onclick="fetchOodaCycles()">Refresh</button></h2>
       <div id="ooda-cycle-trend" style="margin-bottom:.75rem"><span class="loading">Loading…</span></div>
@@ -369,7 +369,7 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
 
   <div class="tab-content" id="tab-brain-failures">
     <h1 class="page-h1">Brain Failures</h1>
-    <p class="page-lede">Every time the daemon's language-model brain returned an unparseable or invalid response and fell back to safe deterministic rules, listed with the failure type, which component triggered it, when it happened, and whether recovery succeeded.</p>
+    <p class="page-lede">How often the daemon's brain failed to parse a model response right now - the current rate and a bounded recent window, kept separate from the all-time total so a stale number never looks like a live problem.</p>
     <div class="card" style="margin-bottom:1rem">
       <h2>Summary <button class="btn" onclick="fetchBrainFailures()">Refresh</button></h2>
       <div id="brain-failures-summary"><span class="loading">Loading…</span></div>

--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -218,6 +218,26 @@ pub(crate) const PART_04: &str = r#"            let fmt;
               <div class="cycle-summary">${esc(humanizeCycleSummary(rpt.summary))}</div>
             </div>`;
           }
+          /* Issue #2580: disposition-aware rendering. A run of identical
+             deferrals to an active engineer is collapsed by the server into a
+             single entry with a repeat_count; render it as one clean line so
+             the tab shows forward progress, not the same line over and over. A
+             genuine stuck loop (loop_suspected) is called out in red. */
+          const disp=rpt.disposition||'';
+          const rc=rpt.repeat_count||1;
+          const cFirst=rpt.cycle_number_first||rpt.cycle_number;
+          const cLast=rpt.cycle_number_last||rpt.cycle_number;
+          const rangeTxt=(cFirst!==cLast)?('Cycles #'+cLast+'–#'+cFirst):('Cycle #'+rpt.cycle_number);
+          let dispoBadge='';
+          if(disp==='deferring'){dispoBadge='<span class="cycle-badge" style="background:#2ea043;color:#fff">deferring'+(rc>1?' ×'+rc:'')+'</span>';}
+          else if(disp==='progressing'){dispoBadge='<span class="cycle-badge" style="background:#1f6feb;color:#fff">progress</span>';}
+          if(rpt.loop_suspected){dispoBadge+='<span class="cycle-badge" style="background:var(--red);color:#fff" title="the same non-progressing decision repeated without the work advancing">⚠ possible loop ×'+rc+'</span>';}
+          if(disp==='deferring'){
+            return `<div class="thinking-cycle">
+              <div class="cycle-header"><span class="cycle-num">${rangeTxt}</span>${dispoBadge}</div>
+              <div class="cycle-summary-inline">${esc(rpt.collapsed_summary||'Deferring to an active engineer')}</div>
+            </div>`;
+          }
           const phases=[];
           if(rpt.observation){
             const obs=rpt.observation;
@@ -284,7 +304,8 @@ pub(crate) const PART_04: &str = r#"            let fmt;
           }
           return `<div class="thinking-cycle">
             <div class="cycle-header">
-              <span class="cycle-num">Cycle #${rpt.cycle_number}</span>
+              <span class="cycle-num">${rangeTxt}</span>
+              ${dispoBadge}
               <span class="cycle-summary-inline">${esc(humanizeCycleSummary(rpt.summary||''))}</span>
             </div>
             <div class="cycle-phases">${phases.join('')}</div>
@@ -382,17 +403,27 @@ pub(crate) const PART_04: &str = r#"            let fmt;
         const sumEl=document.getElementById('brain-failures-summary');
         const listEl=document.getElementById('brain-failures-list');
         const s=d.summary||{};
-        const totalFallbacks=s.total_fallback_count||0;
-        const totalParseFailures=s.total_parse_failure_count||0;
-        const totalFailures=totalFallbacks+totalParseFailures;
         const scanned=s.cycles_scanned||0;
-        const statusClass=totalParseFailures>0?'err':(totalFallbacks>0?'warn':'ok');
-        const statusText=totalFailures===0?'No brain failures detected':''+totalFailures+' failure'+(totalFailures===1?'':'s')+' found';
+        /* Issue #2580: headline the CURRENT bounded window + rate, never a
+           stale cumulative total. Zero current failures renders green. */
+        const rec=d.recent||{};
+        const life=d.lifetime||{};
+        const win=rec.window_minutes||60;
+        const recentTotal=rec.total||0;
+        const recentParse=rec.parse_failure||0;
+        const recentFallback=rec.fallback||0;
+        const rate=Number(rec.rate_per_hour||0);
+        const lifetimeParse=life.parse_failure_count||0;
+        const statusClass=rec.status==='err'?'err':(rec.status==='warn'?'warn':'ok');
+        const statusText=recentTotal===0
+          ?('No brain failures in the last '+win+' min')
+          :(recentTotal+' failure'+(recentTotal===1?'':'s')+' in the last '+win+' min');
         sumEl.innerHTML=`
-          <div class="stat"><span class="label">Status</span><span class="value ${statusClass}">${statusText}</span></div>
-          <div class="stat"><span class="label">Parse failures (model response unparseable)</span><span class="value ${totalParseFailures>0?'err':'ok'}">${totalParseFailures}</span></div>
-          <div class="stat"><span class="label">Deterministic fallbacks (safe rules used instead of model)</span><span class="value ${totalFallbacks>0?'warn':'ok'}">${totalFallbacks}</span></div>
-          <div class="stat"><span class="label">Cycles scanned</span><span class="value">${scanned}</span></div>
+          <div class="stat"><span class="label">Current status (last ${win} min)</span><span class="value ${statusClass}">${statusText}</span></div>
+          <div class="stat"><span class="label">Current failure rate</span><span class="value ${statusClass}">${rate.toFixed(1)} / hr</span></div>
+          <div class="stat"><span class="label">Parse failures (last ${win} min)</span><span class="value ${recentParse>0?'err':'ok'}">${recentParse}</span></div>
+          <div class="stat"><span class="label">Deterministic fallbacks (last ${win} min)</span><span class="value ${recentFallback>0?'warn':'ok'}">${recentFallback}</span></div>
+          <div class="stat"><span class="label">All-time parse failures (cumulative, not current)</span><span class="value" style="opacity:.55">${lifetimeParse}</span></div>
           <div class="stat"><span class="label">Last checked</span><span class="value">${timeAgo(d.timestamp)}</span></div>`;
         const failures=d.failures||[];
         if(!failures.length){

--- a/src/operator_commands_dashboard/index_html/tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tab_meta.rs
@@ -150,7 +150,7 @@ pub const TAB_METADATA: &[TabMeta] = &[
         label: "🧠 Thinking",
         title: "Thinking · Simard",
         h1: "Thinking",
-        lede: "A live stream of the daemon's internal reasoning between actions, showing what it considered before deciding what to do next.",
+        lede: "A live view of what the daemon decided each cycle - repeated deferring-to-an-active-engineer notes are collapsed with a count so genuine forward progress stands out from a stuck loop.",
         tooltip: "Live stream of the agent's reasoning between actions",
     },
     TabMeta {
@@ -158,7 +158,7 @@ pub const TAB_METADATA: &[TabMeta] = &[
         label: "Brain Failures",
         title: "Brain Failures · Simard",
         h1: "Brain Failures",
-        lede: "Every time the daemon's language-model brain returned an unparseable or invalid response and fell back to safe deterministic rules, listed with the failure type, which component triggered it, when it happened, and whether recovery succeeded.",
+        lede: "How often the daemon's brain failed to parse a model response right now - the current rate and a bounded recent window, kept separate from the all-time total so a stale number never looks like a live problem.",
         tooltip: "When and how the agent's brain failed, and whether it recovered",
     },
     TabMeta {

--- a/src/operator_commands_dashboard/metrics.rs
+++ b/src/operator_commands_dashboard/metrics.rs
@@ -151,6 +151,12 @@ pub(crate) async fn ooda_thinking() -> Json<Value> {
         }
     }
 
+    // Issue #2580: collapse consecutive identical deferrals ("goal already has
+    // a live, healthy engineer") into a single counted entry and flag a genuine
+    // loop only when a non-progressing decision repeats, so the tab shows
+    // forward progress instead of the same line over and over.
+    let reports = super::thinking_collapse::collapse_reports(reports);
+
     Json(json!({ "reports": reports }))
 }
 

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -22,6 +22,7 @@ mod registry;
 pub(crate) mod routes;
 mod status;
 mod subagent;
+mod thinking_collapse;
 mod tmux;
 mod workboard;
 

--- a/src/operator_commands_dashboard/thinking_collapse.rs
+++ b/src/operator_commands_dashboard/thinking_collapse.rs
@@ -1,0 +1,371 @@
+//! Thinking-tab display honesty (issue #2580).
+//!
+//! The Thinking tab renders one entry per OODA cycle. When both active goals
+//! already have healthy engineers, the Decide reasoner *correctly* emits a
+//! no-action deferral every cycle ("goal already has a live, healthy engineer"
+//! / "already assigned to subordinate"). Rendered verbatim, cycle after cycle,
+//! this looks like an infinite loop even though the underlying work is
+//! advancing inside the engineers.
+//!
+//! This module post-processes the raw cycle reports at the **display layer**
+//! only — it does not touch the reasoner. It:
+//!
+//!   * classifies each cycle as `deferring` (a deliberate no-action deferral to
+//!     an already-active engineer), `progressing` (launched work / produced an
+//!     artifact), or `reasoning` (anything else);
+//!   * collapses a consecutive run of identical deferrals into a single entry
+//!     carrying a `repeat_count` and the goals being deferred on, so the
+//!     timeline shows "deferring to an active engineer on <goal> (xN)" instead
+//!     of N identical lines; and
+//!   * flags `loop_suspected` only when a **non-progressing, non-deferral**
+//!     decision repeats `LOOP_REPEAT_THRESHOLD` times — a genuine stuck loop,
+//!     not a healthy deferral.
+
+use serde_json::{Value, json};
+
+/// A `reasoning` (non-progress, non-deferral) decision must repeat at least
+/// this many times in a row before it is flagged as a suspected loop.
+const LOOP_REPEAT_THRESHOLD: u64 = 3;
+
+/// Substrings (matched case-insensitively) that mark a cycle's action as a
+/// deliberate no-action deferral to an already-active, healthy engineer. These
+/// are the real skip-path strings emitted by the dispatch/decide paths
+/// (`spawn.rs`, `concurrent.rs`) plus the reasoner's healthy-engineer phrasing.
+const DEFERRAL_MARKERS: &[&str] = &[
+    "already assigned to subordinate",
+    "already has a subordinate",
+    "already has a live, healthy engineer",
+    "already has a live",
+    "live, healthy engineer",
+    "healthy engineer",
+];
+
+/// Substrings (case-insensitive) that mark a cycle as making forward progress —
+/// launching an engineer or producing an artifact.
+const PROGRESS_MARKERS: &[&str] = &["pr #", "commit", "launched", "dispatched"];
+
+/// Disposition of one thinking cycle for display.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Disposition {
+    /// A deliberate, correct no-action deferral to an already-active engineer.
+    Deferring,
+    /// The cycle launched work or produced an artifact.
+    Progressing,
+    /// Any other reasoning cycle (candidate for loop detection if it repeats).
+    Reasoning,
+}
+
+impl Disposition {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Deferring => "deferring",
+            Self::Progressing => "progressing",
+            Self::Reasoning => "reasoning",
+        }
+    }
+}
+
+/// Recursively collect every string value stored under a `"goal_id"` key.
+fn collect_goal_ids(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            for (k, v) in map {
+                if k == "goal_id"
+                    && let Some(id) = v.as_str()
+                    && !id.is_empty()
+                    && !out.iter().any(|g| g == id)
+                {
+                    out.push(id.to_string());
+                }
+                collect_goal_ids(v, out);
+            }
+        }
+        Value::Array(items) => {
+            for v in items {
+                collect_goal_ids(v, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Lower-cased haystack of the report's human-readable decision text: the
+/// summary plus every outcome `detail` string.
+fn decision_haystack(report: &Value) -> String {
+    let mut s = String::new();
+    if let Some(summary) = report.get("summary").and_then(|v| v.as_str()) {
+        s.push_str(summary);
+        s.push(' ');
+    }
+    if let Some(outcomes) = report.get("outcomes").and_then(|v| v.as_array()) {
+        for o in outcomes {
+            for key in ["detail", "action_description", "action_kind"] {
+                if let Some(t) = o.get(key).and_then(|v| v.as_str()) {
+                    s.push_str(t);
+                    s.push(' ');
+                }
+            }
+        }
+    }
+    s.to_ascii_lowercase()
+}
+
+/// True when any outcome shows a live spawned engineer this cycle.
+fn has_live_spawn(report: &Value) -> bool {
+    report
+        .get("outcomes")
+        .and_then(|v| v.as_array())
+        .is_some_and(|outcomes| {
+            outcomes.iter().any(|o| {
+                o.get("spawn_engineer")
+                    .and_then(|se| se.get("status"))
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|s| s.eq_ignore_ascii_case("live"))
+            })
+        })
+}
+
+/// Classify a single cycle report and return its disposition plus the goal ids
+/// it concerns (sorted, de-duplicated).
+pub(crate) fn classify_cycle(report: &Value) -> (Disposition, Vec<String>) {
+    let mut goals = Vec::new();
+    collect_goal_ids(report, &mut goals);
+    goals.sort();
+
+    let haystack = decision_haystack(report);
+    let disposition = if DEFERRAL_MARKERS.iter().any(|m| haystack.contains(m)) {
+        Disposition::Deferring
+    } else if has_live_spawn(report) || PROGRESS_MARKERS.iter().any(|m| haystack.contains(m)) {
+        Disposition::Progressing
+    } else {
+        Disposition::Reasoning
+    };
+    (disposition, goals)
+}
+
+/// Grouping key for collapsing consecutive cycles. Progressing cycles never
+/// collapse (each is distinct forward progress); deferrals collapse by the goal
+/// set they defer on; reasoning cycles collapse by their normalized text so an
+/// identical repeated decision can be counted (and flagged as a loop).
+fn group_key(report: &Value, disposition: Disposition, goals: &[String]) -> String {
+    match disposition {
+        Disposition::Deferring => format!("defer:{}", goals.join(",")),
+        Disposition::Progressing => format!(
+            "progress:{}",
+            report
+                .get("cycle_number")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0)
+        ),
+        Disposition::Reasoning => format!("reason:{}", decision_haystack(report).trim()),
+    }
+}
+
+fn cycle_number(report: &Value) -> u64 {
+    report
+        .get("cycle_number")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0)
+}
+
+/// Collapse a chronologically-ordered (most-recent-first) list of cycle reports
+/// for honest display. Consecutive identical deferrals become a single entry
+/// with a `repeat_count`; a repeated non-progress reasoning decision is flagged
+/// `loop_suspected`. Progressing and one-off cycles pass through annotated with
+/// their disposition.
+pub(crate) fn collapse_reports(reports: Vec<Value>) -> Vec<Value> {
+    let classified: Vec<(Disposition, Vec<String>, String, Value)> = reports
+        .into_iter()
+        .map(|r| {
+            let (disp, goals) = classify_cycle(&r);
+            let key = group_key(&r, disp, &goals);
+            (disp, goals, key, r)
+        })
+        .collect();
+
+    let mut out: Vec<Value> = Vec::new();
+    let mut i = 0;
+    while i < classified.len() {
+        let (disp, ref goals, ref key, _) = classified[i];
+        // Extend the run while the next entry shares the same disposition + key.
+        let mut j = i + 1;
+        while j < classified.len() && classified[j].0 == disp && &classified[j].2 == key {
+            j += 1;
+        }
+        let repeat_count = (j - i) as u64;
+        let representative = classified[i].3.clone();
+        let cycle_first = cycle_number(&representative);
+        let cycle_last = cycle_number(&classified[j - 1].3);
+
+        let mut entry = representative;
+        if let Value::Object(map) = &mut entry {
+            map.insert("disposition".to_string(), json!(disp.as_str()));
+            map.insert("repeat_count".to_string(), json!(repeat_count));
+            map.insert("cycle_number_first".to_string(), json!(cycle_first));
+            map.insert("cycle_number_last".to_string(), json!(cycle_last));
+            match disp {
+                Disposition::Deferring => {
+                    map.insert("deferring_to".to_string(), json!(goals));
+                    let goal_txt = if goals.is_empty() {
+                        "an active engineer".to_string()
+                    } else {
+                        format!("an active engineer on {}", goals.join(", "))
+                    };
+                    let times = if repeat_count == 1 {
+                        String::new()
+                    } else {
+                        format!(" (repeated {repeat_count} cycles)")
+                    };
+                    map.insert(
+                        "collapsed_summary".to_string(),
+                        json!(format!("Deferring to {goal_txt}{times}")),
+                    );
+                }
+                Disposition::Reasoning if repeat_count >= LOOP_REPEAT_THRESHOLD => {
+                    map.insert("loop_suspected".to_string(), json!(true));
+                }
+                _ => {}
+            }
+        }
+        out.push(entry);
+        i = j;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn deferral_report(cycle: u64, goal: &str) -> Value {
+        json!({
+            "cycle_number": cycle,
+            "summary": format!("cycle {cycle}"),
+            "outcomes": [{
+                "action_kind": "AdvanceGoal",
+                "success": true,
+                "goal_id": goal,
+                "detail": "no_action - goal already has a live, healthy engineer",
+            }],
+        })
+    }
+
+    fn progress_report(cycle: u64, goal: &str) -> Value {
+        json!({
+            "cycle_number": cycle,
+            "summary": format!("cycle {cycle}"),
+            "outcomes": [{
+                "action_kind": "AdvanceGoal",
+                "success": true,
+                "goal_id": goal,
+                "detail": "launched sub-agent, opened PR #42",
+                "spawn_engineer": {"status": "live", "goal_id": goal},
+            }],
+        })
+    }
+
+    fn reasoning_report(cycle: u64, text: &str) -> Value {
+        json!({
+            "cycle_number": cycle,
+            "summary": text,
+            "outcomes": [{
+                "action_kind": "Reflect",
+                "success": true,
+                "detail": text,
+            }],
+        })
+    }
+
+    #[test]
+    fn classify_detects_deferral_progress_and_reasoning() {
+        assert_eq!(
+            classify_cycle(&deferral_report(5, "g1")).0,
+            Disposition::Deferring
+        );
+        assert_eq!(
+            classify_cycle(&progress_report(6, "g1")).0,
+            Disposition::Progressing
+        );
+        assert_eq!(
+            classify_cycle(&reasoning_report(7, "considered the backlog")).0,
+            Disposition::Reasoning
+        );
+    }
+
+    #[test]
+    fn classify_uses_real_skip_path_strings() {
+        let r = json!({
+            "cycle_number": 1,
+            "outcomes": [{"detail": "spawn_engineer skipped: goal 'g1' already assigned to subordinate 'engineer-x'"}],
+        });
+        assert_eq!(classify_cycle(&r).0, Disposition::Deferring);
+    }
+
+    #[test]
+    fn collapses_consecutive_deferrals_with_repeat_count() {
+        let reports = vec![
+            deferral_report(10, "g1"),
+            deferral_report(9, "g1"),
+            deferral_report(8, "g1"),
+        ];
+        let out = collapse_reports(reports);
+        assert_eq!(
+            out.len(),
+            1,
+            "three identical deferrals collapse to one entry"
+        );
+        assert_eq!(out[0]["repeat_count"], 3);
+        assert_eq!(out[0]["disposition"], "deferring");
+        assert_eq!(out[0]["cycle_number_first"], 10);
+        assert_eq!(out[0]["cycle_number_last"], 8);
+        assert_eq!(out[0]["deferring_to"], json!(["g1"]));
+        assert!(
+            out[0]["collapsed_summary"]
+                .as_str()
+                .unwrap()
+                .contains("Deferring to an active engineer on g1")
+        );
+        // A healthy deferral is NEVER flagged as a loop.
+        assert!(out[0].get("loop_suspected").is_none());
+    }
+
+    #[test]
+    fn different_goal_deferrals_do_not_collapse_together() {
+        let reports = vec![deferral_report(10, "g1"), deferral_report(9, "g2")];
+        let out = collapse_reports(reports);
+        assert_eq!(out.len(), 2, "deferrals on different goals stay separate");
+    }
+
+    #[test]
+    fn progress_cycles_are_shown_individually() {
+        let reports = vec![progress_report(10, "g1"), progress_report(9, "g1")];
+        let out = collapse_reports(reports);
+        assert_eq!(out.len(), 2, "forward-progress cycles are never collapsed");
+        assert_eq!(out[0]["disposition"], "progressing");
+    }
+
+    #[test]
+    fn repeated_reasoning_is_flagged_as_loop() {
+        let reports = vec![
+            reasoning_report(5, "stuck on the same thing"),
+            reasoning_report(4, "stuck on the same thing"),
+            reasoning_report(3, "stuck on the same thing"),
+        ];
+        let out = collapse_reports(reports);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["repeat_count"], 3);
+        assert_eq!(out[0]["loop_suspected"], true);
+    }
+
+    #[test]
+    fn two_repeats_below_threshold_are_not_a_loop() {
+        let reports = vec![
+            reasoning_report(5, "thinking"),
+            reasoning_report(4, "thinking"),
+        ];
+        let out = collapse_reports(reports);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["repeat_count"], 2);
+        assert!(out[0].get("loop_suspected").is_none());
+    }
+}


### PR DESCRIPTION
Fixes two related operator-facing defects on Simard's goal board and dashboard. Branched off latest `origin/main`.

## DEFECT 1 — Perpetual/standing goals were wrongly marked "completed"
A standing goal (the "STANDING PERPETUAL" continuous-research goal, and the "Standing goal" CI-stewardship goal) has **no terminal done-state**, but goal-curation, the deploy-aware completion gate, and `simard goal complete` were completing them — and `goal complete` even **tombstoned** them, permanently dropping perpetual research/stewardship work.

**Fix**
- First-class notion of a standing/perpetual goal, detected by a durable description marker: `ActiveGoal::is_perpetual()`, `description_marks_standing()`, `STANDING_MARKER_PREFIX`. Marker-based (not a new struct field) so it avoids churning 100+ `ActiveGoal` construction sites **and** auto-reconciles the existing live standing goals — whose descriptions already read "STANDING PERPETUAL goal" / "Standing goal" — with **no `~/.simard` edit**. After the operator redeploys, the live continuous-research goal stays active.
- `archive_completed` and the evidence-aware completion gate **never archive** a perpetual goal. When a unit of work finishes, the goal **rolls to a fresh, actionable cycle** (`roll_to_new_cycle`: status → NotStarted, assignment + stale WIP cleared) instead of terminating.
- `simard goal add --standing` marks a goal perpetual; `simard goal complete <standing-id>` **refuses to terminate** it and **auto-reopens** it (no tombstone).
- A normal goal still completes and tombstones exactly as before (regression-guarded).

## DEFECT 2 — Dashboard "Brain Failures" and "Thinking" tabs were dishonest
**Brain Failures** showed a stale cumulative *lifetime* total, so a scary number persisted even though the current fallback rate is ~0.
- The tab now headlines a **bounded recent window (last 60 min) + per-hour rate**, sourced from the timestamped brain parse-error metric (reads both `brain_parse_error` — the companion workstream's explicit post-sanitization metric — and legacy `brain_parse_failure`). The lifetime total is shown **separately and de-emphasised**, clearly labelled "cumulative, not current". **Zero current failures renders green.**

**Thinking** rendered the reasoner's correct per-cycle `no_action — goal already has a live, healthy engineer` deferral verbatim every cycle, so a healthy system *looked* like an infinite loop.
- New display-layer collapse (`thinking_collapse`) folds a run of identical deferrals into **one** "deferring to an active engineer on `<goal>` (×N)" entry, and flags `loop_suspected` **only** when a non-progressing decision repeats (≥3×) without work advancing. A healthy deferral is never a loop. The tab now shows forward progress instead of repeated lines.

## Scope / coordination
This workstream is **goal-lifecycle + dashboard DISPLAY honesty only**. It reads metrics and real skip-path strings that already exist or that the companion fallback-elimination workstream emits; it does **not** rewrite the reasoner fallback internals or the engineer-registry source. No "Bridge" naming; one-Brain terminology. Structured tracing only.

## Tests
- Perpetual lifecycle: marker detection (incl. false-positive guards for "understanding"/"outstanding"), `is_perpetual`/`mark_standing`/`roll_to_new_cycle`, `archive_completed` rolls perpetual + still archives normal, completion gate never archives perpetual, `is_complete_candidate` false for perpetual.
- Hermetic CLI: `goal add --standing`, standing-goal `complete` auto-reopen (no tombstone), normal-goal `complete` still removes + tombstones, `--standing`/`--repo` flag parsing.
- Brain Failures: recent-window count, per-hour rate, green-only-when-zero status, timestamped metric reader (windowed, both metric names).
- Thinking: classify deferral/progress/reasoning from real skip-path strings, collapse consecutive deferrals with repeat count, loop flagged only for repeated non-progress.

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean (full CI-mirror, ran green in pre-push)
- Full lib suite: **6876 passed / 0 failed**
- No `--no-verify`; no `--admin`. **The operator redeploys after merge.**