### PR TITLE
fix(dashboard): report the TRUE live-engineer set so "Active Engineers" isn't stuck at zero (#2580)

### DIFF
--- a/src/engineer_worktree/discovery.rs
+++ b/src/engineer_worktree/discovery.rs
@@ -1,0 +1,152 @@
+//! Discovery of the LIVE engineer set from on-disk worktree claim sentinels
+//! (issue #2580).
+//!
+//! This is the same claim-liveness contract the daemon's own
+//! [`crate::ooda_actions::advance_goal::find_live_engineer_for_goal`] trusts to
+//! avoid a duplicate spawn, generalized to enumerate EVERY live-claimed goal so
+//! the dashboard's "Active Engineers" gauge reflects the true live set —
+//! including a bare `bin/simard engineer run single-process` subprocess that
+//! never registers a tmux subagent session (the telemetry gap that made the
+//! gauge read ZERO while the daemon was actively running engineers).
+
+use std::path::Path;
+
+use super::WORKTREES_SUBDIR;
+use super::claim::{claim_is_live, read_engineer_claim_full};
+
+/// One live engineer discovered from a worktree claim sentinel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveEngineerWorktree {
+    /// Goal id recovered from the worktree directory name.
+    pub goal_id: String,
+    /// PID recorded in the claim sentinel (the allocating daemon/engineer).
+    pub pid: i32,
+}
+
+/// Enumerate every engineer worktree under `<state_root>/engineer-worktrees/`
+/// whose `.simard-engineer-claim` sentinel still names a live process
+/// (starttime-validated via [`claim_is_live`]).
+///
+/// Tolerant of all I/O errors — a missing root or an unreadable entry yields no
+/// rows, never a panic — so a dashboard read never fails because of transient
+/// filesystem state.
+pub fn live_claimed_engineers(state_root: &Path) -> Vec<LiveEngineerWorktree> {
+    let root = state_root.join(WORKTREES_SUBDIR);
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(claim) = read_engineer_claim_full(&path) else {
+            continue;
+        };
+        if !claim_is_live(&claim) {
+            continue;
+        }
+        let goal_id = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(goal_id_from_worktree_dir)
+            .unwrap_or_default();
+        out.push(LiveEngineerWorktree {
+            goal_id,
+            pid: claim.pid,
+        });
+    }
+    out
+}
+
+/// Recover the goal id from a worktree directory name of the allocator's shape
+/// `<goal-id>-<epoch_secs>-<hex6>` (see `engineer_worktree::cleanup::unique_suffix`).
+///
+/// Only strips the two-field suffix when it actually matches (a run of digits
+/// then a 6-char hex tag); otherwise the whole directory name is returned so an
+/// unexpected name still yields a stable, non-empty dedup key.
+fn goal_id_from_worktree_dir(name: &str) -> String {
+    let mut it = name.rsplitn(3, '-');
+    let last = it.next(); // hex6
+    let mid = it.next(); // epoch secs
+    let head = it.next(); // goal id
+    match (head, mid, last) {
+        (Some(goal), Some(secs), Some(hex))
+            if !goal.is_empty()
+                && secs.len() >= 6
+                && secs.bytes().all(|b| b.is_ascii_digit())
+                && hex.len() == 6
+                && hex.bytes().all(|b| b.is_ascii_hexdigit()) =>
+        {
+            goal.to_string()
+        }
+        _ => name.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::ENGINEER_CLAIM_FILE;
+    use super::super::claim::format_engineer_claim;
+    use super::*;
+    use std::fs;
+
+    fn write_claim(dir: &Path, pid: u32) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join(ENGINEER_CLAIM_FILE), format_engineer_claim(pid)).unwrap();
+    }
+
+    #[test]
+    fn goal_id_recovered_from_allocator_dir_name() {
+        assert_eq!(
+            goal_id_from_worktree_dir("fix-the-thing-1783168109-b000d0"),
+            "fix-the-thing"
+        );
+        // Goal ids that themselves contain hyphens (and a slug hash) survive.
+        assert_eq!(
+            goal_id_from_worktree_dir("advance-agent-parity-f29bb15c-1783168109-b000d0"),
+            "advance-agent-parity-f29bb15c"
+        );
+    }
+
+    #[test]
+    fn goal_id_falls_back_to_whole_name_when_suffix_absent() {
+        assert_eq!(
+            goal_id_from_worktree_dir("no-suffix-here"),
+            "no-suffix-here"
+        );
+        assert_eq!(goal_id_from_worktree_dir("plain"), "plain");
+    }
+
+    #[test]
+    fn missing_worktrees_root_yields_no_engineers() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(live_claimed_engineers(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn live_claim_is_reported_dead_claim_is_ignored() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join(WORKTREES_SUBDIR);
+
+        // A worktree whose claim names THIS live test process → reported.
+        write_claim(
+            &root.join("alive-goal-1783168109-a1b2c3"),
+            std::process::id(),
+        );
+        // A worktree whose claim names an almost-certainly-dead PID → ignored.
+        write_claim(&root.join("dead-goal-1783168110-d4e5f6"), 999_999_999);
+        // A directory with no claim sentinel at all → ignored.
+        fs::create_dir_all(root.join("unclaimed-goal-1783168111-000000")).unwrap();
+
+        let live = live_claimed_engineers(tmp.path());
+        assert_eq!(
+            live.len(),
+            1,
+            "only the live-claim worktree counts: {live:?}"
+        );
+        assert_eq!(live[0].goal_id, "alive-goal");
+        assert_eq!(live[0].pid, std::process::id() as i32);
+    }
+}

--- a/src/engineer_worktree/mod.rs
+++ b/src/engineer_worktree/mod.rs
@@ -68,9 +68,11 @@ pub const WORKTREES_SUBDIR: &str = "engineer-worktrees";
 pub const ENGINEER_CLAIM_FILE: &str = ".simard-engineer-claim";
 
 mod claim;
+mod discovery;
 mod precommit;
 use claim::{claim_is_live, format_engineer_claim, read_engineer_claim_full};
 pub use claim::{is_pid_alive_public, read_pid_starttime_public};
+pub use discovery::{LiveEngineerWorktree, live_claimed_engineers};
 
 /// Maximum length of a `goal_id` accepted by [`EngineerWorktree::allocate`].
 ///

--- a/src/operator_commands_dashboard/current_work.rs
+++ b/src/operator_commands_dashboard/current_work.rs
@@ -2,8 +2,7 @@ use axum::Json;
 use serde_json::{Value, json};
 
 use super::dashboard_goal_board_snapshot;
-use super::routes::{is_pid_alive, resolve_state_root, truncate_with_ellipsis};
-use crate::agent_registry::{AgentRegistry, FileBackedAgentRegistry};
+use super::routes::{resolve_state_root, truncate_with_ellipsis};
 
 /// Real-time snapshot of what Simard is doing right now.
 ///
@@ -135,23 +134,27 @@ pub(crate) async fn current_work() -> Json<Value> {
         })
         .unwrap_or_default();
 
-    // Spawned engineers from agent registry
-    let reg = FileBackedAgentRegistry::new(&state_root);
-    let spawned_engineers: Vec<Value> = reg
-        .list()
-        .unwrap_or_default()
+    // Active engineers — the TRUE live set (issue #2580). Previously this read
+    // the `FileBackedAgentRegistry` (`agent_registry.json`), which nothing
+    // writes in production, so the panel always showed ZERO even while the
+    // daemon ran engineers. Now unions live subagent sessions with live
+    // engineer-worktree claim sentinels (which also surface bare
+    // `bin/simard engineer run single-process` subprocesses).
+    let spawned_engineers: Vec<Value> = super::live_engineers::live_engineers(&state_root)
         .into_iter()
-        .map(|entry| {
-            let alive = is_pid_alive(entry.pid);
+        .map(|e| {
+            let started_at = e
+                .started_at
+                .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0))
+                .map(|dt| dt.to_rfc3339());
             json!({
-                "id": entry.id,
-                "pid": entry.pid,
-                "role": entry.role,
-                "host": entry.host,
-                "state": format!("{:?}", entry.state),
-                "alive": alive,
-                "start_time": entry.start_time.to_rfc3339(),
-                "last_heartbeat": entry.last_heartbeat.to_rfc3339(),
+                "id": e.goal_id,
+                "pid": e.pid,
+                "role": "engineer",
+                "task": e.goal_id,
+                "source": e.source,
+                "alive": e.alive,
+                "start_time": started_at,
             })
         })
         .collect();

--- a/src/operator_commands_dashboard/live_engineers.rs
+++ b/src/operator_commands_dashboard/live_engineers.rs
@@ -1,0 +1,140 @@
+//! Authoritative live-engineer set for the dashboard "Active Engineers" panel
+//! (issue #2580).
+//!
+//! ## Why this exists
+//!
+//! The panel used to read a single, incomplete source and reported ZERO
+//! engineers while the daemon was actively running them:
+//!
+//! - `current_work` read the [`crate::agent_registry::FileBackedAgentRegistry`]
+//!   (`agent_registry.json`), which nothing writes in production — so it was
+//!   always empty.
+//! - `workboard` read the `subagent_sessions` registry, which only records a
+//!   spawn that obtained a tmux session name; a bare `bin/simard engineer run
+//!   single-process` subprocess never appears there.
+//!
+//! Neither source sees an engineer that the daemon dispatched as a bare
+//! subprocess, so the gauge read zero while the daemon believed several goals
+//! were occupied (it uses the worktree claim sentinels — see below — to avoid
+//! duplicate spawns).
+//!
+//! ## The true live set
+//!
+//! The union of both live sources, deduplicated by goal:
+//!   (a) subagent sessions with no `ended_at` (tmux-tracked engineers), and
+//!   (b) engineer worktrees whose `.simard-engineer-claim` sentinel still names
+//!       a live process ([`crate::engineer_worktree::live_claimed_engineers`]) —
+//!       the SAME claim the daemon's own `find_live_engineer_for_goal` trusts,
+//!       which is what makes bare single-process engineers visible.
+
+use std::path::Path;
+
+/// One live engineer, from whichever source proved it live.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LiveEngineer {
+    /// Goal the engineer is working (dedup key + display label).
+    pub goal_id: String,
+    /// PID (the subagent session pid, or the worktree claim's allocating pid).
+    pub pid: i32,
+    /// Whether the pid is currently alive.
+    pub alive: bool,
+    /// Provenance: `"subagent_session"` or `"worktree_claim"`.
+    pub source: &'static str,
+    /// Session start time (epoch secs), when known (subagent sessions only).
+    pub started_at: Option<i64>,
+}
+
+/// Compute the authoritative live-engineer set under `state_root`, deduplicated
+/// by `goal_id`. Subagent-session evidence (which carries a start time) wins
+/// over a bare worktree-claim for the same goal.
+pub(crate) fn live_engineers(state_root: &Path) -> Vec<LiveEngineer> {
+    // BTreeMap keeps a deterministic, goal-sorted order for a stable UI.
+    let mut by_goal: std::collections::BTreeMap<String, LiveEngineer> =
+        std::collections::BTreeMap::new();
+
+    // (a) tmux-tracked subagent sessions still running (read from this state
+    // root so the view is consistent and hermetically testable).
+    let sessions = crate::subagent_sessions::load_from(
+        &crate::subagent_sessions::registry_path_under(state_root),
+    )
+    .sessions;
+    for s in sessions {
+        if s.ended_at.is_some() {
+            continue;
+        }
+        let goal_id = if s.goal_id.is_empty() {
+            s.session_name.clone()
+        } else {
+            s.goal_id.clone()
+        };
+        let pid = s.pid as i32;
+        by_goal.entry(goal_id.clone()).or_insert(LiveEngineer {
+            goal_id,
+            pid,
+            alive: crate::engineer_worktree::is_pid_alive_public(pid),
+            source: "subagent_session",
+            started_at: Some(s.created_at),
+        });
+    }
+
+    // (b) engineer worktrees with a live claim sentinel (starttime-validated).
+    for claim in crate::engineer_worktree::live_claimed_engineers(state_root) {
+        by_goal
+            .entry(claim.goal_id.clone())
+            .or_insert(LiveEngineer {
+                goal_id: claim.goal_id,
+                pid: claim.pid,
+                alive: true, // already filtered to a live, starttime-matched pid
+                source: "worktree_claim",
+                started_at: None,
+            });
+    }
+
+    by_goal.into_values().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engineer_worktree::{ENGINEER_CLAIM_FILE, WORKTREES_SUBDIR};
+    use std::fs;
+
+    fn write_live_claim(state_root: &Path, dir_name: &str) {
+        let dir = state_root.join(WORKTREES_SUBDIR).join(dir_name);
+        fs::create_dir_all(&dir).unwrap();
+        // A PID-only claim (no starttime line) naming THIS live test process is
+        // treated as live by `claim_is_live`'s PID-only fallback.
+        fs::write(
+            dir.join(ENGINEER_CLAIM_FILE),
+            format!("{}\n", std::process::id()),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn worktree_claims_make_bare_single_process_engineers_visible() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Two goals with live worktree claims but NO subagent session recorded
+        // (the exact bare `bin/simard engineer run single-process` gap).
+        write_live_claim(tmp.path(), "goal-alpha-1783168109-a1b2c3");
+        write_live_claim(tmp.path(), "goal-beta-1783168110-d4e5f6");
+
+        let live = live_engineers(tmp.path());
+        assert_eq!(
+            live.len(),
+            2,
+            "both live worktree claims must be counted even with no subagent session: {live:?}"
+        );
+        let goals: Vec<&str> = live.iter().map(|e| e.goal_id.as_str()).collect();
+        assert!(goals.contains(&"goal-alpha"));
+        assert!(goals.contains(&"goal-beta"));
+        assert!(live.iter().all(|e| e.source == "worktree_claim" && e.alive));
+    }
+
+    #[test]
+    fn empty_state_root_reports_no_engineers() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No subagent-sessions registry and no worktrees → zero (honest zero).
+        assert!(live_engineers(tmp.path()).is_empty());
+    }
+}

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -10,6 +10,7 @@ mod goals;
 mod goals_status;
 mod hosts;
 mod index_html;
+mod live_engineers;
 mod logs;
 mod memory;
 mod merge_judge;

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -193,10 +193,6 @@ async fn issues() -> Json<Value> {
     }
 }
 
-pub(crate) fn is_pid_alive(pid: u32) -> bool {
-    std::path::Path::new(&format!("/proc/{pid}")).exists()
-}
-
 /// Run a `gh` CLI command and parse JSON output, returning a `Value`.
 pub(crate) async fn run_gh_json(args: &[&str]) -> Value {
     match tokio::process::Command::new("gh").args(args).output().await {

--- a/src/operator_commands_dashboard/workboard.rs
+++ b/src/operator_commands_dashboard/workboard.rs
@@ -199,36 +199,26 @@ pub(crate) async fn workboard() -> Json<Value> {
         })
         .unwrap_or_default();
 
-    // --- 3. Active engineers from the live subagent-session registry ---
-    // Read from the same source the Terminal tab uses
-    // (`/api/subagent-sessions`) so the Whiteboard's "Active Engineers" panel
-    // agrees with it. The agent registry used previously is empty for the
-    // running daemon, which produced the "No spawned engineers" contradiction
-    // (#1678). "Live" == no recorded end time, matching the Terminal tab.
-    let mut sessions: Vec<crate::subagent_sessions::SubagentSession> =
-        crate::subagent_sessions::load()
-            .sessions
-            .into_iter()
-            .filter(|s| s.ended_at.is_none())
-            .collect();
-    sessions.sort_by_key(|s| std::cmp::Reverse(s.created_at));
-    let spawned_engineers: Vec<Value> = sessions
-        .iter()
-        .map(|s| {
-            let alive = super::routes::is_pid_alive(s.pid);
-            let started_at = chrono::DateTime::from_timestamp(s.created_at, 0)
+    // --- 3. Active engineers — the TRUE live set (issue #2580) ---
+    // Union of live subagent sessions (tmux-tracked) AND live engineer-worktree
+    // claim sentinels. Reading subagent sessions alone (#1678 fix) still missed
+    // bare `bin/simard engineer run single-process` engineers, which never
+    // register a tmux session — so the panel could still read ZERO while the
+    // daemon ran them. The worktree-claim scan is the same liveness the daemon
+    // itself trusts to avoid a duplicate spawn. "Live" == pid alive / claim live.
+    let spawned_engineers: Vec<Value> = super::live_engineers::live_engineers(&state_root)
+        .into_iter()
+        .map(|e| {
+            let started_at = e
+                .started_at
+                .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0))
                 .map(|dt| dt.to_rfc3339())
                 .unwrap_or_default();
-            let task = if !s.goal_id.is_empty() {
-                s.goal_id.clone()
-            } else {
-                s.session_name.clone()
-            };
             json!({
-                "pid": s.pid,
-                "task": task,
-                "alive": alive,
-                "host": s.host,
+                "pid": e.pid,
+                "task": e.goal_id,
+                "alive": e.alive,
+                "source": e.source,
                 "started_at": started_at,
             })
         })

--- a/src/subagent_sessions/mod.rs
+++ b/src/subagent_sessions/mod.rs
@@ -6,7 +6,7 @@
 
 use std::fs;
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -104,8 +104,15 @@ fn now_epoch_seconds() -> i64 {
 
 /// Load the registry from disk. Returns empty `Registry` on missing/corrupt.
 pub fn load() -> Registry {
-    let path = registry_path();
-    let bytes = match fs::read(&path) {
+    load_from(&registry_path())
+}
+
+/// Load the registry from an explicit `<state_root>/state/subagent_sessions.json`
+/// path. Parameterized so the dashboard's live-engineer view (issue #2580) can
+/// read a specific state root hermetically. Returns an empty `Registry` on a
+/// missing or corrupt file (never panics).
+pub fn load_from(path: &Path) -> Registry {
+    let bytes = match fs::read(path) {
         Ok(b) => b,
         Err(e) => {
             if e.kind() != io::ErrorKind::NotFound {
@@ -131,6 +138,12 @@ pub fn load() -> Registry {
             Registry::default()
         }
     }
+}
+
+/// Path of the registry under an explicit state root:
+/// `<state_root>/state/subagent_sessions.json`.
+pub fn registry_path_under(state_root: &Path) -> PathBuf {
+    state_root.join("state").join("subagent_sessions.json")
 }
 
 /// Atomic write: write to a uniquely-named temp file in the same directory,


### PR DESCRIPTION
## Root cause: a TELEMETRY defect (not a real stall)

The dashboard \"Active Engineers\" gauge showed **ZERO** while the daemon was actively running engineers. Confirmed against the live daemon (read-only): the count is **REAL engineers running, wrong telemetry source** — not a decide-brain stall.

| Endpoint | Read source (before) | Why it was 0 |
|---|---|---|
| `/api/current-work` (`current_work.rs`) | `FileBackedAgentRegistry` (`agent_registry.json`) | Nothing writes it in production (zero `.register()` call sites) → always `[]` |
| `/api/workboard` (`workboard.rs`) | `subagent_sessions` registry | Only records spawns that got a **tmux session name**; a bare `bin/simard engineer run single-process` never registers → invisible |

Meanwhile the daemon tracks a live engineer per goal via the `.simard-engineer-claim` worktree sentinel — the **same** check `find_live_engineer_for_goal` uses to avoid a duplicate spawn — so the daemon believed several goals were occupied while the dashboard showed none.

**Live evidence (read-only):** `agent_registry.json == []`; `subagent_sessions.json` had **no** live (un-ended) rows; yet a live `bin/simard engineer run single-process` subprocess **and** several live-claimed engineer-worktrees existed. → **TELEMETRY defect.**

## Fix: one authoritative live source

New `operator_commands_dashboard::live_engineers` returns the **union, deduplicated by goal**, of:
- (a) subagent sessions with no `ended_at` (tmux-tracked engineers), and
- (b) engineer worktrees whose claim sentinel still names a live, starttime-validated process — `engineer_worktree::live_claimed_engineers`, the daemon's own liveness notion (this is what surfaces bare single-process engineers).

Both `current_work` and `workboard` now render this set. A genuinely idle system renders an **honest zero**; a running one reflects the daemon's true live engineer set. Removed the now-dead `routes::is_pid_alive`.

## Tests

- `engineer_worktree::discovery`: reports a live-claim worktree, ignores a dead-claim / unclaimed one, and recovers the goal id from the allocator dir name (`<goal>-<epoch>-<hex6>`), incl. goal ids that contain hyphens.
- `operator_commands_dashboard::live_engineers`: **bare single-process engineers (live worktree claim, no subagent session) are counted**; an empty state root reports honest zero.
- The existing `workboard_active_engineers_come_from_live_subagent_sessions` route test still passes.
- Added `subagent_sessions::load_from(path)` so the view reads a specific state root hermetically.

375 dashboard tests + engineer_worktree suite pass.

## Compliance

- No `println!`/`eprintln!` introduced; no `Bridge` naming introduced.
- Structured tracing only.
- Branched off latest `origin/main`; green pre-commit + pre-push (fmt, `clippy --all-targets --all-features --locked -D warnings`, test subset) with **no `--no-verify`**.
- Do **not** merge with `--admin`; wait for all required CI.

**The operator redeploys the daemon after merge to activate.** (The reasoner fallback-elimination + `brain_parse_error` metric is companion PR #2588.)