### PR TITLE
feat(overseer,dashboard,tui): surface Overseer/operator thread activity (#2419)

### DIFF
--- a/docs/design/overseer.md
+++ b/docs/design/overseer.md
@@ -17,6 +17,8 @@ related:
   - ../concepts/operational-autonomy-model.md
   - ../reference/cognitive-thread-scheduling.md
   - ../howto/add-a-new-cognitive-thread.md
+  - ../reference/overseer-activity-feed.md
+  - ../howto/watch-overseer-activity.md
   - ../reference/status-snapshot-api.md
   - ../concepts/unified-telemetry-and-status.md
   - ../reference/stewardship-api.md

--- a/docs/howto/watch-overseer-activity.md
+++ b/docs/howto/watch-overseer-activity.md
@@ -1,0 +1,209 @@
+---
+title: Watch what the Overseer is doing
+description: How to see the acting Overseer's recent activity — what it observed, what it changed, and why it held — from the dashboard Overseer tab, the TUI Overseer pane, simard status, and the GET /api/overseer endpoint; how to read the honest disabled/observing/absent states; and how to turn the steward up, down, or off.
+last_updated: 2026-07-05
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../reference/overseer-activity-feed.md
+  - ../reference/status-snapshot-api.md
+  - ./simard-status.md
+  - ../dashboard.md
+  - ../reference/simard-tui.md
+  - ./run-ooda-daemon.md
+  - ../reference/cognitive-thread-scheduling.md
+---
+
+# Watch what the Overseer is doing
+
+Simard runs two kinds of work side by side. The **engineer** side picks up
+goals and writes code — you already see that on the dashboard (Goals, live
+engineers) and in the TUI. The **steward** side — the acting **Overseer** — runs
+on its own clock, watching the whole system and quietly stepping in: filing
+issues, launching fixes, verifying and merging green PRs, running guarded
+deploys, escalating to you, or **waiting** when a gate says "not yet".
+
+This guide shows how to *watch* that steward activity — the last ~100 Overseer
+ticks and their outcomes, plus per-thread status — in four places, all showing
+the **same** data:
+
+- the dashboard **Overseer** tab,
+- the TUI **Overseer** pane,
+- the `OVERSEER` section of `simard status`, and
+- the `GET /api/overseer` endpoint (for scripting).
+
+For the data model, file contract, and endpoint schema, see the
+[Overseer activity feed reference](../reference/overseer-activity-feed.md).
+
+## Prerequisites
+
+- The Simard **daemon** running (`simard ooda run` or the systemd unit) so the
+  Overseer ticks and writes `~/.simard/overseer/activity.json`. See
+  [Run the OODA daemon](./run-ooda-daemon.md).
+- For the browser view, the dashboard served: `simard dashboard serve --port=8080`
+  (see [Dashboard](../dashboard.md)).
+- The acting Overseer enabled — which is the **default**. It is off only if you
+  explicitly set `SIMARD_OVERSEER_ENABLED` to a falsey value.
+
+> **Fresh install / just merged?** Until the daemon has ticked at least once you
+> will see **"Overseer: no ticks recorded yet"**. That is the correct, honest
+> state — not a bug.
+
+## Option 1 — the dashboard Overseer tab
+
+1. Open `http://localhost:8080/` and log in.
+2. Click the **Overseer** tab in the top navigation.
+
+You will see three things, newest-first, auto-refreshing every ~30 seconds:
+
+- **Status line** — whether the Overseer is enabled, its cadence ("every 15
+  min"), the identity it acts under, and when it last ran.
+- **Operator threads** — a row per steward thread with its name, whether it is
+  enabled, its cadence, last run, next due, and a one-word health
+  (`ok` / `idle` / `erroring` / `backoff` / `disabled`).
+- **Recent activity** — a timeline of ticks in plain language: what it *saw* and
+  what it *did*, or why it *held*.
+
+A healthy, working tab reads something like:
+
+```
+Overseer — enabled · every 15 min · acting as simard-overseer[bot] · last run 2 min ago
+
+Operator threads
+  overseer                 enabled   every 15 min   last 2 min ago   next in 13 min   ok
+
+Recent activity
+  15:30  observed 2 problems → filed 1 issue, launched 1 fix, held 1 (waiting on a gate)   0.8s
+  15:15  observed 1 problem  → merged 1 green PR                                            1.2s
+  15:00  observing, 0 interventions                                                        0.4s
+```
+
+The language stays plain on purpose — the tab is meant to be understandable
+without knowing Simard's internals.
+
+## Option 2 — the TUI Overseer pane
+
+1. Start the TUI: `simard-tui`.
+2. Press **`Alt+8`** (the footer shows `Alt+1–8`) to open the **Overseer** pane.
+
+It shows the identical status line, operator-thread rows, and recent-activity
+timeline as the dashboard tab, in the TUI's layout. See
+[`simard-tui`](../reference/simard-tui.md).
+
+## Option 3 — inline with `simard status`
+
+The feed is also a section of the unified status report, so you get it for free
+in the CLI, the dashboard **Status** tab, and the TUI **Status** tab:
+
+```console
+$ simard status
+SIMARD STATUS  ·  2026-07-05T15:31:39Z
+…
+OVERSEER
+  Overseer          enabled · every 15 min · acting as simard-overseer[bot]
+  last tick         2026-07-05T15:30:00Z (live)
+  threads           overseer: ok (last 15:30, next 15:45)
+  recent
+    15:30  observed 2 · filed 1 · launched 1 · held 1
+    15:15  observed 1 · merged 1
+    15:00  observing, 0 interventions
+```
+
+See [Read Simard's status](./simard-status.md) for the full report and how
+freshness (`live` / `stale` / `absent`) works.
+
+## Option 4 — script it with `GET /api/overseer`
+
+The endpoint is auth-gated behind the **same** credentials as every other
+dashboard `/api/*` route — a session cookie or a bearer token. Use the token for
+scripts:
+
+```bash
+# The HTTP form of the Overseer tab.
+curl -fsS -H "Authorization: Bearer $SIMARD_DASHBOARD_TOKEN" \
+  http://localhost:8080/api/overseer | jq '.section.freshness'
+# → "live"
+
+# How many green PRs has the steward merged across the retained window?
+curl -fsS -H "Authorization: Bearer $SIMARD_DASHBOARD_TOKEN" \
+  http://localhost:8080/api/overseer | jq '.section.data.totals.prs_merged'
+# → 1
+
+# The three most recent ticks, one line each.
+curl -fsS -H "Authorization: Bearer $SIMARD_DASHBOARD_TOKEN" \
+  http://localhost:8080/api/overseer \
+  | jq -r '.section.data.recent[:3][]
+      | "\(.timestamp)  obs=\(.report.problems) filed=\(.report.issues_filed) merged=\(.report.prs_merged) held=\(.report.held)"'
+```
+
+`recent` is newest-first and capped at 100 ticks; `totals` is summed over the
+records currently retained (a rolling window, not an all-time counter). Always
+check `.section.availability` / `.section.freshness` before reading
+`.section.data`. A request without valid auth returns **401**; a transient
+server-side hiccup returns `{"error": …}` at HTTP 200, never a 500.
+
+You can also read the raw durable file directly on the daemon host:
+
+```bash
+jq '.enabled, .cadence_secs, (.recent | length)' ~/.simard/overseer/activity.json
+```
+
+## Reading the honest states
+
+The feed never shows a blank or misleading panel. If it looks "empty", read the
+status line — it is telling you the truth:
+
+| You see | It means | What to do |
+|---|---|---|
+| `Overseer: disabled` | `SIMARD_OVERSEER_ENABLED` is set falsey — the steward is intentionally off. | Nothing, unless you want it on (below). |
+| `Overseer: no ticks recorded yet` | Enabled, but the daemon hasn't completed an Overseer tick yet (fresh start, or just redeployed). | Wait one cadence (default 15 min), or check the daemon is running. |
+| `Overseer: enabled, observing, 0 interventions` | Enabled and ticking, but nothing needed doing — it looked and correctly held. | Nothing. "Watching and not acting" is a real, healthy outcome. |
+| `Overseer activity feed unavailable` | The feed file couldn't be read (missing/corrupt/permission). | Check `~/.simard/overseer/` perms and daemon logs (`target: "overseer.activity"`). |
+
+**"Observing, 0 interventions" is not the same as "broken".** Most of the time a
+healthy steward *watches and waits*; a quiet timeline is usually good news.
+
+## Turn the steward up, down, or off
+
+The feed has no settings of its own — it records whatever the Overseer does, so
+you tune it through the existing Overseer configuration
+(`src/overseer/config.rs`):
+
+```bash
+# Turn the acting Overseer OFF (surfaces then read "Overseer: disabled"):
+SIMARD_OVERSEER_ENABLED=0 simard ooda run
+
+# Tighten the cadence to every 5 minutes (clamped to a 60s floor):
+SIMARD_OVERSEER_INTERVAL_SECS=300 simard ooda run
+
+# It's ON by default — an unset or truthy value keeps it enabled.
+```
+
+The cadence also drives the feed's `live`/`stale` window: a tick is `live` until
+`2 × cadence` has passed, then `stale`.
+
+## Troubleshooting
+
+- **Tab shows "no ticks recorded yet" and never changes.** The daemon isn't
+  ticking the Overseer. Confirm it's running (`simard status` → DAEMON) and that
+  `SIMARD_OVERSEER_ENABLED` isn't falsey. After a fresh deploy, the first tick
+  arrives within one cadence.
+- **Dashboard tab is blank but `/api/overseer` returns data.** Hard-refresh the
+  browser; the panel polls every ~30 s and the tab-switch fetch may have raced a
+  restart.
+- **`/api/overseer` returns 401.** Your session expired or the bearer token is
+  wrong — use the current `SIMARD_DASHBOARD_TOKEN` or re-log-in.
+- **Timeline stopped updating (`stale`).** The daemon paused or the write
+  failed; the write is non-fatal and logged under `target: "overseer.activity"`.
+  Check the daemon log and disk space in `~/.simard`.
+
+## See also
+
+- [Overseer activity feed reference](../reference/overseer-activity-feed.md) —
+  data model, file contract, and endpoint schema.
+- [Read Simard's status](./simard-status.md) — the full status report.
+- [Dashboard](../dashboard.md) and [`simard-tui`](../reference/simard-tui.md) —
+  the surfaces this tab/pane live in.
+- [Cognitive thread scheduling](../reference/cognitive-thread-scheduling.md) —
+  the per-thread health shown in the operator-threads list.

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,6 +106,8 @@ Bare `simard` prints the unified help text instead of attempting a hidden enviro
 
 - [How to monitor Simard with the TUI](./howto/monitor-simard-with-tui.md) - Launch `simard-tui` and read daemon health, goals, and system stats from a single terminal pane.
 - [simard-tui reference](./reference/simard-tui.md) - Full specification of tabs, data sources, refresh behaviour, environment variables, and security model.
+- [How to watch what the Overseer is doing](./howto/watch-overseer-activity.md) - See the acting Overseer's recent activity — what it observed, what it changed, and why it held — from the dashboard **Overseer** tab, the TUI **Overseer** pane, `simard status`, and `GET /api/overseer`, with the honest disabled/observing/absent states (#2419).
+- [Overseer activity feed reference](./reference/overseer-activity-feed.md) - The bounded, durable "recent Overseer activity" feed: the `OverseerActivity`/`Record`/`ThreadStatus` model, the cross-process `activity.json` file contract, the `StatusSnapshot.overseer` section, and the auth-gated `GET /api/overseer` endpoint that lights up the dashboard/TUI Overseer surfaces (#2419).
 - [Multi-binary self-update reference](./reference/multi-binary-self-update.md) - How `simard update` now replaces the **full** binary set (`simard` plus `simard-tui`, `simard-gym`, and the rest), the dynamic discovery and `InstallReport` main-fatal/aux-best-effort contract, the SHA-256 checksum gate, and the matching release-packaging producer contract (#2252).
 
 ## Compatibility binaries

--- a/docs/reference/overseer-activity-feed.md
+++ b/docs/reference/overseer-activity-feed.md
@@ -1,0 +1,416 @@
+---
+title: Overseer activity feed reference
+description: The bounded, durable "recent Overseer activity" feed — its data model (OverseerActivity / OverseerActivityRecord / OverseerThreadStatus), the cross-process activity.json file contract the daemon writes each tick and the status/dashboard/TUI read, the StatusSnapshot.overseer section, the auth-gated GET /api/overseer dashboard endpoint, the dashboard Overseer tab and TUI Overseer pane, and the honest disabled/observing/absent states.
+last_updated: 2026-07-05
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+related:
+  - ./status-snapshot-api.md
+  - ./telemetry-metrics.md
+  - ./stewardship-api.md
+  - ./cognitive-thread-scheduling.md
+  - ../howto/watch-overseer-activity.md
+  - ../howto/simard-status.md
+  - ../dashboard.md
+  - ./simard-tui.md
+  - ./operator-read-state-root-contract.md
+---
+
+# Overseer activity feed reference
+
+Simard's cognition runs on two clocks. The **engineer** side runs the OODA loop
+that picks up goals, writes code, and opens PRs — and it is already visible on
+the dashboard (goals, live engineers) and in the TUI. The **steward** side —
+the acting **Overseer** meta-loop — runs *alongside* it on its own cadence,
+watching the whole system and quietly intervening: filing stewardship issues,
+launching fix workstreams, verifying and merging green PRs, running guarded
+deploys, escalating to the operator, or *holding* when a gate says "not yet".
+
+Until now that steward activity was invisible outside the daemon's log. The
+**Overseer activity feed** makes it a first-class, queryable surface: the last
+`N` Overseer ticks and their outcomes, plus per-thread status, readable from the
+**dashboard** (`localhost:8080`), the **TUI**, and `simard status`.
+
+> **This feed only *reads and surfaces* Overseer activity.** It does not change
+> what the Overseer decides or does. The producer touches the Overseer only at
+> the tick boundary, to *record* what already happened.
+
+> **Modules:** producer + model `src/overseer/activity.rs` (types + store),
+> `src/overseer/wiring.rs` (`OverseerTickReport`), the daemon tick boundary
+> (`src/operator_commands_ooda/daemon/mod.rs`); reader `src/status/provider.rs`
+> (`assemble_overseer`), `src/status/render.rs` (`OVERSEER` section); surfaces
+> `src/operator_commands_dashboard/overseer.rs` (`GET /api/overseer`) +
+> `.../index_html/` (Overseer tab), `src/bin/simard_tui/tabs/overseer.rs`
+> (Overseer pane).
+
+## At a glance
+
+| You want to… | Use |
+|---|---|
+| Watch Overseer activity in a browser | Dashboard **Overseer** tab (open `http://localhost:8080/`, click **Overseer**) |
+| Watch it in the terminal UI | TUI **Overseer** tab (press **`Alt+8`**) |
+| See it inline with the rest of status | `simard status` → **OVERSEER** section (also the Status tab / `/api/status/snapshot`) |
+| Read it as JSON / script against it | `GET /api/overseer` (auth-gated) |
+| Read the raw durable file | `~/.simard/overseer/activity.json` |
+
+All surfaces render the **same** data because they all read the one durable
+feed the daemon writes each tick.
+
+## Why a durable file (not an in-RAM ring)
+
+The daemon (which *runs* the Overseer), the dashboard server (`simard dashboard
+serve`), and the TUI are **separate processes**. A pure in-memory ring buffer
+in the daemon would be unreachable by the other two. So the feed keeps a
+bounded in-memory `VecDeque` (cap `N = 100`) as the write surface **and**
+persists the whole capped feed atomically to disk each tick. That file is the
+cross-process seam every reader consumes — the same pattern the
+[telemetry snapshot](./telemetry-metrics.md) and
+[status provider](./status-snapshot-api.md) already use.
+
+This mirrors the [operator read / state-root contract](./operator-read-state-root-contract.md):
+the daemon is the single writer; every reader degrades to an honest "no data"
+state rather than fabricating one.
+
+## Data model
+
+Defined in `src/overseer/activity.rs`. Every struct derives
+`Serialize`/`Deserialize` + `Default` and is `#[serde(default)]`, so the schema
+grows additively and an older reader tolerates a newer file (and vice-versa).
+
+```rust
+/// Bumped only on an INCOMPATIBLE shape change. Additive fields do not bump it.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// The whole feed: top-level Overseer status + per-thread status + recent ticks.
+pub struct OverseerActivity {
+    pub schema_version: u32,
+    pub enabled: bool,                       // overseer_acting_enabled() at last write
+    pub cadence_secs: u64,                   // overseer_interval_secs()
+    pub author_login: String,                // the Overseer's distinct git identity
+    pub last_tick_at: Option<String>,        // RFC3339 of the most recent tick, or None
+    pub totals: OverseerTotals,              // summed over the records currently retained
+    pub threads: Vec<OverseerThreadStatus>,  // from Mind::health() (#2531)
+    pub recent: VecDeque<OverseerActivityRecord>, // newest-first, capped at N=100
+}
+
+/// Cumulative outcome counts across the retained records (not since boot).
+pub struct OverseerTotals {
+    pub problems: u64,
+    pub issues_filed: u64,
+    pub recipes_launched: u64,
+    pub prs_merged: u64,
+    pub deploys: u64,
+    pub escalations: u64,
+    pub held: u64,
+    pub errors: u64,
+}
+
+/// One Overseer tick: the outcome report plus time + gate context.
+pub struct OverseerActivityRecord {
+    pub timestamp: String,        // RFC3339, tick completion
+    pub enabled: bool,            // gate state at this tick
+    pub report: OverseerTickReport,
+}
+
+/// Per cognitive thread, derived from ThreadHealth (epochs → RFC3339).
+pub struct OverseerThreadStatus {
+    pub id: String,               // stable thread id, e.g. "overseer"
+    pub enabled: bool,
+    pub last_run: Option<String>, // from last_run_epoch, or None
+    pub next_due: Option<String>, // from next_run_epoch, or None
+    pub last_success: Option<bool>,
+    pub consecutive_errors: u32,
+    pub backoff_until: Option<String>,
+    pub health: String,           // derived label — see below
+}
+```
+
+`OverseerTickReport` is the existing outcome tally emitted by the Overseer
+meta-loop (`src/overseer/wiring.rs`), now `Serialize`/`Deserialize` so it can be
+recorded. Its fields are recorded **verbatim** — no interpretation:
+
+| Field | Meaning |
+|---|---|
+| `problems` | Problems the Overseer *observed* this tick (after de-dup against in-flight work). |
+| `issues_filed` | Stewardship issues filed (deduplicated). |
+| `recipes_launched` | Fix workstreams launched. |
+| `prs_merged` | Green, merge-ready PRs verified **and** merged (normal merge — never admin). |
+| `deploys` | Guarded deploys performed through the canary / self-deploy gates. |
+| `escalations` | Interventions handed off to the operator. |
+| `held` | Interventions a gate held back (autonomy / budget / conflict). |
+| `errors` | Capability errors encountered while acting (isolated, never fatal). |
+| `panicked` | The tick itself panicked and was isolated. Recorded, not swallowed. |
+| `duration_ms` | Wall-clock duration of the tick. |
+
+### `health` derivation
+
+`OverseerThreadStatus.health` is a pure, testable label derived from the raw
+fields (first match wins):
+
+| Condition | `health` |
+|---|---|
+| `!enabled` | `"disabled"` |
+| `backoff_until.is_some()` | `"backoff"` |
+| `consecutive_errors > 0` | `"erroring"` |
+| `last_run.is_none()` | `"idle"` |
+| otherwise | `"ok"` |
+
+### Bounded by construction
+
+`recent` is capped at **`N = 100`** ticks, evicting oldest-first, and the cap is
+enforced **on write** (before serialize) so the file can never grow unbounded.
+`totals` is recomputed from the **retained** records only — it is a rolling
+window, not an all-time counter. On read, an 8 MiB size guard and
+degrade-to-`None`-on-corrupt parse keep readers safe regardless of the file.
+
+## Durable file contract
+
+- **Path:** `~/.simard/overseer/activity.json` (`<state_root>/overseer/activity.json`).
+- **Writer:** the daemon, once per Overseer tick, at the tick boundary — the
+  **single** writer.
+- **Atomic write:** serialize the whole `OverseerActivity`, write
+  `activity.json.tmp` with mode `0o600` under a `0o700` parent, `fsync`, then
+  `rename` over the target. Readers never see a torn or briefly world-readable
+  file. (Mirrors `telemetry::snapshot::write_atomic`.)
+- **Read:** `is_file` check → 8 MiB size guard → `serde` parse; any of missing /
+  oversized / corrupt / permission-denied / unknown-higher-`schema_version`
+  degrades to `None` (never a panic, never a fabricated value).
+- **Write failure is non-fatal.** If the write fails, the daemon logs a
+  structured `tracing::warn!(target: "overseer.activity", …)` and the tick
+  continues untouched. The feed simply reads `stale` next time — surfaced
+  honestly, never silently.
+
+### Freshness rule
+
+A reader computes freshness from the last tick time versus the cadence:
+
+| Condition | Freshness |
+|---|---|
+| `now − last_tick_at ≤ 2 × cadence_secs` | `live` |
+| `now − last_tick_at > 2 × cadence_secs` | `stale` (with `as_of = last_tick_at`) |
+| no file / `last_tick_at` absent | `absent` |
+
+> **Why not the shared `SNAPSHOT_FRESHNESS_SECS`?** The telemetry snapshot uses a
+> *fixed* 300 s stale threshold, but the Overseer ticks on its own (default
+> 15-minute) cadence. Reusing the fixed 300 s constant here would mark a
+> perfectly healthy feed `stale` for two-thirds of every cadence window. This
+> section therefore uses a **cadence-relative** window (`2 × cadence_secs`); the
+> implementation must **not** reuse `SNAPSHOT_FRESHNESS_SECS` for it.
+
+## `StatusSnapshot.overseer` section
+
+The feed is exposed as a normal section on the one typed
+[`StatusSnapshot`](./status-snapshot-api.md), so it lights up **every** status
+surface (CLI, Status tab, TUI Status tab) for free — not just the dedicated tab:
+
+```rust
+pub struct StatusSnapshot {
+    // … existing sections …
+    #[serde(default)]
+    pub overseer: SectionEnvelope<OverseerActivity>,
+}
+```
+
+`status::provider::assemble_overseer(state_root)` reads the durable file and
+returns the section, using `overseer_acting_enabled()` to distinguish the honest
+states below. Like every section it is assembled in **isolation** and never
+panics. `status::render` adds an `OVERSEER` header to `SECTION_HEADERS` and a
+`render_overseer()` that prints the honest header line, per-thread rows, and a
+newest-first timeline.
+
+## Honest states
+
+The feed never shows an empty or misleading panel. Four states are rendered
+plainly and are covered by tests:
+
+| Real situation | availability / freshness | `data.enabled` | Rendered as |
+|---|---|---|---|
+| Acting Overseer **disabled** (`SIMARD_OVERSEER_ENABLED` falsey) | `ok` / `live` | `false` | `Overseer: disabled` |
+| Enabled but **never ticked** (no file yet) | `unavailable` / `absent` | — | `Overseer: no ticks recorded yet` |
+| Enabled, ticked, **zero interventions** | `ok` / `live` (or `stale`) | `true` | `Overseer: enabled, observing, 0 interventions` |
+| Feed file **unreadable / corrupt** | `unavailable` / `absent` | — | `Overseer activity feed unavailable` |
+
+**Disabled is a *present* state**, distinct from *absent*: the UI can say
+"disabled" without pretending there is simply no data. "Zero interventions" is
+stated explicitly rather than shown as a blank list — observing-and-holding is a
+real, truthful outcome.
+
+## Dashboard endpoint — `GET /api/overseer`
+
+A new handler in `src/operator_commands_dashboard/overseer.rs`, registered in
+`routes.rs` **behind** the existing `require_auth` layer — it is **not** a new
+auth path. It accepts the **same** credentials as every other `/api/*` route:
+the `simard_session` cookie set by the dashboard login, or an
+`Authorization: Bearer <SIMARD_DASHBOARD_TOKEN>` header for scripted reads.
+Anything else returns **401**.
+
+It reuses the one `status::assemble` provider on a blocking thread
+(`spawn_blocking`) and returns only the `overseer` section, so the dedicated tab
+and the Status tab can never diverge. It **degrades to an error object at HTTP
+200, never a 500** — a join/serialize failure returns `{"error": "<detail>"}`,
+which the SPA shows as a soft banner while keeping the last good render.
+
+- Method: `GET` · Path: `/api/overseer` · No path params, query params, or body.
+- Auth: inherited `require_auth`. 401 without a valid session/token.
+- Network exposure: inherits the dashboard bind address; restrict the network
+  path (loopback / firewall / SSH tunnel) as for any other dashboard route.
+
+### Response (HTTP 200)
+
+```jsonc
+{
+  "schema_version": 1,                       // overseer::activity::SCHEMA_VERSION
+  "generated_at": "2026-07-05T15:31:39Z",    // RFC3339, snapshot assembly time
+  "section": {                               // serialized SectionEnvelope<OverseerActivity>
+    "availability": "ok",                    // "ok" | "unavailable" | "error"
+    "freshness": "live",                     // "live" | "stale" | "absent"
+    "as_of": "2026-07-05T15:30:00Z",         // last tick time (omitted if none)
+    "note": null,                            // honest-state text (omitted if none)
+    "data": {
+      "schema_version": 1,
+      "enabled": true,
+      "cadence_secs": 900,
+      "author_login": "simard-overseer[bot]",
+      "last_tick_at": "2026-07-05T15:30:00Z",
+      "totals": {
+        "problems": 12, "issues_filed": 3, "recipes_launched": 2,
+        "prs_merged": 1, "deploys": 0, "escalations": 1, "held": 4, "errors": 0
+      },
+      "threads": [
+        {
+          "id": "overseer", "enabled": true,
+          "last_run": "2026-07-05T15:30:00Z",
+          "next_due": "2026-07-05T15:45:00Z",
+          "last_success": true, "consecutive_errors": 0,
+          "backoff_until": null, "health": "ok"
+        }
+      ],
+      "recent": [
+        {
+          "timestamp": "2026-07-05T15:30:00Z",
+          "enabled": true,
+          "report": {
+            "problems": 2, "issues_filed": 1, "recipes_launched": 1,
+            "prs_merged": 0, "deploys": 0, "escalations": 0,
+            "held": 1, "errors": 0, "panicked": false, "duration_ms": 843
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Consumers should treat the section as optional: check `availability` /
+`freshness` before reading `data`. `recent` is newest-first. Unknown fields are
+ignored and missing fields default, so the schema can grow additively.
+
+### Honest-state response example (disabled)
+
+```jsonc
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-05T15:31:39Z",
+  "section": {
+    "availability": "ok",
+    "freshness": "live",
+    "note": "Overseer: disabled",
+    "data": { "enabled": false, "cadence_secs": 900, "totals": { }, "threads": [], "recent": [] }
+  }
+}
+```
+
+## Dashboard **Overseer** tab
+
+A new tab (slug `overseer`, label **Overseer**), declared once in the
+[tab-identity table](../dashboard.md#tab-identity-contract) (`tab_meta.rs`) so
+its nav label, browser title, `<h1>`, and plain-English lede stay in lockstep.
+The lede is **jargon-free** (no "OODA", "meta-loop", "cognitive memory" — it is
+cross-checked against `BANNED_JARGON`). It reads roughly:
+
+> **Overseer** — What Simard's steward has been doing on its own: what it
+> noticed, what it changed, and — when it chose to wait — why. Refreshes
+> automatically.
+
+The panel shows, most-recent-first and auto-refreshing (~30 s, like the other
+tabs):
+
+1. **Overseer status line** — enabled/disabled, cadence (e.g. "every 15 min"),
+   the identity it acts under, and last-tick time. Honest states from the table
+   above render here verbatim.
+2. **Operator threads** — a row per cognitive thread: name, enabled, cadence,
+   last run, next due, and a plain health word (`ok` / `idle` / `erroring` /
+   `backoff` / `disabled`).
+3. **Recent activity timeline** — one line per tick in plain language: what it
+   **saw** (problems observed) and what it **did** (issues filed, workstreams
+   launched, PRs merged, deploys, escalations) — or, when nothing needed doing,
+   **why it held** ("observed 2 problems, held 1 — waiting on a gate", or
+   "observing, 0 interventions").
+
+Every interpolated value is escaped (`esc()` / `escAttr()`) before it reaches
+`innerHTML`, so a value that ever contained markup renders inert — covered by an
+XSS regression test.
+
+## TUI **Overseer** pane
+
+The TUI gains `Tab::Overseer` (`src/bin/simard_tui/tabs/overseer.rs`), reachable
+by pressing **`Alt+8`** (the footer lists `Alt+1–8`; bare digits are ignored so
+they never steal input on the Meeting tab). It assembles the same
+`StatusSnapshot`, reads `snapshot.overseer`, and renders a bordered pane with the
+identical content as the dashboard tab — the Overseer status line, the operator-
+thread rows, and the newest-first activity timeline — in the TUI's existing
+style. The disabled / observing / absent states render as the same honest
+one-liners. See [`simard-tui`](./simard-tui.md).
+
+## Configuration
+
+The feed has **no configuration of its own** — it records whatever the Overseer
+does. Its content is governed entirely by the existing Overseer settings
+(`src/overseer/config.rs`):
+
+| Env var | Effect on the feed | Default |
+|---|---|---|
+| `SIMARD_OVERSEER_ENABLED` | A falsey value (`0`/`false`/`no`/`off`) **disables** the acting Overseer: no new ticks are recorded and every surface shows `Overseer: disabled`. Unset or truthy → enabled (opt-**out**). | enabled |
+| `SIMARD_OVERSEER_INTERVAL_SECS` | The Overseer cadence, which also drives the feed's `cadence_secs` and the `live`/`stale` window (`2 × cadence`). Clamped to a 60 s floor. | `900` (15 min) |
+| `SIMARD_OVERSEER_AUTHOR_LOGIN` | The distinct git identity shown as `author_login`. | `simard-overseer[bot]` |
+
+The feed file location follows the standard
+[state-root resolution](./state-root-resolution.md): `~/.simard/overseer/`
+(honoring `SIMARD_STATE_ROOT`). No new file needs to be created by an operator;
+the daemon creates `overseer/activity.json` on its first tick.
+
+## Guarantees
+
+- **Read-only surfacing.** No Overseer decision or intervention logic is
+  changed. The only producer-side touch is recording a report at the tick
+  boundary (and the additive `Serialize`/`Deserialize` derive on
+  `OverseerTickReport`).
+- **Never panics.** Writers are size-capped and non-fatal; readers degrade
+  missing/corrupt input to `None`.
+- **Bounded.** `N = 100` ticks, enforced on write; 8 MiB read guard.
+- **Honest.** Disabled, observing-with-zero-interventions, and absent are
+  distinct, explicit states — never a blank or a fabricated `0`.
+- **Process-agnostic.** Identical data from the dashboard, the TUI, and
+  `simard status`, because they all read the one durable file.
+- **Auth-inherited.** `/api/overseer` sits behind the same `require_auth` as
+  every other `/api/*` route; no new auth surface.
+
+## Activation
+
+The daemon must be **redeployed** after this feature merges before it starts
+writing `overseer/activity.json`. Until then the surfaces show
+`Overseer: no ticks recorded yet` — which is the honest, correct state.
+
+## See also
+
+- [How to watch Overseer activity](../howto/watch-overseer-activity.md) — the
+  operator walkthrough with rendered output.
+- [StatusSnapshot API reference](./status-snapshot-api.md) — the section model
+  and provider this feed plugs into.
+- [Cognitive thread scheduling](./cognitive-thread-scheduling.md) — where the
+  per-thread `ThreadHealth` comes from.
+- [Stewardship API](./stewardship-api.md) — the issue-filing path the Overseer
+  uses.
+- [Operator read / state-root contract](./operator-read-state-root-contract.md)
+  — the single-writer / many-readers discipline this feed follows.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,12 +176,14 @@ nav:
     - Run Dashboard E2E Tests: howto/run-dashboard-e2e-tests.md
     - Capture and Diagnose a Failing Distill Sample: howto/capture-and-diagnose-a-failing-distill-sample.md
     - Read Simard Status: howto/simard-status.md
+    - Watch Overseer Activity: howto/watch-overseer-activity.md
     - Configure Cognitive-Thread Scheduling: howto/configure-cognitive-thread-scheduling.md
     - Add a New Cognitive Thread: howto/add-a-new-cognitive-thread.md
   - Reference:
     - CLI Reference: reference/simard-cli.md
     - Telemetry Metrics: reference/telemetry-metrics.md
     - StatusSnapshot API: reference/status-snapshot-api.md
+    - Overseer Activity Feed: reference/overseer-activity-feed.md
     - simard-engineer-step CLI: reference/simard-engineer-step.md
     - simard-tui Dashboard: reference/simard-tui.md
     - npx / npm Install: reference/npx-npm-install.md

--- a/src/bin/simard_tui/app.rs
+++ b/src/bin/simard_tui/app.rs
@@ -13,7 +13,7 @@ use crate::goals;
 use crate::system::{self, CpuSample, DaemonInfo};
 use crate::types::GoalBoard;
 
-/// The seven tabs in the TUI.
+/// The tabs in the TUI.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Tab {
     Overview,
@@ -23,10 +23,11 @@ pub enum Tab {
     Meeting,
     Stats,
     Status,
+    Overseer,
 }
 
 /// All tabs in display order.
-pub const ALL_TABS: [Tab; 7] = [
+pub const ALL_TABS: [Tab; 8] = [
     Tab::Overview,
     Tab::Goals,
     Tab::Engineers,
@@ -34,6 +35,7 @@ pub const ALL_TABS: [Tab; 7] = [
     Tab::Meeting,
     Tab::Stats,
     Tab::Status,
+    Tab::Overseer,
 ];
 
 impl Tab {
@@ -47,6 +49,7 @@ impl Tab {
             Self::Meeting => "Meeting",
             Self::Stats => "Stats",
             Self::Status => "Status",
+            Self::Overseer => "Overseer",
         }
     }
 
@@ -67,6 +70,7 @@ impl Tab {
             KeyCode::Char('5') => Some(Tab::Meeting),
             KeyCode::Char('6') => Some(Tab::Stats),
             KeyCode::Char('7') => Some(Tab::Status),
+            KeyCode::Char('8') => Some(Tab::Overseer),
             _ => None,
         }
     }
@@ -81,6 +85,7 @@ impl Tab {
             Self::Meeting => 5,
             Self::Stats => 6,
             Self::Status => 7,
+            Self::Overseer => 8,
         }
     }
 }
@@ -191,7 +196,7 @@ impl App {
 
     /// Handle a key press event.
     ///
-    /// - `Alt+1`–`Alt+7` / `Ctrl+1`–`Ctrl+7`: switch tabs (always)
+    /// - `Alt+1`–`Alt+8` / `Ctrl+1`–`Ctrl+8`: switch tabs (always)
     /// - `Tab`/`Shift+Tab`: cycle tabs forward/backward (always)
     /// - On Meeting tab with Running: chars → input, Enter → send,
     ///   Backspace → delete, Left/Right → cursor, Esc → stop meeting
@@ -927,7 +932,7 @@ mod tests {
 
     #[test]
     fn all_tabs_count() {
-        assert_eq!(ALL_TABS.len(), 7);
+        assert_eq!(ALL_TABS.len(), 8);
     }
 
     #[test]
@@ -946,6 +951,7 @@ mod tests {
         assert_eq!(Tab::Meeting.label(), "Meeting");
         assert_eq!(Tab::Stats.label(), "Stats");
         assert_eq!(Tab::Status.label(), "Status");
+        assert_eq!(Tab::Overseer.label(), "Overseer");
     }
 
     #[test]
@@ -958,6 +964,7 @@ mod tests {
         assert_eq!(Tab::from_key(&alt_key('5')), Some(Tab::Meeting));
         assert_eq!(Tab::from_key(&alt_key('6')), Some(Tab::Stats));
         assert_eq!(Tab::from_key(&alt_key('7')), Some(Tab::Status));
+        assert_eq!(Tab::from_key(&alt_key('8')), Some(Tab::Overseer));
     }
 
     #[test]
@@ -1622,7 +1629,7 @@ mod tests {
     #[test]
     fn handle_key_right_arrow_wraps_at_end() {
         let mut app = App::new("simard-ooda.service".to_string(), None);
-        app.active_tab = Tab::Status; // index 6 (last)
+        app.active_tab = Tab::Overseer; // index 7 (last)
 
         app.handle_key(key_code(KeyCode::Right));
         assert_eq!(app.active_tab, Tab::Overview); // wraps to index 0
@@ -1634,7 +1641,7 @@ mod tests {
         assert_eq!(app.active_tab, Tab::Overview); // index 0
 
         app.handle_key(key_code(KeyCode::Left));
-        assert_eq!(app.active_tab, Tab::Status); // wraps to index 6
+        assert_eq!(app.active_tab, Tab::Overseer); // wraps to index 7 (last)
     }
 
     #[test]

--- a/src/bin/simard_tui/main.rs
+++ b/src/bin/simard_tui/main.rs
@@ -1,7 +1,7 @@
 //! simard-tui: CLI TUI monitoring client for Simard.
 //!
 //! Displays daemon status, goals, and activity in a terminal UI.
-//! Tabs switch with Alt+1–7 / ←→ arrow keys, auto-refreshes every 2s, quit with q.
+//! Tabs switch with Alt+1–8 / ←→ arrow keys, auto-refreshes every 2s, quit with q.
 
 mod app;
 mod goals;

--- a/src/bin/simard_tui/tabs/mod.rs
+++ b/src/bin/simard_tui/tabs/mod.rs
@@ -4,6 +4,7 @@ pub mod activity;
 pub mod engineers;
 pub mod goals;
 pub mod meeting;
+pub mod overseer;
 pub mod overview;
 pub mod stats;
 pub mod status;

--- a/src/bin/simard_tui/tabs/overseer.rs
+++ b/src/bin/simard_tui/tabs/overseer.rs
@@ -1,0 +1,228 @@
+//! Overseer tab: the acting Overseer meta-loop's recent activity (#2419).
+//!
+//! Renders the same honest data the dashboard **Overseer** tab and `simard
+//! status` show — the steward status line, the operator-thread rows, and a
+//! newest-first activity timeline — read from the one durable
+//! [`crate::status::StatusSnapshot`] (its `overseer` section). Disabled,
+//! observing-with-zero-interventions, and absent all render as plain one-liners.
+
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+use simard::overseer::activity::{OverseerActivity, human_cadence, humanize_tick};
+use simard::status::{Availability, Freshness, SectionEnvelope};
+
+/// Render the Overseer tab content within the given area.
+pub fn draw(f: &mut ratatui::Frame, app: &crate::app::App, area: ratatui::layout::Rect) {
+    let _ = app;
+
+    let snapshot = simard::status::assemble(&simard::status::provider::AssembleOptions::default());
+    let lines: Vec<Line> = render_lines(&snapshot.overseer)
+        .into_iter()
+        .map(Line::from)
+        .collect();
+
+    let paragraph = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::ALL).title("Overseer"))
+        .wrap(Wrap { trim: false });
+    f.render_widget(paragraph, area);
+}
+
+/// Build the plain-text lines for the Overseer pane from the section envelope.
+///
+/// Pure and hermetic so the pane is unit-testable without a live daemon: every
+/// honest state (present/disabled/observing/absent) maps to a truthful line.
+fn render_lines(env: &SectionEnvelope<OverseerActivity>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+
+    // Absent / error states: a single honest line, never a blank pane.
+    if !matches!(env.availability, Availability::Ok) || env.data.is_none() {
+        let note = env
+            .note
+            .clone()
+            .unwrap_or_else(|| "Overseer: no ticks recorded yet".to_string());
+        out.push(note);
+        out.push(String::new());
+        out.push(
+            "The steward starts recording activity after the daemon is redeployed.".to_string(),
+        );
+        return out;
+    }
+
+    let a = env.data.as_ref().expect("data present");
+    let stale = if env.freshness == Freshness::Stale {
+        "  (stale)"
+    } else {
+        ""
+    };
+
+    // Status line + cadence + identity + last tick.
+    out.push(format!("Overseer: {}{}", a.status_summary(), stale));
+    out.push(format!(
+        "Runs every {}  ·  acting as {}",
+        human_cadence(a.cadence_secs),
+        a.author_login
+    ));
+    out.push(format!(
+        "Last check: {}",
+        a.last_tick_at.as_deref().unwrap_or("never")
+    ));
+    out.push(String::new());
+
+    // Operator threads.
+    out.push("Operator threads:".to_string());
+    if a.threads.is_empty() {
+        out.push("  (only the steward loop is running)".to_string());
+    } else {
+        for t in &a.threads {
+            out.push(format!(
+                "  {:<16} {}  ·  last {}  ·  next {}  ·  {}",
+                t.id,
+                if t.enabled { "on" } else { "off" },
+                t.last_run.as_deref().unwrap_or("—"),
+                t.next_due.as_deref().unwrap_or("—"),
+                t.health,
+            ));
+        }
+    }
+    out.push(String::new());
+
+    // Recent activity, newest-first.
+    out.push("Recent activity:".to_string());
+    if a.recent.is_empty() {
+        out.push("  enabled and observing — 0 interventions so far".to_string());
+    } else {
+        for r in a.recent.iter().take(RECENT_ROWS) {
+            out.push(format!("  {}  {}", r.timestamp, humanize_tick(&r.report)));
+        }
+        if a.recent.len() > RECENT_ROWS {
+            out.push(format!(
+                "  … {} older tick(s) retained",
+                a.recent.len() - RECENT_ROWS
+            ));
+        }
+    }
+
+    out
+}
+
+/// How many recent-activity rows the pane shows before summarizing the rest.
+const RECENT_ROWS: usize = 30;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use simard::overseer::OverseerTickReport;
+    use simard::overseer::activity::{OverseerActivityRecord, OverseerThreadStatus};
+
+    fn joined(env: &SectionEnvelope<OverseerActivity>) -> String {
+        render_lines(env).join("\n")
+    }
+
+    fn overseer_thread() -> OverseerThreadStatus {
+        OverseerThreadStatus {
+            id: "overseer".to_string(),
+            enabled: true,
+            last_run: Some("2026-07-05T15:30:00Z".to_string()),
+            next_due: Some("2026-07-05T15:45:00Z".to_string()),
+            last_success: Some(true),
+            consecutive_errors: 0,
+            backoff_until: None,
+            health: "ok".to_string(),
+        }
+    }
+
+    fn record(problems: usize, issues_filed: usize, held: usize) -> OverseerActivityRecord {
+        OverseerActivityRecord {
+            timestamp: "2026-07-05T15:30:00Z".to_string(),
+            enabled: true,
+            report: OverseerTickReport {
+                problems,
+                issues_filed,
+                held,
+                ..OverseerTickReport::default()
+            },
+        }
+    }
+
+    #[test]
+    fn renders_threads_and_a_sample_intervention() {
+        let mut feed = OverseerActivity {
+            enabled: true,
+            cadence_secs: 900,
+            threads: vec![overseer_thread()],
+            ..OverseerActivity::default()
+        };
+        feed.push_record(record(2, 1, 1));
+        let text = joined(&SectionEnvelope::live(
+            feed,
+            Some("2026-07-05T15:30:00Z".to_string()),
+        ));
+
+        assert!(
+            text.contains("Operator threads:"),
+            "missing threads header:\n{text}"
+        );
+        // The overseer thread row with its health word.
+        assert!(
+            text.contains("overseer"),
+            "missing overseer thread row:\n{text}"
+        );
+        assert!(text.contains("ok"), "missing thread health:\n{text}");
+        // The sample intervention appears in the timeline.
+        assert!(
+            text.contains("Recent activity:"),
+            "missing recent header:\n{text}"
+        );
+        assert!(
+            text.contains("filed 1 issue"),
+            "missing intervention:\n{text}"
+        );
+    }
+
+    #[test]
+    fn renders_zero_interventions_honestly() {
+        let mut feed = OverseerActivity {
+            enabled: true,
+            cadence_secs: 900,
+            threads: vec![overseer_thread()],
+            ..OverseerActivity::default()
+        };
+        feed.push_record(record(2, 0, 0));
+        let text = joined(&SectionEnvelope::live(
+            feed,
+            Some("2026-07-05T15:30:00Z".to_string()),
+        ));
+        assert!(
+            text.contains("0 interventions"),
+            "an enabled-but-idle overseer must render '0 interventions':\n{text}"
+        );
+    }
+
+    #[test]
+    fn renders_disabled_state() {
+        let feed = OverseerActivity {
+            enabled: false,
+            cadence_secs: 900,
+            ..OverseerActivity::default()
+        };
+        let mut env = SectionEnvelope::live(feed, None);
+        env.note = Some("Overseer: disabled".to_string());
+        let text = joined(&env);
+        assert!(
+            text.to_lowercase().contains("disabled"),
+            "a disabled overseer must say 'disabled':\n{text}"
+        );
+    }
+
+    #[test]
+    fn renders_absent_state_without_blank_pane() {
+        let env: SectionEnvelope<OverseerActivity> =
+            SectionEnvelope::absent("Overseer: no ticks recorded yet");
+        let text = joined(&env);
+        assert!(
+            text.contains("no ticks recorded yet"),
+            "absent must render an honest one-liner, not a blank pane:\n{text}"
+        );
+    }
+}

--- a/src/bin/simard_tui/tabs/overview.rs
+++ b/src/bin/simard_tui/tabs/overview.rs
@@ -52,7 +52,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(""),
         Line::from(Span::styled(
-            " Alt+1\u{2013}7 / Tab / \u{2190}\u{2192} to switch tabs, q to quit",
+            " Alt+1\u{2013}8 / Tab / \u{2190}\u{2192} to switch tabs, q to quit",
             Style::default().fg(Color::DarkGray),
         )),
     ];

--- a/src/bin/simard_tui/ui.rs
+++ b/src/bin/simard_tui/ui.rs
@@ -51,15 +51,16 @@ pub fn draw(f: &mut Frame, app: &App) {
         Tab::Meeting => tabs::meeting::draw(f, app, chunks[1]),
         Tab::Stats => tabs::stats::draw(f, app, chunks[1]),
         Tab::Status => tabs::status::draw(f, app, chunks[1]),
+        Tab::Overseer => tabs::overseer::draw(f, app, chunks[1]),
     }
 
     // If an update notice is available, show it in the footer area
     let footer_text = if let Some(ref notice) = app.update_notice {
         format!(
-            "{notice}  | Alt+1\u{2013}7: tabs | Tab/Shift+Tab: cycle | \u{2190}/\u{2192}: prev/next | q: quit"
+            "{notice}  | Alt+1\u{2013}8: tabs | Tab/Shift+Tab: cycle | \u{2190}/\u{2192}: prev/next | q: quit"
         )
     } else {
-        "Alt+1\u{2013}7: tabs | Tab/Shift+Tab: cycle | \u{2190}/\u{2192}: prev/next | q: quit"
+        "Alt+1\u{2013}8: tabs | Tab/Shift+Tab: cycle | \u{2190}/\u{2192}: prev/next | q: quit"
             .to_string()
     };
     let footer_style = if app.update_notice.is_some() {

--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -37,6 +37,23 @@ pub(crate) const PART_01: &str = r#"      </div>
     </div>
   </div>
 
+  <div class="tab-content" id="tab-overseer">
+    <h1 class="page-h1">Overseer</h1>
+    <p class="page-lede">What Simard's steward has been doing on its own — what it noticed across the system, what it changed, and, when it chose to wait, why it held back. Refreshes automatically.</p>
+    <div class="card" style="max-width:1100px;margin-bottom:1rem">
+      <h2>Steward Status <button class="btn" onclick="fetchOverseer()" style="font-size:.75rem">Refresh</button></h2>
+      <div id="overseer-status"><span class="loading">Loading…</span></div>
+    </div>
+    <div class="card" style="max-width:1100px;margin-bottom:1rem">
+      <h2>Operator Threads</h2>
+      <div id="overseer-threads"><span class="loading">Loading…</span></div>
+    </div>
+    <div class="card" style="max-width:1100px">
+      <h2>Recent Activity</h2>
+      <div id="overseer-recent"><span class="loading">Loading…</span></div>
+    </div>
+  </div>
+
   <div class="tab-content" id="tab-status">
     <h1 class="page-h1">Status</h1>
     <p class="page-lede">One consolidated operational report — the daemon, system resources, model spending, memory and brain health, gym, goals, active work, merged pull requests, and unexpected telemetry signals, all on a single page.</p>
@@ -451,6 +468,7 @@ pub(crate) const PART_01: &str = r#"      </div>
         if(tab.dataset.tab==='brain-failures') {fetchBrainFailures();tabRefreshTimers.brainFailures=setInterval(fetchBrainFailures,30000);}
         if(tab.dataset.tab==='merge-decisions') {fetchMergeJudge();tabRefreshTimers.mergeJudge=setInterval(fetchMergeJudge,30000);}
         if(tab.dataset.tab==='pr-readiness') {fetchPrReadiness();tabRefreshTimers.prReadiness=setInterval(fetchPrReadiness,30000);}
+        if(tab.dataset.tab==='overseer') {fetchOverseer();tabRefreshTimers.overseer=setInterval(fetchOverseer,30000);}
         if(tab.dataset.tab==='status') {fetchStatusSnapshot();tabRefreshTimers.status=setInterval(fetchStatusSnapshot,30000);}
         if(tab.dataset.tab==='terminal') {initAgentLogTerminal();fetchSubagentSessions();tabRefreshTimers.subagent=setInterval(fetchSubagentSessions,5000);fetchTmuxSessions();tabRefreshTimers.tmux=setInterval(fetchTmuxSessions,10000);}
       });

--- a/src/operator_commands_dashboard/index_html/part_05.rs
+++ b/src/operator_commands_dashboard/index_html/part_05.rs
@@ -315,6 +315,100 @@ pub(crate) const PART_05: &str = r#"      try {
       }
     }
 
+    /* --- Overseer activity feed (#2419) --- */
+    function overseerCadenceHuman(secs){
+      secs=Number(secs)||0;
+      if(secs<=0) return '—';
+      if(secs%3600===0) return (secs/3600)+' h';
+      if(secs%60===0) return (secs/60)+' min';
+      return secs+' s';
+    }
+    function overseerTickHuman(r){
+      r=r||{};
+      const n=k=>Number(r[k])||0;
+      const s=x=>x===1?'':'s';
+      const did=[];
+      if(n('issues_filed')>0) did.push('filed '+n('issues_filed')+' issue'+s(n('issues_filed')));
+      if(n('recipes_launched')>0) did.push('launched '+n('recipes_launched')+' workstream'+s(n('recipes_launched')));
+      if(n('prs_merged')>0) did.push('merged '+n('prs_merged')+' PR'+s(n('prs_merged')));
+      if(n('deploys')>0) did.push('ran '+n('deploys')+' deploy'+s(n('deploys')));
+      if(n('escalations')>0) did.push('escalated '+n('escalations')+' to the operator');
+      const saw='saw '+n('problems')+' problem'+s(n('problems'));
+      let action;
+      if(did.length) action=did.join(', ');
+      else if(n('held')>0) action='held '+n('held')+' (waiting on a gate)';
+      else if(r.panicked) action='tick panicked — isolated';
+      else action='observing, no action needed';
+      return saw+' · '+action;
+    }
+    async function fetchOverseer(){
+      const statusEl=document.getElementById('overseer-status');
+      const threadsEl=document.getElementById('overseer-threads');
+      const recentEl=document.getElementById('overseer-recent');
+      if(!statusEl||!threadsEl||!recentEl) return;
+      try {
+        const d = await apiFetch('/api/overseer');
+        if(d.error){
+          statusEl.innerHTML='<span class="err">Failed to load Overseer activity: '+esc(d.error)+'</span>';
+          threadsEl.innerHTML='';recentEl.innerHTML='';
+          return;
+        }
+        const section=d.section||{};
+        const avail=String(section.availability||'unavailable');
+        const note=section.note?String(section.note):'';
+        const data=section.data;
+        if(!data || avail!=='ok'){
+          const msg=note||'The steward has not recorded any activity yet. It starts writing after the daemon is redeployed.';
+          statusEl.innerHTML='<div style="color:#9bb1c4;font-size:.9rem">'+esc(msg)+'</div>';
+          threadsEl.innerHTML='<span style="color:#8b949e;font-size:.85rem">No thread status available.</span>';
+          recentEl.innerHTML='<span style="color:#8b949e;font-size:.85rem">No recent activity.</span>';
+          return;
+        }
+        const staleTag=section.freshness==='stale'?' <span style="color:#d29922">(stale)</span>':'';
+        const summary=note||('Overseer: '+(data.enabled?'enabled':'disabled'));
+        statusEl.innerHTML=
+          '<div style="font-size:1rem;color:#c9d1d9;margin-bottom:.4rem">'+esc(summary)+staleTag+'</div>'
+          +'<div style="font-size:.85rem;color:#8b949e">Runs every '+esc(overseerCadenceHuman(data.cadence_secs))
+          +' · acting as '+esc(data.author_login||'—')
+          +' · last check '+esc(data.last_tick_at||'never')+'</div>';
+
+        const threads=Array.isArray(data.threads)?data.threads:[];
+        if(threads.length===0){
+          threadsEl.innerHTML='<span style="color:#8b949e;font-size:.85rem">Only the steward loop is running; no other operator threads reported.</span>';
+        } else {
+          let rows='';
+          for(const t of threads){
+            rows+='<tr>'
+              +'<td>'+esc(t.id)+'</td>'
+              +'<td>'+(t.enabled?'on':'off')+'</td>'
+              +'<td>'+esc(t.last_run||'—')+'</td>'
+              +'<td>'+esc(t.next_due||'—')+'</td>'
+              +'<td>'+esc(t.health||'—')+'</td>'
+              +'</tr>';
+          }
+          threadsEl.innerHTML='<table class="proc-table" data-testid="overseer-threads-table">'
+            +'<thead><tr><th>Thread</th><th>Enabled</th><th>Last run</th><th>Next due</th><th>Health</th></tr></thead>'
+            +'<tbody>'+rows+'</tbody></table>';
+        }
+
+        const recent=Array.isArray(data.recent)?data.recent:[];
+        if(recent.length===0){
+          recentEl.innerHTML='<span style="color:#8b949e;font-size:.85rem">Enabled and observing — 0 interventions so far.</span>';
+        } else {
+          let items='';
+          for(const rec of recent){
+            items+='<div style="padding:.35rem .1rem;border-bottom:1px solid #21262d;font-size:.85rem">'
+              +'<span style="color:#8b949e">'+esc(rec.timestamp||'')+'</span> — '
+              +'<span style="color:#c9d1d9">'+esc(overseerTickHuman(rec.report))+'</span>'
+              +'</div>';
+          }
+          recentEl.innerHTML='<div data-testid="overseer-recent-list">'+items+'</div>';
+        }
+      } catch(e) {
+        statusEl.innerHTML='<span class="err">Failed to load Overseer activity: '+esc(e.message||e)+'</span>';
+      }
+    }
+
     /* --- Merge Readiness (#1880) --- */
     async function fetchMergeReadiness(){
       const el=document.getElementById('merge-readiness-panel');

--- a/src/operator_commands_dashboard/index_html/tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tab_meta.rs
@@ -186,6 +186,14 @@ pub const TAB_METADATA: &[TabMeta] = &[
         tooltip: "Attach to the agent's tmux terminal session and watch live stdout",
     },
     TabMeta {
+        slug: "overseer",
+        label: "Overseer",
+        title: "Overseer · Simard",
+        h1: "Overseer",
+        lede: "What Simard's steward has been doing on its own — what it noticed across the system, what it changed, and, when it chose to wait, why it held back. Refreshes automatically.",
+        tooltip: "What the steward has done on its own, and why it sometimes waits",
+    },
+    TabMeta {
         slug: "status",
         label: "Status",
         title: "Status · Simard",

--- a/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
@@ -21,7 +21,7 @@ fn tab_meta_slugs_unique() {
             t.slug
         );
     }
-    assert_eq!(TAB_METADATA.len(), 15, "expected 15 tabs");
+    assert_eq!(TAB_METADATA.len(), 16, "expected 16 tabs");
 }
 
 #[test]

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -19,6 +19,7 @@ mod merge_readiness;
 mod metrics;
 mod monitoring;
 mod ooda_cycles;
+mod overseer;
 mod pr_readiness;
 mod registry;
 pub(crate) mod routes;

--- a/src/operator_commands_dashboard/overseer.rs
+++ b/src/operator_commands_dashboard/overseer.rs
@@ -1,0 +1,170 @@
+//! Dashboard **Overseer** endpoint (#2419).
+//!
+//! `GET /api/overseer` returns the `overseer` section of the single unified
+//! [`crate::status::StatusSnapshot`] — the acting Overseer meta-loop's recent
+//! activity feed (last-N ticks + per-thread status) that `simard status`, the
+//! Status tab, and the TUI Overseer pane also render. Reusing the one
+//! `status::assemble` provider means the dedicated Overseer tab and the Status
+//! tab can never diverge.
+//!
+//! It sits **behind** the existing `require_auth` layer in `routes.rs` — it is
+//! not a new auth surface — and degrades to an `error` object at HTTP 200
+//! (never a 500), matching the other dashboard panels, so the SPA can show a
+//! soft banner while keeping the last good render.
+//!
+//! Assembly shells out (systemctl) and reads files, so it runs on a blocking
+//! thread rather than the async reactor.
+
+use axum::Json;
+use serde_json::{Value, json};
+
+use crate::status::{self, StatusSnapshot, provider::AssembleOptions};
+
+/// `GET /api/overseer` — the Overseer activity section plus assembly metadata.
+pub(crate) async fn overseer() -> Json<Value> {
+    let assembled =
+        tokio::task::spawn_blocking(|| status::assemble(&AssembleOptions::default())).await;
+
+    match assembled {
+        Ok(snap) => Json(overseer_response(&snap)),
+        Err(e) => Json(json!({ "error": format!("overseer assembly join error: {e}") })),
+    }
+}
+
+/// Shape the `/api/overseer` response body from an assembled snapshot. Pure and
+/// hermetic so it is unit-testable without a runtime or a live daemon: the SPA
+/// reads `section` (a serialized `SectionEnvelope<OverseerActivity>`), checking
+/// `availability`/`freshness` before `data`.
+pub(crate) fn overseer_response(snap: &StatusSnapshot) -> Value {
+    match serde_json::to_value(&snap.overseer) {
+        Ok(section) => json!({
+            "schema_version": crate::overseer::activity::SCHEMA_VERSION,
+            "generated_at": snap.generated_at,
+            "section": section,
+        }),
+        Err(e) => json!({ "error": format!("serialize overseer section: {e}") }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::overseer::OverseerTickReport;
+    use crate::overseer::activity::{
+        OverseerActivity, OverseerActivityRecord, OverseerThreadStatus,
+    };
+    use crate::status::SectionEnvelope;
+
+    fn record(problems: usize, issues_filed: usize, held: usize) -> OverseerActivityRecord {
+        OverseerActivityRecord {
+            timestamp: "2026-07-05T15:30:00Z".to_string(),
+            enabled: true,
+            report: OverseerTickReport {
+                problems,
+                issues_filed,
+                held,
+                duration_ms: 843,
+                ..OverseerTickReport::default()
+            },
+        }
+    }
+
+    fn overseer_thread() -> OverseerThreadStatus {
+        OverseerThreadStatus {
+            id: "overseer".to_string(),
+            enabled: true,
+            last_run: Some("2026-07-05T15:30:00Z".to_string()),
+            next_due: Some("2026-07-05T15:45:00Z".to_string()),
+            last_success: Some(true),
+            consecutive_errors: 0,
+            backoff_until: None,
+            health: "ok".to_string(),
+        }
+    }
+
+    fn snapshot_with(section: SectionEnvelope<OverseerActivity>) -> StatusSnapshot {
+        let mut snap = StatusSnapshot::empty();
+        snap.generated_at = "2026-07-05T15:31:39Z".to_string();
+        snap.overseer = section;
+        snap
+    }
+
+    #[test]
+    fn response_carries_threads_and_a_sample_intervention() {
+        let mut feed = OverseerActivity {
+            enabled: true,
+            cadence_secs: 900,
+            threads: vec![overseer_thread()],
+            ..OverseerActivity::default()
+        };
+        // A tick that filed one issue — a concrete, surfaced intervention.
+        feed.push_record(record(2, 1, 1));
+
+        let body = overseer_response(&snapshot_with(SectionEnvelope::live(
+            feed,
+            Some("2026-07-05T15:30:00Z".to_string()),
+        )));
+
+        assert_eq!(body["schema_version"], 1);
+        let section = &body["section"];
+        assert_eq!(section["availability"], "ok");
+        assert_eq!(section["freshness"], "live");
+        let data = &section["data"];
+        assert_eq!(data["enabled"], true);
+        // The overseer thread row is present with its status.
+        assert_eq!(data["threads"][0]["id"], "overseer");
+        assert_eq!(data["threads"][0]["health"], "ok");
+        // The sample intervention (an issue filed) is surfaced in totals + recent.
+        assert_eq!(data["totals"]["issues_filed"], 1);
+        assert_eq!(data["recent"][0]["report"]["issues_filed"], 1);
+    }
+
+    #[test]
+    fn response_states_zero_interventions_honestly() {
+        let mut feed = OverseerActivity {
+            enabled: true,
+            cadence_secs: 900,
+            threads: vec![overseer_thread()],
+            ..OverseerActivity::default()
+        };
+        // Enabled, ticked, but took no action.
+        feed.push_record(record(2, 0, 0));
+        assert_eq!(feed.status_summary(), "enabled, observing, 0 interventions");
+
+        let mut env = SectionEnvelope::live(feed, Some("2026-07-05T15:30:00Z".to_string()));
+        env.note = Some("Overseer: enabled, observing, 0 interventions".to_string());
+        let body = overseer_response(&snapshot_with(env));
+
+        assert_eq!(body["section"]["data"]["totals"]["issues_filed"], 0);
+        assert_eq!(
+            body["section"]["note"],
+            "Overseer: enabled, observing, 0 interventions"
+        );
+    }
+
+    #[test]
+    fn response_reports_disabled_state() {
+        let feed = OverseerActivity {
+            enabled: false,
+            cadence_secs: 900,
+            ..OverseerActivity::default()
+        };
+        let mut env = SectionEnvelope::live(feed, None);
+        env.note = Some("Overseer: disabled".to_string());
+        let body = overseer_response(&snapshot_with(env));
+
+        assert_eq!(body["section"]["data"]["enabled"], false);
+        assert_eq!(body["section"]["note"], "Overseer: disabled");
+    }
+
+    #[test]
+    fn response_handles_absent_section() {
+        let body = overseer_response(&snapshot_with(SectionEnvelope::absent(
+            "Overseer: no ticks recorded yet",
+        )));
+        assert_eq!(body["section"]["availability"], "unavailable");
+        assert_eq!(body["section"]["freshness"], "absent");
+        assert_eq!(body["section"]["note"], "Overseer: no ticks recorded yet");
+        assert!(body["section"]["data"].is_null());
+    }
+}

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -23,6 +23,7 @@ use super::merge_readiness::merge_readiness;
 use super::metrics::{memory_metrics, ooda_thinking};
 use super::monitoring::{costs, get_budget, metrics, set_budget};
 use super::ooda_cycles::ooda_cycles;
+use super::overseer::overseer;
 use super::pr_readiness::pr_readiness;
 use super::registry::{
     agent_graph, build_lock_force_release, build_lock_status, registry_deregister, registry_list,
@@ -78,6 +79,7 @@ pub fn build_router() -> Router {
         .route("/api/ooda-thinking", get(ooda_thinking))
         .route("/api/ooda-cycles", get(ooda_cycles))
         .route("/api/brain-failures", get(brain_failures))
+        .route("/api/overseer", get(overseer))
         .route("/api/prs", get(pr_readiness))
         .route("/api/status/snapshot", get(status_snapshot))
         .route("/api/subagent-sessions", get(subagent_sessions))

--- a/src/operator_commands_dashboard/tests_routes_a.rs
+++ b/src/operator_commands_dashboard/tests_routes_a.rs
@@ -731,22 +731,78 @@ mod tests {
         );
     }
 
-    /// Sanity-check on the page-lede count: there must be exactly 15
+    /// Sanity-check on the page-lede count: there must be exactly 16
     /// (one per tab) — a stricter bound than the existing `>= 13`
-    /// assertion. If a refactor accidentally adds a 16th, we want to
+    /// assertion. If a refactor accidentally adds a 17th, we want to
     /// know immediately so we can decide whether the new container is
     /// actually a new tab or a misuse of the class.
     #[test]
     fn index_html_has_exactly_eleven_page_intros() {
         let count = INDEX_HTML.matches(r#"class="page-lede""#).count();
         assert_eq!(
-            count, 15,
-            "expected exactly 15 page-lede paragraphs (one per top-level tab), got {count}"
+            count, 16,
+            "expected exactly 16 page-lede paragraphs (one per top-level tab), got {count}"
         );
         let h1_count = INDEX_HTML.matches(r#"class="page-h1""#).count();
         assert_eq!(
-            h1_count, 15,
-            "expected exactly 15 page-h1 headings (one per top-level tab), got {h1_count}"
+            h1_count, 16,
+            "expected exactly 16 page-h1 headings (one per top-level tab), got {h1_count}"
+        );
+    }
+
+    /// #2419 — the Overseer tab must be wired end-to-end in the SPA: a
+    /// nav entry, a content panel, a fetch function that hits the auth-gated
+    /// `/api/overseer` endpoint, and an auto-refresh dispatch on activation.
+    #[test]
+    fn index_html_wires_overseer_tab() {
+        assert!(
+            INDEX_HTML.contains(r#"data-tab="overseer""#),
+            "Overseer nav entry missing"
+        );
+        assert!(
+            INDEX_HTML.contains(r#"id="tab-overseer""#),
+            "Overseer content panel missing"
+        );
+        assert!(
+            INDEX_HTML.contains("/api/overseer"),
+            "Overseer tab must fetch /api/overseer"
+        );
+        assert!(
+            INDEX_HTML.contains("function fetchOverseer()"),
+            "fetchOverseer() must be defined"
+        );
+        assert!(
+            INDEX_HTML.contains("tab.dataset.tab==='overseer'"),
+            "Overseer tab must be wired into the activation dispatch"
+        );
+    }
+
+    /// #2419 — every value the Overseer tab interpolates into innerHTML must
+    /// pass through `esc(...)` so a feed value that ever contained markup
+    /// renders inert. This locks the XSS-safety contract for the tab.
+    #[test]
+    fn overseer_tab_escapes_all_interpolated_values() {
+        let body = js_fn_body("function fetchOverseer()");
+        // The thread id, health, timestamps, note, author, and per-tick text
+        // are all attacker-influenceable in principle; each must be escaped.
+        for needle in [
+            "esc(summary)",
+            "esc(t.id)",
+            "esc(t.health||'—')",
+            "esc(rec.timestamp||'')",
+            "esc(overseerTickHuman(rec.report))",
+            "esc(data.author_login||'—')",
+        ] {
+            assert!(
+                body.contains(needle),
+                "fetchOverseer must escape interpolated value via `{needle}`; \
+                 an unescaped feed value is an XSS vector.\nbody:\n{body}"
+            );
+        }
+        // And it must never inject a raw feed value straight into innerHTML.
+        assert!(
+            !body.contains("+data.author_login+"),
+            "author_login must not be concatenated unescaped into innerHTML"
         );
     }
 

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -1222,6 +1222,13 @@ pub fn run_ooda_daemon(
                 let mem_for_tick = Arc::clone(&shared_mem);
                 let repo_root_for_tick = overseer_repo_root.clone();
                 let state_root_for_tick = state_root.clone();
+                // Capture the cognitive-thread heartbeats + feed context on the
+                // main loop thread (before the tick spawns) so the Overseer
+                // activity feed (#2419) lists every operator/steward thread, not
+                // just the Overseer meta-thread. Cheap, additive, read-only.
+                let thread_healths = mind.health();
+                let feed_cadence_secs = crate::overseer::config::overseer_interval_secs();
+                let feed_author_login = crate::overseer::config::overseer_author_login();
                 let spawn = std::thread::Builder::new()
                     .name("overseer-tick".to_string())
                     .spawn(move || {
@@ -1258,6 +1265,47 @@ pub fn run_ooda_daemon(
                                 report.duration_ms,
                             ),
                         );
+
+                        // Record this tick into the durable, cross-process
+                        // Overseer activity feed (#2419) so the dashboard, TUI,
+                        // and `simard status` can surface what the steward has
+                        // been doing. Read-only surfacing: this only *records*
+                        // the outcome that already happened; it never changes
+                        // the Overseer's decisions. Write failure is non-fatal —
+                        // the tick already completed — so it is logged and the
+                        // daemon continues.
+                        let mut feed_threads = Vec::with_capacity(thread_healths.len() + 1);
+                        feed_threads.push(
+                            crate::overseer::activity::OverseerThreadStatus::overseer_meta(
+                                feed_cadence_secs,
+                                !report.panicked && report.errors == 0,
+                            ),
+                        );
+                        for h in &thread_healths {
+                            feed_threads.push(
+                                crate::overseer::activity::OverseerThreadStatus::from_thread_health(
+                                    h,
+                                ),
+                            );
+                        }
+                        let feed_record = crate::overseer::activity::OverseerActivityRecord {
+                            timestamp: crate::telemetry::snapshot::now_rfc3339(),
+                            enabled: true,
+                            report,
+                        };
+                        if let Err(e) = crate::overseer::activity::record_tick(
+                            &state_root_for_tick,
+                            feed_record,
+                            feed_threads,
+                            true,
+                            feed_cadence_secs,
+                            &feed_author_login,
+                        ) {
+                            daemon_log(
+                                &state_root_for_tick,
+                                &format!("[simard] WARN: overseer activity feed write failed: {e}"),
+                            );
+                        }
                     });
                 if let Err(e) = spawn {
                     // Spawn failed — clear the guard so the next cadence retries.

--- a/src/overseer/activity.rs
+++ b/src/overseer/activity.rs
@@ -1,0 +1,516 @@
+//! The bounded, durable "recent Overseer activity" feed (#2419).
+//!
+//! Simard's cognition runs on two clocks: the **engineer** OODA loop (already
+//! visible on the dashboard and TUI) and the **steward** side — the acting
+//! [`Overseer`](crate::overseer) meta-loop that runs alongside it on its own
+//! cadence, quietly observing the whole system and intervening (filing issues,
+//! launching fix workstreams, verifying + merging green PRs, guarded deploys,
+//! escalations) or *holding* when a gate says "not yet".
+//!
+//! Until now that steward activity was invisible outside the daemon log. This
+//! module makes it a first-class, queryable surface: the last [`MAX_RECORDS`]
+//! Overseer ticks and their outcomes, plus per-thread status.
+//!
+//! ## Why a durable file (not an in-RAM ring)
+//!
+//! The daemon (which *runs* the Overseer), the dashboard server, and the TUI are
+//! **separate processes**. A pure in-memory ring in the daemon would be
+//! unreachable by the other two. So the feed keeps a bounded in-memory
+//! [`VecDeque`] (cap [`MAX_RECORDS`]) as the write surface **and** persists the
+//! whole capped feed atomically to `<state_root>/overseer/activity.json` each
+//! tick — the same tmp+rename, `0600`, degrade-to-`None` pattern the
+//! [telemetry snapshot](crate::telemetry::snapshot) already uses. That file is
+//! the cross-process seam every reader consumes.
+//!
+//! This module only *records and surfaces* Overseer activity; it never changes
+//! what the Overseer decides or does. The only producer-side touch is
+//! [`record_tick`] at the tick boundary.
+
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::cognitive_threads::ThreadHealth;
+use crate::overseer::OverseerTickReport;
+
+/// Bumped only on an INCOMPATIBLE shape change. Additive fields do not bump it.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// The ring buffer retains the last `N` Overseer ticks, evicting oldest-first.
+pub const MAX_RECORDS: usize = 100;
+
+/// Hard cap on the on-disk feed we will read into memory (bytes). A
+/// pathologically large file degrades to `None` instead of exhausting memory.
+pub const MAX_FEED_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Cumulative outcome counts across the retained records (a rolling window over
+/// the last [`MAX_RECORDS`] ticks — **not** an all-time counter).
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct OverseerTotals {
+    pub problems: u64,
+    pub issues_filed: u64,
+    pub recipes_launched: u64,
+    pub prs_merged: u64,
+    pub deploys: u64,
+    pub escalations: u64,
+    pub held: u64,
+    pub errors: u64,
+}
+
+/// One Overseer tick: the outcome report plus time + gate context.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct OverseerActivityRecord {
+    /// RFC3339 timestamp of tick completion.
+    pub timestamp: String,
+    /// The acting-Overseer gate state at this tick.
+    pub enabled: bool,
+    /// The verbatim outcome tally (never interpreted).
+    pub report: OverseerTickReport,
+}
+
+/// Per cognitive thread, derived from [`ThreadHealth`] (epochs → RFC3339).
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct OverseerThreadStatus {
+    /// Stable thread id, e.g. `"overseer"`.
+    pub id: String,
+    pub enabled: bool,
+    /// From `last_run_epoch`, or `None`.
+    pub last_run: Option<String>,
+    /// From `next_run_epoch`, or `None`.
+    pub next_due: Option<String>,
+    pub last_success: Option<bool>,
+    pub consecutive_errors: u32,
+    pub backoff_until: Option<String>,
+    /// Derived label — see [`derive_health`].
+    pub health: String,
+}
+
+impl OverseerThreadStatus {
+    /// Build the synthetic status row for the acting Overseer meta-thread (which
+    /// is driven directly by the daemon loop, not the [`Mind`](crate::cognitive_threads::Mind)
+    /// scheduler). `last_success` reflects the just-completed tick.
+    pub fn overseer_meta(cadence_secs: u64, last_success: bool) -> Self {
+        let now = chrono::Utc::now();
+        let consecutive_errors = u32::from(!last_success);
+        let last_run = Some(rfc3339(now));
+        let next_due = Some(rfc3339(
+            now + chrono::Duration::seconds(cadence_secs as i64),
+        ));
+        let health = derive_health(true, None, consecutive_errors, last_run.as_deref());
+        Self {
+            id: "overseer".to_string(),
+            enabled: true,
+            last_run,
+            next_due,
+            last_success: Some(last_success),
+            consecutive_errors,
+            backoff_until: None,
+            health,
+        }
+    }
+
+    /// Convert a scheduler [`ThreadHealth`] heartbeat into a feed row, mapping
+    /// unix epochs to RFC3339 and deriving the plain-word `health` label.
+    pub fn from_thread_health(h: &ThreadHealth) -> Self {
+        let last_run = h.last_run_epoch.map(epoch_to_rfc3339);
+        let backoff_until = h.backoff_until_epoch.map(epoch_to_rfc3339);
+        let health = derive_health(
+            h.enabled,
+            backoff_until.as_deref(),
+            h.consecutive_errors,
+            last_run.as_deref(),
+        );
+        Self {
+            id: h.id.clone(),
+            enabled: h.enabled,
+            last_run,
+            next_due: h.next_run_epoch.map(epoch_to_rfc3339),
+            last_success: h.last_success,
+            consecutive_errors: h.consecutive_errors,
+            backoff_until,
+            health,
+        }
+    }
+}
+
+/// Pure, testable `health` label (first match wins), per the feed reference.
+pub fn derive_health(
+    enabled: bool,
+    backoff_until: Option<&str>,
+    consecutive_errors: u32,
+    last_run: Option<&str>,
+) -> String {
+    if !enabled {
+        "disabled"
+    } else if backoff_until.is_some() {
+        "backoff"
+    } else if consecutive_errors > 0 {
+        "erroring"
+    } else if last_run.is_none() {
+        "idle"
+    } else {
+        "ok"
+    }
+    .to_string()
+}
+
+/// The whole feed: top-level Overseer status + per-thread status + recent ticks.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct OverseerActivity {
+    pub schema_version: u32,
+    /// `overseer_acting_enabled()` at the last write.
+    pub enabled: bool,
+    /// `overseer_interval_secs()` — drives the `live`/`stale` window (`2×`).
+    pub cadence_secs: u64,
+    /// The Overseer's distinct git identity.
+    pub author_login: String,
+    /// RFC3339 of the most recent tick, or `None`.
+    pub last_tick_at: Option<String>,
+    /// Summed over the records currently retained.
+    pub totals: OverseerTotals,
+    /// From `Mind::health()` plus the synthetic overseer meta-thread.
+    pub threads: Vec<OverseerThreadStatus>,
+    /// Newest-first, capped at [`MAX_RECORDS`].
+    pub recent: VecDeque<OverseerActivityRecord>,
+}
+
+impl Default for OverseerActivity {
+    fn default() -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            enabled: true,
+            cadence_secs: crate::overseer::config::DEFAULT_OVERSEER_INTERVAL_SECS,
+            author_login: crate::overseer::config::DEFAULT_OVERSEER_AUTHOR_LOGIN.to_string(),
+            last_tick_at: None,
+            totals: OverseerTotals::default(),
+            threads: Vec::new(),
+            recent: VecDeque::new(),
+        }
+    }
+}
+
+impl OverseerActivity {
+    /// Front-push a tick, evict oldest beyond [`MAX_RECORDS`], refresh
+    /// `last_tick_at`, and recompute `totals` over the retained window.
+    pub fn push_record(&mut self, record: OverseerActivityRecord) {
+        self.recent.push_front(record);
+        while self.recent.len() > MAX_RECORDS {
+            self.recent.pop_back();
+        }
+        self.last_tick_at = self.recent.front().map(|r| r.timestamp.clone());
+        self.recompute_totals();
+    }
+
+    fn recompute_totals(&mut self) {
+        let mut t = OverseerTotals::default();
+        for r in &self.recent {
+            let rep = &r.report;
+            t.problems += rep.problems as u64;
+            t.issues_filed += rep.issues_filed as u64;
+            t.recipes_launched += rep.recipes_launched as u64;
+            t.prs_merged += rep.prs_merged as u64;
+            t.deploys += rep.deploys as u64;
+            t.escalations += rep.escalations as u64;
+            t.held += rep.held as u64;
+            t.errors += rep.errors as u64;
+        }
+        self.totals = t;
+    }
+
+    /// Count of *actions taken* over the retained window (issues filed, fix
+    /// workstreams launched, PRs merged, deploys, escalations). `held` is
+    /// deliberately excluded: holding is observing-and-waiting, not an action.
+    pub fn interventions(&self) -> u64 {
+        let t = &self.totals;
+        t.issues_filed + t.recipes_launched + t.prs_merged + t.deploys + t.escalations
+    }
+
+    /// The honest one-line status summary rendered on every surface.
+    ///
+    /// Distinguishes *disabled* from *enabled-but-idle* — "observing, 0
+    /// interventions" is a real, truthful outcome, never a blank list.
+    pub fn status_summary(&self) -> String {
+        if !self.enabled {
+            return "disabled".to_string();
+        }
+        let n = self.interventions();
+        if n == 0 {
+            "enabled, observing, 0 interventions".to_string()
+        } else {
+            format!("enabled, {n} interventions")
+        }
+    }
+}
+
+/// Canonical on-disk path of the feed under a state root:
+/// `<state_root>/overseer/activity.json`.
+pub fn activity_path(state_root: &Path) -> PathBuf {
+    state_root.join("overseer").join("activity.json")
+}
+
+/// Atomically and privately write `activity` to `path`.
+///
+/// Creates the parent `0700`, writes a `0600` temp file, `fsync`s it, then
+/// `rename`s over the target — so `path` is never briefly world-readable and
+/// readers never see a torn document. The `recent` ring is clamped to
+/// [`MAX_RECORDS`] before serialize so the file can never grow unbounded.
+pub fn write_atomic(path: &Path, activity: &OverseerActivity) -> std::io::Result<()> {
+    use std::io::Write;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+        }
+    }
+
+    // Clamp defensively on write, even though `push_record` already bounds it.
+    let capped;
+    let to_write = if activity.recent.len() > MAX_RECORDS {
+        let mut c = activity.clone();
+        c.recent.truncate(MAX_RECORDS);
+        capped = c;
+        &capped
+    } else {
+        activity
+    };
+
+    let body = serde_json::to_vec_pretty(to_write)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    let tmp = path.with_extension("json.tmp");
+    {
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let mut file = opts.open(&tmp)?;
+        file.write_all(&body)?;
+        file.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+/// Read a feed from `path`, degrading to `None` on any problem.
+///
+/// Returns `None` when the file is missing, larger than [`MAX_FEED_BYTES`],
+/// unreadable, unparseable, or carries an unknown-higher `schema_version` —
+/// **never** panics, never fabricates. Freshness is a judgement the caller
+/// makes from `last_tick_at`; this only materializes the document.
+pub fn read(path: &Path) -> Option<OverseerActivity> {
+    let meta = std::fs::metadata(path).ok()?;
+    if !meta.is_file() || meta.len() > MAX_FEED_BYTES {
+        return None;
+    }
+    let bytes = std::fs::read(path).ok()?;
+    let activity = serde_json::from_slice::<OverseerActivity>(&bytes).ok()?;
+    if activity.schema_version > SCHEMA_VERSION {
+        return None;
+    }
+    Some(activity)
+}
+
+/// Durably append one tick to the feed under `state_root` and return the new
+/// feed. Read-modify-write: reads the current file (or starts fresh), pushes the
+/// record, refreshes the top-level status fields, and writes atomically.
+///
+/// Concurrency is last-writer-wins (no cross-process lock), but the atomic
+/// tmp+rename guarantees the file is never torn — every reader always sees a
+/// valid, bounded feed. This is the single producer-side touch the daemon makes,
+/// at the tick boundary, and it is non-fatal to the caller on write error.
+pub fn record_tick(
+    state_root: &Path,
+    record: OverseerActivityRecord,
+    threads: Vec<OverseerThreadStatus>,
+    enabled: bool,
+    cadence_secs: u64,
+    author_login: &str,
+) -> std::io::Result<OverseerActivity> {
+    let path = activity_path(state_root);
+    let mut feed = read(&path).unwrap_or_default();
+    feed.schema_version = SCHEMA_VERSION;
+    feed.enabled = enabled;
+    feed.cadence_secs = cadence_secs;
+    feed.author_login = author_login.to_string();
+    feed.threads = threads;
+    feed.push_record(record);
+    write_atomic(&path, &feed)?;
+    Ok(feed)
+}
+
+/// RFC3339 (UTC, second precision) for a chrono instant.
+fn rfc3339(dt: chrono::DateTime<chrono::Utc>) -> String {
+    dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+/// Convert a unix-epoch-seconds heartbeat into an RFC3339 string. An
+/// out-of-range epoch degrades to the unix origin rather than panicking.
+fn epoch_to_rfc3339(epoch_secs: u64) -> String {
+    let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(epoch_secs as i64, 0)
+        .unwrap_or_else(|| chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap());
+    rfc3339(dt)
+}
+
+/// A plain-language one-liner for one Overseer tick: what it **saw** and what it
+/// **did** — or, when nothing needed doing, that it held or simply observed.
+/// Shared by the `simard status` terminal render and the TUI Overseer pane so
+/// both surfaces stay identical (the dashboard mirrors it in JS).
+pub fn humanize_tick(r: &OverseerTickReport) -> String {
+    fn plural(n: usize) -> &'static str {
+        if n == 1 { "" } else { "s" }
+    }
+    let mut did: Vec<String> = Vec::new();
+    if r.issues_filed > 0 {
+        did.push(format!(
+            "filed {} issue{}",
+            r.issues_filed,
+            plural(r.issues_filed)
+        ));
+    }
+    if r.recipes_launched > 0 {
+        did.push(format!(
+            "launched {} workstream{}",
+            r.recipes_launched,
+            plural(r.recipes_launched)
+        ));
+    }
+    if r.prs_merged > 0 {
+        did.push(format!(
+            "merged {} PR{}",
+            r.prs_merged,
+            plural(r.prs_merged)
+        ));
+    }
+    if r.deploys > 0 {
+        did.push(format!("ran {} deploy{}", r.deploys, plural(r.deploys)));
+    }
+    if r.escalations > 0 {
+        did.push(format!("escalated {} to the operator", r.escalations));
+    }
+
+    let saw = format!("saw {} problem{}", r.problems, plural(r.problems));
+    let action = if !did.is_empty() {
+        did.join(", ")
+    } else if r.held > 0 {
+        format!("held {} (waiting on a gate)", r.held)
+    } else if r.panicked {
+        "tick panicked — isolated".to_string()
+    } else {
+        "observing, no action needed".to_string()
+    };
+    format!("{saw}  ·  {action}")
+}
+
+/// Humanize a cadence in seconds to "15 min" / "2 h" / "45 s". Shared across the
+/// status render and the TUI pane.
+pub fn human_cadence(secs: u64) -> String {
+    if secs == 0 {
+        "—".to_string()
+    } else if secs.is_multiple_of(3600) {
+        format!("{} h", secs / 3600)
+    } else if secs.is_multiple_of(60) {
+        format!("{} min", secs / 60)
+    } else {
+        format!("{secs} s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rep(problems: usize, issues: usize, held: usize) -> OverseerTickReport {
+        OverseerTickReport {
+            problems,
+            issues_filed: issues,
+            held,
+            ..OverseerTickReport::default()
+        }
+    }
+
+    fn record(ts: &str, r: OverseerTickReport) -> OverseerActivityRecord {
+        OverseerActivityRecord {
+            timestamp: ts.to_string(),
+            enabled: true,
+            report: r,
+        }
+    }
+
+    #[test]
+    fn default_feed_uses_schema_and_config_defaults() {
+        let a = OverseerActivity::default();
+        assert_eq!(a.schema_version, SCHEMA_VERSION);
+        assert!(a.enabled);
+        assert_eq!(
+            a.cadence_secs,
+            crate::overseer::config::DEFAULT_OVERSEER_INTERVAL_SECS
+        );
+        assert!(a.recent.is_empty());
+    }
+
+    #[test]
+    fn status_summary_is_honest_for_each_state() {
+        let disabled = OverseerActivity {
+            enabled: false,
+            ..OverseerActivity::default()
+        };
+        assert_eq!(disabled.status_summary(), "disabled");
+
+        let mut idle = OverseerActivity::default();
+        idle.push_record(record("2026-07-05T15:00:00Z", rep(2, 0, 1)));
+        assert_eq!(idle.status_summary(), "enabled, observing, 0 interventions");
+
+        let mut acting = OverseerActivity::default();
+        acting.push_record(record("2026-07-05T15:00:00Z", rep(2, 3, 0)));
+        assert_eq!(acting.status_summary(), "enabled, 3 interventions");
+    }
+
+    #[test]
+    fn derive_health_first_match_wins() {
+        assert_eq!(derive_health(false, None, 0, Some("t")), "disabled");
+        assert_eq!(derive_health(true, Some("t"), 0, Some("t")), "backoff");
+        assert_eq!(derive_health(true, None, 2, Some("t")), "erroring");
+        assert_eq!(derive_health(true, None, 0, None), "idle");
+        assert_eq!(derive_health(true, None, 0, Some("t")), "ok");
+    }
+
+    #[test]
+    fn from_thread_health_maps_epochs_and_health() {
+        let h = ThreadHealth {
+            id: "maintenance".to_string(),
+            enabled: true,
+            last_run_epoch: Some(0),
+            next_run_epoch: Some(900),
+            last_success: Some(true),
+            consecutive_errors: 0,
+            backoff_until_epoch: None,
+        };
+        let s = OverseerThreadStatus::from_thread_health(&h);
+        assert_eq!(s.id, "maintenance");
+        assert_eq!(s.last_run.as_deref(), Some("1970-01-01T00:00:00Z"));
+        assert_eq!(s.health, "ok");
+    }
+
+    #[test]
+    fn overseer_meta_thread_reflects_tick_success() {
+        let ok = OverseerThreadStatus::overseer_meta(900, true);
+        assert_eq!(ok.id, "overseer");
+        assert_eq!(ok.health, "ok");
+        assert_eq!(ok.consecutive_errors, 0);
+
+        let bad = OverseerThreadStatus::overseer_meta(900, false);
+        assert_eq!(bad.health, "erroring");
+        assert_eq!(bad.consecutive_errors, 1);
+    }
+}

--- a/src/overseer/mod.rs
+++ b/src/overseer/mod.rs
@@ -45,6 +45,7 @@
 
 #![allow(dead_code)]
 
+pub mod activity;
 pub mod audit;
 pub mod capabilities;
 pub mod config;

--- a/src/overseer/wiring.rs
+++ b/src/overseer/wiring.rs
@@ -29,6 +29,8 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use serde::{Deserialize, Serialize};
+
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::goal_curation::{BacklogItem, GoalBoard};
 use crate::goal_curation::{
@@ -96,7 +98,12 @@ impl OverseerCadence {
 
 /// Structured tally of one Overseer tick. Every field is emitted as a
 /// `tracing` key so a tick is fully observable without `println!`/`eprintln!`.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+///
+/// Derives `Serialize`/`Deserialize` (additive; no logic change) so the acting
+/// tick's outcome can be recorded verbatim into the durable
+/// [activity feed](crate::overseer::activity).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct OverseerTickReport {
     /// Problems raised this cycle (post-dedup against in-flight work).
     pub problems: usize,

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -153,6 +153,10 @@ pub struct StatusSnapshot {
     pub self_improvement: SectionEnvelope<SelfImprovement>,
     #[serde(default)]
     pub telemetry: SectionEnvelope<TelemetrySignals>,
+    /// OVERSEER — the acting Overseer meta-loop's recent activity feed (#2419):
+    /// last-N ticks, per-thread status, and the honest disabled/observing state.
+    #[serde(default)]
+    pub overseer: SectionEnvelope<crate::overseer::activity::OverseerActivity>,
 }
 
 impl StatusSnapshot {
@@ -171,6 +175,7 @@ impl StatusSnapshot {
             completed: SectionEnvelope::default(),
             self_improvement: SectionEnvelope::default(),
             telemetry: SectionEnvelope::default(),
+            overseer: SectionEnvelope::default(),
         }
     }
 }

--- a/src/status/provider.rs
+++ b/src/status/provider.rs
@@ -16,6 +16,7 @@ use super::{
     CopilotTurn, Daemon, DiskUsage, EdgeCounts, Gym, LedgerWindow, LlmUsage, MemoryBrain,
     NodeCounts, Resources, SectionEnvelope, StatusSnapshot, TelemetrySignals,
 };
+use crate::overseer::activity::{self, OverseerActivity};
 use crate::telemetry::{names, snapshot};
 
 /// How the snapshot is assembled.
@@ -81,6 +82,7 @@ pub fn assemble(opts: &AssembleOptions) -> StatusSnapshot {
         self_improvement: SectionEnvelope::absent("gh: not queried in this context"),
         telemetry: assemble_telemetry(metrics.as_ref(), gym_skipped, n_restarts, budget_over),
         llm,
+        overseer: assemble_overseer(&opts.state_root),
     }
 }
 
@@ -559,6 +561,98 @@ fn snapshot_is_stale(captured_at: &str) -> bool {
         Ok(ts) => {
             let age = chrono::Utc::now().signed_duration_since(ts.with_timezone(&chrono::Utc));
             age.num_seconds() > SNAPSHOT_FRESHNESS_SECS
+        }
+        Err(_) => false,
+    }
+}
+
+// ── overseer activity feed (#2419) ───────────────────────────────────────────
+
+/// Build the OVERSEER section from the durable
+/// [activity feed](crate::overseer::activity), distinguishing the honest states
+/// the feed reference pins. The acting-Overseer gate
+/// ([`overseer_acting_enabled`](crate::overseer::config::overseer_acting_enabled))
+/// is the live source of truth for `enabled`, so a disabled Overseer is a
+/// *present* state (`Overseer: disabled`), never a blank panel — even when no
+/// feed file exists yet. Assembled in isolation; never panics.
+///
+/// Freshness is **cadence-relative** (`2 × cadence_secs`), NOT the fixed
+/// [`SNAPSHOT_FRESHNESS_SECS`]: the Overseer ticks on its own (default 15-minute)
+/// cadence, so reusing the 300 s telemetry threshold would mark a healthy feed
+/// `stale` for two-thirds of every cadence window.
+fn assemble_overseer(state_root: &std::path::Path) -> SectionEnvelope<OverseerActivity> {
+    use crate::overseer::config;
+
+    let enabled = config::overseer_acting_enabled();
+    let path = activity::activity_path(state_root);
+    let file_exists = path.is_file();
+
+    match activity::read(&path) {
+        Some(mut feed) => {
+            // The config gate is the live truth for the acting Overseer; the
+            // stored flag only reflects the state at the last write.
+            feed.enabled = enabled;
+            let note = format!("Overseer: {}", feed.status_summary());
+
+            if !enabled {
+                // Disabled is PRESENT (live), so the UI says "disabled" plainly
+                // rather than pretending there is no data.
+                let as_of = feed.last_tick_at.clone();
+                let mut env = SectionEnvelope::live(feed, as_of);
+                env.note = Some(note);
+                return env;
+            }
+
+            match feed.last_tick_at.clone() {
+                Some(ts) => {
+                    let stale = feed_is_stale(&ts, feed.cadence_secs);
+                    let mut env = if stale {
+                        SectionEnvelope::stale(feed, Some(ts))
+                    } else {
+                        SectionEnvelope::live(feed, Some(ts))
+                    };
+                    env.note = Some(note);
+                    env
+                }
+                // Enabled, file present, but no ticks recorded in it.
+                None => SectionEnvelope::absent("Overseer: no ticks recorded yet"),
+            }
+        }
+        None => {
+            if !enabled {
+                // Disabled with no readable file: synthesize a present, honest
+                // "disabled" section from config so the surfaces still say so.
+                let feed = OverseerActivity {
+                    enabled: false,
+                    cadence_secs: config::overseer_interval_secs(),
+                    author_login: config::overseer_author_login(),
+                    last_tick_at: None,
+                    ..OverseerActivity::default()
+                };
+                let mut env = SectionEnvelope::live(feed, None);
+                env.note = Some("Overseer: disabled".to_string());
+                return env;
+            }
+            // Enabled but unreachable: distinguish "never ticked" (no file) from
+            // "unreadable/corrupt" (file present but did not parse) honestly.
+            if file_exists {
+                SectionEnvelope::absent("Overseer activity feed unavailable")
+            } else {
+                SectionEnvelope::absent("Overseer: no ticks recorded yet")
+            }
+        }
+    }
+}
+
+/// Whether a feed's last tick is older than `2 × cadence_secs`. An unparseable
+/// timestamp is treated as fresh (not stale), matching the telemetry provider's
+/// tolerant behavior.
+fn feed_is_stale(last_tick_at: &str, cadence_secs: u64) -> bool {
+    match chrono::DateTime::parse_from_rfc3339(last_tick_at) {
+        Ok(ts) => {
+            let age = chrono::Utc::now().signed_duration_since(ts.with_timezone(&chrono::Utc));
+            let window = 2 * cadence_secs.max(1) as i64;
+            age.num_seconds() > window
         }
         Err(_) => false,
     }

--- a/src/status/render.rs
+++ b/src/status/render.rs
@@ -20,6 +20,7 @@ pub const SECTION_HEADERS: &[&str] = &[
     "COMPLETED WORK",
     "SELF-IMPROVEMENT",
     "TELEMETRY / UNEXPECTED SIGNALS",
+    "OVERSEER",
 ];
 
 const LABEL_WIDTH: usize = 18;
@@ -40,6 +41,7 @@ pub fn to_terminal(snapshot: &StatusSnapshot) -> String {
     render_completed(&mut out, &snapshot.completed);
     render_self_improvement(&mut out, &snapshot.self_improvement);
     render_telemetry(&mut out, &snapshot.telemetry);
+    render_overseer(&mut out, &snapshot.overseer);
 
     out
 }
@@ -481,3 +483,76 @@ fn render_telemetry(out: &mut String, env: &SectionEnvelope<super::TelemetrySign
     }
     out.push('\n');
 }
+
+// ── overseer activity feed (#2419) ────────────────────────────────────────────
+
+fn render_overseer(
+    out: &mut String,
+    env: &SectionEnvelope<crate::overseer::activity::OverseerActivity>,
+) {
+    header(out, "OVERSEER");
+    if absent_marker(out, env)
+        && let Some(a) = &env.data
+    {
+        // Honest one-line status: "disabled" / "enabled, observing, 0
+        // interventions" / "enabled, N interventions".
+        label(
+            out,
+            "overseer",
+            format!("Overseer: {}{}", a.status_summary(), stale_suffix(env)),
+        );
+        label(
+            out,
+            "cadence",
+            format!(
+                "every {}  ·  as {}",
+                crate::overseer::activity::human_cadence(a.cadence_secs),
+                a.author_login
+            ),
+        );
+        label(out, "last tick", opt_str(&a.last_tick_at));
+
+        // Per-thread status rows (name, on/off, last run, next due, health).
+        if a.threads.is_empty() {
+            label(out, "threads", "none reported");
+        } else {
+            for t in &a.threads {
+                let _ = writeln!(
+                    out,
+                    "  thread {:<16} {}  ·  last {}  ·  next {}  ·  {}",
+                    t.id,
+                    if t.enabled { "on" } else { "off" },
+                    opt_str(&t.last_run),
+                    opt_str(&t.next_due),
+                    t.health,
+                );
+            }
+        }
+
+        // Recent-activity timeline, newest-first, in plain language.
+        if a.recent.is_empty() {
+            label(out, "recent", "no ticks recorded yet");
+        } else {
+            let shown = a.recent.len().min(RECENT_ROWS);
+            for r in a.recent.iter().take(RECENT_ROWS) {
+                let _ = writeln!(
+                    out,
+                    "  {}  {}",
+                    r.timestamp,
+                    crate::overseer::activity::humanize_tick(&r.report)
+                );
+            }
+            if a.recent.len() > shown {
+                label(
+                    out,
+                    "",
+                    format!("… {} older tick(s) retained", a.recent.len() - shown),
+                );
+            }
+        }
+    }
+    out.push('\n');
+}
+
+/// How many recent-activity rows the terminal render shows before summarizing.
+const RECENT_ROWS: usize = 20;

--- a/tests/overseer_activity.rs
+++ b/tests/overseer_activity.rs
@@ -1,0 +1,555 @@
+//! TDD contract tests for the Operator/Overseer recent-activity feed (#2419).
+//!
+//! These tests are written **before** the implementation (Step 7: tests-first).
+//! They FAIL to compile today because `simard::overseer::activity` and the new
+//! `StatusSnapshot.overseer` section do not exist yet; once the feature lands
+//! they must compile and pass unchanged. They pin the public, cross-process
+//! surface only — the durable JSON feed store and the status provider/render
+//! reader — so the dashboard `serve` process and the TUI process (both distinct
+//! from the daemon writer) can surface the same honest data.
+//!
+//! Crate-internal surfaces (the dashboard `/api/overseer` handler, the dashboard
+//! "Overseer" tab HTML, and the TUI Overseer pane) are `pub(crate)` /
+//! binary-internal and therefore cannot be reached from an integration test;
+//! their tests-first specs are delivered as co-located `#[cfg(test)]` modules
+//! (see the session artifacts referenced in the PR / Step 7 output) and land
+//! alongside their implementation.
+//!
+//! Contract summary this file pins (implementer MUST match these names/shapes):
+//!
+//! * `simard::overseer::activity::{SCHEMA_VERSION, MAX_RECORDS}`
+//! * `OverseerActivity { schema_version, enabled, cadence_secs, author_login,
+//!    last_tick_at, totals, threads, recent }` (Serialize + Deserialize + Default)
+//! * `OverseerActivityRecord { timestamp, enabled, report: OverseerTickReport }`
+//! * `OverseerThreadStatus { id, enabled, last_run, next_due, last_success,
+//!    consecutive_errors, backoff_until, health }`
+//! * `OverseerTotals { problems, issues_filed, recipes_launched, prs_merged,
+//!    deploys, escalations, held, errors }`
+//! * `activity_path(&Path) -> PathBuf`  → `<state_root>/overseer/activity.json`
+//! * `write_atomic(&Path, &OverseerActivity) -> io::Result<()>` (0600, tmp+rename)
+//! * `read(&Path) -> Option<OverseerActivity>` (degrade-to-None, never panic)
+//! * `OverseerActivity::push_record(&mut self, OverseerActivityRecord)`
+//!   (front-push, cap `MAX_RECORDS`, refresh `last_tick_at` + recompute `totals`)
+//! * `record_tick(&Path, OverseerActivityRecord, Vec<OverseerThreadStatus>,
+//!   enabled: bool, cadence_secs: u64, author_login: &str)
+//!   -> io::Result<OverseerActivity>` (durable append; thread-safe via atomic file)
+//! * `simard::status::render::SECTION_HEADERS` contains `"OVERSEER"`
+//! * `simard::status::StatusSnapshot.overseer: SectionEnvelope<OverseerActivity>`
+//! * `simard::status::assemble` populates `.overseer` honestly from the feed.
+
+use std::collections::VecDeque;
+use std::path::Path;
+
+use simard::overseer::OverseerTickReport;
+use simard::overseer::activity::{
+    self, MAX_RECORDS, OverseerActivity, OverseerActivityRecord, OverseerThreadStatus,
+    SCHEMA_VERSION, record_tick,
+};
+use simard::status::provider::AssembleOptions;
+
+// ─────────────────────────── test helpers ──────────────────────────────────
+
+/// An `OverseerTickReport` with the given intervention tallies; other fields 0.
+fn report(
+    problems: usize,
+    issues_filed: usize,
+    recipes_launched: usize,
+    prs_merged: usize,
+    held: usize,
+) -> OverseerTickReport {
+    OverseerTickReport {
+        problems,
+        issues_filed,
+        recipes_launched,
+        prs_merged,
+        deploys: 0,
+        escalations: 0,
+        held,
+        errors: 0,
+        panicked: false,
+        duration_ms: 42,
+    }
+}
+
+/// A record stamped `now`, gate-enabled, wrapping `rep`.
+fn record_now(rep: OverseerTickReport) -> OverseerActivityRecord {
+    OverseerActivityRecord {
+        timestamp: simard::telemetry::snapshot::now_rfc3339(),
+        enabled: true,
+        report: rep,
+    }
+}
+
+/// A record stamped `ts`, with an explicit `enabled` gate.
+fn record_at(ts: &str, enabled: bool, rep: OverseerTickReport) -> OverseerActivityRecord {
+    OverseerActivityRecord {
+        timestamp: ts.to_string(),
+        enabled,
+        report: rep,
+    }
+}
+
+/// Set or clear `SIMARD_OVERSEER_ENABLED` for a serialized test.
+///
+/// SAFETY: every caller is annotated `#[serial_test::serial(overseer_env)]`, so
+/// no other thread reads or writes this process-global env var concurrently —
+/// which is exactly the soundness precondition Rust 2024 requires for
+/// `std::env::set_var` / `remove_var`.
+fn set_overseer_enabled(val: Option<&str>) {
+    unsafe {
+        match val {
+            Some(v) => std::env::set_var("SIMARD_OVERSEER_ENABLED", v),
+            None => std::env::remove_var("SIMARD_OVERSEER_ENABLED"),
+        }
+    }
+}
+
+/// RFC3339 timestamp `secs_ago` seconds before now.
+fn rfc3339_secs_ago(secs_ago: i64) -> String {
+    let t = chrono::Utc::now() - chrono::Duration::seconds(secs_ago);
+    t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+/// The single overseer meta-thread status, healthy and enabled.
+fn overseer_thread_ok() -> OverseerThreadStatus {
+    OverseerThreadStatus {
+        id: "overseer".to_string(),
+        enabled: true,
+        last_run: Some(simard::telemetry::snapshot::now_rfc3339()),
+        next_due: Some(rfc3339_secs_ago(-900)),
+        last_success: Some(true),
+        consecutive_errors: 0,
+        backoff_until: None,
+        health: "ok".to_string(),
+    }
+}
+
+/// Build an `OverseerActivity` feed directly (bypassing the durable writer) so
+/// freshness / honesty states can be constructed deterministically.
+fn feed(
+    enabled: bool,
+    cadence_secs: u64,
+    last_tick_at: Option<String>,
+    threads: Vec<OverseerThreadStatus>,
+    recent: Vec<OverseerActivityRecord>,
+) -> OverseerActivity {
+    let mut a = OverseerActivity {
+        schema_version: SCHEMA_VERSION,
+        enabled,
+        cadence_secs,
+        author_login: "simard-overseer[bot]".to_string(),
+        last_tick_at,
+        totals: Default::default(),
+        threads,
+        recent: VecDeque::new(),
+    };
+    for r in recent {
+        a.push_record(r);
+    }
+    a
+}
+
+// ══════════════════════════ 1. store: constants ════════════════════════════
+
+#[test]
+fn schema_version_is_one_and_cap_is_hundred() {
+    assert_eq!(SCHEMA_VERSION, 1, "feed schema starts at 1");
+    assert_eq!(MAX_RECORDS, 100, "ring buffer retains the last 100 ticks");
+}
+
+// ══════════════════ 2. store: ring buffer bounded + newest-first ════════════
+
+#[test]
+fn push_record_caps_at_max_records_newest_first() {
+    let mut a = feed(true, 900, None, vec![], vec![]);
+
+    // Push 150 records; each carries a unique, monotonically increasing problem
+    // count so ordering is observable.
+    for i in 0..150usize {
+        a.push_record(record_now(report(i, 0, 0, 0, 0)));
+    }
+
+    assert_eq!(
+        a.recent.len(),
+        MAX_RECORDS,
+        "the ring must retain exactly the last {MAX_RECORDS} ticks, evicting oldest"
+    );
+    // Newest-first: front is the most recent push (problems == 149), back is the
+    // oldest retained (problems == 50, because 0..=49 were evicted).
+    assert_eq!(
+        a.recent.front().unwrap().report.problems,
+        149,
+        "front of `recent` must be the newest tick"
+    );
+    assert_eq!(
+        a.recent.back().unwrap().report.problems,
+        50,
+        "back of `recent` must be the oldest still-retained tick"
+    );
+}
+
+#[test]
+fn push_record_recomputes_totals_and_last_tick() {
+    let mut a = feed(true, 900, None, vec![], vec![]);
+    a.push_record(record_at(
+        "2026-07-05T15:00:00Z",
+        true,
+        report(2, 1, 1, 0, 1),
+    ));
+    a.push_record(record_at(
+        "2026-07-05T15:15:00Z",
+        true,
+        report(3, 2, 0, 1, 0),
+    ));
+
+    // Totals are the sum over currently-retained records.
+    assert_eq!(a.totals.problems, 5);
+    assert_eq!(a.totals.issues_filed, 3);
+    assert_eq!(a.totals.recipes_launched, 1);
+    assert_eq!(a.totals.prs_merged, 1);
+    assert_eq!(a.totals.held, 1);
+    // last_tick_at tracks the most recent record's timestamp.
+    assert_eq!(a.last_tick_at.as_deref(), Some("2026-07-05T15:15:00Z"));
+}
+
+// ══════════════════ 3. store: durable file round-trip + degrade ═════════════
+
+#[test]
+fn activity_path_is_under_state_root_overseer_dir() {
+    let root = Path::new("/tmp/some-state-root");
+    let p = activity::activity_path(root);
+    assert!(
+        p.ends_with("overseer/activity.json"),
+        "feed path must be <state_root>/overseer/activity.json, got {p:?}"
+    );
+    assert!(p.starts_with(root));
+}
+
+#[test]
+fn write_atomic_then_read_round_trips() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = activity::activity_path(dir.path());
+
+    let original = feed(
+        true,
+        900,
+        Some("2026-07-05T15:15:00Z".to_string()),
+        vec![overseer_thread_ok()],
+        vec![record_at(
+            "2026-07-05T15:15:00Z",
+            true,
+            report(2, 1, 1, 0, 1),
+        )],
+    );
+
+    activity::write_atomic(&path, &original).expect("atomic write must succeed");
+    let read_back = activity::read(&path).expect("readable feed must deserialize");
+
+    assert_eq!(
+        read_back, original,
+        "write→read must be an identity round-trip"
+    );
+}
+
+#[test]
+fn read_missing_file_is_none_not_panic() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = activity::activity_path(dir.path());
+    assert!(
+        activity::read(&path).is_none(),
+        "a missing feed file degrades to None (honest 'no data'), never panics"
+    );
+}
+
+#[test]
+fn read_corrupt_file_is_none() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = activity::activity_path(dir.path());
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, b"{ this is not valid json ]]").unwrap();
+    assert!(
+        activity::read(&path).is_none(),
+        "a corrupt feed file degrades to None, never panics"
+    );
+}
+
+#[test]
+fn write_atomic_never_leaves_world_readable_mode() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    let path = activity::activity_path(dir.path());
+    let a = feed(true, 900, None, vec![], vec![]);
+    activity::write_atomic(&path, &a).unwrap();
+
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o600,
+        "feed file must be private (0600), got {mode:o}"
+    );
+}
+
+// ══════════════════ 4. store: durable writer (record_tick) ══════════════════
+
+#[test]
+fn record_tick_appends_and_persists() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let a1 = record_tick(
+        root,
+        record_now(report(1, 1, 0, 0, 0)),
+        vec![overseer_thread_ok()],
+        true,
+        900,
+        "simard-overseer[bot]",
+    )
+    .expect("record_tick writes the feed");
+    assert_eq!(a1.recent.len(), 1);
+    assert!(a1.enabled);
+    assert_eq!(a1.cadence_secs, 900);
+    assert_eq!(a1.author_login, "simard-overseer[bot]");
+
+    // A second tick appends to the persisted feed (read-modify-write).
+    let a2 = record_tick(
+        root,
+        record_now(report(0, 0, 1, 0, 0)),
+        vec![overseer_thread_ok()],
+        true,
+        900,
+        "simard-overseer[bot]",
+    )
+    .expect("second record_tick appends");
+    assert_eq!(
+        a2.recent.len(),
+        2,
+        "record_tick must accumulate across ticks"
+    );
+
+    // The durable file reflects the latest state.
+    let on_disk = activity::read(&activity::activity_path(root)).unwrap();
+    assert_eq!(on_disk.recent.len(), 2);
+}
+
+#[test]
+fn record_tick_is_bounded_and_thread_safe() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+
+    // 8 concurrent writers × 30 ticks each = 240 attempted appends onto a
+    // 100-slot ring. Concurrency is last-writer-wins (no lock), but the atomic
+    // tmp+rename guarantees the file is NEVER torn: every read yields a valid,
+    // bounded feed.
+    let mut handles = Vec::new();
+    for w in 0..8u32 {
+        let root = root.clone();
+        handles.push(std::thread::spawn(move || {
+            for i in 0..30usize {
+                let _ = record_tick(
+                    &root,
+                    record_now(report(w as usize, i, 0, 0, 0)),
+                    vec![overseer_thread_ok()],
+                    true,
+                    900,
+                    "simard-overseer[bot]",
+                );
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    let feed = activity::read(&activity::activity_path(&root))
+        .expect("after concurrent writers the feed must still be a valid, readable file");
+    assert!(
+        feed.recent.len() <= MAX_RECORDS,
+        "feed must stay bounded at ≤{MAX_RECORDS} under concurrent writers, got {}",
+        feed.recent.len()
+    );
+}
+
+// ══════════════════ 5. serde: record + tick report ══════════════════════════
+
+#[test]
+fn overseer_tick_report_is_serializable() {
+    // The feature adds `#[derive(Serialize, Deserialize)]` to OverseerTickReport
+    // (additive; no logic change). This asserts the derive is present.
+    let rep = report(2, 1, 1, 0, 1);
+    let v = serde_json::to_value(rep).expect("OverseerTickReport must be Serialize");
+    assert_eq!(v["problems"], 2);
+    assert_eq!(v["issues_filed"], 1);
+    assert_eq!(v["recipes_launched"], 1);
+    assert_eq!(v["held"], 1);
+    assert_eq!(v["panicked"], false);
+}
+
+#[test]
+fn activity_record_json_round_trips() {
+    let rec = record_at("2026-07-05T15:15:00Z", true, report(3, 2, 1, 1, 0));
+    let json = serde_json::to_string(&rec).unwrap();
+    let back: OverseerActivityRecord = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, rec);
+    assert_eq!(back.timestamp, "2026-07-05T15:15:00Z");
+    assert_eq!(back.report.issues_filed, 2);
+}
+
+// ══════════════════ 6. provider: honest states via assemble ═════════════════
+//
+// These go through the real `status::assemble`, reading a hermetic state root.
+// They mutate the process env (`SIMARD_OVERSEER_ENABLED`) so they are serialized.
+
+#[test]
+#[serial_test::serial(overseer_env)]
+fn assemble_surfaces_live_feed_when_enabled_and_fresh() {
+    set_overseer_enabled(None); // default = enabled (opt-out)
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let f = feed(
+        true,
+        900,
+        Some(simard::telemetry::snapshot::now_rfc3339()),
+        vec![overseer_thread_ok()],
+        vec![record_now(report(2, 1, 1, 0, 1))],
+    );
+    activity::write_atomic(&activity::activity_path(root), &f).unwrap();
+
+    let snap = simard::status::assemble(&AssembleOptions::with_state_root(root.to_path_buf()));
+    assert!(
+        snap.overseer.is_present(),
+        "a fresh, enabled feed must yield a present overseer section"
+    );
+    let data = snap
+        .overseer
+        .data
+        .as_ref()
+        .expect("live section carries data");
+    assert!(data.enabled, "data.enabled reflects the gate = true");
+    assert_eq!(data.recent.len(), 1);
+    assert!(
+        data.threads.iter().any(|t| t.id == "overseer"),
+        "the overseer meta-thread must be listed"
+    );
+}
+
+#[test]
+#[serial_test::serial(overseer_env)]
+fn assemble_reports_disabled_state_honestly() {
+    // Disabled is a PRESENT state (data.enabled = false), distinct from "no data".
+    set_overseer_enabled(Some("0"));
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // Even with no feed file, a disabled overseer must be reported plainly.
+    let snap = simard::status::assemble(&AssembleOptions::with_state_root(root.to_path_buf()));
+    set_overseer_enabled(None);
+
+    let rendered = simard::status::render::to_terminal(&snap);
+    assert!(
+        rendered.to_lowercase().contains("disabled"),
+        "a disabled overseer must render the word 'disabled', got:\n{rendered}"
+    );
+}
+
+#[test]
+#[serial_test::serial(overseer_env)]
+fn assemble_reports_enabled_observing_zero_interventions_honestly() {
+    set_overseer_enabled(None);
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // Enabled, has ticked, but took zero interventions (all tallies 0).
+    let f = feed(
+        true,
+        900,
+        Some(simard::telemetry::snapshot::now_rfc3339()),
+        vec![overseer_thread_ok()],
+        vec![record_now(report(0, 0, 0, 0, 0))],
+    );
+    activity::write_atomic(&activity::activity_path(root), &f).unwrap();
+
+    let snap = simard::status::assemble(&AssembleOptions::with_state_root(root.to_path_buf()));
+    let rendered = simard::status::render::to_terminal(&snap);
+    assert!(
+        rendered.contains("0 interventions"),
+        "an enabled-but-idle overseer must render 'observing, 0 interventions', got:\n{rendered}"
+    );
+}
+
+#[test]
+#[serial_test::serial(overseer_env)]
+fn assemble_marks_stale_when_last_tick_is_old() {
+    set_overseer_enabled(None);
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // last_tick_at 1 hour ago with a 900s cadence: 3600 > 2×900 ⇒ stale.
+    let old = rfc3339_secs_ago(3600);
+    let f = feed(
+        true,
+        900,
+        Some(old.clone()),
+        vec![overseer_thread_ok()],
+        vec![record_at(&old, true, report(1, 0, 0, 0, 0))],
+    );
+    activity::write_atomic(&activity::activity_path(root), &f).unwrap();
+
+    let snap = simard::status::assemble(&AssembleOptions::with_state_root(root.to_path_buf()));
+    assert_eq!(
+        snap.overseer.freshness,
+        simard::status::Freshness::Stale,
+        "a feed older than 2×cadence must be marked stale"
+    );
+}
+
+#[test]
+#[serial_test::serial(overseer_env)]
+fn assemble_absent_when_enabled_but_never_ticked() {
+    set_overseer_enabled(None);
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    // No feed file written at all.
+    let snap = simard::status::assemble(&AssembleOptions::with_state_root(root.to_path_buf()));
+    assert!(
+        !snap.overseer.is_present(),
+        "with no feed file the overseer section must be absent (no data), honestly"
+    );
+    assert_eq!(snap.overseer.freshness, simard::status::Freshness::Absent);
+}
+
+// ══════════════════ 7. render: OVERSEER section headers ═════════════════════
+
+#[test]
+fn section_headers_include_overseer() {
+    assert!(
+        simard::status::render::SECTION_HEADERS.contains(&"OVERSEER"),
+        "the canonical render must add an OVERSEER section header"
+    );
+}
+
+#[test]
+#[serial_test::serial(overseer_env)]
+fn render_shows_overseer_header_and_thread_row() {
+    set_overseer_enabled(None);
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let f = feed(
+        true,
+        900,
+        Some(simard::telemetry::snapshot::now_rfc3339()),
+        vec![overseer_thread_ok()],
+        vec![record_now(report(2, 1, 1, 0, 1))],
+    );
+    activity::write_atomic(&activity::activity_path(root), &f).unwrap();
+
+    let snap = simard::status::assemble(&AssembleOptions::with_state_root(root.to_path_buf()));
+    let rendered = simard::status::render::to_terminal(&snap);
+    assert!(
+        rendered.contains("OVERSEER"),
+        "must render the OVERSEER header"
+    );
+    assert!(
+        rendered.contains("overseer"),
+        "must render the overseer thread row (thread id)"
+    );
+}


### PR DESCRIPTION
## What & why

Make the acting **Overseer** meta-loop's activity **visible** on every operator surface — the **Dashboard** (`localhost:8080`), the **TUI**, and `simard status`. Closes the gap called out in #2419: the engineer OODA loop is already visible (goals, live engineers), but the **steward** side — the Overseer that observes the whole system and quietly intervenes (files stewardship issues, launches fix workstreams, verifies + merges green PRs, runs guarded deploys, escalates) or **holds** when a gate says "not yet" — was invisible outside the daemon log.

> **Read/surface only.** No Overseer decision or intervention logic changes. The only producer-side touch is *recording* the tick outcome at the tick boundary, plus an additive `Serialize`/`Deserialize` derive on `OverseerTickReport`. This stays clear of the in-flight "whisperer" workstream that changes intervention internals.

## How

- **Durable, bounded feed** (`src/overseer/activity.rs`): a newest-first ring of the last **N=100** ticks + per-thread status, persisted atomically to `<state_root>/overseer/activity.json` (`0600`, tmp+rename, degrade-to-`None` read, 8 MiB guard). The daemon (which runs the Overseer), the dashboard server, and the TUI are **separate processes**, so a pure in-RAM ring would be unreachable — the file is the cross-process seam every reader consumes (same pattern as the telemetry snapshot).
- **Status section**: `StatusSnapshot.overseer` + `assemble_overseer` with **honest states** and **cadence-relative freshness** (`2 × cadence`, not the fixed 300 s telemetry threshold, which would mark a healthy 15-min-cadence feed stale two-thirds of the time).
- **`simard status`**: new `OVERSEER` section (`status/render.rs`).
- **Dashboard**: auth-gated `GET /api/overseer` (behind the existing `require_auth`, not a new auth path) + a jargon-free **Overseer** tab — auto-refreshing like the other tabs, every interpolated value escaped via `esc()` (XSS regression test).
- **TUI**: `Tab::Overseer` (**Alt+8**) rendering the same feed.
- **Daemon**: records each tick into the feed at the tick boundary (non-fatal on write error), including `Mind::health()` cognitive-thread heartbeats (#2531) alongside the synthetic Overseer meta-thread.

## Honesty (truthful telemetry)

Never a blank or misleading panel. Distinct, explicit states:

| Real situation | Rendered as |
|---|---|
| Acting Overseer disabled (`SIMARD_OVERSEER_ENABLED` falsey) | `Overseer: disabled` |
| Enabled but never ticked (no file yet) | `Overseer: no ticks recorded yet` |
| Enabled, ticked, zero interventions | `Overseer: enabled, observing, 0 interventions` |
| Feed file unreadable / corrupt | `Overseer activity feed unavailable` |

## Tests (no network; inject fake tick reports / feeds)

- `tests/overseer_activity.rs` (contract): ring bounded + newest-first, totals/last-tick recompute, durable round-trip + degrade-to-None + `0600`, concurrent-writer bounded, serde on `OverseerTickReport`, provider honest states (live/disabled/observing-0/stale/absent), `OVERSEER` render header + thread row.
- Dashboard (`operator_commands_dashboard::overseer`): `/api/overseer` response shaping — threads + a sample intervention + the honest 0-interventions and disabled cases; INDEX_HTML wires the tab; **XSS-escaping** of every interpolated value.
- TUI (`tabs::overseer`): pane renders thread rows + recent activity + honest disabled/observing/absent states.
- Updated tab-count invariants (15 → 16 tabs; TUI 7 → 8) and tab-wrap tests.

## Coordination

Additive and localized to **telemetry + dashboard + TUI**. Does not touch the Overseer's decision/intervention internals, so it does not conflict with the parallel "whisperer" (context-injection) workstream.

## Activation

⚠️ **The daemon must be redeployed after merge** before it starts writing `overseer/activity.json`. Until then the surfaces show `Overseer: no ticks recorded yet` — the honest, correct state. **This PR does not redeploy anything.**

## Validation

- `cargo fmt --all -- --check` ✅
- `cargo clippy --release --no-deps -- -D warnings` ✅ (pre-commit)
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✅ (pre-push)
- `cargo test` — new contract/unit tests green; full lib suite green except one pre-existing environment-only failure (`base_type_copilot::…meeting_turn_evidence…`, requires Copilot/GitHub auth, unrelated to this change).
- No `--no-verify`, no `--admin`.

Closes #2419.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>