### PR TITLE
feat(cog-mem): emit recall_precision_at_k self-metric + pin regression baseline

### DIFF
--- a/docs/reference/cognitive-memory-ranked-recall.md
+++ b/docs/reference/cognitive-memory-ranked-recall.md
@@ -1,7 +1,7 @@
 ---
 title: Phase-weighted ranked fact recall & snapshot retention
 description: How OODA preparation recalls semantic facts with the library's multi-signal ranked recall (relevance + confidence + importance + recency + usage + graph), how Simard tunes the ranking per OODA phase, and how snapshot/goal-record writes deduplicate via CallerKey so repeated records SUPERSEDE instead of accumulating.
-last_updated: 2026-06-21
+last_updated: 2026-07-04
 owner: simard
 doc_type: reference
 related:
@@ -131,6 +131,66 @@ path:
 
 `search_facts` itself is unchanged and remains available for backward
 compatibility and for callers that want keyword recall without ranking.
+
+### Recall-precision self-metric (`recall_precision_at_k`)
+
+Ranked recall emits a **recall-quality** signal so the ranking cannot silently
+regress. On every `recall_facts_ranked` call the adapter computes
+**precision@k** over the returned order and folds it into an in-process running
+mean; the OODA daemon drains that mean once per cycle into the durable
+`recall_precision_at_k` series in `~/.simard/metrics/metrics.jsonl` (queryable
+via `self_metrics::query_metrics` and surfaced on the dashboard `metrics`
+endpoint alongside `controlled_forgetting` and the distillation rates).
+
+- **Precision@k** = of the top-`k` returned facts, the fraction that are
+  *query-relevant*. Relevance is a coarse keyword proxy: a fact counts when its
+  lowercased `concept` or `content` contains at least one query token
+  (whitespace-split, punctuation-only tokens like the wildcard `*` dropped).
+  This uses the same `.contains` keyword gate as the episodic recall path — it
+  is deliberately **broader** than the ranker's exact token/Jaccard
+  `text_relevance` score (e.g. `cat` matches `concatenate`), which is acceptable
+  for a self-metric baseline: the query itself is the relevance oracle (no
+  external labels), and the proxy moves in the same direction as ranking
+  quality.
+- **Emitted over the returned window.** The durable per-recall value is
+  precision@k with `k` = the number of returned facts (precision over the whole
+  returned set: "of everything surfaced, how much is on-topic"). The fixed-k
+  ordering guarantee (relevant facts occupy the *top* slots) is pinned
+  separately by the regression test below at `k = 1, 2`.
+- **Undefined, not zero.** A wildcard/empty query (no usable tokens) or an empty
+  result set yields `None` and contributes **no** sample, so structural reads do
+  not drag the mean toward zero. The emitted per-cycle value is the mean over
+  the recalls that *had* a measurable relevance target.
+- **Hot-path safe.** The recall path only touches a lock-guarded in-process
+  accumulator — no `metrics.jsonl` write per recall, and the whole-memory recall
+  lock is released before the metric is folded. The single durable write happens
+  once per cycle in the daemon sweep, **unconditionally** (on both successful and
+  errored cycles, so a cycle that recalled then errored cannot bleed its samples
+  into the next emission). No ranked recall in the window ⇒ no sample emitted.
+- **Windowed, cross-source mean.** The emitted value is the mean over every
+  ranked fact recall folded since the last drain, across all in-process sources
+  sharing the store (OODA preparation, IPC-served recalls, consolidation) — not a
+  single-recall or single-source figure. The `samples` count in the metric
+  context conveys the volume behind each mean.
+- **Pure observation.** Computing/recording precision never changes the returned
+  fact set or its order.
+
+The math lives in the pure, deterministic `cognitive_memory::metrics::precision_at_k`
+function, and two fixed-corpus regression tests pin the baseline:
+
+- `recall_precision_at_k_baseline` pins the *combined-signal* baseline
+  `recall_precision_at_1=1.000 recall_precision_at_2=1.000 recall_precision_at_full=0.500`:
+  two topic-relevant facts (also higher-confidence) must occupy the top two slots
+  of a four-fact recall.
+- `recall_precision_isolates_text_relevance` pins the same top-2 precision on a
+  corpus where **every fact has equal confidence**, so `text_relevance` is the
+  only signal that can differentiate them. This is the anti-regression teeth: if
+  the relevance weight were zeroed or broken, the equal-confidence facts would
+  tie on every signal, the relevant pair would no longer be guaranteed on top,
+  and precision@2 would fall below `1.0`. (Empirically, the default weights are
+  confidence-dominated — a *low*-confidence relevant fact loses to
+  high-confidence irrelevant ones — which is exactly why confidence is held
+  equal here to isolate the relevance signal.)
 
 ---
 
@@ -415,6 +475,11 @@ assert):
    leaves `usage_count` and `last_accessed_at` unchanged.
 7. **Superseded never recalled** — preparation recall
    (`include_superseded = false`) never surfaces superseded snapshots.
+8. **Recall-precision is monitored** — every `recall_facts_ranked` with a
+   measurable relevance target folds `precision@k` into the per-cycle
+   `recall_precision_at_k` self-metric; the fixed-corpus baseline
+   (`precision@2 == 1.0`, `precision@full == 0.5`) is pinned so a ranking
+   regression that demotes relevant facts fails CI.
 
 ---
 

--- a/src/cognitive_memory/library_adapter.rs
+++ b/src/cognitive_memory/library_adapter.rs
@@ -781,7 +781,22 @@ impl CognitiveMemoryOps for LibraryCognitiveMemory {
             .map_err(|e| map_op_err("recall_facts_ranked", e))?;
         // The library already sorted by descending score; preserve that order
         // (ordering *is* the ranking — no score is surfaced on `CognitiveFact`).
-        Ok(scored.into_iter().map(|s| to_fact(s.item)).collect())
+        let facts: Vec<CognitiveFact> = scored.into_iter().map(|s| to_fact(s.item)).collect();
+        // Release the whole-memory write lock BEFORE the metric step: `facts` is
+        // fully owned here, and precision folding allocates lowercased copies and
+        // takes a second (metrics) lock — none of which should run inside the
+        // serialized recall critical section on this hot path.
+        drop(guard);
+        // Fold this recall's precision@k into the in-process recall-quality
+        // aggregate so the per-cycle metric sweep emits ONE durable
+        // `recall_precision_at_k` sample (cycle mean) — no `metrics.jsonl` write
+        // on this hot path. Undefined-precision recalls (wildcard/empty query or
+        // an empty result) contribute no sample. Pure observation: it never
+        // changes the returned set.
+        if let Some(p) = super::metrics::precision_at_k(query, &facts, facts.len()) {
+            super::metrics::observe_recall_precision(super::metrics::RECALL_PRECISION_SITE, p);
+        }
+        Ok(facts)
     }
 
     fn recall_facts_ranked_reinforced(
@@ -821,7 +836,7 @@ impl CognitiveMemoryOps for LibraryCognitiveMemory {
         let scored = guard
             .recall_facts_ranked(query, options)
             .map_err(|e| map_op_err("recall_facts_ranked_reinforced", e))?;
-        let facts = scored
+        let facts: Vec<CognitiveFact> = scored
             .into_iter()
             .map(|s| {
                 let item = s.item;
@@ -839,6 +854,16 @@ impl CognitiveMemoryOps for LibraryCognitiveMemory {
                 to_fact(item)
             })
             .collect();
+        // Release the whole-memory write lock before folding the metric (same
+        // rationale as `recall_facts_ranked`). Fold precision here too so the
+        // `recall_precision_at_k` coverage does NOT silently drop to zero if a
+        // future production caller is wired to this reinforced path instead of
+        // the pure `recall_facts_ranked` (invariant #8 — every ranked fact
+        // recall is measured).
+        drop(guard);
+        if let Some(p) = super::metrics::precision_at_k(query, &facts, facts.len()) {
+            super::metrics::observe_recall_precision(super::metrics::RECALL_PRECISION_SITE, p);
+        }
         Ok(facts)
     }
 

--- a/src/cognitive_memory/metrics.rs
+++ b/src/cognitive_memory/metrics.rs
@@ -1,12 +1,22 @@
-//! Cognitive-memory silent-drop counter (issue #1975).
+//! Cognitive-memory in-process self-metrics.
 //!
-//! Mirrors the `meeting_silent_drop_total` pattern from #1956: an in-process
-//! `OnceLock<HashMap<(kind, site), AtomicU64>>` counter that tests can snapshot
-//! and reset without touching global state outside their scope.
+//! Two lightweight, test-snapshotable metric families live here:
+//!
+//! * **Silent-drop counter** (issue #1975) — mirrors the
+//!   `meeting_silent_drop_total` pattern from #1956: an in-process
+//!   `OnceLock<HashMap<(kind, site), AtomicU64>>` counter that tests can
+//!   snapshot and reset without touching global state outside their scope.
+//! * **Recall precision\@k aggregate** — a running mean of the ranked
+//!   fact-recall path's precision\@k, folded on every recall (no per-recall I/O)
+//!   and drained once per OODA cycle into the durable `recall_precision_at_k`
+//!   `metrics.jsonl` series, so ranking quality is observable over time and a
+//!   regression is visible rather than silent.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
+
+use crate::memory_cognitive::CognitiveFact;
 
 /// Label pair for each counter bucket.
 type Key = (String, String);
@@ -36,4 +46,271 @@ pub fn cognitive_memory_silent_drop_count(kind: &str, site: &str) -> u64 {
 pub fn scoped_reset() {
     let mut map = counters().lock().expect("metrics lock poisoned");
     map.clear();
+    drop(map);
+    precision_agg()
+        .lock()
+        .expect("metrics lock poisoned")
+        .clear();
+}
+
+// ───────────────────────── recall precision@k ──────────────────────────────
+//
+// A relevance-ranked-recall quality signal for the ranked fact-recall path
+// (`recall_facts_ranked`). `precision_at_k` is the pure, deterministic spine;
+// the aggregate below folds one observation per recall so the per-cycle sweep
+// can emit a single durable sample instead of writing `metrics.jsonl` on the
+// hot recall path.
+
+/// Durable self-metric name for ranked-recall precision, emitted to
+/// `metrics.jsonl` once per OODA cycle by [`flush_recall_precision_metric`].
+pub const RECALL_PRECISION_METRIC: &str = "recall_precision_at_k";
+
+/// Aggregate site label for the ranked fact-recall (`recall_facts_ranked`)
+/// path.
+pub const RECALL_PRECISION_SITE: &str = "recall_facts_ranked";
+
+/// Tokenize a recall query the same way the keyword recall gate does:
+/// whitespace-split, lowercased, dropping punctuation-only tokens (e.g. the
+/// wildcard `*`) so a wildcard/empty query yields no tokens and is treated as
+/// "no measurable relevance target".
+fn query_tokens(query: &str) -> Vec<String> {
+    query
+        .split_whitespace()
+        .map(str::to_lowercase)
+        .filter(|t| t.chars().any(char::is_alphanumeric))
+        .collect()
+}
+
+/// Whether a fact is query-relevant under the keyword proxy: its lowercased
+/// `concept` or `content` contains at least one query token (substring match,
+/// mirroring the episodic recall keyword gate).
+fn fact_is_relevant(fact: &CognitiveFact, tokens: &[String]) -> bool {
+    let concept = fact.concept.to_lowercase();
+    let content = fact.content.to_lowercase();
+    tokens
+        .iter()
+        .any(|t| concept.contains(t.as_str()) || content.contains(t.as_str()))
+}
+
+/// Precision\@k for a ranked recall result: of the top-`k` returned `facts`, the
+/// fraction that are **query-relevant**.
+///
+/// Relevance is a coarse keyword proxy (see `fact_is_relevant`): a fact counts
+/// when its `concept`/`content` contains a query token as a substring — the same
+/// `.contains` keyword gate the episodic recall path uses, NOT the ranker's
+/// exact token/Jaccard `text_relevance` score. It is deliberately broader than
+/// the ranker (e.g. `cat` matches `concatenate`), which is acceptable for a
+/// self-metric baseline: it needs no external ground-truth labels — the query
+/// itself is the relevance oracle — and it moves in the same direction as
+/// ranking quality. This makes the metric a self-contained, deterministic
+/// measure of *ranking precision*: if the ranker floats an off-topic fact into
+/// the top-`k`, precision falls.
+///
+/// Returns `None` (undefined, **not** `0.0`) when the query has no usable
+/// tokens (empty / wildcard `*`) or the result set is empty, so callers skip
+/// emitting a meaningless sample rather than dragging the mean toward zero.
+/// `k` is clamped to the number of returned facts.
+pub fn precision_at_k(query: &str, facts: &[CognitiveFact], k: usize) -> Option<f64> {
+    let tokens = query_tokens(query);
+    if tokens.is_empty() {
+        return None;
+    }
+    let window = k.min(facts.len());
+    if window == 0 {
+        return None;
+    }
+    let relevant = facts[..window]
+        .iter()
+        .filter(|f| fact_is_relevant(f, &tokens))
+        .count();
+    Some(relevant as f64 / window as f64)
+}
+
+/// Running recall-precision aggregate per site: `(samples, sum_of_precision)`.
+fn precision_agg() -> &'static Mutex<HashMap<String, (u64, f64)>> {
+    static AGG: OnceLock<Mutex<HashMap<String, (u64, f64)>>> = OnceLock::new();
+    AGG.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Fold one recall-precision observation into the running aggregate for `site`.
+///
+/// Cheap and lock-guarded; called on every ranked recall so no per-recall write
+/// hits `metrics.jsonl`. The per-cycle sweep drains it via
+/// [`flush_recall_precision_metric`] / [`drain_recall_precision`].
+pub fn observe_recall_precision(site: &str, value: f64) {
+    let mut map = precision_agg().lock().expect("metrics lock poisoned");
+    let entry = map.entry(site.to_owned()).or_insert((0, 0.0));
+    entry.0 += 1;
+    entry.1 += value;
+}
+
+/// Snapshot (without draining) the running `(mean, samples)` for `site`, or
+/// `None` when nothing has been observed since the last drain/reset. Test-only
+/// peek accessor (the production path drains via [`drain_recall_precision`]).
+#[cfg(test)]
+pub fn recall_precision_mean(site: &str) -> Option<(f64, u64)> {
+    let map = precision_agg().lock().expect("metrics lock poisoned");
+    map.get(site)
+        .and_then(|&(n, sum)| (n > 0).then_some((sum / n as f64, n)))
+}
+
+/// Drain the running aggregate for `site`, returning `(mean, samples)` and
+/// resetting it. `None` when nothing was observed. The per-cycle metric sweep
+/// calls this (via [`flush_recall_precision_metric`]) to emit one aggregated
+/// sample and start the next cycle fresh.
+pub fn drain_recall_precision(site: &str) -> Option<(f64, u64)> {
+    let mut map = precision_agg().lock().expect("metrics lock poisoned");
+    match map.remove(site) {
+        Some((n, sum)) if n > 0 => Some((sum / n as f64, n)),
+        _ => None,
+    }
+}
+
+/// Drain the ranked-recall precision aggregate and, if any recall ran this
+/// cycle, emit ONE aggregated [`RECALL_PRECISION_METRIC`] sample (the mean
+/// precision\@k over the drain window, with the sample count in context) to
+/// `metrics.jsonl`.
+///
+/// Called once per OODA cycle by the daemon metric sweep, **unconditionally**
+/// (on both successful and errored cycles), so a cycle that recalled then
+/// errored cannot bleed its observations into the next emission. The emitted
+/// value is the mean over every ranked fact recall folded since the last drain
+/// — across all in-process sources sharing the store (OODA preparation,
+/// IPC-served recalls, consolidation) — so it is a windowed cross-source mean,
+/// not a single-recall figure; `samples` conveys the volume. No-op when no
+/// ranked recall ran this window, so the series carries signal only.
+/// Best-effort: a metrics-write failure is logged, never propagated. Skipped
+/// under `cfg!(test)` so unit tests never append to the operator's real
+/// `~/.simard/metrics/metrics.jsonl` — the aggregate is still drained so a
+/// stale mean never bleeds across test cases.
+pub fn flush_recall_precision_metric() {
+    let Some((mean, samples)) = drain_recall_precision(RECALL_PRECISION_SITE) else {
+        return;
+    };
+    if cfg!(test) {
+        return;
+    }
+    let context = serde_json::json!({
+        "site": RECALL_PRECISION_SITE,
+        "samples": samples,
+    })
+    .to_string();
+    if let Err(e) = crate::self_metrics::record_metric(RECALL_PRECISION_METRIC, mean, &context) {
+        tracing::warn!(
+            target: "simard::memory",
+            error = %e,
+            "failed to record recall_precision_at_k metric (recall unaffected)",
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fact(concept: &str, content: &str) -> CognitiveFact {
+        CognitiveFact {
+            node_id: format!("n-{concept}"),
+            concept: concept.to_string(),
+            content: content.to_string(),
+            confidence: 1.0,
+            source_id: "test".to_string(),
+            tags: vec![],
+            usage_count: 0,
+            last_accessed_at: None,
+        }
+    }
+
+    // ── precision_at_k: pure math ───────────────────────────────────────────
+
+    #[test]
+    fn precision_all_relevant_is_one() {
+        let facts = [
+            fact("kafka streaming", "backpressure"),
+            fact("kafka broker", "partition rebalance"),
+        ];
+        assert_eq!(precision_at_k("kafka", &facts, 2), Some(1.0));
+    }
+
+    #[test]
+    fn precision_half_relevant_in_window() {
+        // Two relevant (kafka) ranked above two irrelevant → precision@2 == 1.0
+        // but precision over the full window == 0.5.
+        let facts = [
+            fact("kafka streaming", "backpressure"),
+            fact("kafka broker", "rebalance"),
+            fact("postgres index", "btree bloat"),
+            fact("redis cache", "eviction"),
+        ];
+        assert_eq!(precision_at_k("kafka", &facts, 2), Some(1.0));
+        assert_eq!(precision_at_k("kafka", &facts, 4), Some(0.5));
+    }
+
+    #[test]
+    fn precision_matches_on_content_not_only_concept() {
+        let facts = [fact("infra note", "the kafka consumer lagged")];
+        assert_eq!(precision_at_k("kafka", &facts, 1), Some(1.0));
+    }
+
+    #[test]
+    fn precision_zero_when_top_k_all_irrelevant() {
+        let facts = [fact("postgres", "vacuum"), fact("redis", "ttl")];
+        assert_eq!(precision_at_k("kafka", &facts, 2), Some(0.0));
+    }
+
+    #[test]
+    fn precision_clamps_k_to_result_len() {
+        let facts = [fact("kafka", "lag")];
+        // k larger than the result set clamps to the single (relevant) fact.
+        assert_eq!(precision_at_k("kafka", &facts, 10), Some(1.0));
+    }
+
+    #[test]
+    fn precision_is_none_for_empty_results() {
+        let facts: [CognitiveFact; 0] = [];
+        assert_eq!(precision_at_k("kafka", &facts, 5), None);
+    }
+
+    #[test]
+    fn precision_is_none_for_wildcard_or_empty_query() {
+        let facts = [fact("kafka", "lag")];
+        assert_eq!(precision_at_k("*", &facts, 1), None);
+        assert_eq!(precision_at_k("   ", &facts, 1), None);
+        assert_eq!(precision_at_k("", &facts, 1), None);
+    }
+
+    #[test]
+    fn precision_multi_token_query_is_case_insensitive() {
+        let facts = [
+            fact("Kafka Streaming", "Backpressure"),
+            fact("unrelated", "topic"),
+        ];
+        // "streaming" (lowercased) matches fact 0's concept; fact 1 matches
+        // neither token → precision@2 == 0.5.
+        assert_eq!(precision_at_k("KAFKA streaming", &facts, 2), Some(0.5));
+    }
+
+    // ── running aggregate: unique per-test site keys keep it isolation-safe
+    //    under parallel execution (the aggregate is process-global). ─────────
+
+    #[test]
+    fn aggregate_folds_running_mean() {
+        let site = "test-agg-mean";
+        assert_eq!(recall_precision_mean(site), None);
+        observe_recall_precision(site, 1.0);
+        observe_recall_precision(site, 0.0);
+        observe_recall_precision(site, 0.5);
+        assert_eq!(recall_precision_mean(site), Some((0.5, 3)));
+    }
+
+    #[test]
+    fn drain_returns_mean_and_resets() {
+        let site = "test-agg-drain";
+        observe_recall_precision(site, 1.0);
+        observe_recall_precision(site, 0.5);
+        assert_eq!(drain_recall_precision(site), Some((0.75, 2)));
+        // Drained → empty on the next read.
+        assert_eq!(recall_precision_mean(site), None);
+        assert_eq!(drain_recall_precision(site), None);
+    }
 }

--- a/src/cognitive_memory/tests_ranked_recall.rs
+++ b/src/cognitive_memory/tests_ranked_recall.rs
@@ -235,8 +235,186 @@ fn prune_superseded_no_op_when_nothing_superseded() {
     assert_eq!(all_physical_facts(&mem).len(), 1, "live fact retained");
 }
 
-// ─── minimal non-library mock for the default-delegation test ────────────────
+// ─── recall precision@k regression baseline (recall-quality lever) ──────────
 
+/// Fixed-corpus baseline that pins the ranked fact-recall path's **precision@k**
+/// so a future ranking change that floats off-topic facts into the top-k fails
+/// CI instead of silently degrading recall quality.
+///
+/// Corpus: two `kafka`-topic facts (higher confidence) plus two unrelated facts
+/// (`postgres`, `redis`, lower confidence). Query `"kafka"` at `min_confidence
+/// 0.0` returns all four in ranked order. The `text_relevance` + `confidence`
+/// signals must place BOTH kafka facts in the top two slots:
+///
+/// * `precision@1 == 1.000` and `precision@2 == 1.000` — the relevant facts are
+///   ranked first (this is the anti-regression teeth: if an off-topic fact
+///   intrudes into the top two, precision@2 drops below 1.0 and this fails).
+/// * `precision@full (k=4) == 0.500` — two of the four returned facts are
+///   relevant, and precision is non-increasing past the relevant prefix.
+///
+/// Note: here the relevant facts also carry higher confidence, so this pins the
+/// *combined-signal* ranking (relevance + confidence together). The
+/// text_relevance signal is isolated separately — with confidence held equal —
+/// by [`recall_precision_isolates_text_relevance`], which is the teeth against a
+/// pure relevance-signal regression.
+///
+/// The `recall_precision_at_k` value emitted per OODA cycle is exactly this
+/// `precision_at_k` computed over the same returned order, so pinning it here
+/// pins the production self-metric too.
+#[test]
+fn recall_precision_at_k_baseline() {
+    let mem = test_mem();
+    // Relevant to "kafka" — higher confidence so they naturally rank on top.
+    mem.store_fact(
+        "kafka streaming",
+        "backpressure and consumer lag tuning",
+        0.9,
+        &[],
+        "src",
+    )
+    .expect("store kafka-1");
+    mem.store_fact(
+        "kafka partitions",
+        "rebalance and offset commit",
+        0.85,
+        &[],
+        "src",
+    )
+    .expect("store kafka-2");
+    // Unrelated to "kafka" — lower confidence so they rank below.
+    mem.store_fact(
+        "postgres indexing",
+        "btree bloat and vacuum",
+        0.6,
+        &[],
+        "src",
+    )
+    .expect("store pg");
+    mem.store_fact("redis eviction", "lru and ttl policy", 0.55, &[], "src")
+        .expect("store redis");
+
+    let ranked = mem
+        .recall_facts_ranked("kafka", 10, 0.0, RecallWeightSet::default())
+        .expect("ranked recall");
+    assert_eq!(
+        ranked.len(),
+        4,
+        "all four facts are returned at min_confidence 0.0"
+    );
+
+    let p_at_1 = super::metrics::precision_at_k("kafka", &ranked, 1).expect("precision@1 defined");
+    let p_at_2 = super::metrics::precision_at_k("kafka", &ranked, 2).expect("precision@2 defined");
+    let p_full = super::metrics::precision_at_k("kafka", &ranked, ranked.len())
+        .expect("precision@full defined");
+
+    // Greppable baseline line (mirrors the distill fact-yield benchmark style).
+    println!(
+        "recall_precision_at_1={p_at_1:.3} recall_precision_at_2={p_at_2:.3} \
+         recall_precision_at_full={p_full:.3}"
+    );
+
+    assert_eq!(p_at_1, 1.000, "top-1 recalled fact must be relevant");
+    assert_eq!(
+        p_at_2, 1.000,
+        "both relevant facts must occupy the top 2 slots (ranking-quality guard)"
+    );
+    assert_eq!(
+        p_full, 0.500,
+        "2 of 4 returned facts are relevant → full-window precision baseline"
+    );
+    assert!(
+        p_at_2 >= p_full,
+        "precision must be non-increasing past the relevant prefix"
+    );
+}
+
+/// The precision baseline is deterministic across repeated recalls of the same
+/// fixed corpus: recall twice and assert the precision@k values are identical
+/// (the ranked order, hence precision, must not vary run to run), and that the
+/// top-2 precision stays pinned at 1.0. Asserts via the pure `precision_at_k`
+/// over each recall's returned order — it does not touch the process-global
+/// aggregate, so it stays isolation-safe under parallel `--test-threads`.
+#[test]
+fn recall_precision_baseline_line_is_stable_across_runs() {
+    // Determinism guard: the ranked order (hence precision) must not vary run to
+    // run for the fixed corpus. Recall twice and compare.
+    let mem = test_mem();
+    mem.store_fact("kafka streaming", "backpressure", 0.9, &[], "src")
+        .expect("s1");
+    mem.store_fact("kafka partitions", "rebalance", 0.85, &[], "src")
+        .expect("s2");
+    mem.store_fact("postgres indexing", "vacuum", 0.6, &[], "src")
+        .expect("s3");
+
+    let run = || {
+        let ranked = mem
+            .recall_facts_ranked("kafka", 10, 0.0, RecallWeightSet::default())
+            .expect("ranked recall");
+        (
+            super::metrics::precision_at_k("kafka", &ranked, 2),
+            super::metrics::precision_at_k("kafka", &ranked, ranked.len()),
+        )
+    };
+    let first = run();
+    let second = run();
+    assert_eq!(first, second, "precision baseline must be deterministic");
+    assert_eq!(first.0, Some(1.0), "top-2 precision pinned at 1.0");
+}
+
+/// Text-relevance-isolating baseline (the anti-regression teeth the metric is
+/// for). Unlike [`recall_precision_at_k_baseline`] — where the relevant facts
+/// also carry higher confidence, so the combined signals could mask a broken
+/// `text_relevance` term — this corpus gives **every** fact the *same*
+/// confidence (0.7) and no usage/recency/graph advantage, so `text_relevance`
+/// is the ONLY signal that can differentiate them.
+///
+/// Two `kafka` facts (relevant) and two unrelated facts, all at confidence 0.7,
+/// recalled with query `"kafka"`. The two relevant facts must occupy the top
+/// two slots (`precision@2 == 1.000`) — and that can ONLY happen because
+/// `text_relevance` ranks the token-matching facts above the non-matching ones.
+/// If a future change zeroed or broke the `text_relevance` weight, all four
+/// facts would tie on every signal, the relevant pair would no longer be
+/// guaranteed on top, and this precision@2 assertion would fail. Empirically
+/// verified: at equal confidence the ranker orders the `kafka` facts first
+/// (`precision@1 == 1.0`), whereas a low-confidence relevant fact loses to
+/// high-confidence irrelevant ones — i.e. the default weights are
+/// confidence-dominated, which is exactly why the confidence must be held equal
+/// to isolate the relevance signal here.
+#[test]
+fn recall_precision_isolates_text_relevance() {
+    let mem = test_mem();
+    // Relevant to "kafka" — SAME confidence as the irrelevant facts.
+    mem.store_fact("kafka streaming", "consumer lag tuning", 0.7, &[], "src")
+        .expect("rel-1");
+    mem.store_fact("kafka partitions", "offset rebalance", 0.7, &[], "src")
+        .expect("rel-2");
+    // Unrelated — SAME confidence, so only text_relevance separates them.
+    mem.store_fact("postgres vacuum", "btree bloat autovacuum", 0.7, &[], "src")
+        .expect("irr-1");
+    mem.store_fact("redis eviction", "lru ttl policy", 0.7, &[], "src")
+        .expect("irr-2");
+
+    let ranked = mem
+        .recall_facts_ranked("kafka", 10, 0.0, RecallWeightSet::default())
+        .expect("ranked recall");
+    assert_eq!(ranked.len(), 4, "all four equal-confidence facts returned");
+
+    let p_at_1 = super::metrics::precision_at_k("kafka", &ranked, 1).expect("p@1");
+    let p_at_2 = super::metrics::precision_at_k("kafka", &ranked, 2).expect("p@2");
+    println!("recall_precision_relevance_isolated_at_1={p_at_1:.3} at_2={p_at_2:.3}");
+
+    assert_eq!(
+        p_at_1, 1.000,
+        "top-1 must be relevant purely on text_relevance (confidence held equal)"
+    );
+    assert_eq!(
+        p_at_2, 1.000,
+        "both relevant facts must occupy the top 2 slots on text_relevance alone \
+         — this fails if the relevance signal regresses"
+    );
+}
+
+// ─── minimal non-library mock for the default-delegation test ────────────────
 fn fact(concept: &str, content: &str, confidence: f64) -> CognitiveFact {
     CognitiveFact {
         node_id: format!("node-{concept}"),

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -1163,6 +1163,13 @@ pub fn run_ooda_daemon(
                 daemon_log(&state_root, &format!("[simard] OODA cycle error: {e}"));
             }
         }
+        // Flush this cycle's aggregated ranked-recall precision@k into the
+        // durable `recall_precision_at_k` series once per cycle, regardless of
+        // cycle outcome. Draining unconditionally here (not inside the `Ok` arm)
+        // ensures a cycle that recalled and then errored cannot bleed its
+        // observations into the next successful cycle's emission. Best-effort;
+        // no-op when no ranked recall ran this cycle.
+        crate::cognitive_memory::metrics::flush_recall_precision_metric();
 
         cycles_run += 1;
 

--- a/tests/gadugi/recall-precision-baseline.yaml
+++ b/tests/gadugi/recall-precision-baseline.yaml
@@ -1,0 +1,120 @@
+name: "Ranked-Recall Precision@k Baseline"
+description: >
+  qa-team outside-in gate for the perpetual-cognition sub-goal "recall quality".
+  Simard's ranked fact-recall path
+  (src/cognitive_memory/library_adapter.rs::recall_facts_ranked) now emits a
+  measurable recall-quality signal: on every recall it folds precision@k over
+  the returned order into an in-process running mean, which the OODA daemon
+  drains once per cycle into the durable `recall_precision_at_k` series in
+  metrics.jsonl (via self_metrics::record_metric). precision@k is the fraction
+  of the top-k returned facts that are query-relevant (keyword proxy: the fact's
+  concept/content shares a query token) — the same signal the ranker's
+  text_relevance term rewards, so no external labels are needed. A wildcard/empty
+  query or empty result is undefined (None) and emits no sample, so structural
+  reads never drag the mean toward zero, and the recall path never writes
+  metrics.jsonl on the hot path. A deterministic fixed-corpus benchmark pins the
+  baseline (recall_precision_at_1=1.000 recall_precision_at_2=1.000
+  recall_precision_at_full=0.500): two topic-relevant facts must occupy the top
+  two slots of a four-fact recall, so a ranking change that floats an off-topic
+  fact into the top-k drops precision@2 below 1.0 and fails CI. This scenario
+  pins that behaviour end-to-end.
+version: "1.0.0"
+
+config:
+  timeout: 900000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "test-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 900000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Precision@k baseline pinned over the real ranked-recall path"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        cognitive_memory::tests_ranked_recall::recall_precision
+        -- --nocapture
+    timeout: 900000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "recall_precision_at_1=1.000 recall_precision_at_2=1.000 recall_precision_at_full=0.500"
+        - "recall_precision_at_k_baseline ... ok"
+        - "recall_precision_isolates_text_relevance ... ok"
+        - "recall_precision_baseline_line_is_stable_across_runs ... ok"
+        - "test result: ok"
+
+  - name: "precision@k pure-function + running-aggregate contract (undefined-safe, mean, drain)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        cognitive_memory::metrics::tests
+        -- --nocapture
+    timeout: 900000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "precision_all_relevant_is_one ... ok"
+        - "precision_half_relevant_in_window ... ok"
+        - "precision_zero_when_top_k_all_irrelevant ... ok"
+        - "precision_is_none_for_empty_results ... ok"
+        - "precision_is_none_for_wildcard_or_empty_query ... ok"
+        - "aggregate_folds_running_mean ... ok"
+        - "drain_returns_mean_and_resets ... ok"
+        - "test result: ok"
+
+  - name: "Full ranked-recall contract still green (no regression)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib cognitive_memory::tests_ranked_recall
+        -- --nocapture
+    timeout: 900000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "recall_facts_ranked_orders_by_descending_score ... ok"
+        - "recall_facts_ranked_respects_min_confidence ... ok"
+        - "recall_facts_ranked_default_delegates_to_search_facts ... ok"
+        - "test result: ok"
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "test-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "memory"
+    - "cognitive-memory"
+    - "recall"
+    - "recall-precision"
+    - "regression"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Summary

Advances the standing perpetual-cognition goal on the **recall-quality** lever
(the prior sub-goal — distillation fact-yield, PR #2584 — is already merged and
untouched here). Makes ranked fact-recall quality **observable so it cannot
silently regress**.

On every `recall_facts_ranked` (and the reinforced variant), Simard now computes
**precision@k** over the returned facts and folds it into an in-process running
mean. The OODA daemon drains that mean **once per cycle** into the durable
`recall_precision_at_k` series in `~/.simard/metrics/metrics.jsonl` (via
`self_metrics::record_metric`), which surfaces on the dashboard `metrics`
endpoint alongside `controlled_forgetting` and the distillation rates — no
dashboard code change needed.

### Design
- **precision@k** = fraction of the top-`k` returned facts that are
  query-relevant (coarse substring keyword proxy — the same `.contains` gate the
  episodic recall path uses; deliberately broader than the ranker's exact
  Jaccard, documented as such). Pure, deterministic core:
  `cognitive_memory::metrics::precision_at_k`.
- **Undefined ⇒ no sample.** Wildcard/empty queries (no tokens) or empty results
  return `None`, so structural reads never drag the mean toward zero.
- **Hot-path safe.** The whole-memory recall write-lock is released *before* the
  metric is folded; the recall path only touches a lock-guarded in-process
  accumulator — no `metrics.jsonl` write per recall.
- **No bleed.** The per-cycle flush runs **unconditionally** (after the cycle
  `match`, on both Ok and Err cycles), so an errored cycle's observations can't
  bleed into the next emission. `samples` count is recorded in the metric
  context; the mean is a windowed cross-source figure (OODA prep + IPC-served +
  consolidation), documented.
- Recall behavior (returned set, order, error propagation) is **byte-for-byte
  unchanged** — the metric is pure observation.

### Files (focused diff — 6 files, +680/-8)
- `src/cognitive_memory/metrics.rs` — `precision_at_k`, running aggregate, flush.
- `src/cognitive_memory/library_adapter.rs` — fold precision on both ranked-recall paths.
- `src/operator_commands_ooda/daemon/mod.rs` — unconditional per-cycle flush (1 call).
- `src/cognitive_memory/tests_ranked_recall.rs` — 3 regression tests.
- `tests/gadugi/recall-precision-baseline.yaml` — outside-in gate.
- `docs/reference/cognitive-memory-ranked-recall.md` — self-metric section + invariant #8.

---

## Merge-readiness evidence

### 1. qa-team scenarios (gadugi-test validate + run)
`tests/gadugi/recall-precision-baseline.yaml` — 3 steps (baseline pin, pure-fn +
aggregate contract, full ranked-recall no-regression).
- `gadugi-test validate -f tests/gadugi/recall-precision-baseline.yaml` → **1 valid, 0 invalid**.
- `gadugi-test run -s recall-precision-baseline` → **Passed: 1, Failed: 0**.
- Pinned baseline line asserted: `recall_precision_at_1=1.000 recall_precision_at_2=1.000 recall_precision_at_full=0.500`.

### 2. Docs
`docs/reference/cognitive-memory-ranked-recall.md` extended with a
"Recall-precision self-metric" section + invariant #8; `mkdocs build --strict`
passes. New metric surfaces via the existing generic dashboard `metrics`
endpoint (no user-facing surface added beyond the documented metric).

### 3. quality-audit — 3 SEEK→VALIDATE→FIX cycles, clean final
- **Cycle 1** (code-review + rubber-duck): fixed (a) precision folded while
  holding the whole-memory lock → now `drop(guard)` first; (b) flush only ran on
  Ok cycles → moved to run every cycle; (c) docs overclaimed the proxy equals the
  ranker → softened.
- **Cycle 2** (reviewer + architect): fixed 1 **MEDIUM** — baseline test was
  confounded by confidence (would not catch a `text_relevance` regression) →
  added `recall_precision_isolates_text_relevance` (equal-confidence corpus, real
  teeth); plus LOWs — reinforced-recall path now folds precision too (invariant
  #8 coverage), `recall_precision_mean` gated `#[cfg(test)]`, doc corrections.
- **Cycle 3** (code-review + security-review): **clean** — no critical/high/medium;
  **zero security findings** (no injection, bounded memory, no external-triggerable
  panic, guarded float/int math).

### 4. CI / tests green
- `cargo build --lib` ✓; `cargo fmt --all -- --check` ✓.
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓.
- `cargo test --lib cognitive_memory::` → **91 passed, 0 failed**; metrics unit tests **10 passed**.
- Pre-push race subset (`--release --lib`, parallel `--test-threads=$(nproc)`) ✓.
- Full `cargo test --all-features` in a clean, isolated target dir → **no failures**.
  (Note: on this shared host, `--test-threads` runs pick up ambient
  `SIMARD_SCALING=auto` / `SIMARD_MAX_CONCURRENT_ACTIONS=5`, which fail
  pre-existing `ooda_loop`/scaling tests unrelated to this diff; they pass with
  those env vars unset, as CI runs them. This diff touches no OODA/scaling code.)
- Pre-commit + pre-push hooks all **Passed** on commit/push.

### 6. Focused diff
6 files, all on the recall-quality lever; no unrelated edits, no drive-by
refactors, no stubs (`todo!`/`unimplemented!`/TODO scan clean).

---

Note: a Simard self-update will be needed to pick up this metric in the running
operator after merge.
