### PR TITLE
chore(deps): bump amplihack-memory pin to distillation fact-yield commit (5d7db77)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=3c9d956a7e0648f12ef229f587bf3ead79787fe9#3c9d956a7e0648f12ef229f587bf3ead79787fe9"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=5d7db77dd5c3bafb2846c2f50761112588a47563#5d7db77dd5c3bafb2846c2f50761112588a47563"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,13 +62,13 @@ path = "src/bin/simard_tui/main.rs"
 # leaving records only in the quarantined WAL — which a later open reset to empty,
 # permanently dropping tens of thousands of memories), AND the read-only
 # `get_all_prospective` enumerator (Simard #2550) the verified-backup snapshot
-# needs to capture prospective memories. This rev is the squash-merge commit of
-# amplihack-memory-lib PR #111 on `main`: it layers the pure-read
-# `get_all_prospective` enumerator on top of PR #110's durable corrupt-WAL open
-# recovery fix, with no lbug/engine change, so the store format stays v41. The
-# pin now points at an upstream-`main` commit (not a feature branch), so the
-# build can never be frozen against an unmerged, GC-able ref.
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "3c9d956a7e0648f12ef229f587bf3ead79787fe9", features = ["persistent"] }
+# needs to capture prospective memories. Further bumped to the squash-merge commit
+# of amplihack-memory-lib PR #118 on `main` (issue #117), which layers the
+# deterministic episodic->semantic distillation fact-yield benchmark + extractor
+# on top of PR #111 (via #114/#116), with no lbug/engine change, so the store
+# format stays v41. The pin points at an upstream-`main` commit (not a feature
+# branch), so the build can never be frozen against an unmerged, GC-able ref.
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "5d7db77dd5c3bafb2846c2f50761112588a47563", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream


### PR DESCRIPTION
## Dependency-pin bump: amplihack-memory → distillation fact-yield commit

Bumps the pinned `amplihack-memory` git rev in the root `Cargo.toml`
`26d49bf8`/`3c9d956` → `5d7db77dd5c3bafb2846c2f50761112588a47563`.

That commit is the squash-merge of **amplihack-memory-lib PR #118** (closes
amplihack-memory-lib issue #117): a **deterministic episodic→semantic
distillation fact-yield benchmark + atomic-segmentation extractor**
(`distill_episode` / `distill_corpus`, fixed benchmark corpus, recorded baseline
7 → improved 13 durable facts (+86%), regression test). `5d7db77` is a
`main` ancestor-superset of `3c9d956` (#111): it includes #111's
`get_all_prospective` + corrupt-WAL fixes plus #114/#116/#118.

**Why bump here:** `amplihack-memory` is pinned by exact git rev, so the merged
library improvement only reaches Simard's binary once this pin is updated (the
dependency-pin done-gate).

## Merge-ready criteria — evidence

### 1. qa-team scenarios (gadugi-test validate + run)
Three CLI qa-team scenarios exercise the shipped distillation behaviour via
`cargo test` against the pinned crate: `distillation-fact-yield-regression`,
`distillation-baseline-and-gain`, `distillation-determinism`.
- `gadugi-test validate --strict` → **Valid files: 3, Invalid files: 0** ("All 3 file(s) are valid").
- `gadugi-test run` → **Passed: 3, Failed: 0** ("All tests passed!"); each scenario
  passes only on `cargo test … distillation::tests::…` exit 0.
- Simard-side behavioural gate: the pre-push hook ran
  `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)`
  → **Passed** against the new pin (the cognitive-memory consumer of this crate).

### 2. Documentation / surfaces touched
This PR touches **only internal dependency-pin surfaces** —
`Cargo.toml` (the `amplihack-memory` `rev` + its explanatory pin comment, which
is refreshed to describe the #118 distillation bump) and `Cargo.lock` (the one
`amplihack-memory` source-rev line). **No user-facing Simard surface changes**
(no public API, CLI, config, or output changes), so no end-user doc update is
required — internal-only justification. The upstream library's own public API is
documented in amplihack-memory-lib (rustdoc + doctests + CHANGELOG under #118).

### 3. quality-audit — 3 SEEK→VALIDATE→FIX cycles, clean final
Performed on the upstream change landed by this pin (amplihack-memory-lib #118):
- **Cycle 1:** independent code-review found one correctness quirk
  (`split_sentences` dropped interior punctuation in a non-boundary terminator
  run, e.g. `"a.?b"`→`"a.b"`). **Fixed** (lossless) + added a regression test.
- **Cycle 2:** independent re-review of the fix — **no high-confidence issues**.
- **Cycle 3:** final review (independent model) on scope/integration —
  **no issues; diff confirmed focused.**
Result: zero critical/high; zero medium correctness/security. Ended clean.

### 4. CI 100% green (this PR)
All required checks pass on this PR's head `59eacdf3`
(pre-commit, e2e-dashboard, install-real, cargo-audit, cargo-deny, cargo-vet,
npm-audit, GitGuardian) — run:
https://github.com/rysweet/Simard/actions/runs/28729759534 .
Build done-gate: `cargo build --locked` succeeds locally after the bump.

### 5. Evidence present
This description documents concrete evidence for criteria 1–4 and 6.

### 6. Focused diff — no unrelated edits
Exactly two files (`git diff --stat origin/main...HEAD`):

```
 Cargo.lock |  2 +-
 Cargo.toml | 14 +++++++-------
 2 files changed, 8 insertions(+), 8 deletions(-)
```

`Cargo.lock` change is the single `amplihack-memory` source-rev line (no
unrelated lockfile churn); `Cargo.toml` is the `rev` + refreshed pin comment.

## Merge-readiness verdict: ✅ READY TO MERGE

**Verdict: READY TO MERGE.** Rationale: minimal, mechanical dependency-pin bump
to an already-merged, CI-green upstream commit that is a superset of the current
`main` pin; all six criteria are satisfied with cited evidence, the build gate
and cognitive-memory release tests pass against the new pin, the storage format
is unchanged (`lbug` stays `=0.17.1`), and the diff is confined to the two pin
files. No open blockers.
