### PR TITLE
fix(goal_curation): progress-evidence gate fails closed on semantic verdict parse-miss (#2569)

### DIFF
--- a/docs/concepts/progress-evidence-gating.md
+++ b/docs/concepts/progress-evidence-gating.md
@@ -72,10 +72,15 @@ The reviewer **rejects** when the claimed percent looks hallucinated:
 - A 100% claim with no shipped artifact in the plan or WIP.
 - A claim that contradicts the plan (e.g. "blocked on review" but claims 90%).
 
-On **LLM infrastructure failure** (transport error, parse error, empty
-response), the reviewer **accepts** with a diagnostic rationale. The gate's
+On a **genuine infrastructure gap** (LLM transport error, or an *empty*
+response), the reviewer **accepts** with a diagnostic rationale — the gate's
 purpose is to catch hallucinated jumps, not to block goals on LLM
-availability.
+availability. But a **semantic parse-miss** — a *successful, non-empty*
+response that carries no recognizable `accept`/`reject` verdict (unparseable
+output, or an unknown verdict string) — is treated as evidence-absence and
+**rejected**, so a hallucinated "no verdict" bump cannot land. (`Reject`
+keeps the prior percent and logs a hallucination alert; it does not stall the
+goal.)
 
 > **History:** Prior to PR #2007/#2011, evidence was gathered via `git log`
 > and `gh pr list` shellouts (the `DefaultProgressEvidenceChecker`). Per user
@@ -91,9 +96,11 @@ time the brain makes a progress claim. An LLM reviewer can assess whether a
 claimed delta is *proportional to the described plan* — a judgment call that
 a fixed-rule state machine cannot make.
 
-The trade-off is that the reviewer depends on LLM availability. The fail-open
-design means an LLM outage degrades to pre-#1967 behavior (all claims
-accepted) rather than blocking all goals.
+The trade-off is that the reviewer depends on LLM availability. The
+fail-open-on-**infra** design means an LLM outage degrades to pre-#1967
+behavior (claims accepted) rather than blocking all goals — while a
+successful run that produces no parseable verdict still fails **closed**, so
+the outage tolerance never becomes a blanket "accept everything".
 
 ### What does *not* count as evidence
 

--- a/docs/concepts/text-based-brain-protocol.md
+++ b/docs/concepts/text-based-brain-protocol.md
@@ -41,7 +41,7 @@ sites in the codebase parsed JSON from LLM or recipe output:
 | `decide.rs` | `DecideJudgment` from LLM response | `find('{')..rfind('}')` extraction — boundary attacks, partial objects |
 | `orient.rs` | `OrientJudgment` from LLM response | Same extraction pattern |
 | `rustyclawd.rs` | `EngineerLifecycleDecision` from LLM response | JSON fallback path after DECISION marker — two parsers, double failure surface |
-| `progress_reviewer.rs` | `ReviewerResponse` from LLM response | Dead code — replaced by recipe_progress_checker |
+| `progress_reviewer.rs` | `ReviewerResponse` from LLM response | Retained as the live direct-LLM fallback tier (used when `recipe-runner-rs` is unavailable); its tolerant `parse_reviewer_response` is now also reused by `recipe_progress_checker.rs` for JSON-first verdict extraction |
 | `merge_judge.rs` | `JudgeOutcome` from LLM response | Dead code — replaced by recipe_merge_judge |
 
 Every one of these was brittle and unnecessary:
@@ -227,9 +227,12 @@ Several modules were deleted or cleaned up as part of the text-migration changes
   `parse_orient_from_text`, `parse_lifecycle_from_text`) rewritten as trivial
   first-word/first-float extractors.
 
-The daemon wiring in `operator_commands_ooda/daemon/mod.rs` was updated to
-match: the `LlmReviewerProgressChecker` fallback arm was removed. The chain
-is now `RecipeProgressChecker` → `NoopProgressEvidenceChecker`.
+The daemon wiring in `operator_commands_ooda/daemon/mod.rs` resolves the
+progress-evidence gate in three tiers: `RecipeProgressChecker` (recipe-runner
+backed, primary) → `LlmReviewerProgressChecker` (direct-LLM fallback, in
+`progress_reviewer.rs`) → `NoopProgressEvidenceChecker`. Both live LLM tiers
+share the same infra-fail-open / semantic-parse-miss-fail-closed verdict policy
+(see [Progress-evidence API](../reference/progress-evidence-api.md)).
 
 ## Why this matters for engineer spawning
 

--- a/docs/reference/progress-evidence-api.md
+++ b/docs/reference/progress-evidence-api.md
@@ -13,12 +13,14 @@ sibling `simard::goal_curation::operations` module.
 > **History:** Prior to PR #2007, the production implementation was
 > `DefaultProgressEvidenceChecker`, which shelled out to `git log` and
 > `gh pr list`. That struct and its helper traits (`GitRunner`, `GhRunner`)
-> were removed in PR #2011. The gate then delegated to `LlmReviewerProgressChecker`
-> (JSON-based LLM response parsing), which was replaced by
-> `RecipeProgressChecker` with text-based keyword verdict parsing in #1980.
-> The `LlmReviewerProgressChecker` and its module (`progress_reviewer.rs`)
-> have been deleted — they were dead code once the recipe-based checker
-> became the primary tier.
+> were removed in PR #2011. `LlmReviewerProgressChecker`
+> (`progress_reviewer.rs`, JSON-based LLM response parsing) was superseded as
+> the *primary* tier by `RecipeProgressChecker` (text-based keyword verdict
+> parsing) in #1980, but is **retained as the direct-LLM fallback tier**: at
+> daemon boot the gate resolves `RecipeProgressChecker` (recipe-runner-rs
+> backed) first, then `LlmReviewerProgressChecker` (direct LLM), then
+> `NoopProgressEvidenceChecker`. Both live tiers share the same
+> infra-fail-open / semantic-parse-miss-fail-closed policy.
 
 All public symbols below are re-exported from `simard::goal_curation`.
 
@@ -67,9 +69,13 @@ can be installed on `OodaBridges` and shared across all OODA actions.
   a few times per OODA cycle, only on progress-increase attempts.
 - `check` MUST return `Accept` when evidence supports the claim and
   `Reject` otherwise. The production `RecipeProgressChecker`
-  accepts on infrastructure failure (recipe not found, runner not
-  installed, non-zero exit) — the gate's purpose is to catch
-  hallucinated jumps, not to block goals on recipe availability. See
+  splits **infrastructure failure** from a **semantic parse-miss**:
+  it **accepts** on infra failure (recipe not found, runner not
+  installed, non-zero exit, or *empty* output) — the gate's purpose is
+  to catch hallucinated jumps, not to block goals on recipe availability
+  — but it **rejects** on a semantic parse-miss (a *successful,
+  non-empty* run whose output carries no `accept`/`reject` verdict), so
+  a hallucinated "no verdict" bump cannot land. See
   [`SIMARD_PROGRESS_EVIDENCE`](../operations/progress-evidence-kill-switch.md)
   for the operator escape hatch.
 - The `since` argument is provided by the caller; the trait does not
@@ -88,18 +94,22 @@ can be installed on `OodaBridges` and shared across all OODA actions.
 
 The production implementation (`src/goal_curation/recipe_progress_checker.rs`)
 invokes a recipe that runs an LLM agent to review goal progress. The recipe
-stdout is parsed using the keyword verdict protocol — the checker scans for
-`"accept"` or `"reject"` keywords in the text output. See
+stdout is parsed **structured JSON verdict first** (`{"verdict":
+"accept"|"reject", …}`, via the shared `parse_reviewer_response` extractor),
+falling back to an `"accept"`/`"reject"` keyword scan for prose. Parsing the
+JSON object first avoids substring false-positives (e.g. an `accept` verdict
+whose rationale mentions "reject"). See
 [text-parsing wire formats § progress checker](../reference/text-parsing-wire-formats.md#2a-progress-checker-recipe_progress_checkerrs)
 for the full grammar.
 
 | Condition | Result | `reason` template |
 |---|---|---|
-| `new_percent <= old_percent` | `Accept` (auto, no recipe call) | `"progress-assessment-reviewer: downward / no-change (<old> -> <new>) auto-accepted"` |
-| Recipe stdout contains `"accept"` keyword | `Accept` | `"progress-assessment-reviewer: accept — <surrounding text as rationale>"` |
-| Recipe stdout contains `"reject"` keyword | `Reject` | `"progress-assessment-reviewer: reject — <surrounding text as rationale>"` |
-| No keyword found in recipe stdout | `Accept` (fail-open) | `"progress-assessment-reviewer: no verdict keyword found; accepting to avoid blocking goal"` |
-| Recipe invocation failure | `Accept` (fail-open) | `"progress-assessment-reviewer: recipe failed (<error>); accepting to avoid blocking goal"` |
+| `new_percent <= old_percent` | `Accept` (auto, no recipe call) | `"recipe-progress-checker: downward / no-change (<old> -> <new>) auto-accepted"` |
+| Recipe stdout contains `"accept"` keyword | `Accept` | `"recipe-progress-checker: accept — <surrounding text as rationale>"` |
+| Recipe stdout contains `"reject"` keyword | `Reject` | `"recipe-progress-checker: reject — <surrounding text as rationale>"` |
+| No keyword in **non-empty** recipe stdout | `Reject` (fail-closed: semantic parse-miss) | `"recipe-progress-checker: no verdict keyword in non-empty recipe output; rejecting unverified progress"` |
+| **Empty** recipe stdout on a successful run | `Accept` (fail-open: infra gap) | `"recipe-progress-checker: empty recipe output; accepting to avoid blocking goal on infra"` |
+| Recipe invocation failure (spawn / non-zero exit) | `Accept` (fail-open: infra) | `"recipe-progress-checker: recipe … accepting to avoid blocking goal …"` |
 
 The recipe template lives at
 `prompt_assets/simard/recipes/progress-assessment.yaml`. The prompt within
@@ -123,18 +133,23 @@ impl RecipeProgressChecker {
 ```
 
 The production checker. Invokes the progress-assessment recipe via
-`recipe-runner-rs` and parses the verdict from the text output using keyword
-scanning. No JSON parsing. No intermediate `ReviewerResponse` type.
+`recipe-runner-rs` and resolves the verdict **structured JSON first**
+(`{"verdict": …}`, via the shared `parse_reviewer_response` extractor), with an
+`"accept"`/`"reject"` keyword scan as a prose fallback.
 
 The checker:
 
 1. Auto-accepts downward/no-change moves without a recipe call.
 2. Resolves the recipe YAML (hot-reload path, then in-tree).
 3. Invokes `recipe-runner-rs` with goal context as variables.
-4. Scans stdout for `"accept"` or `"reject"` (case-insensitive).
-5. Maps the keyword to `EvidenceDecision`, using surrounding text as rationale.
-6. Fails open on any infrastructure error (recipe not found, runner not
-   installed, non-zero exit).
+4. Parses the structured `{"verdict": …}` JSON first; on a JSON miss, scans
+   stdout for `"accept"` or `"reject"` (case-insensitive).
+5. Maps the verdict to `EvidenceDecision`, using the rationale/surrounding text.
+6. Fails **open** on an infrastructure error (recipe not found, runner not
+   installed, non-zero exit, or empty output) — but fails **closed**
+   (`Reject`) on a semantic parse-miss: a successful, non-empty run whose
+   output carries no `accept`/`reject` verdict, so a hallucinated "no
+   verdict" progress bump is not silently accepted.
 
 ---
 

--- a/docs/reference/text-parsing-wire-formats.md
+++ b/docs/reference/text-parsing-wire-formats.md
@@ -377,16 +377,35 @@ The parser scans the entire stdout for a verdict keyword. Everything else
 
 ### 2a. Progress checker (`recipe_progress_checker.rs`)
 
-**Keywords:**
+**Resolution order (structured verdict first, then keyword prose):** the
+recipe's prompt contract emits a JSON object
+`{"verdict": "accept"|"reject", "rationale": "..."}`, so the parser tries the
+**structured JSON verdict first** (via the shared
+`progress_reviewer::parse_reviewer_response` extractor — as-is / fenced /
+brace-balanced / outermost), mirroring the merge judge's
+`parse_judge_response`-first path. Parsing the object first avoids substring
+false-positives — e.g. an `accept` verdict whose *rationale* mentions "reject"
+(a naive `contains("reject")` scan would wrongly flip it to Reject), or
+"unacceptable" containing the `accept` substring. A valid JSON object with an
+*unknown* verdict string is a semantic parse-miss → `Reject` (fail-closed).
+Only when no verdict JSON parses does it fall back to the plain keyword scan.
+
+**Keywords (prose fallback):**
 
 | Keyword | Maps to | Priority |
 |---------|---------|----------|
 | `reject` | `EvidenceDecision::Reject` | Checked first |
 | `accept` | `EvidenceDecision::Accept` | Checked second |
 
-**Default (no keyword):** `EvidenceDecision::Accept` — fail-open. The gate's
-purpose is to catch hallucinated jumps, not to block goals on keyword-detection
-availability.
+**Default (no verdict):** splits on whether the run produced output. A
+**successful, non-empty** stdout with no `accept`/`reject` verdict is a
+*semantic parse-miss* → `EvidenceDecision::Reject` (**fail-closed**): the
+reviewer ran but gave no verdict, so the unverified progress bump is refused
+rather than silently accepted. Output that strips to **empty** is treated as an
+*infra gap* → `EvidenceDecision::Accept` (**fail-open**), so a lost-output
+hiccup does not block the goal. Genuine invocation failures (spawn / non-zero
+exit) likewise fail open. The gate's purpose is to catch hallucinated jumps
+without blocking goals on infrastructure availability.
 
 **Example recipe stdout:**
 
@@ -399,23 +418,18 @@ WIP summary references new test files in tests/integration/.
 
 The 8-point increase is proportional to the described work.
 
-accept
+{"verdict": "accept", "rationale": "8pt delta matches the described test work"}
 ```
 
-Parser result: `EvidenceDecision::Accept { reason: "After reviewing the plan and progress claims: ..." }`
+Parser result: `EvidenceDecision::Accept { reason: "recipe-progress-checker: accept — …" }`
 
-**Changes from prior implementation:**
-
-- `parse_reviewer_response` (which parsed JSON `ReviewerResponse`) is removed.
-- `RecipeProgressChecker::check()` now calls `parse_verdict_from_text()`
-  directly and returns `EvidenceDecision` without the intermediate
-  `ReviewerResponse` type.
-- The `progress_reviewer.rs` module (containing `LlmReviewerProgressChecker`)
-  is deleted. It was dead code — the daemon wiring already used
-  `RecipeProgressChecker` as the primary tier.
-- The daemon fallback chain is now: `RecipeProgressChecker` →
-  `NoopProgressEvidenceChecker` (was: `RecipeProgressChecker` →
-  `LlmReviewerProgressChecker` → `NoopProgressEvidenceChecker`).
+**Tier relationship:** `RecipeProgressChecker` is the primary tier;
+`progress_reviewer.rs`'s `LlmReviewerProgressChecker` is the live **direct-LLM
+fallback** tier (used when `recipe-runner-rs` is unavailable). The daemon
+resolution chain is `RecipeProgressChecker` → `LlmReviewerProgressChecker` →
+`NoopProgressEvidenceChecker`. Both live tiers share the same
+infra-fail-open / semantic-parse-miss-fail-closed policy and reuse the same
+`parse_reviewer_response` verdict extractor.
 
 ---
 

--- a/src/goal_curation/progress_reviewer.rs
+++ b/src/goal_curation/progress_reviewer.rs
@@ -16,10 +16,20 @@
 //! Prompt template: `prompt_assets/simard/progress_assessment_reviewer.md`.
 //! Response shape: `{"verdict": "accept"|"reject", "rationale": "..."}`.
 //!
-//! Failure handling: on LLM transport error, JSON parse error, or empty
-//! response, the reviewer **accepts** with a diagnostic rationale. The
-//! purpose of this gate is to catch hallucinated progress jumps — not to
-//! block goals on LLM infrastructure issues.
+//! Failure handling splits INFRA failures from SEMANTIC parse-misses
+//! (reasoner-reliability; the sibling of the #2462/#2463/#2569 verdict
+//! family that made the merge judge fail closed to `Unclear`):
+//!   * **Infra failure** — no usable response was produced (LLM transport
+//!     error, or an *empty* response). The reviewer **accepts** with a
+//!     diagnostic so goals are never blocked on LLM infrastructure hiccups.
+//!   * **Semantic parse-miss** — the LLM *did* return a non-empty response
+//!     but it carries no recognizable `accept`/`reject` verdict (unparseable
+//!     JSON, or a valid object with an unknown verdict string). The reviewer
+//!     **rejects**: refusing an unverified upward progress bump is safe
+//!     (`Reject` keeps the prior percent, it does not stall the goal) and
+//!     stops a hallucinated "0%→100% with no verdict" jump from landing.
+//!
+//! The purpose of this gate is to catch hallucinated progress jumps.
 
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
@@ -107,11 +117,26 @@ impl<S: LlmSubmitter> ProgressEvidenceChecker for LlmReviewerProgressChecker<S> 
 
         match parse_reviewer_response(&raw) {
             Ok(parsed) => decision_from_response(parsed),
-            Err(parse_err) => EvidenceDecision::Accept {
-                reason: format!(
-                    "{ADAPTER_TAG}: parse error ({parse_err}); accepting to avoid blocking goal"
-                ),
-            },
+            Err(parse_err) => {
+                if raw.trim().is_empty() {
+                    // Empty response = LLM infra hiccup (no output produced).
+                    // Keep fail-OPEN so goals are not blocked on transport gaps.
+                    EvidenceDecision::Accept {
+                        reason: format!(
+                            "{ADAPTER_TAG}: empty LLM response ({parse_err}); accepting to avoid blocking goal on infra"
+                        ),
+                    }
+                } else {
+                    // Non-empty but unparseable = the reviewer ran yet produced
+                    // no recognizable verdict. Fail CLOSED so a hallucinated
+                    // progress bump is not silently accepted.
+                    EvidenceDecision::Reject {
+                        reason: format!(
+                            "{ADAPTER_TAG}: unparseable non-empty response ({parse_err}); rejecting unverified progress"
+                        ),
+                    }
+                }
+            }
         }
     }
 }
@@ -152,10 +177,12 @@ fn decision_from_response(r: ReviewerResponse) -> EvidenceDecision {
             reason: format!("{ADAPTER_TAG}: reject — {rationale}"),
         }
     } else {
-        // Unknown verdict string — accept with diagnostic.
-        EvidenceDecision::Accept {
+        // Unknown verdict string on a successful, non-empty response — the
+        // reviewer ran but gave no clear accept/reject. Fail CLOSED: refuse
+        // the unverified progress bump rather than silently accepting it.
+        EvidenceDecision::Reject {
             reason: format!(
-                "{ADAPTER_TAG}: unknown verdict {:?}; accepting to avoid blocking goal",
+                "{ADAPTER_TAG}: unknown verdict {:?}; rejecting unverified progress",
                 r.verdict
             ),
         }
@@ -412,32 +439,57 @@ mod tests {
     }
 
     #[test]
-    fn parse_error_falls_back_to_accept() {
+    fn unparseable_nonempty_response_fails_closed_to_reject() {
+        // The LLM returned non-empty text that carries no parseable verdict.
+        // This is a SEMANTIC parse-miss (not an infra gap), so the gate must
+        // fail CLOSED and refuse the unverified progress bump.
         let stub = StubSubmitter {
             response: Ok("this is not json at all".to_string()),
         };
         let c = LlmReviewerProgressChecker::new(stub);
         let g = goal_with_activity(None);
         match c.check(&g, 10, 20, now()) {
-            EvidenceDecision::Accept { reason } => {
-                assert!(reason.contains("parse error"), "got: {reason}");
+            EvidenceDecision::Reject { reason } => {
+                assert!(reason.contains("unparseable"), "got: {reason}");
             }
-            EvidenceDecision::Reject { .. } => panic!("expected accept on parse failure"),
+            EvidenceDecision::Accept { .. } => {
+                panic!("expected reject on unparseable non-empty response")
+            }
         }
     }
 
     #[test]
-    fn unknown_verdict_falls_back_to_accept() {
+    fn empty_response_falls_back_to_accept() {
+        // An EMPTY LLM response is treated as an infra hiccup (no output
+        // produced), so the gate stays fail-OPEN to avoid blocking the goal.
+        let stub = StubSubmitter {
+            response: Ok("   ".to_string()),
+        };
+        let c = LlmReviewerProgressChecker::new(stub);
+        let g = goal_with_activity(None);
+        match c.check(&g, 10, 20, now()) {
+            EvidenceDecision::Accept { reason } => {
+                assert!(reason.contains("empty LLM response"), "got: {reason}");
+            }
+            EvidenceDecision::Reject { .. } => panic!("expected accept on empty response"),
+        }
+    }
+
+    #[test]
+    fn unknown_verdict_fails_closed_to_reject() {
+        // A valid JSON object with an unrecognized verdict string is a
+        // SEMANTIC parse-miss: the reviewer ran but gave no clear accept/
+        // reject, so the gate must fail CLOSED (reasoner-reliability).
         let stub = StubSubmitter {
             response: Ok(r#"{"verdict": "maybe", "rationale": "shrug"}"#.to_string()),
         };
         let c = LlmReviewerProgressChecker::new(stub);
         let g = goal_with_activity(None);
         match c.check(&g, 10, 20, now()) {
-            EvidenceDecision::Accept { reason } => {
+            EvidenceDecision::Reject { reason } => {
                 assert!(reason.contains("unknown verdict"), "got: {reason}");
             }
-            EvidenceDecision::Reject { .. } => panic!("expected accept on unknown verdict"),
+            EvidenceDecision::Accept { .. } => panic!("expected reject on unknown verdict"),
         }
     }
 

--- a/src/goal_curation/recipe_progress_checker.rs
+++ b/src/goal_curation/recipe_progress_checker.rs
@@ -13,9 +13,16 @@
 //! with `-c` context vars and parses its stdout using the same
 //! `parse_reviewer_response` logic from `progress_reviewer`.
 //!
-//! Fallback on recipe failure: accept with diagnostic (matches the
-//! existing `LlmReviewerProgressChecker` behaviour so goals are never
-//! blocked on infrastructure issues).
+//! Fallback policy splits INFRA failures from SEMANTIC parse-misses
+//! (reasoner-reliability; the sibling of the merge judge's
+//! fail-closed-to-`Unclear` for the same class of parse-miss):
+//!   * **Infra failure** — no usable output was produced (recipe spawn
+//!     failure, non-zero exit, or an *empty* stdout): accept with a
+//!     diagnostic so goals are never blocked on infrastructure issues.
+//!   * **Semantic parse-miss** — the recipe exited 0 with non-empty output
+//!     that carries no `accept`/`reject` keyword: reject, refusing the
+//!     unverified progress bump so a hallucinated "no verdict" jump cannot
+//!     land (`Reject` keeps the prior percent; it does not stall the goal).
 
 use chrono::{DateTime, Utc};
 use std::path::PathBuf;
@@ -169,28 +176,35 @@ fn render_wip_summary(goal: &ActiveGoal) -> String {
     s
 }
 
-/// Parse recipe stdout text for verdict keywords (accept/reject).
+/// Parse recipe stdout for the progress verdict.
 ///
-/// The recipe runs an agent that produces natural language output.
-/// We scan for the verdict keyword and use the surrounding text as
-/// the rationale. No JSON parsing needed — the agent already makes
-/// the decision; we just need to read it.
+/// The recipe's prompt contract emits a JSON object
+/// `{"verdict": "accept"|"reject", "rationale": "..."}`. This parser tries the
+/// **structured JSON verdict first** — mirroring the merge judge's
+/// `parse_judge_response`-first path and the direct-LLM tier's
+/// [`super::progress_reviewer::decision_from_response`] — and only falls back
+/// to a plain keyword scan for prose. Parsing the object first avoids substring
+/// false-positives, e.g. an `accept` verdict whose *rationale* mentions
+/// "reject" (which a naive `contains("reject")` scan would wrongly flip to
+/// Reject), or "unacceptable" containing the `accept` substring.
 ///
-/// Scan rules:
-/// - Case-insensitive search for "accept" or "reject"
-/// - First match wins
-/// - The full text (truncated) becomes the rationale
-/// - If neither keyword found, accept with diagnostic (same fallback
-///   as the old JSON parse-error path)
+/// Resolution:
+/// 1. Structured `{"verdict": …}` JSON → exact accept/reject; an unknown
+///    verdict string is a semantic parse-miss → reject (fail-closed).
+/// 2. Prose keyword scan (negative keyword first) for non-JSON output.
+/// 3. Non-empty output with no keyword → reject (semantic parse-miss: the
+///    recipe ran but gave no verdict, so the unverified bump is refused).
+/// 4. Output that strips to empty → accept (infra gap: no verdict produced,
+///    keep fail-open so a lost-output hiccup does not block the goal).
 pub fn parse_verdict_from_text(text: &str) -> EvidenceDecision {
     parse_verdict_outcome(text).0
 }
 
-/// Like [`parse_verdict_from_text`] but also returns whether a verdict keyword
-/// was actually found (`true`) versus the permissive accept-to-avoid-blocking
-/// default firing (`false`). The flag drives the `recipe_parse_*_total{phase}`
-/// counter at the subprocess call site (issue #2484); the pure parser stays
-/// metric-free so unit tests write no metrics.
+/// Like [`parse_verdict_from_text`] but also returns whether a real verdict was
+/// resolved (`true`) versus a parse-miss default firing (`false`). The flag
+/// drives the `recipe_parse_*_total{phase}` counter at the subprocess call site
+/// (issue #2484); the pure parser stays metric-free so unit tests write no
+/// metrics.
 pub fn parse_verdict_outcome(text: &str) -> (EvidenceDecision, bool) {
     // Strip ANSI escapes + drop whole tracing-log / runner-banner lines first
     // (shared #2484 extractor) so a noise-obscured verdict is not silently
@@ -198,6 +212,42 @@ pub fn parse_verdict_outcome(text: &str) -> (EvidenceDecision, bool) {
     // ANSI-coloured log prefix, and an "already"/"accepted" substring inside a
     // dropped log line cannot fabricate a verdict.
     let cleaned = crate::recipe_output::strip_recipe_noise(text);
+
+    // 1. Structured JSON verdict first (robust against rationale text that
+    //    happens to contain the opposite keyword). Reuses the direct-LLM tier's
+    //    tolerant extractor (as-is / fenced / brace-balanced / outermost).
+    if let Ok(parsed) = super::progress_reviewer::parse_reviewer_response(&cleaned) {
+        let verdict_lc = parsed.verdict.trim().to_ascii_lowercase();
+        let rationale = truncate(parsed.rationale.trim(), RATIONALE_MAX_CHARS);
+        return match verdict_lc.as_str() {
+            "accept" => (
+                EvidenceDecision::Accept {
+                    reason: format!("{ADAPTER_TAG}: accept — {rationale}"),
+                },
+                true,
+            ),
+            "reject" => (
+                EvidenceDecision::Reject {
+                    reason: format!("{ADAPTER_TAG}: reject — {rationale}"),
+                },
+                true,
+            ),
+            // Valid JSON object but an unknown verdict string → semantic
+            // parse-miss → fail CLOSED (refuse the unverified progress bump).
+            _ => (
+                EvidenceDecision::Reject {
+                    reason: format!(
+                        "{ADAPTER_TAG}: unknown verdict {:?}; rejecting unverified progress",
+                        parsed.verdict
+                    ),
+                },
+                false,
+            ),
+        };
+    }
+
+    // 2. Prose keyword fallback (no parseable JSON object). Negative keyword
+    //    first so a "cannot accept … reject" ordering resolves to reject.
     let lower = cleaned.to_ascii_lowercase();
     let rationale = truncate(cleaned.trim(), RATIONALE_MAX_CHARS);
 
@@ -215,11 +265,29 @@ pub fn parse_verdict_outcome(text: &str) -> (EvidenceDecision, bool) {
             },
             true,
         )
-    } else {
+    } else if cleaned.trim().is_empty() {
+        // No reviewable content after noise-stripping — the run produced only
+        // banner/log noise (or nothing at all), so no verdict was ever
+        // emitted. Treat as an infra gap and keep fail-OPEN so a lost-output
+        // hiccup does not block the goal. (Real, substantive prose that simply
+        // omits a verdict keyword falls through to the fail-CLOSED branch.)
         (
             EvidenceDecision::Accept {
                 reason: format!(
-                    "{ADAPTER_TAG}: no verdict keyword found in recipe output; accepting to avoid blocking goal"
+                    "{ADAPTER_TAG}: empty recipe output; accepting to avoid blocking goal on infra"
+                ),
+            },
+            false,
+        )
+    } else {
+        // Successful, non-empty output but NO accept/reject keyword: the
+        // reviewer ran yet produced no recognizable verdict. Fail CLOSED —
+        // refuse the unverified progress bump so a hallucinated "no verdict"
+        // jump cannot land (reasoner-reliability).
+        (
+            EvidenceDecision::Reject {
+                reason: format!(
+                    "{ADAPTER_TAG}: no verdict keyword in non-empty recipe output; rejecting unverified progress"
                 ),
             },
             false,
@@ -307,6 +375,70 @@ mod tests {
     // Text-based verdict parser (issue #1980)
     // ------------------------------------------------------------------
 
+    // ------------------------------------------------------------------
+    // Structured JSON verdict first (robustness against rationale text that
+    // contains the opposite keyword — the recipe tier now parses the object
+    // before the prose keyword scan, matching the merge judge + direct-LLM tier).
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn json_accept_verdict_with_reject_in_rationale_accepts() {
+        // Regression: a naive `contains("reject")`-first scan would wrongly
+        // flip this legitimate accept to Reject because the RATIONALE mentions
+        // "reject". Parsing the JSON verdict first fixes that.
+        let text =
+            r#"{"verdict": "accept", "rationale": "8pt delta matches plan; no reason to reject"}"#;
+        let (decision, matched) = parse_verdict_outcome(text);
+        match decision {
+            EvidenceDecision::Accept { reason } => {
+                assert!(reason.contains("accept"), "got: {reason}");
+                assert!(reason.contains("no reason to reject"), "got: {reason}");
+            }
+            EvidenceDecision::Reject { .. } => {
+                panic!("JSON accept must win even when the rationale mentions 'reject'")
+            }
+        }
+        assert!(matched, "a real JSON verdict must report matched=true");
+    }
+
+    #[test]
+    fn json_reject_verdict_parses() {
+        let text = r#"{"verdict": "reject", "rationale": "100% claim with no shipped artifact"}"#;
+        let (decision, matched) = parse_verdict_outcome(text);
+        assert!(matches!(decision, EvidenceDecision::Reject { .. }));
+        assert!(matched);
+    }
+
+    #[test]
+    fn json_unknown_verdict_fails_closed() {
+        // A valid JSON object with an unrecognized verdict string is a semantic
+        // parse-miss → fail CLOSED.
+        let text = r#"{"verdict": "accepted", "rationale": "typo verdict"}"#;
+        let (decision, matched) = parse_verdict_outcome(text);
+        match decision {
+            EvidenceDecision::Reject { reason } => {
+                assert!(reason.contains("unknown verdict"), "got: {reason}");
+            }
+            EvidenceDecision::Accept { .. } => {
+                panic!("unknown JSON verdict string must fail closed, not accept")
+            }
+        }
+        assert!(
+            !matched,
+            "unknown verdict default must report matched=false"
+        );
+    }
+
+    #[test]
+    fn json_fenced_verdict_parses() {
+        let text =
+            "Here is my verdict:\n```json\n{\"verdict\":\"reject\",\"rationale\":\"stalled\"}\n```";
+        assert!(matches!(
+            parse_verdict_from_text(text),
+            EvidenceDecision::Reject { .. }
+        ));
+    }
+
     #[test]
     fn text_verdict_accept_detected() {
         let text = "After reviewing the evidence, I accept the claimed progress.";
@@ -353,24 +485,30 @@ mod tests {
     }
 
     #[test]
-    fn text_verdict_no_keyword_falls_back_to_accept() {
+    fn text_verdict_no_keyword_fails_closed_to_reject() {
+        // Non-empty output with no accept/reject keyword is a SEMANTIC
+        // parse-miss: the recipe ran but gave no verdict, so the gate must
+        // fail CLOSED and refuse the unverified progress bump.
         let text = "The progress looks reasonable for this stage.";
         match parse_verdict_from_text(text) {
-            EvidenceDecision::Accept { reason } => {
+            EvidenceDecision::Reject { reason } => {
                 assert!(reason.contains("no verdict keyword"), "got: {reason}");
+                assert!(reason.contains("non-empty"), "got: {reason}");
             }
-            EvidenceDecision::Reject { .. } => {
-                panic!("expected accept fallback when no keyword found")
+            EvidenceDecision::Accept { .. } => {
+                panic!("expected reject fallback when no keyword found in non-empty output")
             }
         }
     }
 
     #[test]
     fn text_verdict_empty_falls_back_to_accept() {
+        // EMPTY output is an infra gap (no verdict produced), so the gate
+        // stays fail-OPEN to avoid blocking the goal.
         let text = "";
         match parse_verdict_from_text(text) {
             EvidenceDecision::Accept { reason } => {
-                assert!(reason.contains("no verdict keyword"), "got: {reason}");
+                assert!(reason.contains("empty recipe output"), "got: {reason}");
             }
             EvidenceDecision::Reject { .. } => panic!("expected accept on empty text"),
         }
@@ -424,12 +562,97 @@ mod tests {
     #[test]
     fn parse_verdict_outcome_reports_match_flag_for_counter() {
         // The `bool` drives the `recipe_parse_*_total{progress_checker}` counter:
-        // a real keyword ⇒ true (success), the permissive default ⇒ false.
+        // a real keyword ⇒ true (success), a parse-miss default ⇒ false.
+        // A non-empty parse-miss now fails CLOSED (reject) rather than the old
+        // permissive accept.
         let (decision, matched) = parse_verdict_outcome("just prose, no verdict keyword here");
-        assert!(matches!(decision, EvidenceDecision::Accept { .. }));
-        assert!(!matched, "permissive default must report matched=false");
+        assert!(matches!(decision, EvidenceDecision::Reject { .. }));
+        assert!(!matched, "parse-miss default must report matched=false");
+
+        // An EMPTY body stays fail-open (infra gap) and also reports matched=false.
+        let (empty_decision, empty_matched) = parse_verdict_outcome("   ");
+        assert!(matches!(empty_decision, EvidenceDecision::Accept { .. }));
+        assert!(
+            !empty_matched,
+            "empty-output default must report matched=false"
+        );
 
         let (_, matched_reject) = parse_verdict_outcome("Verdict: reject — insufficient evidence");
         assert!(matched_reject, "a real verdict must report matched=true");
+    }
+
+    #[test]
+    fn no_verdict_keyword_rejects_unverified_progress_bump() {
+        // Reasoner-reliability regression (the "0%→100% with no verdict keyword"
+        // false-done scenario): a recipe that runs and emits prose WITHOUT an
+        // accept/reject keyword must NOT wave through the claimed progress.
+        let recipe_output =
+            "Looking at the plan and the WIP, the work appears to be moving along nicely.";
+        let (decision, matched) = parse_verdict_outcome(recipe_output);
+        assert!(
+            matches!(decision, EvidenceDecision::Reject { .. }),
+            "unverified progress must be rejected, not accepted"
+        );
+        assert!(!matched, "no keyword ⇒ matched=false");
+    }
+
+    #[test]
+    fn text_verdict_multiline_no_keyword_fails_closed() {
+        let text = "Reviewing the evidence:\n\n- some commits exist\n- plan referenced\n\nOverall this seems fine.";
+        assert!(matches!(
+            parse_verdict_from_text(text),
+            EvidenceDecision::Reject { .. }
+        ));
+    }
+
+    #[test]
+    fn log_noise_only_output_is_infra_accept() {
+        // Output that is ONLY strippable log/banner noise that collapses to
+        // *nothing* (ISO-timestamp tracing lines, `Recipe:`, `Steps:`,
+        // `[completed]`) is treated as an infra gap → fail-OPEN. This is the
+        // safety net for a genuinely content-free run; it must NOT be conflated
+        // with the fail-CLOSED semantic parse-miss (real prose without verdict).
+        let esc = '\u{1b}';
+        let noise = format!(
+            "{esc}[2m2026-06-28T08:08:58.151133Z{esc}[0m  INFO runner: starting\n\
+             Recipe: progress-assessment SUCCESS (12.0s)\n\
+             Steps: 1/1 completed\n\
+             [completed] assess (12.0s)\n"
+        );
+        let (decision, matched) = parse_verdict_outcome(&noise);
+        match decision {
+            EvidenceDecision::Accept { reason } => {
+                assert!(reason.contains("empty recipe output"), "got: {reason}");
+            }
+            EvidenceDecision::Reject { .. } => {
+                panic!("fully-stripped noise-only output must be infra-accept")
+            }
+        }
+        assert!(!matched, "noise-only default must report matched=false");
+    }
+
+    #[test]
+    fn production_success_banner_without_verdict_fails_closed() {
+        // The real recipe-runner-rs SUCCESS banner keeps its
+        // `Recipe '<name>': SUCCESS (Ns)` summary line (it starts with
+        // `Recipe '`, NOT `Recipe:`, so `strip_recipe_noise` does not drop it).
+        // A run that emits ONLY this banner and no agent verdict therefore
+        // leaves non-empty residue → fail-CLOSED (Reject), the progress-gate
+        // analogue of the merge judge's #2569 banner → `Unclear`. This is the
+        // reliability win: a recipe that ran but produced no verdict must not
+        // wave through the claimed progress.
+        let banner = "Recipe: progress-assessment (v1.0.0)\n\
+                      Steps: 1\n\
+                      Recipe 'progress-assessment': SUCCESS (30.0s)\n\
+                      \x20 [completed] assess (30.0s)\n";
+        match parse_verdict_from_text(banner) {
+            EvidenceDecision::Reject { reason } => {
+                assert!(reason.contains("no verdict keyword"), "got: {reason}");
+                assert!(reason.contains("non-empty"), "got: {reason}");
+            }
+            EvidenceDecision::Accept { .. } => {
+                panic!("a SUCCESS-banner-only progress run must fail closed, not accept")
+            }
+        }
     }
 }

--- a/src/ooda_brain/prompt_store_tests.rs
+++ b/src/ooda_brain/prompt_store_tests.rs
@@ -1623,7 +1623,8 @@ fn engineer_system_dep_bump_preserves_2410_landing() {
 
 #[test]
 fn progress_reviewer_rejects_unbumped_dep_after_upstream_landing() {
-    // The reviewer cannot diff git revs (text-only, fails open on unknown verdicts),
+    // The reviewer cannot diff git revs (text-only; it fails CLOSED on a
+    // semantic verdict parse-miss but cannot inspect commits),
     // so the rule is EVIDENCE-ABSENCE: reject a done/100% claim that describes landing
     // an upstream build-dependency change but shows no evidence of BOTH the own
     // Cargo.toml rev bump AND a verified `cargo build`.

--- a/src/stewardship/recipe_merge_judge.rs
+++ b/src/stewardship/recipe_merge_judge.rs
@@ -781,6 +781,34 @@ mod issue_2428_production_tests {
     }
 
     #[test]
+    fn issue_2569_reported_banners_fail_closed_to_unclear() {
+        // #2569 (a user-reported duplicate of the #2462/#2463 family, filed
+        // against released v0.22.0): `simard merge-pr` hard-FAILED because the
+        // SUCCESS-with-no-verdict banner produced "no verdict keyword found".
+        // The reporter observed it at BOTH 30s and 102s ("not a timeout race").
+        // On current main both must fail CLOSED to `Unclear` (→ merge Refused),
+        // never a hard error and never a `ready`-without-verdict.
+        for secs in ["30.0s", "102.0s"] {
+            let banner = format!(
+                "Recipe: merge-readiness-judge (v1.0.0)\nSteps: 1\n\nRecipe 'merge-readiness-judge': SUCCESS ({secs})\n  [completed] judge-merge-readiness ({secs})\n\n"
+            );
+            let (out, oc) = parse_merge_outcome(&banner);
+            assert_eq!(
+                out.verdict,
+                Verdict::Unclear,
+                "banner @ {secs} must fail closed to Unclear (issue #2569)"
+            );
+            assert!(
+                oc.is_parse_failure(),
+                "banner @ {secs} must classify as a parse-failure, not a real verdict"
+            );
+            // Never a hard error, never a spurious `ready` (the #2569 impact was
+            // that NO PR could land): a defaulted verdict must be non-`ready`.
+            assert_ne!(out.verdict, Verdict::Ready);
+        }
+    }
+
+    #[test]
     fn verdict_label_covers_all_variants() {
         assert_eq!(verdict_label(&Verdict::Ready), "ready");
         assert_eq!(verdict_label(&Verdict::NotReady), "not_ready");

--- a/tests/gadugi/progress-verdict-fail-closed.sh
+++ b/tests/gadugi/progress-verdict-fail-closed.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Outside-in scenario for the reasoner-reliability fix: the progress-evidence
+# gate must fail CLOSED on a SEMANTIC verdict parse-miss (a successful,
+# non-empty reviewer run that carries no accept/reject verdict), while staying
+# fail-OPEN on a genuine infra gap (empty output / transport error). This is
+# the sibling policy of the merge judge's fail-closed-to-`Unclear`
+# (#2462 / #2463 / #2569).
+#
+# What this proves, without an LLM, via the in-tree parser + decision tests:
+#
+#   (a) recipe-progress-checker: non-empty output with no verdict keyword now
+#       yields Reject (fail-closed), while EMPTY output stays Accept (fail-open).
+#   (b) progress-reviewer (direct-LLM fallback tier): an unknown verdict string
+#       and a non-empty unparseable response now yield Reject; an empty response
+#       stays Accept.
+#   (c) merge judge (#2569 regression): the reporter's exact SUCCESS-with-no-
+#       verdict banner (BOTH 30s and 102s) fails closed to `Verdict::Unclear`,
+#       never a hard error and never a spurious `ready`.
+#
+# Each rung captures `cargo test` output and asserts the NAMED tests actually
+# ran (a cargo filter that matches zero tests still exits 0), so a future rename
+# cannot silently turn this scenario into a no-op.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+WORK="$(mktemp -d /tmp/simard-progress-fail-closed.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+TEST_LOG="$WORK/progress-verdict-cargo-test.log"
+
+echo "== progress-evidence + merge-judge verdict fail-closed unit/decision tests =="
+# Run the three modules' tests together and capture output for name-pinning.
+cargo test --lib --locked -- \
+    progress_reviewer recipe_progress_checker recipe_merge_judge --nocapture \
+    >"$TEST_LOG" 2>&1
+
+PASSED_LINE="$(grep -oE 'test result: ok\. [0-9]+ passed' "$TEST_LOG" | tail -1 || true)"
+echo "final ${PASSED_LINE:-<no ok line>}"
+grep -qE 'test result: ok\.' "$TEST_LOG" \
+  || { echo "FAIL: cargo test did not report an ok result" >&2; cat "$TEST_LOG" >&2; exit 1; }
+if grep -qE 'test result: FAILED' "$TEST_LOG"; then
+  echo "FAIL: one or more verdict tests FAILED" >&2; cat "$TEST_LOG" >&2; exit 1
+fi
+
+# --- (a) recipe-progress-checker fail-closed on non-empty parse-miss ---------
+echo "== (a) recipe-progress-checker: JSON-first robustness + fail-closed parse-miss =="
+for t in \
+  'recipe_progress_checker::tests::json_accept_verdict_with_reject_in_rationale_accepts' \
+  'recipe_progress_checker::tests::json_unknown_verdict_fails_closed' \
+  'recipe_progress_checker::tests::text_verdict_no_keyword_fails_closed_to_reject' \
+  'recipe_progress_checker::tests::text_verdict_empty_falls_back_to_accept' \
+  'recipe_progress_checker::tests::no_verdict_keyword_rejects_unverified_progress_bump' \
+  'recipe_progress_checker::tests::log_noise_only_output_is_infra_accept' \
+  'recipe_progress_checker::tests::production_success_banner_without_verdict_fails_closed' \
+  'recipe_progress_checker::tests::parse_verdict_outcome_reports_match_flag_for_counter'
+do
+  grep -qF "$t ... ok" "$TEST_LOG" \
+    || { echo "FAIL: expected test did not run/pass: $t" >&2; exit 1; }
+done
+echo "OK: recipe-progress-checker fails closed on a semantic parse-miss."
+
+# --- (b) progress-reviewer (direct-LLM fallback) fail-closed -----------------
+echo "== (b) progress-reviewer fallback: unknown verdict / unparseable ⇒ Reject =="
+for t in \
+  'progress_reviewer::tests::unknown_verdict_fails_closed_to_reject' \
+  'progress_reviewer::tests::unparseable_nonempty_response_fails_closed_to_reject' \
+  'progress_reviewer::tests::empty_response_falls_back_to_accept' \
+  'progress_reviewer::tests::llm_submit_failure_falls_back_to_accept'
+do
+  grep -qF "$t ... ok" "$TEST_LOG" \
+    || { echo "FAIL: expected test did not run/pass: $t" >&2; exit 1; }
+done
+echo "OK: progress-reviewer fallback fails closed on a semantic parse-miss, open on infra."
+
+# --- (c) merge-judge #2569 regression ---------------------------------------
+echo "== (c) merge judge: #2569 banners (30s AND 102s) ⇒ Unclear (fail-closed) =="
+grep -qF 'recipe_merge_judge::issue_2428_production_tests::issue_2569_reported_banners_fail_closed_to_unclear ... ok' "$TEST_LOG" \
+  || { echo "FAIL: the #2569 banner regression test did not run/pass" >&2; exit 1; }
+echo "OK: #2569 SUCCESS-with-no-verdict banners fail closed to Unclear."
+
+echo "PASS: progress-verdict-fail-closed scenario (reasoner reliability; #2569 family)"

--- a/tests/gadugi/progress-verdict-fail-closed.yaml
+++ b/tests/gadugi/progress-verdict-fail-closed.yaml
@@ -1,0 +1,57 @@
+name: "Progress-evidence verdict fails closed on semantic parse-miss (#2569 family)"
+description: "Outside-in proof that the progress-evidence gate fails CLOSED (Reject) on a semantic verdict parse-miss — a successful, non-empty reviewer run with no accept/reject verdict — while staying fail-OPEN (Accept) on a genuine infra gap (empty output / transport error). Covers both live tiers (RecipeProgressChecker + LlmReviewerProgressChecker fallback) and pins the merge judge's #2569 SUCCESS-with-no-verdict banner regression (30s AND 102s) as fail-closed to Unclear. Runs the in-tree parser/decision tests and asserts the NAMED tests actually ran so a rename cannot silently no-op the scenario."
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Progress-evidence + merge-judge verdict fail-closed policy (parser + decision tests)"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/progress-verdict-fail-closed.sh"
+    timeout: 300000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "behavior"
+    - "simard"
+    - "ooda"
+    - "goal-curation"
+    - "progress-evidence"
+    - "reasoner-reliability"
+    - "verdict-parsing"
+    - "issue-2569"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Summary

Hardens Simard's **progress-evidence gate** — the reviewer that decides whether a claimed goal-progress % increase is honest — from **fail-open** to **fail-closed** on a *semantic verdict parse-miss*. Previously, when the LLM/recipe reviewer produced no recognizable `accept`/`reject` verdict **on a successful, non-empty run**, the gate returned `Accept`, letting hallucinated "0%→100% with no verdict" bumps land as false "done" states (a recurring reasoner-reliability failure).

### Policy (mirrors the merge judge's infra-vs-semantic split), applied to both live tiers

The daemon resolves the gate in three tiers: `RecipeProgressChecker` (primary) → `LlmReviewerProgressChecker` (direct-LLM fallback, `progress_reviewer.rs`) → `Noop`. Both live LLM tiers now follow:

- **INFRA failure** → keep **fail-OPEN** (`Accept`): LLM transport error; recipe spawn failure / non-zero exit; output that strips to entirely empty. Goals are never blocked on infra hiccups.
- **SEMANTIC parse-miss** → **fail-CLOSED** (`Reject`): a *successful, non-empty* response with no recognizable verdict, or a valid JSON object with an unknown verdict string. `Reject` only keeps the prior percent and logs a hallucination alert (`operations.rs`); it does **not** stall the goal, and the claim is re-attemptable next cycle.

### Robustness fix (recipe tier)

The recipe tier previously used a naïve substring scan (`contains("reject")` then `contains("accept")`), which wrongly **Rejected** a legitimate `{"verdict":"accept","rationale":"…no reason to reject…"}` and could **Accept** `"unacceptable"`. It now parses the **structured `{"verdict": …}` JSON first** (reusing the direct-LLM tier's tolerant `parse_reviewer_response`), falling back to the keyword scan only for prose — matching the merge judge and direct-LLM tier.

## Relationship to #2569

#2569 reports `simard merge-pr` **hard-failing** with `no verdict keyword found` on a SUCCESS-with-no-verdict recipe run. That **merge-path** hard-fail was already fixed on `main` by #2486 / #2490 / #2504 (JSON-envelope transport + graceful fail-closed to `Verdict::Unclear` → `MergeOutcome::Refused`), all merged **before** #2569 was filed against released v0.22.0. This PR:

1. Adds a **regression test** pinning the reporter's *exact* SUCCESS banners (both **30s and 102s**, per "not a timeout race") → `Verdict::Unclear`, locking #2569's repro.
2. Fixes the **analogous fail-open in the progress path** (the same verdict-transport family, but on the goal-progress gate rather than the merge gate).

## Merge-ready evidence

### 1. qa-team scenarios (gadugi-test)
- New outside-in scenario: `tests/gadugi/progress-verdict-fail-closed.{yaml,sh}`.
- `gadugi-test validate -f tests/gadugi/progress-verdict-fail-closed.yaml --strict` → **Valid files: 1**.
- `gadugi-test run -d tests/gadugi -s progress-verdict-fail-closed` → **Passed: 1, Failed: 0**.
- The scenario pins 13 named `#[test]` fns across the 3 modules (guards against silent rename→no-op) and proves: JSON-accept-with-reject-in-rationale → Accept; unknown verdict → Reject; non-empty no-keyword → Reject; empty/noise-only → Accept; production SUCCESS-banner-only → Reject; direct-LLM tier fail-closed/open; #2569 banners → Unclear.

### 2. Docs (user-facing reference surfaces updated)
- `docs/reference/progress-evidence-api.md`, `docs/reference/text-parsing-wire-formats.md` (§2a), `docs/concepts/progress-evidence-gating.md`, `docs/concepts/text-based-brain-protocol.md` — updated to the new infra/semantic policy and the JSON-first parse order. Also corrected a stale claim that `progress_reviewer.rs` "was deleted" (it is the live direct-LLM fallback tier) and a wrong `ADAPTER_TAG` prefix in a decision table.
- `mkdocs build --strict` → exit 0.

### 3. Quality-audit (3 SEEK→VALIDATE→FIX cycles, clean final)
- **Cycle 1** (code-review): no blockers; confirmed the discriminator + downstream `Reject` safety.
- **Cycle 2** (rubber-duck): **1 blocking** finding — the recipe tier's substring scan undermined the reliability claim (accept-with-reject-in-rationale → wrong Reject). **Fixed** by parsing structured JSON first + added 4 regression tests.
- **Cycle 3** (code-review): **clean — zero Critical/High/Medium findings.** One LOW doc-consistency nit (sibling doc repeating the stale "deleted" claim) was also fixed.

### 4. CI green (validated locally against the CI invocation)
- `cargo test --all-features --locked --no-fail-fast -- --skip install_packages_runs_and_self_installs` → **0 failures, 7327 passed** (clean env matching CI).
- `cargo clippy --all-targets --all-features --locked -- -D warnings` → pass.
- `cargo fmt --all -- --check` → pass. Pre-commit + pre-push hooks (incl. `cargo test --release` + full clippy) → pass.
- Note: in *this* live-engineer shell, `SIMARD_SCALING=auto` is exported, which makes the pre-existing, unrelated `ooda_loop::decide::tests::decide_respects_max_concurrent_actions` read a scaler override and fail. It passes with the var unset (as in CI). Not touched by this PR.

### 6. Focused diff
10 files: 4 source (2 behavior + 1 comment-only + 1 test-only), 4 docs, 2 new gadugi scenario files. No unrelated edits.

Closes #2569
