### PR TITLE
fix(meeting): default idle-liveness window to hours not minutes

### DIFF
--- a/docs/howto/start-a-meeting.md
+++ b/docs/howto/start-a-meeting.md
@@ -302,7 +302,7 @@ streamed chunk resets the clock, so a working turn is never killed:
 
 | Env var | Default | Effect |
 |---------|---------|--------|
-| `SIMARD_MEETING_IDLE_LIVENESS_SECS` | `300` | Idle-liveness window in seconds — max time with **no output** before the child is treated as hung. `0` disables idle detection (fully unbounded escape hatch); unset/malformed uses the default. |
+| `SIMARD_MEETING_IDLE_LIVENESS_SECS` | `3600` | Idle-liveness window in seconds — max time with **no output** before the child is treated as hung. Default is an hours-scale window (1 hour), not a minutes-scale one, so a legitimately long-thinking-but-momentarily-silent agent is never killed prematurely. `0` disables idle detection (fully unbounded escape hatch); unset/malformed uses the default. |
 | `SIMARD_MEETING_TURN_TIMEOUT_SECS` | _(unset)_ | **Deprecated alias** for `SIMARD_MEETING_IDLE_LIVENESS_SECS`, kept working for existing config. It is **no longer a wall-clock cap** — when set it configures the same idle-liveness window. |
 
 When a child is idle for the whole window it is terminated and the turn
@@ -330,7 +330,7 @@ If you see the prompt cursor blinking with no response after 2–3 minutes, chec
    the turn returns an `AdapterInvocationFailed` error immediately.
 3. **Long compute in progress?** A turn has **no wall-clock cap** — it runs as
    long as it keeps producing output. Only a genuinely idle child (no output for
-   `SIMARD_MEETING_IDLE_LIVENESS_SECS`, default 300 s) is reaped, degrading
+   `SIMARD_MEETING_IDLE_LIVENESS_SECS`, default 3600 s / 1 hour) is reaped, degrading
    honestly with a `[meeting:error] WARNING` banner — the REPL never hangs
    indefinitely and never kills a working turn. To change the idle window use
    `SIMARD_MEETING_IDLE_LIVENESS_SECS=600 simard meeting repl`, or set it to `0`

--- a/src/meeting_backend/agent_proxy.rs
+++ b/src/meeting_backend/agent_proxy.rs
@@ -98,8 +98,13 @@ const TURN_TIMEOUT_ENV: &str = "SIMARD_MEETING_TURN_TIMEOUT_SECS";
 /// treated as hung and reaped, so a dead/stuck `copilot -p` child cannot block
 /// the chat/meeting REPL forever (Pillar 11: honest degradation beats hidden
 /// silence). Generous on purpose: real turns stream output within seconds, so
-/// only a genuinely stalled child stays silent this long. Issues #2549, #2581.
-const DEFAULT_IDLE_LIVENESS_SECS: u64 = 300;
+/// only a genuinely stalled child stays silent this long. The default is an
+/// *hours*-scale window, not a minutes-scale one, so a legitimately
+/// long-thinking-but-momentarily-silent agent is never killed prematurely;
+/// only a truly wedged child hits this bound. Operators can still tighten or
+/// disable it via `SIMARD_MEETING_IDLE_LIVENESS_SECS` (`0` = unbounded).
+/// Issues #2549, #2581.
+const DEFAULT_IDLE_LIVENESS_SECS: u64 = 3600;
 
 /// Env var giving an explicit directory the meeting agent should operate in.
 /// When set to an existing directory it wins over cwd-derived resolution. This


### PR DESCRIPTION
## What

Raise the default meeting-agent **idle-liveness window** (`SIMARD_MEETING_IDLE_LIVENESS_SECS`) from **300 s (5 minutes)** to **3600 s (1 hour)** — an hours-scale bound instead of a minutes-scale one.

## Why

Per operator feedback: *"the timeouts should be an hours not minutes."*

The idle-liveness window (introduced in #2581) is the max time an agent child may produce **no output** before it is treated as hung and reaped. Every streamed chunk resets the clock, so a working turn is never killed. However, a legitimately long-thinking-but-momentarily-silent agent could still be reaped at the 5-minute mark. An hours-scale default means only a *truly* wedged child hits the bound, while honest degradation on a genuine hang is preserved.

## Scope

- `src/meeting_backend/agent_proxy.rs` — `DEFAULT_IDLE_LIVENESS_SECS: 300 → 3600` + rationale comment.
- `docs/howto/start-a-meeting.md` — env-var table default + troubleshooting note.

No behavioral change to the streaming/reset logic or the `0 = unbounded` escape hatch. Operators can still tighten the window via the env var.

## Tests

- `cargo test --lib meeting_backend::agent_proxy` — 21 passed (all assert via the named constant, no hardcoded 300).
- Pre-commit + pre-push gates green (fmt, clippy `-D warnings`, release test subset).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>