### PR TITLE
fix(meeting): remove wall-clock turn kill (idle-liveness) + true incremental streaming

### DIFF
--- a/docs/howto/start-a-meeting.md
+++ b/docs/howto/start-a-meeting.md
@@ -294,17 +294,26 @@ If you launch a meeting from **outside any git checkout** and set no override,
 the agent runs in the process working directory with **no explicit repo
 grant** — it never falls back to some other worktree.
 
-Each agent turn is bounded by a **default per-turn timeout** so a hung agent
-turn cannot freeze the REPL:
+Each agent turn is protected by an **idle-liveness timeout** so a genuinely
+wedged agent cannot freeze the REPL — while a long-but-productive turn is
+*never* killed by a fixed wall-clock bound:
 
 | Env var | Default | Effect |
 |---------|---------|--------|
-| `SIMARD_MEETING_TURN_TIMEOUT_SECS` | `120` | Per-turn bound in seconds. A positive value overrides the default; `0` disables the timeout (unbounded — operator escape hatch); an unset or malformed value uses the bounded default. |
+| `SIMARD_MEETING_TURN_IDLE_SECS` | `600` | Idle window in seconds. A turn is terminated only after the agent produces **no output** (stdout content or stderr heartbeat) for this long. As long as the agent keeps producing output the turn runs with **no upper time bound**. Configurable but **not disableable** (the honest hung-child safety net); values below `5 s` clamp up; an unset or malformed value uses the default. |
 
-When a turn exceeds the timeout, the child process is terminated and the turn
-**degrades honestly** with a `[meeting:error] WARNING` banner (the meeting
-stays usable — retry your message or `/close`) rather than blocking silently
-(Pillar 11: honest degradation beats hidden silence).
+As long as the agent keeps streaming output, the turn continues indefinitely —
+there is deliberately **no wall-clock cap** (mirrors the amplihack recipe-runner
+idle-timeout rule, issue #439). When a turn goes fully idle past the window, the
+child process group is terminated and the turn **degrades honestly** with a
+`[meeting:error] WARNING` banner (the meeting stays usable — retry your message
+or `/close`) rather than blocking silently (Pillar 11: honest degradation beats
+hidden silence). The idle-timeout is also surfaced as an error-level trace and a
+`meeting_turn_idle_timeout` metric, so a real hang is never swallowed.
+
+> The removed `SIMARD_MEETING_TURN_TIMEOUT_SECS` wall-clock variable is no
+> longer honored. If it is still set, the proxy logs a one-time deprecation
+> warning pointing at `SIMARD_MEETING_TURN_IDLE_SECS`.
 
 ## 9. Carry meeting outcomes into engineer sessions
 
@@ -324,13 +333,15 @@ If you see the prompt cursor blinking with no response after 2–3 minutes, chec
 2. **`copilot` on PATH?** Meeting mode invokes the `copilot` binary directly (not
    `amplihack copilot`). Run `which copilot` to verify. If the binary is not found,
    the turn returns an `AdapterInvocationFailed` error immediately.
-3. **Long compute in progress?** Each agent turn is bounded by
-   `SIMARD_MEETING_TURN_TIMEOUT_SECS` (default 120 s). If a turn exceeds it,
-   the child is killed and the turn degrades honestly with a `[meeting:error]
+3. **Long compute in progress?** Each agent turn is protected by an
+   **idle-liveness** window, `SIMARD_MEETING_TURN_IDLE_SECS` (default 600 s) —
+   the turn is killed only if the agent produces *no* output for that long. A
+   long-but-productive turn is never killed by a wall-clock bound, so slow
+   providers that keep streaming are fine. If a turn goes fully idle, the child
+   is terminated and the turn degrades honestly with a `[meeting:error]
    WARNING` banner — the REPL never hangs indefinitely. If your provider is
-   consistently slow, raise the bound (e.g.
-   `SIMARD_MEETING_TURN_TIMEOUT_SECS=300 simard meeting repl`) or set it to `0`
-   to disable the per-turn timeout entirely.
+   consistently slow to *start*, raise the idle window (e.g.
+   `SIMARD_MEETING_TURN_IDLE_SECS=1200 simard meeting repl`).
 
 ### Simard responds with OODA action plans instead of conversation
 

--- a/docs/reference/dashboard-chat.md
+++ b/docs/reference/dashboard-chat.md
@@ -308,13 +308,14 @@ Immediately after upgrade the server sends a `ready` frame:
 | `streaming` | `true` when the server will emit `chunk`/`done` frames for assistant replies; `false` when it will emit single `assistant` frames. |
 | `protocol_version` | Wire-protocol version. Currently `1`. |
 
-`streaming` advertises a **server capability**, not a per-provider outcome.
-Because replies are chunked server-side (see the streaming implementation note
-below), the current implementation reports `true` for every connection; the
-field exists so a future true token-stream — or a deployment that disables
-chunking — can flip it without a protocol change. Clients must therefore branch
-on the **frame shape they actually receive** (`type: "chunk"`/`"done"` vs. a
-single `role: "assistant"` frame), not assume a path from the flag alone.
+`streaming` advertises a **backend capability** (`MeetingBackend::supports_streaming()`),
+not a per-provider outcome. The meeting backend (`PersistentAgentProxy`) streams
+the agent's stdout **incrementally as it is produced**, so it reports `true`; a
+backend that cannot stream reports `false` and the server emits the whole reply
+as one chunk (an explicit declared capability, not a silent failure). Clients
+must therefore branch on the **frame shape they actually receive**
+(`type: "chunk"`/`"done"` vs. a single `role: "assistant"` frame), not assume a
+path from the flag alone.
 
 ### Restore — server → client (resume only)
 
@@ -353,7 +354,8 @@ clients.
 ### Streaming an assistant reply — server → client
 
 When `streaming: true`, an assistant reply is delivered as an ordered run of
-`chunk` frames terminated by a single `done` frame:
+`chunk` frames — one per output fragment **as the agent produces it** —
+terminated by a single `done` frame:
 
 ```json
 { "type": "chunk", "content": "Start by inspecting " }
@@ -364,15 +366,19 @@ When `streaming: true`, an assistant reply is delivered as an ordered run of
 
 The client appends each `chunk.content` to the in-progress assistant bubble and
 finalizes it on `done`. The full assistant text is persisted as one
-`ConversationMessage` regardless of how many chunks were emitted.
+`ConversationMessage` exactly once, regardless of how many chunks were emitted.
 
-> **Streaming implementation note.** The meeting backend's `run_turn` is
-> synchronous and returns the complete reply. Streaming is implemented as
-> **server-side chunking** of that completed text over the existing WebSocket:
-> incremental *appearance* is achieved without a token-level model API. The
-> `streaming` capability flag and the `chunk`/`done` frames keep the wire
-> protocol forward-compatible with a future true token-stream — the client code
-> path does not change when real token streaming lands.
+> **Streaming implementation note.** This is *true incremental* streaming: the
+> meeting backend exposes `MeetingBackend::send_message_streaming`, which drives
+> the agent's `run_turn_streaming` and forwards each cleaned stdout fragment to
+> the `/ws/chat` handler as the child process emits it. The handler bridges the
+> synchronous, blocking turn to the async socket over an unbounded channel and
+> emits one `chunk` frame per fragment (no post-hoc char-window chunking, no
+> artificial delays). Each streamed fragment also resets the agent proxy's
+> idle-liveness clock, so continued output both drives the stream and proves the
+> turn is alive. A backend that cannot stream falls back — explicitly, via the
+> `supports_streaming()` capability — to a single `chunk` carrying the whole
+> reply, followed by `done`.
 
 ### Non-streaming (fallback) reply — server → client
 

--- a/docs/testing/ci-resilient-test-patterns.md
+++ b/docs/testing/ci-resilient-test-patterns.md
@@ -107,10 +107,10 @@ agent is first validated.
 The lifecycle is:
 
 ```
-new()        → allocates struct, reads optional SIMARD_MEETING_TURN_TIMEOUT_SECS
-               (with fallback default), does NOT call RuntimeConfig::load()
+new()        → allocates struct, reads optional SIMARD_MEETING_TURN_IDLE_SECS
+               (with a generous default), does NOT call RuntimeConfig::load()
 open()       → resolves agent command from RuntimeConfig, validates agent
-run_turn()   → sends a prompt and collects the response
+run_turn()   → sends a prompt and collects the response (streaming or not)
 Drop         → tears down the agent process
 ```
 

--- a/src/base_types.rs
+++ b/src/base_types.rs
@@ -178,6 +178,44 @@ pub trait BaseTypeSession: Send {
 
     fn run_turn(&mut self, input: BaseTypeTurnInput) -> SimardResult<BaseTypeOutcome>;
 
+    /// Whether this session can stream incremental output deltas during a turn.
+    ///
+    /// Defaults to `false`: the session produces the whole reply and returns it
+    /// in one piece. Adapters that expose the underlying agent's output as it is
+    /// generated (e.g. `PersistentAgentProxy`) override this to return `true` so
+    /// callers can advertise *real* streaming rather than faking it. This is a
+    /// declared capability, not a silent fallback — see
+    /// [`BaseTypeSession::run_turn_streaming`].
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
+    /// Run a turn, invoking `on_delta` with output fragments as they are
+    /// produced.
+    ///
+    /// The default implementation runs the turn to completion via
+    /// [`BaseTypeSession::run_turn`] and emits the whole reply as a single
+    /// delta, so every existing adapter keeps working unchanged and callers get
+    /// one honest code path regardless of streaming support. Streaming adapters
+    /// override this to emit fragments incrementally as the child produces them;
+    /// each emitted fragment doubles as a liveness signal (see the meeting
+    /// proxy's idle-timeout).
+    ///
+    /// `on_delta` is a synchronous `&mut dyn FnMut(&str)` so the trait stays
+    /// object-safe (`Box<dyn BaseTypeSession>`); callers bridge it to async
+    /// channels themselves.
+    fn run_turn_streaming(
+        &mut self,
+        input: BaseTypeTurnInput,
+        on_delta: &mut dyn FnMut(&str),
+    ) -> SimardResult<BaseTypeOutcome> {
+        let outcome = self.run_turn(input)?;
+        if !outcome.execution_summary.is_empty() {
+            on_delta(&outcome.execution_summary);
+        }
+        Ok(outcome)
+    }
+
     fn close(&mut self) -> SimardResult<()>;
 
     /// Optional memory + knowledge bridges used to enrich each turn.
@@ -299,6 +337,97 @@ pub fn process_output_evidence(prefix: &str, output: &std::process::Output) -> V
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::metadata::{BackendDescriptor, Freshness};
+    use crate::runtime::RuntimeTopology;
+
+    /// Minimal `BaseTypeSession` returning a canned reply, used to exercise the
+    /// default (non-overridden) streaming methods.
+    struct CannedSession {
+        descriptor: BaseTypeDescriptor,
+        reply: String,
+        run_turn_calls: u32,
+    }
+
+    impl CannedSession {
+        fn new(reply: &str) -> Self {
+            Self {
+                descriptor: BaseTypeDescriptor {
+                    id: BaseTypeId::new("canned-test-session"),
+                    backend: BackendDescriptor::for_runtime_type::<Self>(
+                        "canned",
+                        "test:canned-session",
+                        Freshness::now().unwrap(),
+                    ),
+                    capabilities: standard_session_capabilities(),
+                    supported_topologies: [RuntimeTopology::SingleProcess].into_iter().collect(),
+                },
+                reply: reply.to_string(),
+                run_turn_calls: 0,
+            }
+        }
+    }
+
+    impl BaseTypeSession for CannedSession {
+        fn descriptor(&self) -> &BaseTypeDescriptor {
+            &self.descriptor
+        }
+        fn open(&mut self) -> SimardResult<()> {
+            Ok(())
+        }
+        fn run_turn(&mut self, _input: BaseTypeTurnInput) -> SimardResult<BaseTypeOutcome> {
+            self.run_turn_calls += 1;
+            Ok(BaseTypeOutcome {
+                plan: String::new(),
+                execution_summary: self.reply.clone(),
+                evidence: Vec::new(),
+            })
+        }
+        fn close(&mut self) -> SimardResult<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn default_supports_streaming_is_false() {
+        let session = CannedSession::new("hi");
+        assert!(!session.supports_streaming());
+    }
+
+    #[test]
+    fn default_run_turn_streaming_emits_single_delta() {
+        let mut session = CannedSession::new("hello world");
+        let mut deltas = Vec::new();
+        let outcome = session
+            .run_turn_streaming(BaseTypeTurnInput::objective_only("x"), &mut |d| {
+                deltas.push(d.to_string())
+            })
+            .unwrap();
+        assert_eq!(deltas, vec!["hello world".to_string()]);
+        assert_eq!(outcome.execution_summary, "hello world");
+    }
+
+    #[test]
+    fn default_run_turn_streaming_matches_run_turn_noop() {
+        let mut a = CannedSession::new("abc def");
+        let via_run_turn = a.run_turn(BaseTypeTurnInput::objective_only("x")).unwrap();
+        let mut b = CannedSession::new("abc def");
+        let via_stream = b
+            .run_turn_streaming(BaseTypeTurnInput::objective_only("x"), &mut |_| {})
+            .unwrap();
+        assert_eq!(via_run_turn.execution_summary, via_stream.execution_summary);
+    }
+
+    #[test]
+    fn default_run_turn_streaming_skips_empty_delta() {
+        let mut session = CannedSession::new("");
+        let mut delta_count = 0u32;
+        let _ = session
+            .run_turn_streaming(BaseTypeTurnInput::objective_only("x"), &mut |_| {
+                delta_count += 1
+            })
+            .unwrap();
+        assert_eq!(delta_count, 0, "an empty reply must not emit a delta");
+    }
 
     #[test]
     fn capability_set_collects_unique_capabilities() {

--- a/src/meeting_backend/agent_proxy.rs
+++ b/src/meeting_backend/agent_proxy.rs
@@ -25,65 +25,37 @@ use crate::error::{SimardError, SimardResult};
 use crate::metadata::{BackendDescriptor, Freshness};
 use crate::runtime::RuntimeTopology;
 
-/// Strip copilot CLI noise (usage stats, bootstrap lines, progress indicators)
-/// from raw output, keeping only the substantive response.
-fn strip_copilot_noise(raw: &str) -> String {
-    let mut result = String::with_capacity(raw.len());
-    let mut skip_rest = false;
+use super::streaming_sanitizer::StreamingSanitizer;
 
-    for line in raw.lines() {
-        let trimmed = line.trim();
+/// Env var (removed) that used to impose a fixed wall-clock per-turn timeout.
+/// It is no longer honored: a long-but-productive agent turn must never be
+/// killed by a wall-clock bound (operator directive; mirrors the amplihack
+/// recipe-runner idle-timeout switch, issue #439). If an operator still has it
+/// set, [`resolve_turn_idle_timeout`] emits a deprecation warning pointing at
+/// [`TURN_IDLE_ENV`]. Issue #2586 follow-up.
+const LEGACY_TURN_TIMEOUT_ENV: &str = "SIMARD_MEETING_TURN_TIMEOUT_SECS";
 
-        if result.is_empty() && trimmed.is_empty() {
-            continue;
-        }
-        if trimmed.starts_with("Total usage est:")
-            || trimmed.starts_with("API time spent:")
-            || trimmed.starts_with("Total session time:")
-            || trimmed.starts_with("Changes ")
-            || trimmed.starts_with("Requests ")
-            || trimmed.starts_with("Tokens ")
-        {
-            skip_rest = true;
-            continue;
-        }
-        if skip_rest {
-            continue;
-        }
-        if trimmed.contains("Staged") && trimmed.contains("hook") {
-            continue;
-        }
-        if trimmed.contains("XPIA") || trimmed.starts_with("Script started on") {
-            continue;
-        }
-        if trimmed.starts_with("Warning:") {
-            continue;
-        }
-        if trimmed.len() <= 2 && !trimmed.is_empty() {
-            continue;
-        }
-        if trimmed.starts_with('●') {
-            continue;
-        }
+/// Env var overriding the per-turn *idle* timeout in seconds. A turn is only
+/// terminated when the child produces NO output (stdout content or stderr
+/// heartbeat) for this long; as long as it keeps producing output the turn runs
+/// with no upper bound. Configurable but not disableable — it is the honest
+/// hung-child safety net. Values below [`MIN_TURN_IDLE_SECS`] are clamped up.
+const TURN_IDLE_ENV: &str = "SIMARD_MEETING_TURN_IDLE_SECS";
 
-        result.push_str(line);
-        result.push('\n');
-    }
+/// Default per-turn idle timeout: a generous 10 minutes. A healthy agent emits
+/// tokens/log lines far more often than this; the window only fires for a
+/// genuinely wedged child.
+const DEFAULT_TURN_IDLE_SECS: u64 = 600;
 
-    result.trim().to_string()
-}
+/// Floor for the configured idle window. Guards against an operator setting a
+/// tiny value that would false-positive on a slow-but-live turn (and against a
+/// `0` that would otherwise disable the honest hang detector).
+const MIN_TURN_IDLE_SECS: u64 = 5;
 
-/// Env var override for turn timeout in seconds. When set to a positive value
-/// it overrides [`DEFAULT_TURN_TIMEOUT_SECS`]; when explicitly set to `0` the
-/// per-turn timeout is disabled (unbounded — operator escape hatch); when unset
-/// or malformed the bounded default applies.
-const TURN_TIMEOUT_ENV: &str = "SIMARD_MEETING_TURN_TIMEOUT_SECS";
-
-/// Default per-turn timeout. A hung `copilot -p` child must not block the
-/// meeting REPL indefinitely — after this bound the child is killed and the
-/// turn degrades honestly via the `[meeting:error]`/`[meeting] WARNING` banner
-/// (Pillar 11: honest degradation beats hidden silence). Issue #2549.
-const DEFAULT_TURN_TIMEOUT_SECS: u64 = 120;
+/// Metric emitted (value `1.0`) when a turn is terminated for idle-timeout, so
+/// a real hang is surfaced explicitly, never silently swallowed. Snake_case to
+/// match the `self_metrics` JSONL convention.
+const IDLE_TIMEOUT_METRIC: &str = "meeting_turn_idle_timeout";
 
 /// Env var giving an explicit directory the meeting agent should operate in.
 /// When set to an existing directory it wins over cwd-derived resolution. This
@@ -91,27 +63,39 @@ const DEFAULT_TURN_TIMEOUT_SECS: u64 = 120;
 /// per-operator absolute path baked into the binary.
 const WORKDIR_ENV: &str = "SIMARD_MEETING_AGENT_DIR";
 
-/// Resolve the per-turn timeout from the environment, falling back to the
-/// bounded default. Issue #2549.
-///
-/// - `SIMARD_MEETING_TURN_TIMEOUT_SECS=<n>` with `n > 0` → `Some(n secs)`
-/// - `SIMARD_MEETING_TURN_TIMEOUT_SECS=0` → `None` (explicitly disabled)
-/// - unset or malformed → `Some(DEFAULT_TURN_TIMEOUT_SECS)`
-fn resolve_turn_timeout() -> Option<Duration> {
-    parse_turn_timeout(std::env::var(TURN_TIMEOUT_ENV).ok().as_deref())
+/// Resolve the per-turn idle timeout from the environment, clamped to
+/// [`MIN_TURN_IDLE_SECS`] and defaulting to [`DEFAULT_TURN_IDLE_SECS`]. Emits a
+/// deprecation warning if the removed wall-clock env var is still set.
+fn resolve_turn_idle_timeout() -> Duration {
+    if let Ok(stale) = std::env::var(LEGACY_TURN_TIMEOUT_ENV) {
+        warn!(
+            removed_var = LEGACY_TURN_TIMEOUT_ENV,
+            stale_value = %stale,
+            replacement = TURN_IDLE_ENV,
+            "{LEGACY_TURN_TIMEOUT_ENV} is no longer honored — a productive turn is \
+             never killed by a wall-clock bound; only idle turns time out. Set \
+             {TURN_IDLE_ENV} to tune the idle window instead."
+        );
+    }
+    parse_turn_idle_timeout(std::env::var(TURN_IDLE_ENV).ok().as_deref())
 }
 
-/// Pure (env-free) core of [`resolve_turn_timeout`] so the fallback/override
+/// Pure (env-free) core of [`resolve_turn_idle_timeout`] so the clamp/default
 /// semantics are testable without mutating process-global environment state.
-fn parse_turn_timeout(raw: Option<&str>) -> Option<Duration> {
-    match raw {
+///
+/// - `Some("<n>")` with `n >= MIN` → `n` seconds.
+/// - `Some("<n>")` with `n < MIN` (including `0`) → clamped to
+///   [`MIN_TURN_IDLE_SECS`] — the idle detector is not disableable.
+/// - `None` or malformed → [`DEFAULT_TURN_IDLE_SECS`].
+fn parse_turn_idle_timeout(raw: Option<&str>) -> Duration {
+    let secs = match raw {
         Some(value) => match value.trim().parse::<u64>() {
-            Ok(0) => None,
-            Ok(secs) => Some(Duration::from_secs(secs)),
-            Err(_) => Some(Duration::from_secs(DEFAULT_TURN_TIMEOUT_SECS)),
+            Ok(secs) => secs.max(MIN_TURN_IDLE_SECS),
+            Err(_) => DEFAULT_TURN_IDLE_SECS,
         },
-        None => Some(Duration::from_secs(DEFAULT_TURN_TIMEOUT_SECS)),
-    }
+        None => DEFAULT_TURN_IDLE_SECS,
+    };
+    Duration::from_secs(secs)
 }
 
 /// Resolve the directory the meeting agent should operate in — the active
@@ -201,6 +185,187 @@ fn resolve_agent_command() -> SimardResult<(String, Vec<String>)> {
     }
 }
 
+// ── Idle-liveness drain seams (issue #2586 follow-up) ───────────────────────
+//
+// The per-turn drain loop is extracted behind two tiny traits so its
+// idle-timeout behavior is deterministically testable with a fake child + fake
+// clock — no real subprocess, no real sleeps. [`ChildOutput`] yields the
+// child's output events with idle-aware waiting; [`TurnClock`] supplies
+// monotonic elapsed time for logging/idle accounting.
+
+/// One unit of progress observed from the agent child.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ChildEvent {
+    /// A line of stdout — substantive content AND a liveness signal.
+    Stdout(String),
+    /// A line of stderr — a liveness heartbeat only (logged at debug).
+    Stderr(String),
+    /// The child's stdout reached EOF: all content has been produced.
+    StdoutEof,
+}
+
+/// Source of [`ChildEvent`]s with idle-aware waiting. The production impl wraps
+/// the reader-thread channel; tests substitute a scripted fake.
+trait ChildOutput {
+    /// Wait up to `idle_budget` for the next event. `Some(event)` if one
+    /// arrived within the budget; `None` if the budget elapsed with no activity
+    /// (the child is idle).
+    fn next_event(&mut self, idle_budget: Duration) -> Option<ChildEvent>;
+}
+
+/// Real [`ChildOutput`] over the stdout/stderr reader-thread channel. A
+/// `recv_timeout` that times out is exactly "no output within the idle window";
+/// a disconnect (all readers gone) is treated as stdout EOF.
+struct PipeChildOutput {
+    rx: std::sync::mpsc::Receiver<ChildEvent>,
+}
+
+impl ChildOutput for PipeChildOutput {
+    fn next_event(&mut self, idle_budget: Duration) -> Option<ChildEvent> {
+        match self.rx.recv_timeout(idle_budget) {
+            Ok(event) => Some(event),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => None,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => Some(ChildEvent::StdoutEof),
+        }
+    }
+}
+
+/// Monotonic clock seam so idle accounting is deterministic under test.
+trait TurnClock {
+    /// Milliseconds elapsed since the turn started (monotonic, non-decreasing).
+    fn elapsed_ms(&self) -> u64;
+}
+
+/// Production [`TurnClock`] backed by [`Instant`].
+struct SystemClock {
+    start: Instant,
+}
+
+impl SystemClock {
+    fn new() -> Self {
+        Self {
+            start: Instant::now(),
+        }
+    }
+}
+
+impl TurnClock for SystemClock {
+    fn elapsed_ms(&self) -> u64 {
+        self.start.elapsed().as_millis() as u64
+    }
+}
+
+/// Outcome of [`drain_with_liveness`].
+#[derive(Debug, PartialEq, Eq)]
+enum DrainOutcome {
+    /// stdout reached EOF; the turn produced its full output. `elapsed_ms` is
+    /// the total wall time (unbounded — proves there is no wall-clock cap).
+    Completed { elapsed_ms: u64 },
+    /// No output for a full idle window: the child is wedged. `elapsed_ms` is
+    /// the total wall time at the point of detection.
+    IdleTimeout { idle: Duration, elapsed_ms: u64 },
+}
+
+/// Drain a child's output, resetting the idle window on every event and only
+/// giving up when NO output arrives for a full `idle_timeout`.
+///
+/// Productive turns run with no upper time bound: each stdout line is forwarded
+/// to `on_stdout` (a combined content + liveness signal) as it arrives — true
+/// incremental streaming — and stderr heartbeats keep the turn alive without
+/// producing content. Only a genuinely silent child trips the idle timeout.
+fn drain_with_liveness(
+    src: &mut dyn ChildOutput,
+    clock: &dyn TurnClock,
+    idle_timeout: Duration,
+    on_stdout: &mut dyn FnMut(&str),
+) -> DrainOutcome {
+    loop {
+        match src.next_event(idle_timeout) {
+            Some(ChildEvent::Stdout(line)) => on_stdout(&line),
+            Some(ChildEvent::Stderr(line)) => {
+                debug!(stderr_line = %line, "agent stderr (liveness heartbeat)");
+            }
+            Some(ChildEvent::StdoutEof) => {
+                return DrainOutcome::Completed {
+                    elapsed_ms: clock.elapsed_ms(),
+                };
+            }
+            None => {
+                return DrainOutcome::IdleTimeout {
+                    idle: idle_timeout,
+                    elapsed_ms: clock.elapsed_ms(),
+                };
+            }
+        }
+    }
+}
+
+/// Structured description of an idle-timeout hang, used to build the honest
+/// error and emit the surfacing metric.
+struct IdleTimeoutReport {
+    idle: Duration,
+    pid: Option<u32>,
+    turn: u32,
+}
+
+/// Surface an idle-timeout hang: structured error-level tracing plus a metric
+/// (identifiers only — never user/model content), returning the honest
+/// degradation error. `metric` is injected so tests can assert emission without
+/// writing to the metrics store. A real hang is never silently swallowed.
+fn report_idle_timeout(
+    report: &IdleTimeoutReport,
+    metric: &mut dyn FnMut(&str, f64, &str),
+) -> SimardError {
+    let idle_secs = report.idle.as_secs();
+    let context = format!(
+        "idle_secs={idle_secs};pid={};turn={}",
+        report
+            .pid
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| "unknown".to_string()),
+        report.turn
+    );
+    tracing::error!(
+        idle_secs,
+        pid = report.pid,
+        turn = report.turn,
+        "meeting agent turn idle-timeout — no output for {idle_secs}s; terminating wedged child ({TURN_IDLE_ENV})"
+    );
+    metric(IDLE_TIMEOUT_METRIC, 1.0, &context);
+    SimardError::AdapterInvocationFailed {
+        base_type: "persistent-agent-proxy".to_string(),
+        reason: format!(
+            "agent turn idle-timeout: no output for {idle_secs}s \
+             ({TURN_IDLE_ENV}); terminated wedged child — honest degradation, \
+             retry your message or /close"
+        ),
+    }
+}
+
+/// Best-effort bounded reap of a child that has already closed stdout. The
+/// turn's full output is already in hand; this only stops a descendant that
+/// lingers after closing stdout from orphaning. Never blocks unbounded — after
+/// a short grace the process group is killed.
+fn reap_after_eof(child: &mut std::process::Child, pid: u32) {
+    let grace = Duration::from_millis(500);
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return,
+            Ok(None) => {
+                if start.elapsed() >= grace {
+                    kill_process_group(pid);
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Err(_) => return,
+        }
+    }
+}
+
 /// A direct-invoke agent proxy that spawns the coding agent per-turn via
 /// `copilot -p "MESSAGE"` with piped stdout.
 ///
@@ -214,7 +379,13 @@ pub struct PersistentAgentProxy {
     is_open: bool,
     is_closed: bool,
     turn_count: u32,
-    turn_timeout: Option<Duration>,
+    /// Per-turn *idle* timeout: the turn is killed only after the child
+    /// produces no output for this long. A productive turn has no upper bound.
+    turn_idle_timeout: Duration,
+    /// Whether idle-timeout terminations emit a metric to the metrics store.
+    /// Always `true` in production; tests set it `false` so the suite never
+    /// writes to `~/.simard`.
+    emit_metrics: bool,
     /// Directory the agent operates in (cwd + `--add-dir` grant), resolved in
     /// `open()` from the active repo / explicit config. `None` when no repo can
     /// be resolved — the agent then inherits the process cwd with no grant.
@@ -236,7 +407,7 @@ impl std::fmt::Debug for PersistentAgentProxy {
 impl PersistentAgentProxy {
     /// Create a new proxy (does NOT validate agent yet — call `open()` first).
     pub fn new() -> SimardResult<Self> {
-        let turn_timeout = resolve_turn_timeout();
+        let turn_idle_timeout = resolve_turn_idle_timeout();
 
         Ok(Self {
             descriptor: BaseTypeDescriptor {
@@ -255,7 +426,8 @@ impl PersistentAgentProxy {
             is_open: false,
             is_closed: false,
             turn_count: 0,
-            turn_timeout,
+            turn_idle_timeout,
+            emit_metrics: true,
             workdir: None,
             agent_cmd: String::new(),
             agent_base_args: Vec::new(),
@@ -281,8 +453,30 @@ impl PersistentAgentProxy {
         Ok(())
     }
 
-    /// Invoke the agent with a prompt and return the response.
+    /// Invoke the agent with a prompt and return the (noise-stripped) response,
+    /// discarding streamed deltas. Thin wrapper over
+    /// [`PersistentAgentProxy::invoke_agent_streaming`], used by the tests that
+    /// assert non-streaming behavior. Production turns go through
+    /// `run_turn_streaming` → `invoke_agent_streaming` directly.
+    #[cfg(test)]
     fn invoke_agent(&self, prompt: &str) -> SimardResult<String> {
+        self.invoke_agent_streaming(prompt, &mut |_| {})
+    }
+
+    /// Invoke the agent, forwarding cleaned output fragments to `on_delta` as
+    /// the child produces them (true incremental streaming) and returning the
+    /// full noise-stripped response.
+    ///
+    /// The turn is terminated ONLY if the child goes idle — no stdout content
+    /// and no stderr heartbeat — for the configured idle window
+    /// ([`TURN_IDLE_ENV`]); a productive turn runs with no upper time bound. An
+    /// idle kill reaps the whole process group, surfaces the hang via
+    /// error-level tracing + a metric, and degrades honestly.
+    fn invoke_agent_streaming(
+        &self,
+        prompt: &str,
+        on_delta: &mut dyn FnMut(&str),
+    ) -> SimardResult<String> {
         info!(
             cmd = %self.agent_cmd,
             prompt_len = prompt.len(),
@@ -297,41 +491,31 @@ impl PersistentAgentProxy {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
 
-        // Run the agent as the leader of its own process group so a per-turn
-        // timeout can kill the WHOLE subtree, not just the direct child. The
-        // agent CLIs (`copilot`/`claude`) are Node processes that spawn
-        // descendants which inherit the stdout/stderr pipe write-ends; killing
-        // only the direct child would leave those descendants alive, holding
-        // the pipes open so the reader threads never see EOF (leaked threads +
-        // FDs + orphaned processes). Because the timeout is now default-on
-        // (issue #2549) this kill path is regularly exercised. `process_group(0)`
-        // makes the child's PGID equal its PID; the timeout handler then
-        // signals the negated PGID.
-        //
-        // Tradeoff: the child no longer shares Simard's foreground process
-        // group, so a terminal SIGINT (Ctrl-C) sent to Simard mid-turn no
-        // longer reaches the agent. That is acceptable here — the agent is a
-        // one-shot `-p` invocation that self-terminates, and the bounded
-        // per-turn timeout still reaps a genuinely hung subtree.
+        // Run the agent as the leader of its own process group so an idle-timeout
+        // kill can reap the WHOLE subtree, not just the direct child. The agent
+        // CLIs (`copilot`/`claude`) are Node processes that spawn descendants
+        // inheriting the stdout/stderr pipe write-ends; killing only the direct
+        // child would leave those descendants holding the pipes open so the
+        // reader threads never see EOF (leaked threads + FDs + orphans).
+        // `process_group(0)` makes the child's PGID equal its PID; the idle
+        // handler signals the negated PGID. Tradeoff: a terminal SIGINT to
+        // Simard no longer reaches the agent mid-turn — acceptable for a
+        // one-shot `-p` invocation whose idle timeout still reaps a wedged tree.
         cmd.process_group(0);
 
-        // Operate in the active repository so the agent can inspect code and
-        // run `simard` commands in the correct context. Resolved in `open()`
-        // from the active repo / explicit config — never a hardcoded operator
-        // path (issue #2549). When unresolved, inherit the process cwd.
         if let Some(dir) = &self.workdir {
             cmd.current_dir(dir);
         }
 
-        let start = Instant::now();
+        let clock = SystemClock::new();
         let mut child = cmd
             .spawn()
             .map_err(|e| SimardError::AdapterInvocationFailed {
                 base_type: "persistent-agent-proxy".to_string(),
                 reason: format!("failed to spawn '{}': {e}", self.agent_cmd),
             })?;
+        let child_pid = child.id();
 
-        // Read stdout in a thread with timeout
         let stdout = child
             .stdout
             .take()
@@ -340,116 +524,87 @@ impl PersistentAgentProxy {
                 reason: "failed to capture agent stdout".to_string(),
             })?;
 
-        let (tx, rx) = std::sync::mpsc::channel::<String>();
+        // Both reader threads feed one ordered channel of `ChildEvent`s. The
+        // stdout thread emits an explicit `StdoutEof` at end-of-output — the
+        // authoritative "all content produced" signal — so the drain finishes
+        // without ever blocking on `child.wait()`.
+        let (tx, rx) = std::sync::mpsc::channel::<ChildEvent>();
+        let stdout_tx = tx.clone();
         std::thread::spawn(move || {
             let reader = BufReader::new(stdout);
             for line in reader.lines().map_while(Result::ok) {
-                if tx.send(line).is_err() {
-                    break;
+                if stdout_tx.send(ChildEvent::Stdout(line)).is_err() {
+                    return;
                 }
             }
+            let _ = stdout_tx.send(ChildEvent::StdoutEof);
         });
-
-        // Drain stderr in a thread
         if let Some(stderr) = child.stderr.take() {
+            let stderr_tx = tx.clone();
             std::thread::spawn(move || {
                 let reader = BufReader::new(stderr);
                 for line in reader.lines().map_while(Result::ok) {
-                    debug!(stderr_line = %line, "agent stderr");
+                    if stderr_tx.send(ChildEvent::Stderr(line)).is_err() {
+                        return;
+                    }
                 }
             });
         }
+        // Drop our own sender so the channel disconnects once both reader
+        // threads finish (defensive: the stdout thread already emits StdoutEof).
+        drop(tx);
 
-        // Collect stdout lines. The channel disconnects EXACTLY when the reader
-        // thread reaches stdout EOF (every writer has closed the pipe) — that is
-        // the authoritative "all output received" signal. Draining via the
-        // blocking `recv_timeout` until `Disconnected` (rather than `try_wait` +
-        // a non-blocking `try_recv` drain) guarantees we never drop a burst the
-        // child flushed just before exiting — critical because `copilot`/`claude`
-        // write to a pipe (block-buffered) and tend to flush a large final chunk.
-        //
-        // The loop stays deadline-centric: it NEVER blocks on `child.wait()`
-        // unbounded, so a child that closes stdout then hangs (`exec 1>&-; sleep
-        // 999`), or one that never closes stdout, still degrades via the per-turn
-        // timeout (issue #2549).
-        let mut lines: Vec<String> = Vec::new();
-        let mut timed_out = false;
-        let mut stdout_eof = false;
-        loop {
-            if let Some(timeout) = self.turn_timeout
-                && start.elapsed() >= timeout
-            {
+        let mut src = PipeChildOutput { rx };
+        let mut sanitizer = StreamingSanitizer::new();
+        let outcome = {
+            // Each raw stdout line runs through the single incremental sanitizer;
+            // kept fragments are forwarded to the live stream. Concatenating the
+            // fragments and trimming equals `sanitizer.finish()` — so what
+            // streams matches what is persisted, by construction.
+            let mut on_stdout = |line: &str| {
+                if let Some(delta) = sanitizer.push_line(line) {
+                    on_delta(&delta);
+                }
+            };
+            drain_with_liveness(&mut src, &clock, self.turn_idle_timeout, &mut on_stdout)
+        };
+
+        match outcome {
+            DrainOutcome::IdleTimeout { idle, elapsed_ms } => {
                 warn!(
-                    timeout_secs = timeout.as_secs(),
-                    "Agent turn timeout reached, killing process"
+                    idle_secs = idle.as_secs(),
+                    elapsed_ms, "Agent turn idle-timeout reached — killing wedged child"
                 );
-                // Kill the entire process group (the agent + any descendants it
-                // spawned) so no orphan keeps the stdout/stderr pipes open —
-                // otherwise the reader threads block on `read()` forever. The
-                // child leads its own group (`process_group(0)` above), so its
-                // PID is the group id; signalling the negated PID reaches the
-                // whole group. Fall back to a direct child kill if the group
-                // signal fails for any reason.
-                kill_process_group(child.id());
+                kill_process_group(child_pid);
                 let _ = child.kill();
                 let _ = child.wait();
-                timed_out = true;
-                break;
+                let report = IdleTimeoutReport {
+                    idle,
+                    pid: Some(child_pid),
+                    turn: self.turn_count,
+                };
+                let emit = self.emit_metrics;
+                let mut sink = |name: &str, value: f64, ctx: &str| {
+                    if emit {
+                        let _ = crate::self_metrics::record_metric(name, value, ctx);
+                    }
+                };
+                Err(report_idle_timeout(&report, &mut sink))
             }
-
-            if stdout_eof {
-                // All output has been received (reader reached EOF). Finish once
-                // the child is reaped; if it closed stdout yet keeps running,
-                // keep polling so the deadline above can still fire.
-                match child.try_wait() {
-                    Ok(Some(_)) => break,
-                    _ => std::thread::sleep(Duration::from_millis(50)),
-                }
-                continue;
-            }
-
-            match rx.recv_timeout(Duration::from_secs(1)) {
-                Ok(line) => lines.push(line),
-                // No line this tick — loop to re-check the deadline.
-                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
-                // Reader hit stdout EOF and forwarded every line before dropping
-                // its sender: `lines` is now complete. The child may still be
-                // running (it closed stdout early), so switch to bounded
-                // exit/deadline polling above.
-                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => stdout_eof = true,
+            DrainOutcome::Completed { elapsed_ms } => {
+                // stdout EOF: the turn's full output is in hand. Reap the child
+                // (bounded, best-effort) so a descendant lingering after closing
+                // stdout doesn't orphan — but never block on it.
+                reap_after_eof(&mut child, child_pid);
+                let response = sanitizer.finish();
+                info!(
+                    elapsed_ms,
+                    raw_len = response.len(),
+                    "Agent invocation complete"
+                );
+                Ok(response)
             }
         }
-
-        // Honest degradation (Pillar 11, issue #2549): a hung child that hit
-        // the per-turn timeout surfaces as a specific error rather than
-        // blocking the REPL or masquerading as an empty response. The REPL's
-        // `render_backend_error` turns this into the `[meeting:error] WARNING`
-        // banner with a "retry or /close" hint.
-        if timed_out {
-            let secs = self
-                .turn_timeout
-                .map(|d| d.as_secs())
-                .unwrap_or(DEFAULT_TURN_TIMEOUT_SECS);
-            return Err(SimardError::AdapterInvocationFailed {
-                base_type: "persistent-agent-proxy".to_string(),
-                reason: format!(
-                    "agent turn exceeded {secs}s per-turn timeout \
-                     ({TURN_TIMEOUT_ENV}); terminated hung child — honest \
-                     degradation, retry your message or /close"
-                ),
-            });
-        }
-
-        let elapsed = start.elapsed();
-        let raw_response = lines.join("\n");
-        info!(
-            elapsed_ms = elapsed.as_millis() as u64,
-            raw_len = raw_response.len(),
-            lines = lines.len(),
-            "Agent invocation complete"
-        );
-
-        Ok(strip_copilot_noise(&raw_response))
     }
 }
 
@@ -492,6 +647,20 @@ impl BaseTypeSession for PersistentAgentProxy {
     }
 
     fn run_turn(&mut self, input: BaseTypeTurnInput) -> SimardResult<BaseTypeOutcome> {
+        // Single code path: the non-streaming turn is streaming with a no-op
+        // delta sink, so behavior cannot diverge between the two.
+        self.run_turn_streaming(input, &mut |_| {})
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn run_turn_streaming(
+        &mut self,
+        input: BaseTypeTurnInput,
+        on_delta: &mut dyn FnMut(&str),
+    ) -> SimardResult<BaseTypeOutcome> {
         ensure_session_not_closed(&self.descriptor, self.is_closed, "run_turn")?;
         ensure_session_open(&self.descriptor, self.is_open, "run_turn")?;
 
@@ -519,7 +688,7 @@ impl BaseTypeSession for PersistentAgentProxy {
         );
         let start = Instant::now();
 
-        let response_text = self.invoke_agent(&prompt)?;
+        let response_text = self.invoke_agent_streaming(&prompt, on_delta)?;
 
         info!(
             elapsed_ms = start.elapsed().as_millis() as u64,
@@ -590,83 +759,256 @@ mod tests {
         let _result = resolve_agent_command();
     }
 
-    #[test]
-    fn strip_copilot_noise_removes_usage_stats() {
-        let input = "Here is the answer.\nTotal usage est: 1234 tokens\nAPI time spent: 2.3s";
-        let result = strip_copilot_noise(input);
-        assert_eq!(result, "Here is the answer.");
-    }
+    // ── issue #2586 follow-up: idle-liveness timeout config ──
 
     #[test]
-    fn strip_copilot_noise_removes_bootstrap() {
-        let input = "Staged 3 hook files\nXPIA defender loaded\nActual response here.";
-        let result = strip_copilot_noise(input);
-        assert_eq!(result, "Actual response here.");
-    }
-
-    #[test]
-    fn strip_copilot_noise_passes_clean_text() {
-        let input = "Normal response.\nWith multiple lines.";
-        let result = strip_copilot_noise(input);
-        assert_eq!(result, "Normal response.\nWith multiple lines.");
-    }
-
-    // ── issue #2549: default per-turn timeout ──
-
-    #[test]
-    fn parse_turn_timeout_unset_uses_bounded_default() {
+    fn parse_turn_idle_unset_uses_generous_default() {
         assert_eq!(
-            parse_turn_timeout(None),
-            Some(Duration::from_secs(DEFAULT_TURN_TIMEOUT_SECS)),
-            "unset env must yield the bounded default, not None (no hang)"
+            parse_turn_idle_timeout(None),
+            Duration::from_secs(DEFAULT_TURN_IDLE_SECS),
+            "unset env must yield the generous idle default"
         );
     }
 
     #[test]
-    fn parse_turn_timeout_positive_override_wins() {
+    fn parse_turn_idle_positive_override_wins() {
+        assert_eq!(parse_turn_idle_timeout(Some("30")), Duration::from_secs(30));
         assert_eq!(
-            parse_turn_timeout(Some("30")),
-            Some(Duration::from_secs(30))
-        );
-        assert_eq!(
-            parse_turn_timeout(Some("  45  ")),
-            Some(Duration::from_secs(45)),
+            parse_turn_idle_timeout(Some("  45  ")),
+            Duration::from_secs(45),
             "surrounding whitespace must be tolerated"
         );
     }
 
     #[test]
-    fn parse_turn_timeout_zero_disables_explicitly() {
+    fn parse_turn_idle_is_not_disableable_clamps_to_floor() {
+        // The idle detector is the honest hung-child safety net: `0` (or any
+        // sub-floor value) must clamp up, never disable it.
         assert_eq!(
-            parse_turn_timeout(Some("0")),
-            None,
-            "0 is the explicit operator escape hatch (unbounded)"
+            parse_turn_idle_timeout(Some("0")),
+            Duration::from_secs(MIN_TURN_IDLE_SECS),
+            "0 must clamp to the floor — idle detection is not disableable"
+        );
+        assert_eq!(
+            parse_turn_idle_timeout(Some("1")),
+            Duration::from_secs(MIN_TURN_IDLE_SECS),
+            "a below-floor value must clamp up"
         );
     }
 
     #[test]
-    fn parse_turn_timeout_malformed_falls_back_to_default() {
+    fn parse_turn_idle_malformed_falls_back_to_default() {
         assert_eq!(
-            parse_turn_timeout(Some("not-a-number")),
-            Some(Duration::from_secs(DEFAULT_TURN_TIMEOUT_SECS)),
-            "malformed value must degrade to the bounded default, never None"
+            parse_turn_idle_timeout(Some("not-a-number")),
+            Duration::from_secs(DEFAULT_TURN_IDLE_SECS),
+            "malformed value must degrade to the generous default"
         );
     }
 
     #[test]
-    fn new_defaults_to_bounded_turn_timeout_when_env_unset() {
-        // Guard against the reproduction in #2549: with the env unset the
-        // proxy must carry a bounded timeout so a hung child cannot block the
-        // REPL forever. Only assert the default when the operator has NOT set
-        // an override in this environment.
-        if std::env::var(TURN_TIMEOUT_ENV).is_err() {
+    fn new_defaults_to_generous_idle_timeout_when_env_unset() {
+        // With the idle env unset the proxy must carry the generous default.
+        // Only assert when the operator has NOT set an override here.
+        if std::env::var(TURN_IDLE_ENV).is_err() {
             let proxy = PersistentAgentProxy::new().unwrap();
             assert_eq!(
-                proxy.turn_timeout,
-                Some(Duration::from_secs(DEFAULT_TURN_TIMEOUT_SECS)),
-                "new() must default to a bounded per-turn timeout"
+                proxy.turn_idle_timeout,
+                Duration::from_secs(DEFAULT_TURN_IDLE_SECS),
+                "new() must default to the generous idle timeout"
             );
         }
+    }
+
+    // ── issue #2586 follow-up: idle-liveness drain (fake child + fake clock) ──
+
+    /// A deterministic clock whose virtual "now" the test advances explicitly.
+    #[derive(Clone, Default)]
+    struct FakeClock {
+        ms: std::rc::Rc<std::cell::Cell<u64>>,
+    }
+
+    impl FakeClock {
+        fn advance(&self, by_ms: u64) {
+            self.ms.set(self.ms.get() + by_ms);
+        }
+    }
+
+    impl TurnClock for FakeClock {
+        fn elapsed_ms(&self) -> u64 {
+            self.ms.get()
+        }
+    }
+
+    /// A scripted [`ChildOutput`]: each step is either an event (optionally
+    /// advancing the shared clock to model the passage of time between events)
+    /// or an idle gap that returns `None` (no output within the budget).
+    struct FakeChild {
+        clock: FakeClock,
+        /// (advance_ms_before, Some(event) | None-for-idle)
+        steps: std::collections::VecDeque<(u64, Option<ChildEvent>)>,
+    }
+
+    impl ChildOutput for FakeChild {
+        fn next_event(&mut self, _idle_budget: Duration) -> Option<ChildEvent> {
+            match self.steps.pop_front() {
+                Some((advance_ms, event)) => {
+                    self.clock.advance(advance_ms);
+                    event
+                }
+                // No script left: behave as stdout EOF so the drain terminates.
+                None => Some(ChildEvent::StdoutEof),
+            }
+        }
+    }
+
+    /// A turn that keeps producing output for far longer than the former 120s
+    /// wall-clock limit is NOT killed: it completes and every delta streams.
+    #[test]
+    fn drain_productive_turn_over_120s_is_not_killed_and_streams() {
+        let clock = FakeClock::default();
+        // 200 stdout lines, 30 virtual seconds apart → 6000s virtual elapsed,
+        // ~50x the old 120s cap. No wall-clock bound exists any more.
+        let mut steps: std::collections::VecDeque<(u64, Option<ChildEvent>)> = (0..200)
+            .map(|i| {
+                (
+                    30_000u64,
+                    Some(ChildEvent::Stdout(format!("token line {i}"))),
+                )
+            })
+            .collect();
+        steps.push_back((1_000, Some(ChildEvent::StdoutEof)));
+        let mut child = FakeChild {
+            clock: clock.clone(),
+            steps,
+        };
+
+        let mut deltas = Vec::new();
+        let outcome = drain_with_liveness(&mut child, &clock, Duration::from_secs(600), &mut |d| {
+            deltas.push(d.to_string())
+        });
+
+        match outcome {
+            DrainOutcome::Completed { elapsed_ms } => {
+                assert!(
+                    elapsed_ms > 120_000,
+                    "virtual elapsed {elapsed_ms}ms must far exceed the old 120s cap"
+                );
+            }
+            other => panic!("a productive turn must complete, got {other:?}"),
+        }
+        assert_eq!(
+            deltas.len(),
+            200,
+            "every produced line must stream as a delta"
+        );
+        assert_eq!(deltas[0], "token line 0");
+    }
+
+    /// A child that goes fully idle past the window IS terminated, and the hang
+    /// is surfaced explicitly (honest error + metric emitted).
+    #[test]
+    fn drain_idle_child_times_out_and_reports_hang_with_metric() {
+        let clock = FakeClock::default();
+        let mut steps = std::collections::VecDeque::new();
+        steps.push_back((1_000, Some(ChildEvent::Stdout("thinking...".to_string()))));
+        // Then an idle gap: the source returns None (no output within budget).
+        steps.push_back((600_000, None));
+        let mut child = FakeChild {
+            clock: clock.clone(),
+            steps,
+        };
+
+        let outcome =
+            drain_with_liveness(&mut child, &clock, Duration::from_secs(600), &mut |_| {});
+        let idle = match outcome {
+            DrainOutcome::IdleTimeout { idle, .. } => idle,
+            other => panic!("a fully-idle child must idle-timeout, got {other:?}"),
+        };
+
+        // The hang must surface as an honest error AND emit exactly one metric,
+        // via the injected sink (so no write to ~/.simard).
+        let mut emitted: Vec<(String, f64, String)> = Vec::new();
+        let report = IdleTimeoutReport {
+            idle,
+            pid: Some(4321),
+            turn: 2,
+        };
+        let err = report_idle_timeout(&report, &mut |name, value, ctx| {
+            emitted.push((name.to_string(), value, ctx.to_string()));
+        });
+        let msg = err.to_string();
+        assert!(
+            msg.contains("idle-timeout") && msg.contains("honest"),
+            "error must be an honest idle-timeout degradation, got: {msg}"
+        );
+        assert_eq!(emitted.len(), 1, "exactly one metric must be emitted");
+        assert_eq!(emitted[0].0, IDLE_TIMEOUT_METRIC);
+        assert_eq!(emitted[0].1, 1.0);
+        assert!(
+            emitted[0].2.contains("idle_secs=600") && emitted[0].2.contains("pid=4321"),
+            "metric context must carry identifiers only, got: {}",
+            emitted[0].2
+        );
+    }
+
+    /// Continued output past the idle window keeps the turn alive: streaming
+    /// deltas reset the idle clock, so a turn producing output for longer than
+    /// the idle window is never killed.
+    #[test]
+    fn drain_streaming_deltas_reset_the_idle_clock() {
+        let clock = FakeClock::default();
+        // Each line arrives just under the idle budget; total elapsed (5 * 90s
+        // = 450s) exceeds the 100s idle window many times over, yet — because
+        // every event resets the window — the turn completes, never idles out.
+        let mut steps: std::collections::VecDeque<(u64, Option<ChildEvent>)> = (0..5)
+            .map(|i| (90_000u64, Some(ChildEvent::Stdout(format!("chunk {i}")))))
+            .collect();
+        steps.push_back((10_000, Some(ChildEvent::StdoutEof)));
+        let mut child = FakeChild {
+            clock: clock.clone(),
+            steps,
+        };
+
+        let mut deltas = 0u32;
+        let outcome =
+            drain_with_liveness(&mut child, &clock, Duration::from_secs(100), &mut |_| {
+                deltas += 1
+            });
+        assert!(
+            matches!(outcome, DrainOutcome::Completed { .. }),
+            "continued output must keep resetting the idle clock (no kill)"
+        );
+        assert_eq!(deltas, 5, "each output should have streamed a delta");
+    }
+
+    /// A stderr heartbeat (no stdout content) also proves liveness and resets
+    /// the idle window — a child logging progress on stderr is not "idle".
+    #[test]
+    fn drain_stderr_heartbeat_keeps_turn_alive() {
+        let clock = FakeClock::default();
+        let mut steps = std::collections::VecDeque::new();
+        for _ in 0..4 {
+            steps.push_back((90_000, Some(ChildEvent::Stderr("progress...".to_string()))));
+        }
+        steps.push_back((1_000, Some(ChildEvent::StdoutEof)));
+        let mut child = FakeChild {
+            clock: clock.clone(),
+            steps,
+        };
+
+        let mut deltas = 0u32;
+        let outcome =
+            drain_with_liveness(&mut child, &clock, Duration::from_secs(100), &mut |_| {
+                deltas += 1
+            });
+        assert!(
+            matches!(outcome, DrainOutcome::Completed { .. }),
+            "stderr heartbeats must keep the turn alive"
+        );
+        assert_eq!(
+            deltas, 0,
+            "stderr heartbeats are liveness only, not content"
+        );
     }
 
     // ── issue #2549: repo-derived workdir (no hardcoded operator path) ──
@@ -742,17 +1084,19 @@ mod tests {
         );
     }
 
-    // ── issue #2549: honest degradation on a hung turn ──
+    // ── idle-liveness: honest degradation on a wedged turn ──
 
     #[test]
-    fn invoke_agent_degrades_honestly_on_timeout() {
+    fn invoke_agent_degrades_honestly_on_idle_timeout() {
         // Drive `invoke_agent` against a child that never produces output and
-        // never exits within the bound. `sh -c 'sleep 30'` ignores the trailing
-        // `-p <prompt>` args (they become $0/$1), so it hangs deterministically.
+        // never exits. `sh -c 'sleep 30'` ignores the trailing `-p <prompt>`
+        // args (they become $0/$1), so it stays silent — a genuine hang the
+        // idle window must reap.
         let mut proxy = PersistentAgentProxy::new().unwrap();
         proxy.agent_cmd = "sh".to_string();
         proxy.agent_base_args = vec!["-c".to_string(), "sleep 30".to_string()];
-        proxy.turn_timeout = Some(Duration::from_millis(500));
+        proxy.turn_idle_timeout = Duration::from_millis(500);
+        proxy.emit_metrics = false; // never write to ~/.simard from the test suite
 
         let started = Instant::now();
         let result = proxy.invoke_agent("hello");
@@ -760,27 +1104,30 @@ mod tests {
 
         assert!(
             elapsed < Duration::from_secs(10),
-            "invoke_agent must not block indefinitely on a hung child (took {elapsed:?})"
+            "invoke_agent must not block indefinitely on a wedged child (took {elapsed:?})"
         );
-        let err = result.expect_err("a timed-out turn must surface an error, not Ok");
+        let err = result.expect_err("an idle-timed-out turn must surface an error, not Ok");
         let msg = err.to_string();
         assert!(
-            msg.contains("timeout") && msg.contains("honest"),
-            "error must be a clear honest-degradation timeout, got: {msg}"
+            msg.contains("idle-timeout") && msg.contains("honest"),
+            "error must be a clear honest idle-timeout degradation, got: {msg}"
         );
     }
 
     #[test]
-    fn invoke_agent_degrades_when_child_closes_stdout_then_hangs() {
-        // Regression for the disconnected-branch hang (issue #2549 review): a
-        // child that closes its stdout but keeps running must STILL hit the
-        // per-turn timeout, not block the REPL forever. `exec 1>&-` closes the
-        // stdout write-end (the reader thread sees EOF immediately) and then the
-        // shell sleeps — the deadline-centric loop must reap it via timeout.
+    fn invoke_agent_returns_output_when_child_closes_stdout_then_lingers() {
+        // Idle semantics: stdout EOF means the turn's output is complete. A
+        // child that prints, closes stdout (`exec 1>&-`), then lingers must
+        // return its output PROMPTLY — never wait on the lingering process — and
+        // the linger must be reaped (no orphan).
         let mut proxy = PersistentAgentProxy::new().unwrap();
         proxy.agent_cmd = "sh".to_string();
-        proxy.agent_base_args = vec!["-c".to_string(), "exec 1>&-; sleep 30".to_string()];
-        proxy.turn_timeout = Some(Duration::from_secs(2));
+        proxy.agent_base_args = vec![
+            "-c".to_string(),
+            "printf 'partial-answer\\n'; exec 1>&-; sleep 30".to_string(),
+        ];
+        proxy.turn_idle_timeout = Duration::from_secs(30);
+        proxy.emit_metrics = false;
 
         let started = Instant::now();
         let result = proxy.invoke_agent("hello");
@@ -788,23 +1135,23 @@ mod tests {
 
         assert!(
             elapsed < Duration::from_secs(10),
-            "must not block when the child closes stdout then hangs (took {elapsed:?})"
+            "EOF means output complete — must not block on the lingering child (took {elapsed:?})"
         );
-        let err = result.expect_err("a hung turn (stdout closed) must surface a timeout error");
-        assert!(
-            err.to_string().contains("timeout"),
-            "error must name the timeout, got: {err}"
+        assert_eq!(
+            result.expect("output produced before stdout close must return Ok"),
+            "partial-answer",
+            "the produced output must be returned as soon as stdout closes"
         );
     }
 
     #[test]
-    fn invoke_agent_timeout_reaps_descendant_processes() {
-        // A hung turn must kill the WHOLE agent subtree, not just the direct
+    fn invoke_agent_idle_timeout_reaps_descendant_processes() {
+        // A wedged turn must kill the WHOLE agent subtree, not just the direct
         // child — otherwise a descendant holding the stdout pipe leaks (and the
         // reader thread blocks forever). We spawn a shell that backgrounds a
-        // grandchild `sleep` and records its PID, then force a timeout. After
-        // the group-kill the grandchild must be gone. Without the process-group
-        // kill (only `child.kill()`), the grandchild would survive its full 30s.
+        // grandchild `sleep` and records its PID, then wait (no output → idle).
+        // After the group-kill the grandchild must be gone. Without the
+        // process-group kill (only `child.kill()`), it would survive its 30s.
         //
         // A process is treated as terminated when `/proc/<pid>` is gone OR the
         // process is a zombie (state `Z`) — a zombie no longer holds the pipe
@@ -830,18 +1177,22 @@ mod tests {
         proxy.agent_cmd = "sh".to_string();
         // Single-quote the pidfile path so an unusual temp path can't break the
         // shell word-splitting. The grandchild PID is recorded immediately, well
-        // before the timeout fires.
+        // before the idle window fires.
         proxy.agent_base_args = vec![
             "-c".to_string(),
             format!("sleep 30 & echo $! > '{pidpath}'; wait"),
         ];
-        // 3s is comfortably longer than the shell needs to record the PID, and
-        // far shorter than the grandchild's 30s sleep, so the grandchild is
-        // guaranteed alive when the group-kill fires.
-        proxy.turn_timeout = Some(Duration::from_secs(3));
+        // 3s idle window: comfortably longer than the shell needs to record the
+        // PID, far shorter than the grandchild's 30s sleep, so it is guaranteed
+        // alive when the group-kill fires.
+        proxy.turn_idle_timeout = Duration::from_secs(3);
+        proxy.emit_metrics = false;
 
         let result = proxy.invoke_agent("hello");
-        assert!(result.is_err(), "hung turn must surface a timeout error");
+        assert!(
+            result.is_err(),
+            "wedged turn must surface an idle-timeout error"
+        );
 
         // Read the grandchild PID the shell recorded before it was killed.
         let mut grandchild_pid = None;
@@ -874,7 +1225,7 @@ mod tests {
         }
         assert!(
             reaped,
-            "timeout must reap the agent's descendant (pid {pid}); it survived the group-kill"
+            "idle timeout must reap the agent's descendant (pid {pid}); it survived the group-kill"
         );
     }
 
@@ -895,7 +1246,7 @@ mod tests {
              printf ' stdout='; if [ -t 1 ]; then printf 'tty'; else printf 'notty'; fi"
                 .to_string(),
         ];
-        proxy.turn_timeout = Some(Duration::from_secs(30));
+        proxy.turn_idle_timeout = Duration::from_secs(30);
 
         let response = proxy
             .invoke_agent("hello")
@@ -914,7 +1265,7 @@ mod tests {
         let mut proxy = PersistentAgentProxy::new().unwrap();
         proxy.agent_cmd = "sh".to_string();
         proxy.agent_base_args = vec!["-c".to_string(), "printf 'meeting-proxy-ok\\n'".to_string()];
-        proxy.turn_timeout = Some(Duration::from_secs(30));
+        proxy.turn_idle_timeout = Duration::from_secs(30);
 
         let response = proxy
             .invoke_agent("hello")
@@ -935,7 +1286,7 @@ mod tests {
         let mut proxy = PersistentAgentProxy::new().unwrap();
         proxy.agent_cmd = "sh".to_string();
         proxy.agent_base_args = vec!["-c".to_string(), "seq 1000 7000".to_string()];
-        proxy.turn_timeout = Some(Duration::from_secs(30));
+        proxy.turn_idle_timeout = Duration::from_secs(30);
 
         let response = proxy
             .invoke_agent("hello")

--- a/src/meeting_backend/lightweight.rs
+++ b/src/meeting_backend/lightweight.rs
@@ -139,6 +139,64 @@ impl BaseTypeSession for LightweightChatSession {
         Ok(outcome)
     }
 
+    fn supports_streaming(&self) -> bool {
+        self.inner
+            .as_ref()
+            .map(|i| i.supports_streaming())
+            .unwrap_or(false)
+    }
+
+    fn run_turn_streaming(
+        &mut self,
+        input: BaseTypeTurnInput,
+        on_delta: &mut dyn FnMut(&str),
+    ) -> SimardResult<BaseTypeOutcome> {
+        ensure_session_not_closed(&self.descriptor, self.is_closed, "run_turn")?;
+        ensure_session_open(&self.descriptor, self.is_open, "run_turn")?;
+
+        self.turn_count += 1;
+
+        let inner = self
+            .inner
+            .as_mut()
+            .ok_or_else(|| SimardError::AdapterInvocationFailed {
+                base_type: "lightweight-chat".to_string(),
+                reason: "inner session not initialized (open() not called?)".to_string(),
+            })?;
+
+        info!(
+            turn = self.turn_count,
+            prompt_len = input.objective.len(),
+            "Lightweight chat: streaming turn via SessionBuilder"
+        );
+        let start = std::time::Instant::now();
+
+        // Delegate to the inner session's streaming path so real streaming (or
+        // the single-delta default) propagates through the wrapper unchanged.
+        let outcome = inner.run_turn_streaming(input, on_delta)?;
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+
+        info!(
+            elapsed_ms,
+            response_len = outcome.execution_summary.len(),
+            turn = self.turn_count,
+            "Lightweight chat: received response"
+        );
+
+        // Record cost estimate
+        if let Err(e) = crate::cost_tracking::record_cost(
+            "lightweight-chat",
+            "session-builder",
+            outcome.plan.len(),
+            outcome.execution_summary.len(),
+            &format!("lightweight chat turn {}", self.turn_count),
+        ) {
+            debug!("Cost tracking write failed: {e}");
+        }
+
+        Ok(outcome)
+    }
+
     fn close(&mut self) -> SimardResult<()> {
         ensure_session_not_closed(&self.descriptor, self.is_closed, "close")?;
         ensure_session_open(&self.descriptor, self.is_open, "close")?;

--- a/src/meeting_backend/messaging.rs
+++ b/src/meeting_backend/messaging.rs
@@ -10,12 +10,45 @@ use super::sanitize::extract_response;
 use super::types::{MeetingResponse, Role};
 
 impl MeetingBackend {
+    /// Whether the underlying agent streams incremental output during a turn.
+    ///
+    /// A declared capability (not a silent fallback): callers use it to decide
+    /// whether to advertise real streaming. The meeting agent
+    /// (`PersistentAgentProxy`) streams; other adapters fall back to the
+    /// single-delta default in [`send_message_streaming`].
+    pub fn supports_streaming(&self) -> bool {
+        self.agent
+            .as_ref()
+            .map(|a| a.supports_streaming())
+            .unwrap_or(false)
+    }
+
     /// Send a user message and get Simard's response.
     ///
     /// Appends both the user message and the assistant response to history.
     /// The full conversation context is sent to the LLM on each turn.
     #[tracing::instrument(skip(self), fields(input_len = user_input.len()))]
     pub fn send_message(&mut self, user_input: &str) -> SimardResult<MeetingResponse> {
+        // Non-streaming callers get the exact same behavior via a no-op delta
+        // sink — one code path, so streaming and non-streaming cannot diverge.
+        self.send_message_streaming(user_input, &mut |_| {})
+    }
+
+    /// Send a user message, forwarding the agent's output fragments to
+    /// `on_delta` as they are produced (true incremental streaming), and return
+    /// the complete assistant reply once the turn finishes.
+    ///
+    /// The full assistant turn is still assembled and appended to history
+    /// exactly once, so persistence is unchanged from the non-streaming path.
+    /// Backends whose agent does not support streaming (`supports_streaming()`
+    /// is `false`) transparently emit the whole reply as a single delta via the
+    /// `BaseTypeSession::run_turn_streaming` default — an explicit declared
+    /// capability, never a silent failure.
+    pub fn send_message_streaming(
+        &mut self,
+        user_input: &str,
+        on_delta: &mut dyn FnMut(&str),
+    ) -> SimardResult<MeetingResponse> {
         if !self.is_open {
             return Err(SimardError::ActionExecutionFailed {
                 action: "send-message".to_string(),
@@ -66,7 +99,7 @@ impl MeetingBackend {
                 reason: "meeting agent is no longer available (close pipeline took it)".to_string(),
             })?;
 
-        let outcome = match agent.run_turn(turn_input) {
+        let outcome = match agent.run_turn_streaming(turn_input, on_delta) {
             Ok(o) => {
                 info!(
                     elapsed_ms = start.elapsed().as_millis() as u64,
@@ -102,7 +135,7 @@ impl MeetingBackend {
         }
         let response_text = extracted;
 
-        // Append assistant response
+        // Append assistant response (the full turn, persisted exactly once)
         self.push_message(Role::Assistant, response_text.clone());
 
         // Auto-save transcript after every turn so killed meetings don't lose data

--- a/src/meeting_backend/mod.rs
+++ b/src/meeting_backend/mod.rs
@@ -9,6 +9,7 @@ pub mod close_guard;
 pub mod command;
 pub mod lightweight;
 pub mod persist;
+pub mod streaming_sanitizer;
 #[cfg(test)]
 mod tests_goal_records_migration;
 #[cfg(test)]

--- a/src/meeting_backend/streaming_sanitizer.rs
+++ b/src/meeting_backend/streaming_sanitizer.rs
@@ -1,0 +1,169 @@
+//! Incremental sanitizer for the meeting agent proxy's streamed stdout.
+//!
+//! Copilot/Claude CLI stdout wraps the substantive reply in usage stats,
+//! bootstrap banners and progress markers. Historically these were stripped in
+//! one pass over the *completed* output (`strip_copilot_noise`). True
+//! incremental streaming (the #2586 follow-up) needs the SAME cleaning applied
+//! line-by-line as bytes arrive, so the fragments the operator sees stream
+//! match — by construction — the text that is finally persisted.
+//!
+//! [`StreamingSanitizer`] is that single source of truth: feed it raw stdout
+//! lines with [`StreamingSanitizer::push_line`], forward each returned delta to
+//! the live stream, and call [`StreamingSanitizer::finish`] for the assembled
+//! clean reply. Feeding every line of a completed output then calling `finish`
+//! yields exactly what the old whole-output pass produced — the free function
+//! [`strip_copilot_noise`] is that one-shot form, kept so existing callers and
+//! tests are unchanged.
+
+/// Incremental line filter mirroring the legacy `strip_copilot_noise` pass.
+///
+/// Stateful across lines: it suppresses leading blank lines until the first
+/// substantive line and, once a usage/stats trailer appears, drops every
+/// subsequent line (the trailer marks the end of the conversational reply).
+#[derive(Debug, Default)]
+pub struct StreamingSanitizer {
+    /// True once a kept line has been emitted. Mirrors the old pass's
+    /// `result.is_empty()` leading-blank suppression.
+    started: bool,
+    /// Once a usage/stats trailer line is seen every later line is dropped.
+    skip_rest: bool,
+    /// Assembled clean reply (kept lines, each with its trailing newline).
+    cleaned: String,
+}
+
+impl StreamingSanitizer {
+    /// A fresh sanitizer with no lines consumed.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed one raw stdout line. Returns `Some(delta)` — the exact fragment to
+    /// stream (the kept line plus its newline) — or `None` when the line is
+    /// noise and produces no output.
+    pub fn push_line(&mut self, line: &str) -> Option<String> {
+        let trimmed = line.trim();
+
+        // Suppress leading blank lines until the first substantive line.
+        if !self.started && trimmed.is_empty() {
+            return None;
+        }
+        // Usage/stats trailer: drop this and every subsequent line.
+        if trimmed.starts_with("Total usage est:")
+            || trimmed.starts_with("API time spent:")
+            || trimmed.starts_with("Total session time:")
+            || trimmed.starts_with("Changes ")
+            || trimmed.starts_with("Requests ")
+            || trimmed.starts_with("Tokens ")
+        {
+            self.skip_rest = true;
+            return None;
+        }
+        if self.skip_rest {
+            return None;
+        }
+        if trimmed.contains("Staged") && trimmed.contains("hook") {
+            return None;
+        }
+        if trimmed.contains("XPIA") || trimmed.starts_with("Script started on") {
+            return None;
+        }
+        if trimmed.starts_with("Warning:") {
+            return None;
+        }
+        if trimmed.len() <= 2 && !trimmed.is_empty() {
+            return None;
+        }
+        if trimmed.starts_with('●') {
+            return None;
+        }
+
+        self.started = true;
+        let mut delta = String::with_capacity(line.len() + 1);
+        delta.push_str(line);
+        delta.push('\n');
+        self.cleaned.push_str(&delta);
+        Some(delta)
+    }
+
+    /// The assembled clean reply, trimmed — identical to running the legacy
+    /// whole-output `strip_copilot_noise` over the same lines.
+    pub fn finish(&self) -> String {
+        self.cleaned.trim().to_string()
+    }
+}
+
+/// One-shot form mirroring the legacy `strip_copilot_noise`: feed every line of
+/// `raw` through a fresh [`StreamingSanitizer`] and return
+/// [`StreamingSanitizer::finish`].
+pub fn strip_copilot_noise(raw: &str) -> String {
+    let mut sanitizer = StreamingSanitizer::new();
+    for line in raw.lines() {
+        let _ = sanitizer.push_line(line);
+    }
+    sanitizer.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_shot_removes_usage_stats() {
+        let input = "Here is the answer.\nTotal usage est: 1234 tokens\nAPI time spent: 2.3s";
+        assert_eq!(strip_copilot_noise(input), "Here is the answer.");
+    }
+
+    #[test]
+    fn one_shot_removes_bootstrap() {
+        let input = "Staged 3 hook files\nXPIA defender loaded\nActual response here.";
+        assert_eq!(strip_copilot_noise(input), "Actual response here.");
+    }
+
+    #[test]
+    fn one_shot_passes_clean_text() {
+        let input = "Normal response.\nWith multiple lines.";
+        assert_eq!(
+            strip_copilot_noise(input),
+            "Normal response.\nWith multiple lines."
+        );
+    }
+
+    /// The core streaming invariant: concatenating the incremental deltas and
+    /// trimming equals the one-shot whole-output pass — streamed == persisted
+    /// by construction.
+    #[test]
+    fn incremental_deltas_concat_equals_one_shot() {
+        let raw =
+            "\n\nTotal session time: 9s\nHello there.\n●\nx\nSecond line.\nTotal usage est: 5";
+        let mut sanitizer = StreamingSanitizer::new();
+        let mut streamed = String::new();
+        for line in raw.lines() {
+            if let Some(delta) = sanitizer.push_line(line) {
+                streamed.push_str(&delta);
+            }
+        }
+        assert_eq!(streamed.trim(), sanitizer.finish());
+        assert_eq!(sanitizer.finish(), strip_copilot_noise(raw));
+    }
+
+    /// A leading usage trailer must suppress every later line, and short/marker
+    /// lines are dropped, incrementally.
+    #[test]
+    fn incremental_drops_noise_lines() {
+        let mut s = StreamingSanitizer::new();
+        assert_eq!(s.push_line(""), None, "leading blank suppressed");
+        assert_eq!(s.push_line("●●● progress"), None, "bullet marker dropped");
+        assert_eq!(s.push_line("ok"), None, "<=2 char line dropped");
+        assert_eq!(
+            s.push_line("Real content line."),
+            Some("Real content line.\n".to_string())
+        );
+        assert_eq!(
+            s.push_line("Total usage est: 9"),
+            None,
+            "trailer starts skip"
+        );
+        assert_eq!(s.push_line("trailing noise"), None, "post-trailer dropped");
+        assert_eq!(s.finish(), "Real content line.");
+    }
+}

--- a/src/meeting_backend/tests_mod.rs
+++ b/src/meeting_backend/tests_mod.rs
@@ -61,6 +61,143 @@ impl BaseTypeSession for MockAgent {
     }
 }
 
+/// Mock agent that streams its canned response as several deltas, so backend
+/// streaming can be asserted without a real subprocess.
+struct StreamingMockAgent {
+    descriptor: BaseTypeDescriptor,
+    deltas: Vec<String>,
+    is_open: bool,
+    is_closed: bool,
+}
+
+impl StreamingMockAgent {
+    fn new(deltas: &[&str]) -> Self {
+        Self {
+            descriptor: BaseTypeDescriptor {
+                id: BaseTypeId::new("streaming-mock-meeting-backend"),
+                backend: BackendDescriptor::for_runtime_type::<Self>(
+                    "streaming-mock",
+                    "test:streaming-mock-meeting-backend",
+                    Freshness::now().unwrap(),
+                ),
+                capabilities: standard_session_capabilities(),
+                supported_topologies: [RuntimeTopology::SingleProcess].into_iter().collect(),
+            },
+            deltas: deltas.iter().map(|s| s.to_string()).collect(),
+            is_open: true,
+            is_closed: false,
+        }
+    }
+}
+
+impl BaseTypeSession for StreamingMockAgent {
+    fn descriptor(&self) -> &BaseTypeDescriptor {
+        &self.descriptor
+    }
+    fn open(&mut self) -> SimardResult<()> {
+        self.is_open = true;
+        Ok(())
+    }
+    fn run_turn(&mut self, input: BaseTypeTurnInput) -> SimardResult<BaseTypeOutcome> {
+        self.run_turn_streaming(input, &mut |_| {})
+    }
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+    fn run_turn_streaming(
+        &mut self,
+        _input: BaseTypeTurnInput,
+        on_delta: &mut dyn FnMut(&str),
+    ) -> SimardResult<BaseTypeOutcome> {
+        ensure_session_open(&self.descriptor, self.is_open, "run_turn")?;
+        for delta in &self.deltas {
+            on_delta(delta);
+        }
+        Ok(BaseTypeOutcome {
+            plan: String::new(),
+            execution_summary: self.deltas.concat(),
+            evidence: Vec::new(),
+        })
+    }
+    fn close(&mut self) -> SimardResult<()> {
+        self.is_closed = true;
+        Ok(())
+    }
+}
+
+#[test]
+fn send_message_streaming_forwards_deltas_and_returns_full_reply() {
+    let agent = StreamingMockAgent::new(&["Hello, ", "streaming ", "world."]);
+    let mut backend = MeetingBackend::new_session("Stream", Box::new(agent), None, String::new());
+    assert!(
+        backend.supports_streaming(),
+        "backend must declare streaming when its agent streams"
+    );
+
+    let mut deltas = Vec::new();
+    let resp = backend
+        .send_message_streaming("hi", &mut |d| deltas.push(d.to_string()))
+        .unwrap();
+
+    assert_eq!(
+        deltas,
+        vec![
+            "Hello, ".to_string(),
+            "streaming ".to_string(),
+            "world.".to_string()
+        ],
+        "each fragment must stream incrementally as produced"
+    );
+    assert_eq!(
+        resp.content, "Hello, streaming world.",
+        "the complete reply must still be returned"
+    );
+    // The full assistant turn is persisted to history exactly once (user +
+    // assistant == 2), matching the non-streaming path.
+    assert_eq!(resp.message_count, 2);
+}
+
+#[test]
+fn non_streaming_capability_path_returns_complete_reply_as_one_delta() {
+    // A backend whose agent does not override streaming still works via the
+    // default single-delta path — an explicit declared capability, not a
+    // silent failure.
+    let agent = MockAgent::new("complete non-streaming reply");
+    let mut backend = MeetingBackend::new_session("Plain", Box::new(agent), None, String::new());
+    assert!(
+        !backend.supports_streaming(),
+        "a non-streaming agent must declare no streaming capability"
+    );
+
+    let mut deltas = Vec::new();
+    let resp = backend
+        .send_message_streaming("hi", &mut |d| deltas.push(d.to_string()))
+        .unwrap();
+
+    assert_eq!(
+        deltas,
+        vec!["complete non-streaming reply".to_string()],
+        "the whole reply is emitted as a single delta"
+    );
+    assert_eq!(resp.content, "complete non-streaming reply");
+    assert_eq!(resp.message_count, 2);
+}
+
+#[test]
+fn send_message_persists_assistant_turn_exactly_once() {
+    // Regression guard for #2586 persistence: one turn appends exactly one
+    // assistant message (never zero, never duplicated).
+    let agent = StreamingMockAgent::new(&["a", "b"]);
+    let mut backend = MeetingBackend::new_session("Once", Box::new(agent), None, String::new());
+    backend.send_message("q").unwrap();
+    let assistant_msgs = backend
+        .history()
+        .iter()
+        .filter(|m| matches!(m.role, Role::Assistant))
+        .count();
+    assert_eq!(assistant_msgs, 1, "exactly one assistant turn persisted");
+}
+
 #[test]
 fn new_session_creates_open_session() {
     let agent = MockAgent::new("hello");

--- a/src/operator_commands_dashboard/chat.rs
+++ b/src/operator_commands_dashboard/chat.rs
@@ -10,17 +10,19 @@ use serde::Deserialize;
 use serde_json::json;
 
 use crate::error::{SimardError, SimardResult};
-use crate::meeting_backend::{ConversationMessage, Role};
+use crate::meeting_backend::{ConversationMessage, MeetingBackend, MeetingResponse, Role};
 
 /// Maximum size (bytes) of a single inbound chat WebSocket frame / user
 /// message. The channel is text chat, not file transfer; oversized frames are
 /// refused, never persisted.
 const MAX_CHAT_FRAME_BYTES: usize = 64 * 1024;
 
-/// Target character count per streamed assistant `chunk` frame. The completed
-/// reply is split into fixed char windows so the client renders it
-/// incrementally (server-side chunking — see docs/reference/dashboard-chat.md).
-const STREAM_CHUNK_CHARS: usize = 48;
+/// Maximum characters carried in a single streamed `chunk` frame. Real agent
+/// output deltas are typically small (a line at a time); this only splits a
+/// pathologically large single delta so no frame approaches
+/// [`MAX_CHAT_FRAME_BYTES`]. (Worst case a char is 4 bytes, plus the small JSON
+/// envelope — 16K chars stays well under 64 KiB.)
+const MAX_STREAM_CHUNK_CHARS: usize = 16 * 1024;
 
 /// Query parameters for `GET /ws/chat`. `session_id` selects an existing
 /// session to resume; when absent a fresh session is minted lazily on the
@@ -148,13 +150,19 @@ async fn persist_turn(state_root: &std::path::Path, session_id: &str, role: Role
     .await;
 }
 
-/// Deliver a completed assistant reply as an ordered run of `chunk` frames
-/// terminated by a single `done` frame (server-side chunking). Incremental
-/// *appearance* is achieved over the existing socket without a token-level
-/// model API; the wire protocol stays forward-compatible with true streaming.
-async fn stream_assistant(socket: &mut WebSocket, content: &str) {
+/// Send one `chunk` frame carrying `content`, splitting a pathologically large
+/// delta so no single frame approaches [`MAX_CHAT_FRAME_BYTES`]. Returns `false`
+/// when the socket has closed (so the caller can stop streaming).
+///
+/// The client renders `chunk.content` as `textContent`, so no server-side HTML
+/// escaping is required; the meeting sanitizer already strips ANSI/control
+/// sequences upstream, keeping the stream display-safe.
+async fn send_chunk(socket: &mut WebSocket, content: &str) -> bool {
+    if content.is_empty() {
+        return true;
+    }
     let chars: Vec<char> = content.chars().collect();
-    for window in chars.chunks(STREAM_CHUNK_CHARS) {
+    for window in chars.chunks(MAX_STREAM_CHUNK_CHARS) {
         let piece: String = window.iter().collect();
         if socket
             .send(Message::Text(
@@ -165,21 +173,66 @@ async fn stream_assistant(socket: &mut WebSocket, content: &str) {
             .await
             .is_err()
         {
-            return;
+            return false;
         }
-        // A small delay so text visibly streams; each delay is tiny and the
-        // chunk size bounds the frame count for long replies.
-        tokio::time::sleep(std::time::Duration::from_millis(15)).await;
     }
+    true
+}
+
+/// Send the terminating `done` frame that closes a streamed assistant reply.
+async fn send_done(socket: &mut WebSocket) {
     let _ = socket
         .send(Message::Text(json!({ "type": "done" }).to_string().into()))
         .await;
 }
 
+/// Result of a turn produced off the async runtime by [`spawn_turn`].
+type TurnJoin = tokio::task::JoinHandle<(
+    MeetingBackend,
+    std::thread::Result<SimardResult<MeetingResponse>>,
+)>;
+
+/// Run one conversational turn against `backend` off the async runtime,
+/// returning a receiver of output deltas (each a future `chunk` frame) and the
+/// join handle that yields the moved-back backend plus the turn result.
+///
+/// This is the transport-independent core of the `/ws/chat` conversation
+/// handler: `send_message_streaming` forwards each fragment as the agent
+/// produces it (real incremental streaming — the proxy's idle timeout bounds
+/// the turn, so the channel always closes), while a non-streaming backend runs
+/// to completion and the caller emits the whole reply as one chunk. Extracted
+/// so the streaming bridge is unit-testable without a live socket.
+fn spawn_turn(
+    mut backend: MeetingBackend,
+    user_text: String,
+    streaming: bool,
+) -> (tokio::sync::mpsc::UnboundedReceiver<String>, TurnJoin) {
+    let (delta_tx, delta_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let join = tokio::task::spawn_blocking(move || {
+        // `catch_unwind` keeps an agent panic from crashing the chat task.
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if streaming {
+                let mut on_delta = |delta: &str| {
+                    // Unbounded send never blocks the synchronous agent thread.
+                    let _ = delta_tx.send(delta.to_string());
+                };
+                backend.send_message_streaming(&user_text, &mut on_delta)
+            } else {
+                // Non-streaming capability: drop the sender (no deltas) and run
+                // to completion; the caller emits the reply as a single chunk.
+                drop(delta_tx);
+                backend.send_message(&user_text)
+            }
+        }));
+        (backend, outcome)
+    });
+    (delta_rx, join)
+}
+
 pub(crate) async fn handle_ws_chat(mut socket: WebSocket, requested_session_id: Option<String>) {
     use crate::conversation_channel::apply_record;
     use crate::meeting_backend::{
-        MeetingBackend, MeetingCommand, parse_command, render_help_plain, unknown_command_notice,
+        MeetingCommand, parse_command, render_help_plain, unknown_command_notice,
     };
 
     let state_root = super::routes::resolve_state_root();
@@ -539,23 +592,27 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket, requested_session_id: 
                         // before the agent replies.
                         persist_turn(&state_root, &session_id, Role::User, user_text.clone()).await;
 
-                        // send_message is synchronous — use spawn_blocking
-                        // wrapped with catch_unwind so a panic in the agent
-                        // doesn't crash the chat task.
-                        let for_agent = user_text.clone();
-                        let result = tokio::task::spawn_blocking(move || {
-                            let outcome =
-                                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                                    backend.send_message(&for_agent)
-                                }));
-                            (backend, outcome)
-                        })
-                        .await;
-                        match result {
+                        // Real incremental streaming when the backend declares
+                        // the capability; an explicit single-shot path otherwise
+                        // (a declared capability, never a silent fallback).
+                        let streaming = backend.supports_streaming();
+                        let (mut delta_rx, join) =
+                            spawn_turn(backend, user_text.clone(), streaming);
+
+                        // Emit a `chunk` frame per delta as the agent produces
+                        // it. Keep draining even if the socket closed so the
+                        // blocking task can finish and hand the backend back.
+                        let mut socket_alive = true;
+                        while let Some(delta) = delta_rx.recv().await {
+                            if socket_alive && !send_chunk(&mut socket, &delta).await {
+                                socket_alive = false;
+                            }
+                        }
+
+                        match join.await {
                             Ok((returned_backend, Ok(Ok(resp)))) => {
                                 backend = returned_backend;
-                                // Persist the assistant reply as one turn, then
-                                // stream it incrementally to the client.
+                                // Persist the full assistant turn exactly once.
                                 persist_turn(
                                     &state_root,
                                     &session_id,
@@ -563,10 +620,22 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket, requested_session_id: 
                                     resp.content.clone(),
                                 )
                                 .await;
-                                stream_assistant(&mut socket, &resp.content).await;
+                                // Non-streaming path produced no deltas: deliver
+                                // the complete reply as one chunk so the client
+                                // still renders it.
+                                if !streaming && socket_alive && !resp.content.is_empty() {
+                                    socket_alive = send_chunk(&mut socket, &resp.content).await;
+                                }
+                                if socket_alive {
+                                    send_done(&mut socket).await;
+                                }
                             }
                             Ok((returned_backend, Ok(Err(e)))) => {
                                 backend = returned_backend;
+                                // Honest error surface (e.g. the idle-timeout
+                                // degradation). The client's fallback frame
+                                // handler clears the busy state; also send `done`
+                                // so a partially-streamed bubble is finalized.
                                 let _ = socket
                                     .send(Message::Text(
                                         json!({"role":"system","content": format!("[error: {e}]")})
@@ -574,6 +643,7 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket, requested_session_id: 
                                             .into(),
                                     ))
                                     .await;
+                                send_done(&mut socket).await;
                             }
                             Ok((returned_backend, Err(_panic))) => {
                                 eprintln!("[simard][PANIC] ws_chat send_message panicked");
@@ -585,6 +655,7 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket, requested_session_id: 
                                             .into(),
                                     ))
                                     .await;
+                                send_done(&mut socket).await;
                             }
                             Err(e) => {
                                 let _ = socket
@@ -613,6 +684,154 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket, requested_session_id: 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::base_types::{
+        BaseTypeDescriptor, BaseTypeId, BaseTypeOutcome, BaseTypeSession, BaseTypeTurnInput,
+        standard_session_capabilities,
+    };
+    use crate::metadata::{BackendDescriptor, Freshness};
+    use crate::runtime::RuntimeTopology;
+
+    /// Streaming mock agent that emits its canned reply as several deltas — the
+    /// same real-streaming contract as `PersistentAgentProxy`, without a
+    /// subprocess — so the `/ws/chat` bridge can be exercised offline.
+    struct WsStreamingMock {
+        descriptor: BaseTypeDescriptor,
+        deltas: Vec<String>,
+    }
+
+    impl WsStreamingMock {
+        fn new(deltas: &[&str]) -> Self {
+            Self {
+                descriptor: BaseTypeDescriptor {
+                    id: BaseTypeId::new("ws-streaming-mock"),
+                    backend: BackendDescriptor::for_runtime_type::<Self>(
+                        "ws-streaming-mock",
+                        "test:ws-streaming-mock",
+                        Freshness::now().unwrap(),
+                    ),
+                    capabilities: standard_session_capabilities(),
+                    supported_topologies: [RuntimeTopology::SingleProcess].into_iter().collect(),
+                },
+                deltas: deltas.iter().map(|s| s.to_string()).collect(),
+            }
+        }
+    }
+
+    impl BaseTypeSession for WsStreamingMock {
+        fn descriptor(&self) -> &BaseTypeDescriptor {
+            &self.descriptor
+        }
+        fn open(&mut self) -> SimardResult<()> {
+            Ok(())
+        }
+        fn run_turn(&mut self, input: BaseTypeTurnInput) -> SimardResult<BaseTypeOutcome> {
+            self.run_turn_streaming(input, &mut |_| {})
+        }
+        fn supports_streaming(&self) -> bool {
+            true
+        }
+        fn run_turn_streaming(
+            &mut self,
+            _input: BaseTypeTurnInput,
+            on_delta: &mut dyn FnMut(&str),
+        ) -> SimardResult<BaseTypeOutcome> {
+            for delta in &self.deltas {
+                on_delta(delta);
+            }
+            Ok(BaseTypeOutcome {
+                plan: String::new(),
+                execution_summary: self.deltas.concat(),
+                evidence: Vec::new(),
+            })
+        }
+        fn close(&mut self) -> SimardResult<()> {
+            Ok(())
+        }
+    }
+
+    /// The `/ws/chat` streaming bridge must emit each agent fragment as it is
+    /// produced (real incremental streaming) and yield the complete reply for
+    /// persistence — no post-hoc char-window chunking of a completed reply.
+    #[tokio::test]
+    async fn spawn_turn_streams_real_deltas_and_returns_full_reply() {
+        let agent = WsStreamingMock::new(&["Hello, ", "incremental ", "world."]);
+        let backend = MeetingBackend::new_session("Chat", Box::new(agent), None, String::new());
+        assert!(backend.supports_streaming());
+
+        let (mut delta_rx, join) = spawn_turn(backend, "hi".to_string(), true);
+        let mut deltas = Vec::new();
+        while let Some(d) = delta_rx.recv().await {
+            deltas.push(d);
+        }
+        let (_backend, outcome) = join.await.expect("blocking task joins");
+        let resp = outcome.expect("no panic").expect("turn ok");
+
+        assert_eq!(
+            deltas,
+            vec![
+                "Hello, ".to_string(),
+                "incremental ".to_string(),
+                "world.".to_string()
+            ],
+            "each fragment must arrive as its own chunk, in order"
+        );
+        assert_eq!(
+            resp.content, "Hello, incremental world.",
+            "the complete reply must be returned for one-time persistence"
+        );
+    }
+
+    /// A non-streaming backend produces no deltas; the handler then delivers the
+    /// whole reply as a single chunk (the explicit non-streaming capability).
+    #[tokio::test]
+    async fn spawn_turn_non_streaming_produces_no_deltas() {
+        struct PlainMock(BaseTypeDescriptor);
+        impl BaseTypeSession for PlainMock {
+            fn descriptor(&self) -> &BaseTypeDescriptor {
+                &self.0
+            }
+            fn open(&mut self) -> SimardResult<()> {
+                Ok(())
+            }
+            fn run_turn(&mut self, _i: BaseTypeTurnInput) -> SimardResult<BaseTypeOutcome> {
+                Ok(BaseTypeOutcome {
+                    plan: String::new(),
+                    execution_summary: "whole reply".to_string(),
+                    evidence: Vec::new(),
+                })
+            }
+            fn close(&mut self) -> SimardResult<()> {
+                Ok(())
+            }
+        }
+        let descriptor = BaseTypeDescriptor {
+            id: BaseTypeId::new("plain-mock"),
+            backend: BackendDescriptor::for_runtime_type::<PlainMock>(
+                "plain-mock",
+                "test:plain-mock",
+                Freshness::now().unwrap(),
+            ),
+            capabilities: standard_session_capabilities(),
+            supported_topologies: [RuntimeTopology::SingleProcess].into_iter().collect(),
+        };
+        let backend = MeetingBackend::new_session(
+            "Chat",
+            Box::new(PlainMock(descriptor)),
+            None,
+            String::new(),
+        );
+        assert!(!backend.supports_streaming());
+
+        let (mut delta_rx, join) = spawn_turn(backend, "hi".to_string(), false);
+        let mut deltas = Vec::new();
+        while let Some(d) = delta_rx.recv().await {
+            deltas.push(d);
+        }
+        let (_backend, outcome) = join.await.expect("joins");
+        let resp = outcome.expect("no panic").expect("ok");
+        assert!(deltas.is_empty(), "non-streaming path emits no deltas");
+        assert_eq!(resp.content, "whole reply");
+    }
 
     // ---- load_dashboard_meeting_prompt ------------------------------------
 


### PR DESCRIPTION
## Problem

The dashboard chat merged in #2586 routes through the meeting backend via `backend.send_message`, so the operator's core complaint was **not** fixed by #2586:

1. **Wall-clock turn kill.** A fixed 120s per-turn timeout (`SIMARD_MEETING_TURN_TIMEOUT_SECS`) terminated *any* long agent turn — even a productive one — with `agent turn exceeded 120s per-turn timeout … terminated hung child`.
2. **Cosmetic streaming.** #2586's "streaming" char-chunked an **already-completed** reply with 15ms sleeps — not real incremental output.

Both meeting surfaces — the CLI `simard meeting` and the dashboard chat — share one choke point: `SessionBuilder::open(Meeting)` → `PersistentAgentProxy`. Fixing the proxy fixes both.

## What changed

### 1. Idle-liveness instead of a wall-clock cap
- **Removed** the wall-clock kill. A productive turn now runs with **no upper time bound** (operator directive; mirrors the amplihack recipe-runner idle switch, #439). `SIMARD_MEETING_TURN_TIMEOUT_SECS` is no longer honored — the proxy logs a one-time deprecation warning if it is still set.
- **New `SIMARD_MEETING_TURN_IDLE_SECS`** (generous **600s** default, clamped to a 5s floor, **not disableable**): a turn is terminated **only** after the child produces **no output** — stdout content *or* stderr heartbeat — for the idle window.
- **Honest hung-child detection preserved.** An idle kill reaps the whole process group and surfaces the hang via **error-level tracing + a `meeting_turn_idle_timeout` metric** (identifiers only — never user/model content). A real hang is never silently swallowed.
- The drain loop is extracted behind injectable `ChildOutput` + `TurnClock` seams so idle behavior is deterministically testable with a fake child + fake clock (no real sleeps, no network).

### 2. True incremental streaming end-to-end
- `BaseTypeSession` gains object-safe `supports_streaming()` + `run_turn_streaming(input, &mut dyn FnMut(&str))`. The **default** emits the whole reply as a single delta, so every other adapter compiles and behaves unchanged.
- `PersistentAgentProxy` overrides it to emit **cleaned stdout fragments as the child produces them**. Each fragment also **resets the idle clock**, so streaming output both drives the stream and proves liveness.
- New **`StreamingSanitizer`** is the single incremental source of truth for noise-stripping, so streamed fragments concatenate to the persisted text by construction.
- `MeetingBackend` gains `send_message_streaming` + `supports_streaming`; `send_message` delegates with a no-op sink (one code path). The full assistant turn is still **persisted exactly once** (#2586 persistence preserved).
- **`/ws/chat`** now streams **real `chunk` frames** as deltas arrive (`spawn_blocking` → tokio mpsc bridge), terminated by `done`. The 15ms/48-char post-hoc chunker is gone. The non-streaming path is an **explicit declared capability** (`supports_streaming()`), not a silent fallback. The existing frontend contract (`appendChunk`/`finalizeStream`) is unchanged.

### 3. Both surfaces stay consistent
`simard meeting` (CLI) and the dashboard chat share `PersistentAgentProxy`; the CLI path is unregressed.

## Tests (fake child + injectable clock; no network)
- A turn producing output for well over the former 120s is **not** killed and its deltas stream incrementally.
- A fully-idle child past the window **is** terminated and the hang is reported (**error + metric**), asserted via an injected metric sink (no writes to `~/.simard`).
- Streaming deltas (and stderr heartbeats) **reset the idle clock**.
- The full assistant turn is **persisted exactly once**.
- The **non-streaming capability path** still returns a complete reply (single delta).
- `simard meeting` send path unregressed; `StreamingSanitizer` parity with the legacy one-shot pass; `/ws/chat` `spawn_turn` bridge streams real deltas + returns the full reply.

## Validation
- `cargo fmt --all -- --check` ✅
- `cargo clippy --release --no-deps -- -D warnings` ✅ (pre-commit)
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✅ (pre-push)
- `cargo test --lib` ✅ (6987 passed; the one flaky failure is a pre-existing **real-`copilot`** integration test in `base_type_copilot`, which this PR does not touch — it passes in isolation)
- `mkdocs build --strict` ✅ (docs updated: idle env var + real streaming)
- No `--no-verify`, no `--admin`. Branched off latest `origin/main` (includes #2586).

## Deploy note
**The operator redeploys after merge.** No redeploy was performed by this change; `~/.simard` and the live daemon were not touched.