### PR TITLE
feat(overseer): wire the acting Overseer co-process into the OODA daemon

### DIFF
--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -591,19 +591,13 @@ pub fn run_ooda_daemon(
         mind.register(Box::new(
             crate::cognitive_threads::EngineerLogAnalysisThread::from_env(),
         ));
-        // Overseer M1 read-only observer sensor. Additive and default-OFF: only
-        // registered when SIMARD_OVERSEER_ENABLED is truthy (see
-        // `crate::overseer::config`). It Observes → Orients → Reports → files
-        // DEDUPLICATED issues and takes no write action beyond issue-filing, so
-        // it fits the least-authority ThreadContext. The daemon's default
-        // behaviour is unchanged when the flag is unset.
-        if crate::overseer::overseer_enabled() {
-            mind.register(Box::new(crate::overseer::OverseerSensorThread::from_env()));
-            daemon_log(
-                &state_root,
-                "[simard] OODA daemon: Overseer read-only observer ENABLED (M1 sensor; SIMARD_OVERSEER_ENABLED)",
-            );
-        }
+        // NOTE: the Overseer M1 read-only observer sensor that previously
+        // registered here (default-OFF, `SIMARD_OVERSEER_ENABLED` truthy) is
+        // SUPERSEDED by the acting Overseer periodic task driven below in the
+        // main loop (default-ON). Both observe and file DEDUPLICATED issues;
+        // running both would double-file and split the enable-gate, so the
+        // acting co-process owns Observe→Orient→Decide→Act now. See
+        // `crate::overseer::wiring`.
         daemon_log(
             &state_root,
             &format!(
@@ -612,6 +606,36 @@ pub fn run_ooda_daemon(
             ),
         );
     }
+
+    // ── Acting Overseer co-process (issue #2539 wiring) ─────────────────
+    // ADDITIVE and DEFAULT-ON: the daemon drives the Overseer's meta-OODA loop
+    // (Observe→Orient→Decide→Act) on its own cadence, in THIS process but on a
+    // background thread so it never runs inside or blocks the authoritative OODA
+    // cycle. The operator opts OUT with `SIMARD_OVERSEER_ENABLED=0`. A panic or
+    // error in a tick is caught and logged and never crashes or stalls the
+    // daemon (see `crate::overseer::wiring::run_overseer_tick_isolated`). The
+    // Overseer runs under a DISTINCT anti-recursion identity so it never
+    // verifies/merges/deploys its own PRs and never fights the OODA loop.
+    let overseer_acting_enabled = crate::overseer::overseer_acting_enabled();
+    let overseer_interval_secs = crate::overseer::overseer_tick_interval_secs();
+    // Monotonic origin for the cadence; virtual seconds since daemon start.
+    let overseer_epoch = Instant::now();
+    let mut overseer_cadence = crate::overseer::OverseerCadence::new(overseer_interval_secs, 0);
+    // Prevents overlapping ticks from stacking up if one runs long.
+    let overseer_tick_running = Arc::new(AtomicBool::new(false));
+    let overseer_repo_root = bridges.repo_root.clone();
+    daemon_log(
+        &state_root,
+        &format!(
+            "[simard] OODA daemon: acting Overseer {} (interval = {overseer_interval_secs}s; \
+             SIMARD_OVERSEER_ENABLED opt-out)",
+            if overseer_acting_enabled {
+                "ENABLED (default)"
+            } else {
+                "DISABLED"
+            }
+        ),
+    );
 
     let mut cycles_run = 0u32;
 
@@ -1150,6 +1174,73 @@ pub fn run_ooda_daemon(
                     daemon_log(
                         &state_root,
                         &format!("[simard] cognitive-thread: {}", outcome.summary),
+                    );
+                }
+            }
+        }
+
+        // ── Acting Overseer meta-OODA tick (issue #2539 wiring) ─────────
+        // DEFAULT-ON. Fires on its own cadence, AFTER the authoritative OODA
+        // cycle so OODA is never starved. Runs on a background thread — never
+        // inline — so a long (network-bound) tick cannot block or stall the
+        // OODA loop; an overlap guard drops a tick if the previous one is still
+        // running. The tick builds a fresh Overseer under the DISTINCT identity
+        // and runs panic-isolated, so a panic/error is caught and logged and
+        // never crashes the daemon.
+        if overseer_acting_enabled {
+            let now_secs = overseer_epoch.elapsed().as_secs();
+            if overseer_cadence.due(now_secs)
+                && overseer_tick_running
+                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+            {
+                let running = Arc::clone(&overseer_tick_running);
+                let mem_for_tick = Arc::clone(&shared_mem);
+                let repo_root_for_tick = overseer_repo_root.clone();
+                let state_root_for_tick = state_root.clone();
+                let spawn = std::thread::Builder::new()
+                    .name("overseer-tick".to_string())
+                    .spawn(move || {
+                        // Always clear the overlap guard, even on panic.
+                        struct ClearOnDrop(Arc<AtomicBool>);
+                        impl Drop for ClearOnDrop {
+                            fn drop(&mut self) {
+                                self.0.store(false, Ordering::SeqCst);
+                            }
+                        }
+                        let _clear = ClearOnDrop(running);
+
+                        let mut overseer = crate::overseer::build_overseer(
+                            mem_for_tick,
+                            repo_root_for_tick,
+                            state_root_for_tick.clone(),
+                        );
+                        let report = crate::overseer::run_overseer_tick_isolated(&mut overseer);
+                        daemon_log(
+                            &state_root_for_tick,
+                            &format!(
+                                "[simard] overseer tick: problems={} issues_filed={} \
+                                 recipes_launched={} prs_merged={} deploys={} escalations={} \
+                                 held={} errors={} panicked={} ({}ms)",
+                                report.problems,
+                                report.issues_filed,
+                                report.recipes_launched,
+                                report.prs_merged,
+                                report.deploys,
+                                report.escalations,
+                                report.held,
+                                report.errors,
+                                report.panicked,
+                                report.duration_ms,
+                            ),
+                        );
+                    });
+                if let Err(e) = spawn {
+                    // Spawn failed — clear the guard so the next cadence retries.
+                    overseer_tick_running.store(false, Ordering::SeqCst);
+                    daemon_log(
+                        &state_root,
+                        &format!("[simard] WARN: overseer tick thread spawn failed: {e}"),
                     );
                 }
             }

--- a/src/overseer/config.rs
+++ b/src/overseer/config.rs
@@ -28,6 +28,17 @@ pub const DAILY_BUDGET_ENV: &str = "SIMARD_DAILY_BUDGET_USD";
 /// self-tuning (M4) can never drive the observer into a hot loop.
 pub const OVERSEER_INTERVAL_ENV: &str = "SIMARD_OVERSEER_INTERVAL_SECS";
 
+/// GitHub login the acting Overseer authors its own workstreams under. Sourced
+/// here so the daemon and the merge/recursion path agree on ONE stable, DISTINCT
+/// identity (never the human operator's login). Defaults to
+/// [`DEFAULT_OVERSEER_AUTHOR_LOGIN`] when unset.
+pub const OVERSEER_AUTHOR_LOGIN_ENV: &str = "SIMARD_OVERSEER_AUTHOR_LOGIN";
+
+/// The Overseer's well-known bot login, distinct from the engineer/OODA
+/// identity. Used by the anti-recursion guard so the Overseer never
+/// verifies/merges/deploys its OWN PRs and never re-opens its own goals.
+pub const DEFAULT_OVERSEER_AUTHOR_LOGIN: &str = "simard-overseer[bot]";
+
 /// Default observer cadence: 15 minutes — frequent enough to catch churn, far
 /// below any launch/merge cadence (M1 files at most one deduped issue per
 /// recurring signature, so a tighter interval adds no writes).
@@ -54,6 +65,41 @@ pub fn overseer_enabled_from(lookup: impl Fn(&str) -> Option<String>) -> bool {
 /// Production entry point: read the real process environment.
 pub fn overseer_enabled() -> bool {
     overseer_enabled_from(|k| std::env::var(k).ok())
+}
+
+/// Resolve the **acting** Overseer master flag with **default ON** semantics
+/// (M2+ co-process). The daemon runs the acting Overseer UNLESS
+/// `SIMARD_OVERSEER_ENABLED` is explicitly set to a falsey value
+/// (`0`/`false`/`no`/`off`, case-insensitive). This is deliberately the inverse
+/// default of [`overseer_enabled_from`] — which gates the M1 read-only sensor
+/// default-**OFF** — because the acting co-process is opt-**out**: the operator
+/// disables it explicitly, and an unset/empty var leaves it enabled.
+pub fn overseer_acting_enabled_from(lookup: impl Fn(&str) -> Option<String>) -> bool {
+    // Enabled unless an explicit falsey value is set. `matches!` returns true for
+    // the falsey case; negate for the enabled result.
+    !matches!(
+        lookup(OVERSEER_ENABLED_ENV).as_deref().map(str::trim),
+        Some(v) if is_falsey(v)
+    )
+}
+
+/// Production entry point: read the real process environment.
+pub fn overseer_acting_enabled() -> bool {
+    overseer_acting_enabled_from(|k| std::env::var(k).ok())
+}
+
+/// Resolve the Overseer's DISTINCT author login. Falls back to
+/// [`DEFAULT_OVERSEER_AUTHOR_LOGIN`] when unset or empty.
+pub fn overseer_author_login_from(lookup: impl Fn(&str) -> Option<String>) -> String {
+    match lookup(OVERSEER_AUTHOR_LOGIN_ENV).as_deref().map(str::trim) {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => DEFAULT_OVERSEER_AUTHOR_LOGIN.to_string(),
+    }
+}
+
+/// Production entry point: read the real process environment.
+pub fn overseer_author_login() -> String {
+    overseer_author_login_from(|k| std::env::var(k).ok())
 }
 
 /// Resolve the daily budget from an env resolver, falling back to
@@ -98,6 +144,15 @@ fn is_truthy(v: &str) -> bool {
     matches!(norm.as_str(), "1" | "true" | "yes" | "on")
 }
 
+/// Recognise an explicit falsey env value used by the **acting** Overseer's
+/// opt-out gate. Case-insensitive; trims surrounding whitespace. Only these
+/// exact values disable the acting Overseer; everything else (including unset,
+/// empty, or garbage) leaves it enabled.
+fn is_falsey(v: &str) -> bool {
+    let norm = v.trim().to_ascii_lowercase();
+    matches!(norm.as_str(), "0" | "false" | "no" | "off")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,6 +194,54 @@ mod tests {
                 "{falsey:?} must NOT enable the Overseer"
             );
         }
+    }
+
+    #[test]
+    fn acting_overseer_enabled_by_default_when_unset() {
+        // Opt-OUT semantics: an unset var leaves the acting co-process ENABLED.
+        assert!(overseer_acting_enabled_from(env(&[])));
+    }
+
+    #[test]
+    fn acting_overseer_disabled_only_on_explicit_falsey_values() {
+        for falsey in ["0", "false", "FALSE", "False", "no", "off", "  off  "] {
+            assert!(
+                !overseer_acting_enabled_from(env(&[(OVERSEER_ENABLED_ENV, falsey)])),
+                "{falsey:?} should DISABLE the acting Overseer"
+            );
+        }
+    }
+
+    #[test]
+    fn acting_overseer_stays_on_for_truthy_empty_or_garbage_values() {
+        // Anything that is not an explicit falsey value leaves it ON, including
+        // empty/whitespace (treated as unset) and unrecognised strings.
+        for on in ["1", "true", "yes", "on", "", "  ", "maybe", "2", "enabled"] {
+            assert!(
+                overseer_acting_enabled_from(env(&[(OVERSEER_ENABLED_ENV, on)])),
+                "{on:?} must leave the acting Overseer ON (default)"
+            );
+        }
+    }
+
+    #[test]
+    fn author_login_defaults_to_the_distinct_bot_identity() {
+        assert_eq!(
+            overseer_author_login_from(env(&[])),
+            DEFAULT_OVERSEER_AUTHOR_LOGIN
+        );
+        assert_eq!(
+            overseer_author_login_from(env(&[(OVERSEER_AUTHOR_LOGIN_ENV, "  ")])),
+            DEFAULT_OVERSEER_AUTHOR_LOGIN
+        );
+    }
+
+    #[test]
+    fn author_login_reads_explicit_value() {
+        assert_eq!(
+            overseer_author_login_from(env(&[(OVERSEER_AUTHOR_LOGIN_ENV, " simard-bot ")])),
+            "simard-bot"
+        );
     }
 
     #[test]

--- a/src/overseer/mod.rs
+++ b/src/overseer/mod.rs
@@ -61,6 +61,7 @@ pub mod pr_verify;
 pub mod sensor;
 pub mod signal;
 pub mod tuning;
+pub mod wiring;
 
 #[cfg(test)]
 mod tests_m1;
@@ -71,7 +72,9 @@ pub use capabilities::{
     Auditor, Deployer, GoalCurator, IssueFiler, MeetingHost, ObservedState, OrchestratorRunBrief,
     OverseerError, PrOps, RecipeBrief, RecipeLauncher, StatusReader,
 };
-pub use config::{daily_budget_usd, overseer_enabled};
+pub use config::{
+    daily_budget_usd, overseer_acting_enabled, overseer_author_login, overseer_enabled,
+};
 pub use guardrails::{
     AutonomyGate, BudgetGate, ConflictSequencer, RecursionGuard, RiskClass, Subject, classify,
 };
@@ -82,6 +85,11 @@ pub use sensor::{
     in_flight_from_board, observed_from_snapshot, run_observer_cycle,
 };
 pub use signal::{Priority, Problem, ProblemKind, Signal, signals_from};
+pub use wiring::{
+    BoardGoalCurator, OverseerCadence, OverseerTickReport, RefuseDeployer, assemble_capabilities,
+    build_overseer, overseer_identity, overseer_tick, overseer_tick_interval_secs,
+    run_overseer_tick_isolated,
+};
 
 use capabilities::{DeployReport, GoalBrief, InFlightItem, IssueOutcome, WorkstreamHandle};
 

--- a/src/overseer/wiring.rs
+++ b/src/overseer/wiring.rs
@@ -1,0 +1,705 @@
+//! Daemon wiring for the acting Overseer co-process (M2+).
+//!
+//! This module is the seam that turns the Overseer from an inert design sketch
+//! into a live, in-process co-process the OODA daemon drives on a cadence. It
+//! provides four things:
+//!
+//! 1. [`OverseerCadence`] — a tiny, injected-clock-testable interval scheduler
+//!    (mirrors the daemon's sibling `should_run_*` periodic-task pattern).
+//! 2. [`overseer_tick`] / [`run_overseer_tick_isolated`] — the drive helper that
+//!    runs one meta-OODA turn (`run_cycle` → act on every admitted intervention)
+//!    with structured per-tick tracing and **panic isolation**, so an error or
+//!    panic in a tick is caught and logged and never crashes or stalls the
+//!    daemon or the OODA loop.
+//! 3. [`assemble_capabilities`] / [`build_overseer`] — construct the production
+//!    [`Overseer`] from the already-shipped capability adapters, under a
+//!    DISTINCT anti-recursion identity ([`overseer_identity`]) and with acting
+//!    autonomy (verify-merge + HIGH-RISK) enabled.
+//! 4. [`BoardGoalCurator`] — the production [`GoalCurator`] adapter that reads
+//!    Simard's live goal board so Orient dedups against in-flight engineer work
+//!    and the Overseer never fights the OODA loop.
+//!
+//! Reuse (never reimplementation): every capability is a thin adapter over an
+//! existing Simard entry point — `SnapshotStatusReader` (status::assemble),
+//! `SmartOrchestratorLauncher` (amplihack recipe run), `MergePrOps` (gated merge
+//! authority: poll-until-green, NEVER `--admin`/`--no-verify`, notify-on-merge),
+//! `MeetingGoalTransfer`, `StewardshipIssueFiler`, `SelfQualityAuditor`, and the
+//! goal board via `goal_curation`.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::goal_curation::{BacklogItem, GoalBoard};
+use crate::goal_curation::{
+    DEFAULT_STEWARD_SCORE, add_backlog_item, load_goal_board, save_goal_board,
+};
+
+use crate::overseer::audit::SelfQualityAuditor;
+use crate::overseer::capabilities::{
+    DeployReport, Deployer, GoalBrief, GoalCurator, InFlightItem, OverseerError,
+};
+use crate::overseer::config::{overseer_author_login, overseer_interval_secs};
+use crate::overseer::deploy::GuardedDeployer;
+use crate::overseer::guardrails::RecursionGuard;
+use crate::overseer::launch::SmartOrchestratorLauncher;
+use crate::overseer::meeting_ops::MeetingGoalTransfer;
+use crate::overseer::merge_ops::MergePrOps;
+use crate::overseer::observer::StewardshipIssueFiler;
+use crate::overseer::sensor::{SnapshotStatusReader, in_flight_from_board};
+use crate::overseer::{ActOutcome, Capabilities, Overseer};
+
+// ─────────────────────────── cadence scheduler ─────────────────────────────
+
+/// Interval scheduler for the periodic Overseer tick. Deliberately clock-free:
+/// the caller feeds a monotonic `now_secs`, so production uses
+/// `Instant::elapsed().as_secs()` while tests inject a virtual clock and assert
+/// the tick fires exactly on/after the interval boundary. Mirrors the daemon's
+/// sibling periodic tasks (backup / disk-health / brain-introspection).
+#[derive(Clone, Copy, Debug)]
+pub struct OverseerCadence {
+    interval_secs: u64,
+    last_tick_secs: u64,
+}
+
+impl OverseerCadence {
+    /// Start the cadence at `now_secs` (the first tick fires one full interval
+    /// later — nothing useful to do at t=0). The interval is floored at 1s so a
+    /// pathological `0` can never busy-fire.
+    pub fn new(interval_secs: u64, now_secs: u64) -> Self {
+        Self {
+            interval_secs: interval_secs.max(1),
+            last_tick_secs: now_secs,
+        }
+    }
+
+    /// The interval this cadence fires on (seconds).
+    pub fn interval_secs(&self) -> u64 {
+        self.interval_secs
+    }
+
+    /// Return `true` (and advance the last-tick marker to `now_secs`) exactly
+    /// when at least one interval has elapsed since the previous tick; otherwise
+    /// `false` and no state change. Monotonic: `now_secs` going backwards never
+    /// fires.
+    pub fn due(&mut self, now_secs: u64) -> bool {
+        if now_secs.saturating_sub(self.last_tick_secs) >= self.interval_secs {
+            self.last_tick_secs = now_secs;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+// ─────────────────────────── per-tick report ───────────────────────────────
+
+/// Structured tally of one Overseer tick. Every field is emitted as a
+/// `tracing` key so a tick is fully observable without `println!`/`eprintln!`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct OverseerTickReport {
+    /// Problems raised this cycle (post-dedup against in-flight work).
+    pub problems: usize,
+    /// Deduplicated issues filed via the stewardship path.
+    pub issues_filed: usize,
+    /// Fix workstreams launched (smart-orchestrator/default-workflow).
+    pub recipes_launched: usize,
+    /// Green, merge-ready PRs verified-and-merged (normal merge; never admin).
+    pub prs_merged: usize,
+    /// Guarded deploys performed (through the canary/self-deploy gates).
+    pub deploys: usize,
+    /// Interventions handed off to the operator (escalations).
+    pub escalations: usize,
+    /// Interventions the gates held (autonomy/budget/conflict).
+    pub held: usize,
+    /// Capability errors encountered while acting (isolated, never fatal).
+    pub errors: usize,
+    /// Set when the tick itself panicked and was isolated by
+    /// [`run_overseer_tick_isolated`].
+    pub panicked: bool,
+    /// Wall-clock duration of the tick in milliseconds.
+    pub duration_ms: u64,
+}
+
+/// Run ONE Overseer meta-OODA turn: `run_cycle` (Observe→Orient→Decide→plan)
+/// then execute every ADMITTED intervention via `act`, tallying outcomes and
+/// emitting one structured `tracing` event. Errors from `run_cycle` or any
+/// `act` are caught and counted (never propagated) so a single bad capability
+/// call cannot abort the tick — and the daemon never sees a `Result::Err`.
+///
+/// This does NOT catch panics; wrap it in [`run_overseer_tick_isolated`] for
+/// the full fail-safe boundary the daemon uses.
+pub fn overseer_tick(overseer: &mut Overseer) -> OverseerTickReport {
+    let start = Instant::now();
+    let mut report = OverseerTickReport::default();
+
+    match overseer.run_cycle() {
+        Ok(cycle) => {
+            report.problems = cycle.problems.len();
+            for planned in &cycle.plan {
+                if !planned.admitted {
+                    report.held += 1;
+                    continue;
+                }
+                match overseer.act(&planned.intervention) {
+                    Ok(outcome) => tally_outcome(&mut report, &outcome),
+                    Err(e) => {
+                        report.errors += 1;
+                        tracing::warn!(
+                            target: "overseer::tick",
+                            intervention = planned.intervention.label(),
+                            error = %e,
+                            "overseer intervention failed — isolated, continuing"
+                        );
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            report.errors += 1;
+            tracing::warn!(
+                target: "overseer::tick",
+                error = %e,
+                "overseer run_cycle failed — isolated, no actions taken"
+            );
+        }
+    }
+
+    report.duration_ms = start.elapsed().as_millis() as u64;
+    tracing::info!(
+        target: "overseer::tick",
+        enabled = true,
+        problems = report.problems,
+        issues_filed = report.issues_filed,
+        recipes_launched = report.recipes_launched,
+        prs_merged = report.prs_merged,
+        deploys = report.deploys,
+        escalations = report.escalations,
+        held = report.held,
+        errors = report.errors,
+        duration_ms = report.duration_ms,
+        "overseer tick complete"
+    );
+    report
+}
+
+/// Panic-isolated wrapper around [`overseer_tick`]. A panic inside a capability
+/// adapter is caught, logged, and turned into a report with `panicked = true`;
+/// the daemon loop continues unaffected. This is the boundary that guarantees
+/// "a panicking overseer tick never crashes or stalls the daemon".
+pub fn run_overseer_tick_isolated(overseer: &mut Overseer) -> OverseerTickReport {
+    let start = Instant::now();
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| overseer_tick(overseer))) {
+        Ok(report) => report,
+        Err(_) => {
+            tracing::error!(
+                target: "overseer::tick",
+                panicked = true,
+                "overseer tick panicked — isolated; daemon continues"
+            );
+            OverseerTickReport {
+                panicked: true,
+                errors: 1,
+                duration_ms: start.elapsed().as_millis() as u64,
+                ..OverseerTickReport::default()
+            }
+        }
+    }
+}
+
+fn tally_outcome(report: &mut OverseerTickReport, outcome: &ActOutcome) {
+    match outcome {
+        ActOutcome::Launched(_) => report.recipes_launched += 1,
+        ActOutcome::Merged => report.prs_merged += 1,
+        ActOutcome::Deployed(_) => report.deploys += 1,
+        ActOutcome::IssueFiled(_) => report.issues_filed += 1,
+        ActOutcome::Escalated => report.escalations += 1,
+        ActOutcome::ConflictResolved
+        | ActOutcome::GoalTransferred
+        | ActOutcome::Reported
+        | ActOutcome::Audited => {}
+    }
+}
+
+// ─────────────────────────── identity ──────────────────────────────────────
+
+/// The Overseer's DISTINCT anti-recursion identity: a stable, well-known bot
+/// login plus the branch/goal namespaces its launched work uses. Sourced from
+/// [`overseer_author_login`] so the daemon, the merge path, and goal dedup all
+/// agree on ONE identity that is never the human operator's login. A fully
+/// populated guard fails CLOSED and refuses the Overseer's own PRs/commits,
+/// branches, and goals.
+pub fn overseer_identity() -> RecursionGuard {
+    RecursionGuard {
+        author_login: overseer_author_login(),
+        branch_prefix: "overseer/".to_string(),
+        goal_source_tag: "overseer:".to_string(),
+    }
+}
+
+// ─────────────────────────── goal-board curator ────────────────────────────
+
+/// Production [`GoalCurator`]: reads Simard's live goal board so Orient dedups
+/// the Overseer's problems against in-flight engineer goals, and enqueues
+/// proposed goals onto the backlog under the Overseer's own source tag.
+///
+/// Reuse: `goal_curation::{load_goal_board, add_backlog_item, save_goal_board}`
+/// and [`in_flight_from_board`].
+pub struct BoardGoalCurator {
+    mem: Arc<dyn CognitiveMemoryOps>,
+}
+
+impl BoardGoalCurator {
+    pub fn new(mem: Arc<dyn CognitiveMemoryOps>) -> Self {
+        Self { mem }
+    }
+
+    fn load(&self) -> Result<GoalBoard, OverseerError> {
+        load_goal_board(self.mem.as_ref()).map_err(|e| OverseerError::Capability {
+            what: "goal_board.load",
+            detail: e.to_string(),
+        })
+    }
+}
+
+impl GoalCurator for BoardGoalCurator {
+    fn propose(&self, goal: &GoalBrief) -> Result<(), OverseerError> {
+        let mut board = self.load()?;
+        let id = format!("overseer-{}", slugify(&goal.title));
+        // Idempotent: never double-enqueue nor collide with an active goal.
+        if board.backlog.iter().any(|b| b.id == id) || board.active.iter().any(|g| g.id == id) {
+            return Ok(());
+        }
+        let item = BacklogItem {
+            id,
+            description: format!("{} — {}", goal.title, goal.rationale),
+            // Stamp the Overseer's DISTINCT source tag so anti-recursion never
+            // re-opens a goal the Overseer itself filed.
+            source: format!("overseer:{}", goal.target_repo),
+            score: DEFAULT_STEWARD_SCORE,
+        };
+        add_backlog_item(&mut board, item).map_err(|e| OverseerError::Capability {
+            what: "goal_board.enqueue",
+            detail: e.to_string(),
+        })?;
+        save_goal_board(&board, self.mem.as_ref()).map_err(|e| OverseerError::Capability {
+            what: "goal_board.save",
+            detail: e.to_string(),
+        })
+    }
+
+    fn in_flight(&self) -> Result<Vec<InFlightItem>, OverseerError> {
+        Ok(in_flight_from_board(&self.load()?))
+    }
+}
+
+/// Lowercase, hyphenate, and bound a title into a stable backlog id fragment.
+fn slugify(s: &str) -> String {
+    let mut out = String::with_capacity(s.len().min(48));
+    let mut last_dash = false;
+    for c in s.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+            last_dash = false;
+        } else if !last_dash {
+            out.push('-');
+            last_dash = true;
+        }
+        if out.len() >= 48 {
+            break;
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+// ─────────────────────────── deployer (safe stub) ──────────────────────────
+
+/// A [`Deployer`] that REFUSES autonomous deploys. The deterministic Decide
+/// mapping the wired daemon uses never emits `Intervention::Deploy`, so a live
+/// deploy is never planned through this path; if one ever were, it escalates
+/// rather than blindly swapping the binary. Guarded self-deploy stays the
+/// operator's canary/self-deploy gates (unit-tested via `GuardedDeployer` and
+/// `evaluate_deploy_gate`), never a blind deploy from the acting loop.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct RefuseDeployer;
+
+impl Deployer for RefuseDeployer {
+    fn deploy(&self, _commit: &str) -> Result<DeployReport, OverseerError> {
+        Err(OverseerError::Capability {
+            what: "deploy",
+            detail: "autonomous deploy is not wired into the acting loop — escalate to the \
+                     operator's canary/self-deploy gates (never a blind deploy)"
+                .to_string(),
+        })
+    }
+
+    fn deployed_commit(&self) -> Result<String, OverseerError> {
+        Ok(GuardedDeployer::running_commit_marker().to_string())
+    }
+}
+
+// ─────────────────────────── assembly ──────────────────────────────────────
+
+/// Assemble the production [`Capabilities`] from the already-shipped adapters.
+/// Every handle is a thin reuse of an existing Simard subsystem; the merge path
+/// carries the Overseer's DISTINCT anti-recursion identity so it can never merge
+/// its OWN PR.
+pub fn assemble_capabilities(
+    mem: Arc<dyn CognitiveMemoryOps>,
+    repo_root: std::path::PathBuf,
+    state_root: std::path::PathBuf,
+) -> Capabilities {
+    Capabilities {
+        status: Box::new(SnapshotStatusReader::from_env()),
+        recipes: Box::new(SmartOrchestratorLauncher::from_env()),
+        prs: Box::new(MergePrOps::from_env().with_recursion_guard(overseer_identity())),
+        deployer: Box::new(RefuseDeployer),
+        meetings: Box::new(MeetingGoalTransfer::from_env()),
+        issues: Box::new(StewardshipIssueFiler::new(Arc::new(
+            crate::stewardship::RealGhClient,
+        ))),
+        goals: Box::new(BoardGoalCurator::new(mem)),
+        auditor: Box::new(SelfQualityAuditor::from_env(repo_root, state_root)),
+    }
+}
+
+/// Build the production acting [`Overseer`]: the assembled capabilities, the
+/// DISTINCT anti-recursion identity, and acting autonomy ON (verify-merge +
+/// HIGH-RISK). The merge path still only merges GREEN, merge-ready PRs through
+/// the gated authority (never `--admin`/`--no-verify`) and notifies the operator
+/// on every merge; the review gate is fail-closed until an operator wires a
+/// reviewer, so nothing is merged unreviewed.
+pub fn build_overseer(
+    mem: Arc<dyn CognitiveMemoryOps>,
+    repo_root: std::path::PathBuf,
+    state_root: std::path::PathBuf,
+) -> Overseer {
+    Overseer::new(assemble_capabilities(mem, repo_root, state_root))
+        .with_verify_merge_autonomy(true)
+        .with_high_risk_autonomy(true)
+        .with_identity(overseer_identity())
+}
+
+/// Resolve the acting Overseer's tick cadence (seconds), clamped to the config
+/// floor so self-tuning can never drive a hot loop.
+pub fn overseer_tick_interval_secs() -> u64 {
+    overseer_interval_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::overseer::capabilities::{
+        AuditReport, AuditScope, Auditor, CheckItem, IssueOutcome, ObservedState,
+        OrchestratorRunBrief, PrOps, RecipeBrief, RecipeLauncher, StatusReader, VerifyReport,
+        WorkstreamHandle, WorkstreamStatus,
+    };
+    use crate::overseer::intervention::Intervention;
+    use std::sync::Mutex;
+
+    // ── cadence ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn cadence_fires_only_after_the_interval_elapses() {
+        // Injected virtual clock (seconds). Interval 900s, started at t=0.
+        let mut cadence = OverseerCadence::new(900, 0);
+        assert!(!cadence.due(1), "1s in — far below interval, no tick");
+        assert!(!cadence.due(899), "just under the interval — no tick");
+        assert!(cadence.due(900), "exactly at the interval — tick fires");
+        assert!(!cadence.due(901), "immediately after a tick — no re-fire");
+        assert!(!cadence.due(1799), "still within the next window — no tick");
+        assert!(cadence.due(1800), "one more interval elapsed — tick fires");
+    }
+
+    #[test]
+    fn cadence_interval_is_floored_to_avoid_a_hot_loop() {
+        let mut cadence = OverseerCadence::new(0, 0);
+        assert_eq!(cadence.interval_secs(), 1);
+        assert!(!cadence.due(0));
+        assert!(cadence.due(1));
+    }
+
+    #[test]
+    fn cadence_never_fires_when_the_clock_goes_backwards() {
+        let mut cadence = OverseerCadence::new(60, 100);
+        assert!(!cadence.due(50), "clock moved backwards — never fires");
+        assert!(cadence.due(160), "forward past the interval — fires");
+    }
+
+    // ── fakes for the tick driver ─────────────────────────────────────────
+
+    struct FakeStatus(ObservedState);
+    impl StatusReader for FakeStatus {
+        fn snapshot(&self) -> Result<ObservedState, OverseerError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    /// A status reader that panics — used to prove panic isolation.
+    struct PanicStatus;
+    impl StatusReader for PanicStatus {
+        fn snapshot(&self) -> Result<ObservedState, OverseerError> {
+            panic!("boom: capability adapter blew up mid-observe");
+        }
+    }
+
+    struct FakeRecipes;
+    impl RecipeLauncher for FakeRecipes {
+        fn launch(&self, _b: &RecipeBrief) -> Result<WorkstreamHandle, OverseerError> {
+            Ok(WorkstreamHandle {
+                id: "ws-1".to_string(),
+            })
+        }
+        fn poll(&self, _h: &WorkstreamHandle) -> Result<WorkstreamStatus, OverseerError> {
+            Ok(WorkstreamStatus::Running)
+        }
+    }
+
+    type MergeLog = Arc<Mutex<Vec<(String, u32)>>>;
+
+    /// Records every `merge` call and returns `ready` from `verify`, so a tick
+    /// that drives a green PR to merge is observable without any network. The
+    /// merge log is a shared handle so the test can inspect it after the
+    /// recorder is boxed into the Overseer — no `unsafe`.
+    struct RecordingPrs {
+        ready: bool,
+        merges: MergeLog,
+    }
+    impl RecordingPrs {
+        fn new(ready: bool) -> (Self, MergeLog) {
+            let merges: MergeLog = Arc::new(Mutex::new(vec![]));
+            (
+                Self {
+                    ready,
+                    merges: Arc::clone(&merges),
+                },
+                merges,
+            )
+        }
+    }
+    impl PrOps for RecordingPrs {
+        fn verify(&self, _repo: &str, _pr: u32) -> Result<VerifyReport, OverseerError> {
+            Ok(VerifyReport {
+                ready: self.ready,
+                checks: vec![CheckItem {
+                    name: "objective gates".to_string(),
+                    passed: self.ready,
+                    note: "test".to_string(),
+                }],
+            })
+        }
+        fn merge(&self, repo: &str, pr: u32) -> Result<(), OverseerError> {
+            self.merges.lock().unwrap().push((repo.to_string(), pr));
+            Ok(())
+        }
+        fn resolve_conflict(&self, _repo: &str, _pr: u32) -> Result<(), OverseerError> {
+            Ok(())
+        }
+    }
+
+    struct FakeDeployer;
+    impl Deployer for FakeDeployer {
+        fn deploy(&self, commit: &str) -> Result<DeployReport, OverseerError> {
+            Ok(DeployReport {
+                deployed_commit: commit.to_string(),
+                gates_passed: true,
+            })
+        }
+        fn deployed_commit(&self) -> Result<String, OverseerError> {
+            Ok("deadbeef".to_string())
+        }
+    }
+
+    struct FakeMeetings;
+    impl crate::overseer::capabilities::MeetingHost for FakeMeetings {
+        fn transfer_goal(&self, _g: &GoalBrief) -> Result<(), OverseerError> {
+            Ok(())
+        }
+    }
+
+    struct FakeIssues;
+    impl crate::overseer::capabilities::IssueFiler for FakeIssues {
+        fn file(&self, _run: &OrchestratorRunBrief) -> Result<IssueOutcome, OverseerError> {
+            Ok(IssueOutcome::FiledNew {
+                url: "https://example/issues/1".to_string(),
+            })
+        }
+    }
+
+    struct FakeGoals(Vec<InFlightItem>);
+    impl GoalCurator for FakeGoals {
+        fn propose(&self, _g: &GoalBrief) -> Result<(), OverseerError> {
+            Ok(())
+        }
+        fn in_flight(&self) -> Result<Vec<InFlightItem>, OverseerError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    struct FakeAuditor;
+    impl Auditor for FakeAuditor {
+        fn run_audit(&self, scope: &AuditScope) -> Result<AuditReport, OverseerError> {
+            Ok(AuditReport {
+                scope: scope.clone(),
+                passed: true,
+                findings: vec![],
+            })
+        }
+    }
+
+    fn caps_with(status: Box<dyn StatusReader>, prs: Box<dyn PrOps>) -> Capabilities {
+        Capabilities {
+            status,
+            recipes: Box::new(FakeRecipes),
+            prs,
+            deployer: Box::new(FakeDeployer),
+            meetings: Box::new(FakeMeetings),
+            issues: Box::new(FakeIssues),
+            goals: Box::new(FakeGoals(vec![])),
+            auditor: Box::new(FakeAuditor),
+        }
+    }
+
+    // ── tick driver ───────────────────────────────────────────────────────
+
+    #[test]
+    fn tick_drives_run_cycle_then_launches_a_fix_for_a_process_health_signal() {
+        // A high distill-failure rate raises one ProcessHealth problem → Decide
+        // maps it to a LaunchRecipe → the tick executes it via `act`.
+        let observed = ObservedState {
+            distill_fail_pct: Some(62.0),
+            ..ObservedState::default()
+        };
+        let (prs, _merges) = RecordingPrs::new(true);
+        let mut overseer = Overseer::new(caps_with(Box::new(FakeStatus(observed)), Box::new(prs)));
+        let report = overseer_tick(&mut overseer);
+        assert_eq!(report.problems, 1);
+        assert_eq!(
+            report.recipes_launched, 1,
+            "the tick must ACT, not just plan"
+        );
+        assert_eq!(report.errors, 0);
+        assert!(!report.panicked);
+    }
+
+    #[test]
+    fn tick_verifies_and_merges_a_green_ready_pr_and_records_the_merge() {
+        // Seed a merge-ready PR signal → Decide maps to VerifyAndMergePr →
+        // with verify-merge autonomy ON, the tick merges it (normal merge).
+        let observed = ObservedState {
+            ready_prs: vec![crate::overseer::capabilities::PrRef {
+                repo: "rysweet/Simard".to_string(),
+                pr: 42,
+            }],
+            ..ObservedState::default()
+        };
+        let (prs, merges) = RecordingPrs::new(true);
+        let mut overseer = Overseer::new(caps_with(Box::new(FakeStatus(observed)), Box::new(prs)))
+            .with_verify_merge_autonomy(true);
+        let report = overseer_tick(&mut overseer);
+        assert_eq!(report.prs_merged, 1, "green ready PR must be merged");
+        assert_eq!(
+            *merges.lock().unwrap(),
+            vec![("rysweet/Simard".to_string(), 42)]
+        );
+    }
+
+    #[test]
+    fn tick_holds_the_merge_when_autonomy_is_not_opted_in() {
+        let observed = ObservedState {
+            ready_prs: vec![crate::overseer::capabilities::PrRef {
+                repo: "rysweet/Simard".to_string(),
+                pr: 7,
+            }],
+            ..ObservedState::default()
+        };
+        // Default autonomy (verify-merge OFF) → the merge is HELD (escalated).
+        let (prs, merges) = RecordingPrs::new(true);
+        let mut overseer = Overseer::new(caps_with(Box::new(FakeStatus(observed)), Box::new(prs)));
+        let report = overseer_tick(&mut overseer);
+        assert_eq!(report.prs_merged, 0);
+        assert_eq!(report.held, 1, "verify-merge is opt-in; held by default");
+        assert!(
+            merges.lock().unwrap().is_empty(),
+            "nothing merged when held"
+        );
+    }
+
+    // ── panic isolation ───────────────────────────────────────────────────
+
+    #[test]
+    fn a_panicking_tick_is_isolated_and_the_overseer_survives() {
+        let (prs, _merges) = RecordingPrs::new(true);
+        let mut overseer = Overseer::new(caps_with(Box::new(PanicStatus), Box::new(prs)));
+        // The panic inside `snapshot` must be caught, not propagated.
+        let report = run_overseer_tick_isolated(&mut overseer);
+        assert!(report.panicked, "the tick panicked and was isolated");
+        assert_eq!(report.prs_merged, 0);
+        // The overseer is still usable — a second isolated tick also survives.
+        let report2 = run_overseer_tick_isolated(&mut overseer);
+        assert!(report2.panicked);
+    }
+
+    #[test]
+    fn a_run_cycle_error_is_isolated_without_panicking() {
+        struct ErrStatus;
+        impl StatusReader for ErrStatus {
+            fn snapshot(&self) -> Result<ObservedState, OverseerError> {
+                Err(OverseerError::Capability {
+                    what: "status",
+                    detail: "degraded".to_string(),
+                })
+            }
+        }
+        let (prs, _merges) = RecordingPrs::new(true);
+        let mut overseer = Overseer::new(caps_with(Box::new(ErrStatus), Box::new(prs)));
+        let report = overseer_tick(&mut overseer);
+        assert!(!report.panicked, "an error is not a panic");
+        assert_eq!(report.errors, 1);
+        assert_eq!(report.problems, 0);
+    }
+
+    // ── identity ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn overseer_identity_is_configured_and_refuses_its_own_pr() {
+        let guard = overseer_identity();
+        assert!(guard.is_configured(), "identity must be fully populated");
+        let own = crate::overseer::guardrails::Subject::Pr {
+            repo: "rysweet/Simard".to_string(),
+            pr: 1,
+            author: guard.author_login.clone(),
+        };
+        assert!(guard.admit(&own).is_err(), "must refuse its OWN PR");
+        let foreign = crate::overseer::guardrails::Subject::Pr {
+            repo: "rysweet/Simard".to_string(),
+            pr: 2,
+            author: "a-human-operator".to_string(),
+        };
+        assert!(guard.admit(&foreign).is_ok(), "must admit a human's PR");
+    }
+
+    #[test]
+    fn slugify_is_stable_and_bounded() {
+        assert_eq!(slugify("Fix the OODA loop!"), "fix-the-ooda-loop");
+        assert_eq!(slugify("  spaced  "), "spaced");
+        assert!(slugify(&"x".repeat(200)).len() <= 48);
+    }
+
+    #[test]
+    fn refuse_deployer_never_deploys_but_reports_running_commit() {
+        let d = RefuseDeployer;
+        assert!(d.deploy("abc123").is_err(), "never a blind deploy");
+        assert!(d.deployed_commit().is_ok());
+    }
+
+    #[test]
+    fn intervention_labels_are_stable_for_tracing() {
+        // Guard the labels the tracing/tally path depends on.
+        assert_eq!(
+            Intervention::Report.label(),
+            "report",
+            "label churn would break tracing dashboards"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The Overseer module (`src/overseer/`, milestones M1–M4) shipped fully built but **inert** — nothing constructed `Overseer` or called `run_cycle`/`act`, so its meta-OODA co-process never ran. This PR **wires the acting Overseer into the OODA daemon** so it is part of the daemon process **and actively operates**, additively and **default-ON**. It runs in the same process, on its own cadence, next to the existing brain-introspection / monthly-audit periodic tasks — but on a background thread so it **never runs inside or blocks the OODA cycle**, and a panic/error in a tick is caught and logged and never crashes or stalls the daemon.

Before: `grep` for callers of `Overseer::new`/`run_cycle`/`act` in `src/operator_commands_ooda/daemon/` returned **nothing**. After: the daemon constructs (`build_overseer`) and drives (`run_cycle` → `act` via `run_overseer_tick_isolated`) the Overseer.

## What changed

- **`overseer::config`** — added an acting-enable resolver with **default-ON opt-out** semantics: the daemon runs the Overseer unless `SIMARD_OVERSEER_ENABLED` is explicitly falsey (`0`/`false`/`no`/`off`); unset/empty leaves it enabled. Added a **distinct bot author identity** knob (`SIMARD_OVERSEER_AUTHOR_LOGIN`, default `simard-overseer[bot]`). The M1 default-OFF sensor gate is left intact.
- **`overseer::wiring`** (new) — the drive layer:
  - `OverseerCadence` — an injected-clock-testable interval scheduler (interval from `SIMARD_OVERSEER_INTERVAL_SECS`, respecting the existing MIN clamp).
  - `overseer_tick` / `run_overseer_tick_isolated` — run one meta-OODA turn (`run_cycle`, then `act` on every **admitted** intervention) with structured per-tick tracing and **panic isolation** (`catch_unwind`).
  - `assemble_capabilities` / `build_overseer` — construct the production Overseer from the already-shipped adapters (status / recipes / merge / meetings / issues / audit) under a **distinct anti-recursion identity** with acting autonomy (`with_verify_merge_autonomy(true)` + `with_high_risk_autonomy(true)`).
  - `BoardGoalCurator` — production `GoalCurator` reading the **live goal board** so Orient dedups against in-flight engineer goals (never fights the OODA loop).
  - `RefuseDeployer` — a safe, never-blind-deploy stub (the deterministic Decide never emits `Deploy`; guarded self-deploy stays the operator's canary/self-deploy gates).
- **daemon `mod.rs`** — **supersedes** the default-OFF M1 sensor registration with a **default-ON** periodic Overseer task. It fires on cadence **after** the OODA cycle and runs on an **overlap-guarded background thread** so it never blocks OODA.

## Safety gates (all preserved via the shipped adapters)

- **Merge**: polls until **all required checks are GREEN**, then merges **normally** through the gated authority — **never `--admin`, never `--no-verify`** (the no-admin guarantee is structural: the PR client exposes no admin method). Not green ⇒ it does not merge (escalates). The review gate is **fail-closed** until an operator wires a reviewer, so nothing merges unreviewed.
- **Notify**: every merge fires `NotifyOperator` on **email + Signal**; an unconfigured channel **queues + logs** (never silently dropped) and the merge is **still recorded**.
- **Anti-recursion**: `RecursionGuard` fails **closed** under a **distinct identity** — the Overseer never verifies/merges/deploys its **own** PRs and never re-opens its own goals.
- **Budget**: from `SIMARD_DAILY_BUDGET_USD` plus a per-cycle launch cap.
- **Tracing**: structured per-tick (`enabled`, `problems`, `issues_filed`, `recipes_launched`, `prs_merged`, `deploys`, `duration`); no `println!`/`eprintln!` introduced. No `Bridge` naming; one-Brain / reasoner terminology.

## Tests (no network; capability fakes + an injected clock)

New (`overseer::wiring`, `overseer::config`):
- cadence fires only on/after the interval (injected virtual clock);
- acting enable-gate: OFF on `=0`/`false`, ON when unset (default);
- a panicking tick is isolated and the Overseer survives;
- the tick drives `run_cycle` → `act` (launches a fix; merges a green, ready PR and records the **normal** merge; holds the merge when autonomy is not opted in);
- the distinct identity refuses its **own** PR but admits a human's; `RefuseDeployer` never deploys.

Already-shipped module tests continue to cover: green-only merge + notify on both channels (queue-not-drop when unconfigured), recursion own-PR refusal, dedup against in-flight goals, the budget / per-cycle-launch cap, and deploy refusals (red canary / no-op / rollback / crash-loop).

## Verification

- `cargo build --bin simard --locked` ✅
- `cargo test --all-features --locked` ✅ (the only local failures were environmental — Unix-socket `SUN_LEN` from an oversized sandbox `TMPDIR`, and one pre-existing missing-`#[serial]` cognitive-memory flake — all pass in isolation and under a normal `TMPDIR`)
- `cargo fmt --all -- --check` ✅ · `cargo clippy --release --no-deps -- -D warnings` ✅ · `cargo clippy --all-targets --all-features --locked -- -D warnings` ✅
- pre-commit **and** pre-push hooks pass **without `--no-verify`**.

## Activation

Additive and safe to land. **The operator redeploys the daemon after merge to activate** the co-process (the running binary is unchanged until then).
