### PR TITLE
feat(dashboard-chat): idle-liveness (no wall-clock turn timeout) + true incremental streaming (#2581)

### DIFF
--- a/docs/howto/start-a-meeting.md
+++ b/docs/howto/start-a-meeting.md
@@ -277,7 +277,7 @@ See [Copilot meeting mode](../reference/copilot-meeting-mode.md) for the full
 technical reference, or [LightweightChatSession API reference](../reference/lightweight-chat-session.md)
 for the alternative `SessionBuilder`-based path.
 
-### Repository context and per-turn timeout
+### Repository context and idle-liveness
 
 The meeting agent operates **in the repository you launched the meeting from**,
 so it can inspect code and run `simard` commands in the right context. The
@@ -294,14 +294,18 @@ If you launch a meeting from **outside any git checkout** and set no override,
 the agent runs in the process working directory with **no explicit repo
 grant** — it never falls back to some other worktree.
 
-Each agent turn is bounded by a **default per-turn timeout** so a hung agent
-turn cannot freeze the REPL:
+There is **no wall-clock cap** on a turn (issue #2581): a long-but-productive
+turn runs unbounded as long as it keeps producing output. Liveness is instead
+governed by an **idle-liveness window** — the agent child is reaped only when it
+produces *no* output for the whole window (a genuinely hung/dead child). Every
+streamed chunk resets the clock, so a working turn is never killed:
 
 | Env var | Default | Effect |
 |---------|---------|--------|
-| `SIMARD_MEETING_TURN_TIMEOUT_SECS` | `120` | Per-turn bound in seconds. A positive value overrides the default; `0` disables the timeout (unbounded — operator escape hatch); an unset or malformed value uses the bounded default. |
+| `SIMARD_MEETING_IDLE_LIVENESS_SECS` | `300` | Idle-liveness window in seconds — max time with **no output** before the child is treated as hung. `0` disables idle detection (fully unbounded escape hatch); unset/malformed uses the default. |
+| `SIMARD_MEETING_TURN_TIMEOUT_SECS` | _(unset)_ | **Deprecated alias** for `SIMARD_MEETING_IDLE_LIVENESS_SECS`, kept working for existing config. It is **no longer a wall-clock cap** — when set it configures the same idle-liveness window. |
 
-When a turn exceeds the timeout, the child process is terminated and the turn
+When a child is idle for the whole window it is terminated and the turn
 **degrades honestly** with a `[meeting:error] WARNING` banner (the meeting
 stays usable — retry your message or `/close`) rather than blocking silently
 (Pillar 11: honest degradation beats hidden silence).
@@ -324,13 +328,13 @@ If you see the prompt cursor blinking with no response after 2–3 minutes, chec
 2. **`copilot` on PATH?** Meeting mode invokes the `copilot` binary directly (not
    `amplihack copilot`). Run `which copilot` to verify. If the binary is not found,
    the turn returns an `AdapterInvocationFailed` error immediately.
-3. **Long compute in progress?** Each agent turn is bounded by
-   `SIMARD_MEETING_TURN_TIMEOUT_SECS` (default 120 s). If a turn exceeds it,
-   the child is killed and the turn degrades honestly with a `[meeting:error]
-   WARNING` banner — the REPL never hangs indefinitely. If your provider is
-   consistently slow, raise the bound (e.g.
-   `SIMARD_MEETING_TURN_TIMEOUT_SECS=300 simard meeting repl`) or set it to `0`
-   to disable the per-turn timeout entirely.
+3. **Long compute in progress?** A turn has **no wall-clock cap** — it runs as
+   long as it keeps producing output. Only a genuinely idle child (no output for
+   `SIMARD_MEETING_IDLE_LIVENESS_SECS`, default 300 s) is reaped, degrading
+   honestly with a `[meeting:error] WARNING` banner — the REPL never hangs
+   indefinitely and never kills a working turn. To change the idle window use
+   `SIMARD_MEETING_IDLE_LIVENESS_SECS=600 simard meeting repl`, or set it to `0`
+   to disable idle detection entirely.
 
 ### Simard responds with OODA action plans instead of conversation
 

--- a/docs/testing/ci-resilient-test-patterns.md
+++ b/docs/testing/ci-resilient-test-patterns.md
@@ -107,10 +107,12 @@ agent is first validated.
 The lifecycle is:
 
 ```
-new()        → allocates struct, reads optional SIMARD_MEETING_TURN_TIMEOUT_SECS
-               (with fallback default), does NOT call RuntimeConfig::load()
+new()        → allocates struct, reads optional SIMARD_MEETING_IDLE_LIVENESS_SECS
+               (deprecated alias SIMARD_MEETING_TURN_TIMEOUT_SECS, with fallback
+               default), does NOT call RuntimeConfig::load()
 open()       → resolves agent command from RuntimeConfig, validates agent
-run_turn()   → sends a prompt and collects the response
+run_turn()   → sends a prompt and streams/collects the response (no wall-clock
+               cap; only a genuinely idle child is reaped via idle-liveness)
 Drop         → tears down the agent process
 ```
 

--- a/src/base_types.rs
+++ b/src/base_types.rs
@@ -178,6 +178,26 @@ pub trait BaseTypeSession: Send {
 
     fn run_turn(&mut self, input: BaseTypeTurnInput) -> SimardResult<BaseTypeOutcome>;
 
+    /// Run a turn, streaming incremental output chunks to `on_chunk` as the
+    /// agent produces them, and returning the final outcome.
+    ///
+    /// The default implementation runs the turn to completion via
+    /// [`BaseTypeSession::run_turn`] and emits the full result as a single
+    /// chunk, so adapters that cannot stream incrementally still satisfy the
+    /// contract (the caller sees exactly one chunk equal to the final text).
+    /// Adapters that support true incremental output (e.g. the
+    /// `persistent-agent-proxy`) override this to tee each line as it arrives
+    /// (issue #2581).
+    fn run_turn_streaming(
+        &mut self,
+        input: BaseTypeTurnInput,
+        on_chunk: &mut dyn FnMut(&str),
+    ) -> SimardResult<BaseTypeOutcome> {
+        let outcome = self.run_turn(input)?;
+        on_chunk(&outcome.execution_summary);
+        Ok(outcome)
+    }
+
     fn close(&mut self) -> SimardResult<()>;
 
     /// Optional memory + knowledge bridges used to enrich each turn.

--- a/src/meeting_backend/agent_proxy.rs
+++ b/src/meeting_backend/agent_proxy.rs
@@ -25,6 +25,26 @@ use crate::error::{SimardError, SimardResult};
 use crate::metadata::{BackendDescriptor, Freshness};
 use crate::runtime::RuntimeTopology;
 
+/// True when a single agent output line is copilot CLI noise (usage stats,
+/// bootstrap banners, progress indicators) that should never be surfaced as
+/// substantive response content. Shared by [`strip_copilot_noise`] (final
+/// authoritative text) and the incremental streaming path (issue #2581) so the
+/// live preview and the final message filter the same lines.
+fn line_is_noise(trimmed: &str) -> bool {
+    trimmed.starts_with("Total usage est:")
+        || trimmed.starts_with("API time spent:")
+        || trimmed.starts_with("Total session time:")
+        || trimmed.starts_with("Changes ")
+        || trimmed.starts_with("Requests ")
+        || trimmed.starts_with("Tokens ")
+        || (trimmed.contains("Staged") && trimmed.contains("hook"))
+        || trimmed.contains("XPIA")
+        || trimmed.starts_with("Script started on")
+        || trimmed.starts_with("Warning:")
+        || (trimmed.len() <= 2 && !trimmed.is_empty())
+        || trimmed.starts_with('●')
+}
+
 /// Strip copilot CLI noise (usage stats, bootstrap lines, progress indicators)
 /// from raw output, keeping only the substantive response.
 fn strip_copilot_noise(raw: &str) -> String {
@@ -37,6 +57,7 @@ fn strip_copilot_noise(raw: &str) -> String {
         if result.is_empty() && trimmed.is_empty() {
             continue;
         }
+        // The usage-stats footer (and everything after it) is discarded wholesale.
         if trimmed.starts_with("Total usage est:")
             || trimmed.starts_with("API time spent:")
             || trimmed.starts_with("Total session time:")
@@ -50,19 +71,7 @@ fn strip_copilot_noise(raw: &str) -> String {
         if skip_rest {
             continue;
         }
-        if trimmed.contains("Staged") && trimmed.contains("hook") {
-            continue;
-        }
-        if trimmed.contains("XPIA") || trimmed.starts_with("Script started on") {
-            continue;
-        }
-        if trimmed.starts_with("Warning:") {
-            continue;
-        }
-        if trimmed.len() <= 2 && !trimmed.is_empty() {
-            continue;
-        }
-        if trimmed.starts_with('●') {
+        if line_is_noise(trimmed) {
             continue;
         }
 
@@ -73,17 +82,24 @@ fn strip_copilot_noise(raw: &str) -> String {
     result.trim().to_string()
 }
 
-/// Env var override for turn timeout in seconds. When set to a positive value
-/// it overrides [`DEFAULT_TURN_TIMEOUT_SECS`]; when explicitly set to `0` the
-/// per-turn timeout is disabled (unbounded — operator escape hatch); when unset
-/// or malformed the bounded default applies.
+/// Primary env var setting the idle-liveness window in seconds — the maximum
+/// time the agent child may produce **no output** before it is treated as
+/// genuinely hung and terminated. Issue #2581: this replaces the old
+/// wall-clock per-turn cap. A long-but-productive turn is never killed because
+/// every streamed chunk resets the clock (see [`PersistentAgentProxy::invoke_agent_streaming`]).
+const IDLE_LIVENESS_ENV: &str = "SIMARD_MEETING_IDLE_LIVENESS_SECS";
+
+/// Deprecated alias for [`IDLE_LIVENESS_ENV`], kept working so existing
+/// operator config does not break. It is NO LONGER a wall-clock per-turn cap
+/// (issue #2581): when set it now configures the same idle-liveness window.
 const TURN_TIMEOUT_ENV: &str = "SIMARD_MEETING_TURN_TIMEOUT_SECS";
 
-/// Default per-turn timeout. A hung `copilot -p` child must not block the
-/// meeting REPL indefinitely — after this bound the child is killed and the
-/// turn degrades honestly via the `[meeting:error]`/`[meeting] WARNING` banner
-/// (Pillar 11: honest degradation beats hidden silence). Issue #2549.
-const DEFAULT_TURN_TIMEOUT_SECS: u64 = 120;
+/// Default idle-liveness window. A child that emits nothing for this long is
+/// treated as hung and reaped, so a dead/stuck `copilot -p` child cannot block
+/// the chat/meeting REPL forever (Pillar 11: honest degradation beats hidden
+/// silence). Generous on purpose: real turns stream output within seconds, so
+/// only a genuinely stalled child stays silent this long. Issues #2549, #2581.
+const DEFAULT_IDLE_LIVENESS_SECS: u64 = 300;
 
 /// Env var giving an explicit directory the meeting agent should operate in.
 /// When set to an existing directory it wins over cwd-derived resolution. This
@@ -91,26 +107,32 @@ const DEFAULT_TURN_TIMEOUT_SECS: u64 = 120;
 /// per-operator absolute path baked into the binary.
 const WORKDIR_ENV: &str = "SIMARD_MEETING_AGENT_DIR";
 
-/// Resolve the per-turn timeout from the environment, falling back to the
-/// bounded default. Issue #2549.
+/// Resolve the idle-liveness window from the environment, falling back to the
+/// generous default. The primary [`IDLE_LIVENESS_ENV`] wins; the deprecated
+/// [`TURN_TIMEOUT_ENV`] alias is consulted only when the primary is unset.
+/// Issues #2549, #2581.
 ///
-/// - `SIMARD_MEETING_TURN_TIMEOUT_SECS=<n>` with `n > 0` → `Some(n secs)`
-/// - `SIMARD_MEETING_TURN_TIMEOUT_SECS=0` → `None` (explicitly disabled)
-/// - unset or malformed → `Some(DEFAULT_TURN_TIMEOUT_SECS)`
-fn resolve_turn_timeout() -> Option<Duration> {
+/// - `<n>` with `n > 0` → `Some(n secs)` idle window.
+/// - `0` → `None` (idle detection explicitly disabled — fully unbounded escape hatch).
+/// - unset or malformed → `Some(DEFAULT_IDLE_LIVENESS_SECS)`.
+fn resolve_idle_window() -> Option<Duration> {
+    if let Ok(raw) = std::env::var(IDLE_LIVENESS_ENV) {
+        return parse_turn_timeout(Some(&raw));
+    }
     parse_turn_timeout(std::env::var(TURN_TIMEOUT_ENV).ok().as_deref())
 }
 
-/// Pure (env-free) core of [`resolve_turn_timeout`] so the fallback/override
+/// Pure (env-free) core of [`resolve_idle_window`] so the fallback/override
 /// semantics are testable without mutating process-global environment state.
+/// The returned `Duration` is the idle-liveness window (issue #2581).
 fn parse_turn_timeout(raw: Option<&str>) -> Option<Duration> {
     match raw {
         Some(value) => match value.trim().parse::<u64>() {
             Ok(0) => None,
             Ok(secs) => Some(Duration::from_secs(secs)),
-            Err(_) => Some(Duration::from_secs(DEFAULT_TURN_TIMEOUT_SECS)),
+            Err(_) => Some(Duration::from_secs(DEFAULT_IDLE_LIVENESS_SECS)),
         },
-        None => Some(Duration::from_secs(DEFAULT_TURN_TIMEOUT_SECS)),
+        None => Some(Duration::from_secs(DEFAULT_IDLE_LIVENESS_SECS)),
     }
 }
 
@@ -214,7 +236,11 @@ pub struct PersistentAgentProxy {
     is_open: bool,
     is_closed: bool,
     turn_count: u32,
-    turn_timeout: Option<Duration>,
+    /// Idle-liveness window: the child is reaped only after producing no output
+    /// for this long (`None` = idle detection disabled). Every streamed chunk
+    /// resets the clock, so a productive turn of any length is never killed
+    /// (issue #2581). Replaces the former wall-clock per-turn cap.
+    idle_window: Option<Duration>,
     /// Directory the agent operates in (cwd + `--add-dir` grant), resolved in
     /// `open()` from the active repo / explicit config. `None` when no repo can
     /// be resolved — the agent then inherits the process cwd with no grant.
@@ -236,7 +262,7 @@ impl std::fmt::Debug for PersistentAgentProxy {
 impl PersistentAgentProxy {
     /// Create a new proxy (does NOT validate agent yet — call `open()` first).
     pub fn new() -> SimardResult<Self> {
-        let turn_timeout = resolve_turn_timeout();
+        let idle_window = resolve_idle_window();
 
         Ok(Self {
             descriptor: BaseTypeDescriptor {
@@ -255,7 +281,7 @@ impl PersistentAgentProxy {
             is_open: false,
             is_closed: false,
             turn_count: 0,
-            turn_timeout,
+            idle_window,
             workdir: None,
             agent_cmd: String::new(),
             agent_base_args: Vec::new(),
@@ -281,12 +307,33 @@ impl PersistentAgentProxy {
         Ok(())
     }
 
-    /// Invoke the agent with a prompt and return the response.
+    /// Invoke the agent with a prompt and return the full (noise-stripped)
+    /// response. Thin wrapper over [`Self::invoke_agent_streaming`] with a
+    /// no-op chunk sink, for callers that don't need incremental output.
+    #[cfg(test)]
     fn invoke_agent(&self, prompt: &str) -> SimardResult<String> {
+        self.invoke_agent_streaming(prompt, &mut |_| {})
+    }
+
+    /// Invoke the agent, streaming each substantive output line to `on_chunk`
+    /// as it is produced, and returning the full noise-stripped response.
+    ///
+    /// Liveness model (issue #2581): there is **no** wall-clock cap on the
+    /// turn. The child is terminated only when it produces no output for the
+    /// idle-liveness window ([`Self::idle_window`]) — every line received
+    /// resets that clock, so a long-but-productive turn streams indefinitely
+    /// and is never killed. A genuinely hung/dead child (no output for the full
+    /// window) is still reaped and surfaced as an honest idle-timeout error.
+    fn invoke_agent_streaming(
+        &self,
+        prompt: &str,
+        on_chunk: &mut dyn FnMut(&str),
+    ) -> SimardResult<String> {
         info!(
             cmd = %self.agent_cmd,
             prompt_len = prompt.len(),
-            "Invoking agent"
+            idle_window_secs = self.idle_window.map(|d| d.as_secs()),
+            "Invoking agent (streaming)"
         );
 
         let mut cmd = Command::new(&self.agent_cmd);
@@ -297,22 +344,20 @@ impl PersistentAgentProxy {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
 
-        // Run the agent as the leader of its own process group so a per-turn
-        // timeout can kill the WHOLE subtree, not just the direct child. The
+        // Run the agent as the leader of its own process group so the liveness
+        // reaper can kill the WHOLE subtree, not just the direct child. The
         // agent CLIs (`copilot`/`claude`) are Node processes that spawn
         // descendants which inherit the stdout/stderr pipe write-ends; killing
         // only the direct child would leave those descendants alive, holding
         // the pipes open so the reader threads never see EOF (leaked threads +
-        // FDs + orphaned processes). Because the timeout is now default-on
-        // (issue #2549) this kill path is regularly exercised. `process_group(0)`
-        // makes the child's PGID equal its PID; the timeout handler then
-        // signals the negated PGID.
+        // FDs + orphaned processes). `process_group(0)` makes the child's PGID
+        // equal its PID; the reaper then signals the negated PGID.
         //
         // Tradeoff: the child no longer shares Simard's foreground process
         // group, so a terminal SIGINT (Ctrl-C) sent to Simard mid-turn no
         // longer reaches the agent. That is acceptable here — the agent is a
-        // one-shot `-p` invocation that self-terminates, and the bounded
-        // per-turn timeout still reaps a genuinely hung subtree.
+        // one-shot `-p` invocation that self-terminates, and the idle-liveness
+        // reaper still reaps a genuinely hung subtree.
         cmd.process_group(0);
 
         // Operate in the active repository so the agent can inspect code and
@@ -331,7 +376,7 @@ impl PersistentAgentProxy {
                 reason: format!("failed to spawn '{}': {e}", self.agent_cmd),
             })?;
 
-        // Read stdout in a thread with timeout
+        // Read stdout in a thread, forwarding each line over a channel.
         let stdout = child
             .stdout
             .take()
@@ -360,28 +405,32 @@ impl PersistentAgentProxy {
             });
         }
 
-        // Collect stdout lines. The channel disconnects EXACTLY when the reader
-        // thread reaches stdout EOF (every writer has closed the pipe) — that is
-        // the authoritative "all output received" signal. Draining via the
-        // blocking `recv_timeout` until `Disconnected` (rather than `try_wait` +
-        // a non-blocking `try_recv` drain) guarantees we never drop a burst the
-        // child flushed just before exiting — critical because `copilot`/`claude`
-        // write to a pipe (block-buffered) and tend to flush a large final chunk.
+        // Collect stdout lines, streaming each substantive one to `on_chunk`.
+        // The channel disconnects EXACTLY when the reader thread reaches stdout
+        // EOF (every writer has closed the pipe) — the authoritative "all output
+        // received" signal. Draining via the blocking `recv_timeout` until
+        // `Disconnected` (rather than `try_wait` + a non-blocking `try_recv`
+        // drain) guarantees we never drop a burst the child flushed just before
+        // exiting — critical because `copilot`/`claude` write to a pipe
+        // (block-buffered) and tend to flush a large final chunk.
         //
-        // The loop stays deadline-centric: it NEVER blocks on `child.wait()`
-        // unbounded, so a child that closes stdout then hangs (`exec 1>&-; sleep
-        // 999`), or one that never closes stdout, still degrades via the per-turn
-        // timeout (issue #2549).
+        // Liveness (issue #2581): the loop tracks `last_activity`, reset on every
+        // line. It NEVER blocks on `child.wait()` unbounded, so a child that
+        // closes stdout then hangs (`exec 1>&-; sleep 999`), or one that never
+        // closes stdout, still degrades once it has been idle for the full
+        // window — while a child that keeps producing output runs unbounded.
         let mut lines: Vec<String> = Vec::new();
-        let mut timed_out = false;
+        let mut hung = false;
         let mut stdout_eof = false;
+        let mut last_activity = Instant::now();
         loop {
-            if let Some(timeout) = self.turn_timeout
-                && start.elapsed() >= timeout
+            if let Some(idle) = self.idle_window
+                && last_activity.elapsed() >= idle
             {
                 warn!(
-                    timeout_secs = timeout.as_secs(),
-                    "Agent turn timeout reached, killing process"
+                    idle_window_secs = idle.as_secs(),
+                    elapsed_ms = start.elapsed().as_millis() as u64,
+                    "Agent produced no output for the idle-liveness window — reaping genuinely-hung child"
                 );
                 // Kill the entire process group (the agent + any descendants it
                 // spawned) so no orphan keeps the stdout/stderr pipes open —
@@ -393,14 +442,14 @@ impl PersistentAgentProxy {
                 kill_process_group(child.id());
                 let _ = child.kill();
                 let _ = child.wait();
-                timed_out = true;
+                hung = true;
                 break;
             }
 
             if stdout_eof {
                 // All output has been received (reader reached EOF). Finish once
                 // the child is reaped; if it closed stdout yet keeps running,
-                // keep polling so the deadline above can still fire.
+                // keep polling so the idle deadline above can still fire.
                 match child.try_wait() {
                     Ok(Some(_)) => break,
                     _ => std::thread::sleep(Duration::from_millis(50)),
@@ -408,33 +457,42 @@ impl PersistentAgentProxy {
                 continue;
             }
 
-            match rx.recv_timeout(Duration::from_secs(1)) {
-                Ok(line) => lines.push(line),
-                // No line this tick — loop to re-check the deadline.
+            match rx.recv_timeout(Duration::from_millis(200)) {
+                Ok(line) => {
+                    // Fresh output — reset the idle-liveness clock so a
+                    // productive turn is never reaped regardless of total length.
+                    last_activity = Instant::now();
+                    if !line_is_noise(line.trim()) {
+                        on_chunk(&line);
+                    }
+                    lines.push(line);
+                }
+                // No line this tick — loop to re-check the idle deadline.
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
                 // Reader hit stdout EOF and forwarded every line before dropping
                 // its sender: `lines` is now complete. The child may still be
                 // running (it closed stdout early), so switch to bounded
-                // exit/deadline polling above.
+                // exit/idle polling above.
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => stdout_eof = true,
             }
         }
 
-        // Honest degradation (Pillar 11, issue #2549): a hung child that hit
-        // the per-turn timeout surfaces as a specific error rather than
-        // blocking the REPL or masquerading as an empty response. The REPL's
-        // `render_backend_error` turns this into the `[meeting:error] WARNING`
-        // banner with a "retry or /close" hint.
-        if timed_out {
+        // Honest degradation (Pillar 11, issues #2549/#2581): a child that went
+        // idle for the full liveness window is genuinely hung — surface a
+        // specific error rather than blocking the REPL or masquerading as an
+        // empty response. The REPL's `render_backend_error` turns this into the
+        // `[meeting:error] WARNING` banner with a "retry or /close" hint. This
+        // fires ONLY on genuine inactivity, never on a still-streaming turn.
+        if hung {
             let secs = self
-                .turn_timeout
+                .idle_window
                 .map(|d| d.as_secs())
-                .unwrap_or(DEFAULT_TURN_TIMEOUT_SECS);
+                .unwrap_or(DEFAULT_IDLE_LIVENESS_SECS);
             return Err(SimardError::AdapterInvocationFailed {
                 base_type: "persistent-agent-proxy".to_string(),
                 reason: format!(
-                    "agent turn exceeded {secs}s per-turn timeout \
-                     ({TURN_TIMEOUT_ENV}); terminated hung child — honest \
+                    "agent produced no output for {secs}s (idle-liveness timeout, \
+                     {IDLE_LIVENESS_ENV}); terminated genuinely-hung child — honest \
                      degradation, retry your message or /close"
                 ),
             });
@@ -450,6 +508,79 @@ impl PersistentAgentProxy {
         );
 
         Ok(strip_copilot_noise(&raw_response))
+    }
+
+    /// Shared turn logic behind both [`BaseTypeSession::run_turn`] and
+    /// [`BaseTypeSession::run_turn_streaming`]. Builds the prompt, invokes the
+    /// agent (streaming each chunk to `on_chunk`), records cost, and returns the
+    /// outcome. A no-op `on_chunk` yields the classic blocking behaviour.
+    fn run_turn_streaming_impl(
+        &mut self,
+        input: BaseTypeTurnInput,
+        on_chunk: &mut dyn FnMut(&str),
+    ) -> SimardResult<BaseTypeOutcome> {
+        ensure_session_not_closed(&self.descriptor, self.is_closed, "run_turn")?;
+        ensure_session_open(&self.descriptor, self.is_open, "run_turn")?;
+
+        self.turn_count += 1;
+
+        // Build the full prompt including context on first turn
+        let prompt = if self.turn_count == 1 {
+            let mut parts = Vec::new();
+            if !input.identity_context.is_empty() {
+                parts.push(input.identity_context.as_str());
+            }
+            if !input.prompt_preamble.is_empty() {
+                parts.push(input.prompt_preamble.as_str());
+            }
+            parts.push(&input.objective);
+            parts.join("\n\n")
+        } else {
+            input.objective.clone()
+        };
+
+        info!(
+            turn = self.turn_count,
+            prompt_len = prompt.len(),
+            "Agent proxy: sending turn"
+        );
+        let start = Instant::now();
+
+        let response_text = self.invoke_agent_streaming(&prompt, on_chunk)?;
+
+        info!(
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            response_len = response_text.len(),
+            turn = self.turn_count,
+            "Agent proxy: received response"
+        );
+
+        if response_text.trim().is_empty() {
+            return Err(SimardError::AdapterInvocationFailed {
+                base_type: "persistent-agent-proxy".to_string(),
+                reason: "agent returned empty response".to_string(),
+            });
+        }
+
+        // Record cost estimate
+        if let Err(e) = crate::cost_tracking::record_cost(
+            "persistent-agent-proxy",
+            "direct-invoke",
+            prompt.len(),
+            response_text.len(),
+            &format!("agent proxy turn {}", self.turn_count),
+        ) {
+            debug!("Cost tracking write failed: {e}");
+        }
+
+        Ok(BaseTypeOutcome {
+            plan: format!("Agent proxy turn {} (direct-invoke).", self.turn_count),
+            execution_summary: response_text,
+            evidence: vec![
+                format!("agent-proxy-turn={}", self.turn_count),
+                format!("elapsed-ms={}", start.elapsed().as_millis()),
+            ],
+        })
     }
 }
 
@@ -492,68 +623,15 @@ impl BaseTypeSession for PersistentAgentProxy {
     }
 
     fn run_turn(&mut self, input: BaseTypeTurnInput) -> SimardResult<BaseTypeOutcome> {
-        ensure_session_not_closed(&self.descriptor, self.is_closed, "run_turn")?;
-        ensure_session_open(&self.descriptor, self.is_open, "run_turn")?;
+        self.run_turn_streaming_impl(input, &mut |_| {})
+    }
 
-        self.turn_count += 1;
-
-        // Build the full prompt including context on first turn
-        let prompt = if self.turn_count == 1 {
-            let mut parts = Vec::new();
-            if !input.identity_context.is_empty() {
-                parts.push(input.identity_context.as_str());
-            }
-            if !input.prompt_preamble.is_empty() {
-                parts.push(input.prompt_preamble.as_str());
-            }
-            parts.push(&input.objective);
-            parts.join("\n\n")
-        } else {
-            input.objective.clone()
-        };
-
-        info!(
-            turn = self.turn_count,
-            prompt_len = prompt.len(),
-            "Agent proxy: sending turn"
-        );
-        let start = Instant::now();
-
-        let response_text = self.invoke_agent(&prompt)?;
-
-        info!(
-            elapsed_ms = start.elapsed().as_millis() as u64,
-            response_len = response_text.len(),
-            turn = self.turn_count,
-            "Agent proxy: received response"
-        );
-
-        if response_text.trim().is_empty() {
-            return Err(SimardError::AdapterInvocationFailed {
-                base_type: "persistent-agent-proxy".to_string(),
-                reason: "agent returned empty response".to_string(),
-            });
-        }
-
-        // Record cost estimate
-        if let Err(e) = crate::cost_tracking::record_cost(
-            "persistent-agent-proxy",
-            "direct-invoke",
-            prompt.len(),
-            response_text.len(),
-            &format!("agent proxy turn {}", self.turn_count),
-        ) {
-            debug!("Cost tracking write failed: {e}");
-        }
-
-        Ok(BaseTypeOutcome {
-            plan: format!("Agent proxy turn {} (direct-invoke).", self.turn_count),
-            execution_summary: response_text,
-            evidence: vec![
-                format!("agent-proxy-turn={}", self.turn_count),
-                format!("elapsed-ms={}", start.elapsed().as_millis()),
-            ],
-        })
+    fn run_turn_streaming(
+        &mut self,
+        input: BaseTypeTurnInput,
+        on_chunk: &mut dyn FnMut(&str),
+    ) -> SimardResult<BaseTypeOutcome> {
+        self.run_turn_streaming_impl(input, on_chunk)
     }
 
     fn close(&mut self) -> SimardResult<()> {
@@ -611,14 +689,14 @@ mod tests {
         assert_eq!(result, "Normal response.\nWith multiple lines.");
     }
 
-    // ── issue #2549: default per-turn timeout ──
+    // ── issues #2549/#2581: default idle-liveness window ──
 
     #[test]
     fn parse_turn_timeout_unset_uses_bounded_default() {
         assert_eq!(
             parse_turn_timeout(None),
-            Some(Duration::from_secs(DEFAULT_TURN_TIMEOUT_SECS)),
-            "unset env must yield the bounded default, not None (no hang)"
+            Some(Duration::from_secs(DEFAULT_IDLE_LIVENESS_SECS)),
+            "unset env must yield the bounded idle-liveness default, not None (no hang)"
         );
     }
 
@@ -640,7 +718,7 @@ mod tests {
         assert_eq!(
             parse_turn_timeout(Some("0")),
             None,
-            "0 is the explicit operator escape hatch (unbounded)"
+            "0 is the explicit operator escape hatch (idle detection fully disabled)"
         );
     }
 
@@ -648,23 +726,23 @@ mod tests {
     fn parse_turn_timeout_malformed_falls_back_to_default() {
         assert_eq!(
             parse_turn_timeout(Some("not-a-number")),
-            Some(Duration::from_secs(DEFAULT_TURN_TIMEOUT_SECS)),
+            Some(Duration::from_secs(DEFAULT_IDLE_LIVENESS_SECS)),
             "malformed value must degrade to the bounded default, never None"
         );
     }
 
     #[test]
     fn new_defaults_to_bounded_turn_timeout_when_env_unset() {
-        // Guard against the reproduction in #2549: with the env unset the
-        // proxy must carry a bounded timeout so a hung child cannot block the
-        // REPL forever. Only assert the default when the operator has NOT set
-        // an override in this environment.
-        if std::env::var(TURN_TIMEOUT_ENV).is_err() {
+        // With neither env var set the proxy must carry a bounded idle-liveness
+        // window so a genuinely-hung child cannot block the REPL forever (a
+        // still-streaming child is never reaped — the clock resets per chunk).
+        // Only assert the default when the operator has NOT set an override.
+        if std::env::var(TURN_TIMEOUT_ENV).is_err() && std::env::var(IDLE_LIVENESS_ENV).is_err() {
             let proxy = PersistentAgentProxy::new().unwrap();
             assert_eq!(
-                proxy.turn_timeout,
-                Some(Duration::from_secs(DEFAULT_TURN_TIMEOUT_SECS)),
-                "new() must default to a bounded per-turn timeout"
+                proxy.idle_window,
+                Some(Duration::from_secs(DEFAULT_IDLE_LIVENESS_SECS)),
+                "new() must default to a bounded idle-liveness window"
             );
         }
     }
@@ -742,17 +820,20 @@ mod tests {
         );
     }
 
-    // ── issue #2549: honest degradation on a hung turn ──
+    // ── issues #2549/#2581: honest degradation on a genuinely idle/hung turn ──
 
     #[test]
     fn invoke_agent_degrades_honestly_on_timeout() {
-        // Drive `invoke_agent` against a child that never produces output and
-        // never exits within the bound. `sh -c 'sleep 30'` ignores the trailing
-        // `-p <prompt>` args (they become $0/$1), so it hangs deterministically.
+        // AC (b): a genuinely idle/hung child — one that produces NO output for
+        // the whole idle-liveness window — must still be detected and reaped,
+        // surfacing an honest idle-timeout error (never a silent hang, never a
+        // masqueraded empty response). `sh -c 'sleep 30'` ignores the trailing
+        // `-p <prompt>` args (they become $0/$1), so it hangs, silent,
+        // deterministically.
         let mut proxy = PersistentAgentProxy::new().unwrap();
         proxy.agent_cmd = "sh".to_string();
         proxy.agent_base_args = vec!["-c".to_string(), "sleep 30".to_string()];
-        proxy.turn_timeout = Some(Duration::from_millis(500));
+        proxy.idle_window = Some(Duration::from_millis(500));
 
         let started = Instant::now();
         let result = proxy.invoke_agent("hello");
@@ -762,25 +843,26 @@ mod tests {
             elapsed < Duration::from_secs(10),
             "invoke_agent must not block indefinitely on a hung child (took {elapsed:?})"
         );
-        let err = result.expect_err("a timed-out turn must surface an error, not Ok");
+        let err = result.expect_err("a genuinely-idle turn must surface an error, not Ok");
         let msg = err.to_string();
         assert!(
-            msg.contains("timeout") && msg.contains("honest"),
-            "error must be a clear honest-degradation timeout, got: {msg}"
+            msg.contains("idle-liveness") && msg.contains("timeout") && msg.contains("honest"),
+            "error must be a clear honest idle-liveness timeout, got: {msg}"
         );
     }
 
     #[test]
     fn invoke_agent_degrades_when_child_closes_stdout_then_hangs() {
         // Regression for the disconnected-branch hang (issue #2549 review): a
-        // child that closes its stdout but keeps running must STILL hit the
-        // per-turn timeout, not block the REPL forever. `exec 1>&-` closes the
-        // stdout write-end (the reader thread sees EOF immediately) and then the
-        // shell sleeps — the deadline-centric loop must reap it via timeout.
+        // child that closes its stdout but keeps running (and produces no
+        // output) must STILL be reaped by idle-liveness, not block the REPL
+        // forever. `exec 1>&-` closes the stdout write-end (the reader thread
+        // sees EOF immediately) and then the shell sleeps — the idle-centric
+        // loop must reap it once the window elapses with no activity.
         let mut proxy = PersistentAgentProxy::new().unwrap();
         proxy.agent_cmd = "sh".to_string();
         proxy.agent_base_args = vec!["-c".to_string(), "exec 1>&-; sleep 30".to_string()];
-        proxy.turn_timeout = Some(Duration::from_secs(2));
+        proxy.idle_window = Some(Duration::from_secs(2));
 
         let started = Instant::now();
         let result = proxy.invoke_agent("hello");
@@ -838,7 +920,7 @@ mod tests {
         // 3s is comfortably longer than the shell needs to record the PID, and
         // far shorter than the grandchild's 30s sleep, so the grandchild is
         // guaranteed alive when the group-kill fires.
-        proxy.turn_timeout = Some(Duration::from_secs(3));
+        proxy.idle_window = Some(Duration::from_secs(3));
 
         let result = proxy.invoke_agent("hello");
         assert!(result.is_err(), "hung turn must surface a timeout error");
@@ -895,7 +977,7 @@ mod tests {
              printf ' stdout='; if [ -t 1 ]; then printf 'tty'; else printf 'notty'; fi"
                 .to_string(),
         ];
-        proxy.turn_timeout = Some(Duration::from_secs(30));
+        proxy.idle_window = Some(Duration::from_secs(30));
 
         let response = proxy
             .invoke_agent("hello")
@@ -914,7 +996,7 @@ mod tests {
         let mut proxy = PersistentAgentProxy::new().unwrap();
         proxy.agent_cmd = "sh".to_string();
         proxy.agent_base_args = vec!["-c".to_string(), "printf 'meeting-proxy-ok\\n'".to_string()];
-        proxy.turn_timeout = Some(Duration::from_secs(30));
+        proxy.idle_window = Some(Duration::from_secs(30));
 
         let response = proxy
             .invoke_agent("hello")
@@ -935,7 +1017,7 @@ mod tests {
         let mut proxy = PersistentAgentProxy::new().unwrap();
         proxy.agent_cmd = "sh".to_string();
         proxy.agent_base_args = vec!["-c".to_string(), "seq 1000 7000".to_string()];
-        proxy.turn_timeout = Some(Duration::from_secs(30));
+        proxy.idle_window = Some(Duration::from_secs(30));
 
         let response = proxy
             .invoke_agent("hello")
@@ -949,5 +1031,81 @@ mod tests {
         );
         assert_eq!(received.first().copied(), Some("1000"));
         assert_eq!(received.last().copied(), Some("7000"));
+    }
+
+    // ── issue #2581: idle-liveness never kills a productive turn + streaming ──
+
+    #[test]
+    fn long_productive_turn_is_not_killed_and_streams_incrementally() {
+        // AC (a): a turn whose TOTAL runtime far exceeds the idle-liveness
+        // window must NOT be killed, as long as it keeps producing output — and
+        // its output must arrive incrementally (streamed), not in one final
+        // blob. The child prints a 4-digit line (survives noise-stripping) every
+        // 100 ms for 20 lines (~2 s total) with a 1 s idle window: 2× the window
+        // overall, but each gap (0.1 s) is well under it, so the clock keeps
+        // resetting. Under the OLD wall-clock cap this turn would have been
+        // killed at 1 s; under idle-liveness it runs to completion. This is the
+        // bounded, CI-safe stand-in for the ">120 s productive turn" case — the
+        // property proven (no upper bound while output flows) is identical.
+        let mut proxy = PersistentAgentProxy::new().unwrap();
+        proxy.agent_cmd = "sh".to_string();
+        proxy.agent_base_args = vec![
+            "-c".to_string(),
+            "i=1000; while [ $i -lt 1020 ]; do echo $i; i=$((i+1)); sleep 0.1; done".to_string(),
+        ];
+        proxy.idle_window = Some(Duration::from_secs(1));
+
+        let mut chunks: Vec<String> = Vec::new();
+        let started = Instant::now();
+        let response = proxy
+            .invoke_agent_streaming("hello", &mut |c| chunks.push(c.to_string()))
+            .expect("a long-but-productive turn must return Ok, never be killed");
+        let elapsed = started.elapsed();
+
+        // It ran the full duration — proof it was not reaped early at ~1 s.
+        assert!(
+            elapsed >= Duration::from_millis(1500),
+            "productive turn was cut short (took only {elapsed:?}) — idle-liveness wrongly killed it"
+        );
+        // Output arrived incrementally: one streamed chunk per produced line.
+        assert_eq!(
+            chunks.len(),
+            20,
+            "expected 20 incrementally-streamed chunks, got {}",
+            chunks.len()
+        );
+        assert_eq!(chunks.first().map(String::as_str), Some("1000"));
+        assert_eq!(chunks.last().map(String::as_str), Some("1019"));
+        // The final aggregate response carries every line.
+        assert_eq!(response.lines().count(), 20);
+    }
+
+    #[test]
+    fn streaming_filters_noise_lines_from_chunks() {
+        // Streamed chunks are the substantive lines only — copilot usage/banner
+        // noise is filtered from the live preview exactly as it is from the
+        // final text, so the two never disagree.
+        let mut proxy = PersistentAgentProxy::new().unwrap();
+        proxy.agent_cmd = "sh".to_string();
+        proxy.agent_base_args = vec![
+            "-c".to_string(),
+            "printf 'hello world\\nTotal usage est: 5 tokens\\n'".to_string(),
+        ];
+        proxy.idle_window = Some(Duration::from_secs(30));
+
+        let mut chunks: Vec<String> = Vec::new();
+        let response = proxy
+            .invoke_agent_streaming("hi", &mut |c| chunks.push(c.to_string()))
+            .expect("clean child must return Ok");
+
+        assert_eq!(
+            chunks,
+            vec!["hello world".to_string()],
+            "noise must be filtered from stream"
+        );
+        assert_eq!(
+            response, "hello world",
+            "final text must match the streamed substantive content"
+        );
     }
 }

--- a/src/meeting_backend/messaging.rs
+++ b/src/meeting_backend/messaging.rs
@@ -115,4 +115,103 @@ impl MeetingBackend {
             message_count: self.history.len(),
         })
     }
+
+    /// Streaming variant of [`MeetingBackend::send_message`] (issue #2581).
+    ///
+    /// Behaves identically — appends the user message, dispatches the turn with
+    /// full conversation context, records the assistant reply, and auto-saves —
+    /// but tees each incremental output chunk to `on_chunk` as the agent
+    /// produces it, so a caller (the dashboard chat websocket) can render a live
+    /// preview. The returned [`MeetingResponse`] still carries the final,
+    /// authoritative (sanitized) assistant text, which is what gets persisted to
+    /// history; the streamed chunks are a live preview only.
+    pub fn send_message_streaming(
+        &mut self,
+        user_input: &str,
+        on_chunk: &mut dyn FnMut(&str),
+    ) -> SimardResult<MeetingResponse> {
+        if !self.is_open {
+            return Err(SimardError::ActionExecutionFailed {
+                action: "send-message".to_string(),
+                reason: "meeting session is closed".to_string(),
+            });
+        }
+
+        let trimmed = user_input.trim();
+        if trimmed.is_empty() {
+            return Ok(MeetingResponse {
+                content: String::new(),
+                message_count: self.history.len(),
+            });
+        }
+
+        self.push_message(Role::User, trimmed.to_string());
+        let preamble = self.build_conversation_preamble();
+        let turn_input = BaseTypeTurnInput {
+            objective: trimmed.to_string(),
+            identity_context: self.system_prompt.clone(),
+            prompt_preamble: preamble,
+        };
+
+        info!(
+            topic = self.topic,
+            messages = self.history.len(),
+            input_len = trimmed.len(),
+            "Streaming message to LLM agent…"
+        );
+        let start = std::time::Instant::now();
+
+        let agent = self
+            .agent
+            .as_mut()
+            .ok_or_else(|| SimardError::ActionExecutionFailed {
+                action: "send-message".to_string(),
+                reason: "meeting agent is no longer available (close pipeline took it)".to_string(),
+            })?;
+
+        let outcome = match agent.run_turn_streaming(turn_input, on_chunk) {
+            Ok(o) => {
+                info!(
+                    elapsed_ms = start.elapsed().as_millis() as u64,
+                    response_len = o.execution_summary.len(),
+                    "LLM agent returned streamed response"
+                );
+                o
+            }
+            Err(e) => {
+                warn!(elapsed_ms = start.elapsed().as_millis() as u64, error = %e, "LLM agent returned error");
+                return Err(e);
+            }
+        };
+
+        let extracted = extract_response(&outcome);
+        if extracted.trim().is_empty() {
+            error!(
+                raw_len = outcome.execution_summary.len(),
+                topic = self.topic,
+                "MeetingBackend: adapter returned empty streamed response — failing the turn"
+            );
+            return Err(SimardError::ActionExecutionFailed {
+                action: "send-message".to_string(),
+                reason: format!(
+                    "empty_adapter_response: extract_response produced empty result \
+                     (raw_summary_len={})",
+                    outcome.execution_summary.len()
+                ),
+            });
+        }
+        let response_text = extracted;
+
+        self.push_message(Role::Assistant, response_text.clone());
+        self.auto_save_transcript();
+        debug!(
+            messages = self.history.len(),
+            "Meeting streamed turn completed"
+        );
+
+        Ok(MeetingResponse {
+            content: response_text,
+            message_count: self.history.len(),
+        })
+    }
 }

--- a/src/meeting_backend/tests_mod.rs
+++ b/src/meeting_backend/tests_mod.rs
@@ -587,3 +587,63 @@ fn snapshot_session_round_trips_through_wip_persistence() {
     let gone = crate::meeting_facilitator::load_session_wip(dir.path()).expect("load after remove");
     assert!(gone.is_none(), "WIP file should be gone after remove");
 }
+
+// ── issue #2581: streaming turns + resume continuity ──
+
+#[test]
+fn send_message_streaming_tees_chunks_and_accumulates_history() {
+    // The streaming turn tees output to `on_chunk` and still records the
+    // user+assistant pair in history. A `MockAgent` uses the trait's default
+    // `run_turn_streaming` (one chunk == the full reply), which is exactly the
+    // contract non-incremental adapters must honour.
+    let agent = MockAgent::new("streamed reply");
+    let mut backend = MeetingBackend::new_session("Stream", Box::new(agent), None, String::new());
+
+    let mut chunks: Vec<String> = Vec::new();
+    let resp = backend
+        .send_message_streaming("hello there", &mut |c| chunks.push(c.to_string()))
+        .expect("streaming turn must succeed");
+
+    assert_eq!(resp.content, "streamed reply");
+    assert_eq!(resp.message_count, 2, "user + assistant recorded");
+    assert_eq!(
+        chunks,
+        vec!["streamed reply".to_string()],
+        "chunk must be teed"
+    );
+}
+
+#[test]
+fn restored_history_continues_the_same_conversation() {
+    // AC (c) continuity: a resumed session restores its transcript and the next
+    // turn continues on top of it (same conversation), not a fresh one.
+    let prior = vec![
+        ConversationMessage {
+            role: Role::User,
+            content: "what is the plan?".to_string(),
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+        },
+        ConversationMessage {
+            role: Role::Assistant,
+            content: "first reply".to_string(),
+            timestamp: "2026-01-01T00:00:01Z".to_string(),
+        },
+    ];
+    let agent = MockAgent::new("second reply");
+    let mut backend = MeetingBackend::new_session("Chat", Box::new(agent), None, String::new());
+    backend.restore(prior.clone());
+    assert_eq!(
+        backend.history(),
+        prior.as_slice(),
+        "prior transcript restored"
+    );
+
+    let resp = backend
+        .send_message("and the next step?")
+        .expect("resumed turn");
+    assert_eq!(resp.content, "second reply");
+    assert_eq!(
+        resp.message_count, 4,
+        "the new turn continues on top of the restored 2-message transcript"
+    );
+}

--- a/src/operator_commands_dashboard/chat.rs
+++ b/src/operator_commands_dashboard/chat.rs
@@ -8,6 +8,7 @@ use axum::{
 
 use serde::Deserialize;
 use serde_json::json;
+use tracing::warn;
 
 use crate::error::{SimardError, SimardResult};
 use crate::meeting_backend::{ConversationMessage, Role};
@@ -539,23 +540,50 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket, requested_session_id: 
                         // before the agent replies.
                         persist_turn(&state_root, &session_id, Role::User, user_text.clone()).await;
 
-                        // send_message is synchronous — use spawn_blocking
-                        // wrapped with catch_unwind so a panic in the agent
-                        // doesn't crash the chat task.
+                        // True incremental streaming (issue #2581): run the turn
+                        // on a blocking thread and tee each agent output chunk to
+                        // the client as a `chunk` frame the moment it is produced.
+                        // The proxy's idle-liveness clock resets on every chunk, so
+                        // a long-but-productive turn streams unbounded and is never
+                        // killed by a wall-clock timeout.
+                        let (chunk_tx, mut chunk_rx) =
+                            tokio::sync::mpsc::unbounded_channel::<String>();
                         let for_agent = user_text.clone();
-                        let result = tokio::task::spawn_blocking(move || {
+                        let handle = tokio::task::spawn_blocking(move || {
+                            let mut on_chunk = move |c: &str| {
+                                let _ = chunk_tx.send(c.to_string());
+                            };
                             let outcome =
                                 std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                                    backend.send_message(&for_agent)
+                                    backend.send_message_streaming(&for_agent, &mut on_chunk)
                                 }));
                             (backend, outcome)
-                        })
-                        .await;
-                        match result {
+                        });
+
+                        // Forward interim chunks until the turn completes (the
+                        // blocking task drops its sender). Each agent line is one
+                        // `chunk` frame; the trailing newline keeps multi-line
+                        // replies readable as the client coalesces them.
+                        let mut streamed_any = false;
+                        while let Some(chunk) = chunk_rx.recv().await {
+                            streamed_any = true;
+                            if socket
+                                .send(Message::Text(
+                                    json!({ "type": "chunk", "content": format!("{chunk}\n") })
+                                        .to_string()
+                                        .into(),
+                                ))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+
+                        match handle.await {
                             Ok((returned_backend, Ok(Ok(resp)))) => {
                                 backend = returned_backend;
-                                // Persist the assistant reply as one turn, then
-                                // stream it incrementally to the client.
+                                // Persist the authoritative assistant reply.
                                 persist_turn(
                                     &state_root,
                                     &session_id,
@@ -563,10 +591,34 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket, requested_session_id: 
                                     resp.content.clone(),
                                 )
                                 .await;
-                                stream_assistant(&mut socket, &resp.content).await;
+                                if streamed_any {
+                                    // Finalize the streamed bubble, replacing the
+                                    // live preview with the authoritative
+                                    // (sanitized) text via the `done` frame.
+                                    let _ = socket
+                                        .send(Message::Text(
+                                            json!({ "type": "done", "content": resp.content })
+                                                .to_string()
+                                                .into(),
+                                        ))
+                                        .await;
+                                } else {
+                                    // A non-incremental adapter produced no interim
+                                    // chunks — deliver the reply as chunk/done now.
+                                    stream_assistant(&mut socket, &resp.content).await;
+                                }
                             }
                             Ok((returned_backend, Ok(Err(e)))) => {
                                 backend = returned_backend;
+                                // Close any open streamed bubble, then surface the
+                                // honest error (idle-liveness, empty response, …).
+                                if streamed_any {
+                                    let _ = socket
+                                        .send(Message::Text(
+                                            json!({ "type": "done" }).to_string().into(),
+                                        ))
+                                        .await;
+                                }
                                 let _ = socket
                                     .send(Message::Text(
                                         json!({"role":"system","content": format!("[error: {e}]")})
@@ -576,8 +628,15 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket, requested_session_id: 
                                     .await;
                             }
                             Ok((returned_backend, Err(_panic))) => {
-                                eprintln!("[simard][PANIC] ws_chat send_message panicked");
+                                warn!("ws_chat send_message panicked");
                                 backend = returned_backend;
+                                if streamed_any {
+                                    let _ = socket
+                                        .send(Message::Text(
+                                            json!({ "type": "done" }).to_string().into(),
+                                        ))
+                                        .await;
+                                }
                                 let _ = socket
                                     .send(Message::Text(
                                         json!({"role":"system","content":"[error: agent panicked — recovered, conversation continues]"})

--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -129,7 +129,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
       }
       // Streaming: coalesce chunk frames into one assistant bubble.
       if(m && m.type==='chunk'){ removeTypingIndicator(); appendChunk(m.content||''); return; }
-      if(m && m.type==='done'){ finalizeStream(); setChatBusy(false); return; }
+      if(m && m.type==='done'){ finalizeStream(m.content); setChatBusy(false); return; }
       // Legacy / fallback frames: {role, content} rendered in one update.
       removeTypingIndicator();setChatBusy(false);finalizeStream();
       appendMsg((m&&m.role)||'system', (m&&m.content!==undefined)?m.content:ev.data);
@@ -165,7 +165,15 @@ pub(crate) const PART_04: &str = r#"            let fmt;
       const el=document.getElementById('chat-messages');
       el.scrollTop=el.scrollHeight;
     }
-    function finalizeStream(){ streamSpan=null; streamText=''; }
+    function finalizeStream(finalText){
+      // On `done`, replace the streamed preview with the authoritative
+      // (sanitized) reply when the server supplies one (issue #2581); otherwise
+      // keep whatever was streamed (server-side chunking fallback).
+      if(streamSpan && finalText!==undefined && finalText!==null && finalText!==''){
+        streamSpan.textContent=' '+finalText;
+      }
+      streamSpan=null; streamText='';
+    }
 
     function clearMessages(){
       finalizeStream();


### PR DESCRIPTION
Closes #2581. Builds on top of #2586 (#2577), which already landed durable/resumable chat sessions, a session list, a full-height layout, and server-side chunking — but left the operator-reported bug unfixed and streamed no interim output.

## The operator bug (requirement 1)
Sending a message failed with:

> [error: base type 'persistent-agent-proxy' failed during invocation: agent turn exceeded 120s per-turn timeout (SIMARD_MEETING_TURN_TIMEOUT_SECS); terminated hung child …]

A **hard 120s per-turn wall-clock timeout** in the `persistent-agent-proxy` killed turns while the agent was still legitimately working. `main` still has this even after #2586 (which only chunks the *completed* blocking reply after the whole turn returns).

## What this PR adds (the missing pieces)

### 1. No turn-killing wall-clock timeout → idle-liveness
`src/meeting_backend/agent_proxy.rs`: removed the wall-clock cap. `invoke_agent_streaming` now tracks an **idle-liveness window** that **resets on every output line**, so a long-but-productive turn runs unbounded and is never killed. Only a genuinely hung/dead child (no output for the *whole* window) is reaped — degrading honestly with a clear idle-timeout error (no silent swallow, no killed working turn).
- New env `SIMARD_MEETING_IDLE_LIVENESS_SECS` (default `300`); `0` disables idle detection entirely.
- `SIMARD_MEETING_TURN_TIMEOUT_SECS` kept as a **deprecated alias** (no longer a wall-clock cap).

### 2. True incremental streaming (not post-hoc chunking)
- `BaseTypeSession::run_turn_streaming` (default emits the full output once); `PersistentAgentProxy` overrides it to tee each line as it is produced.
- `MeetingBackend::send_message_streaming` tees chunks; the final content stays the authoritative sanitized text.
- `chat.rs`: the conversation turn now uses `send_message_streaming`, emitting #2586's existing `chunk`/`done` wire frames from **real interim agent output as it is produced** (the "true streaming" upgrade #2586 explicitly designed the protocol to be forward-compatible with). The idle-liveness clock resets on each streamed chunk. `done` now carries the authoritative text; the frontend replaces the live preview with it on finalize (a 2-line, backward-compatible `finalizeStream` tweak).

### Requirements 3–5 — reused from #2586 unchanged
Durable + resumable sessions (`MeetingBackend::restore`, `chat_store`, per-turn persistence), the session-list endpoints (`/api/chat/sessions[/{id}]`) and sidebar, and the full-height flex layout are already on `main` from #2586 and are reused as-is.

## Constraints honored
All-Rust backend + the dashboard's existing HTML/JS-in-Rust frontend. No "Bridge" naming; structured `tracing` in the touched code. Streaming/persistence robust to daemon restart. No `--no-verify`, no `--admin`. Rebased on latest `origin/main`. Live daemon / `~/.simard` untouched.

## Tests
- `long_productive_turn_is_not_killed_and_streams_incrementally` — a turn whose total runtime far exceeds the idle window is not killed and streams one chunk per line (CI-safe stand-in proving the unbounded-while-productive property behind the ">120s" case).
- `invoke_agent_degrades_honestly_on_timeout` / `..._child_closes_stdout_then_hangs` / `..._reaps_descendant_processes` — a genuinely idle/hung child is still detected + reaped + reported via idle-liveness.
- `send_message_streaming_tees_chunks_and_accumulates_history`, `streaming_filters_noise_lines_from_chunks` — streaming tee + noise filtering.
- `restored_history_continues_the_same_conversation` — resume continuity.
- #2586's `chat_store` / `chat_routes` unit tests and the `dashboard_chat_persistence` integration test stay green.

Green locally: full `cargo test --lib`, `cargo fmt --check`, `cargo clippy --all-targets --all-features --locked -- -D warnings`, and the full pre-commit **and** pre-push hook suites.

## Activation
The operator redeploys after merge to activate.