### PR TITLE
feat(overseer): add the Simard Whisperer — advisory OODA steering (#2605)

### DIFF
--- a/docs/concepts/simard-whisperer.md
+++ b/docs/concepts/simard-whisperer.md
@@ -1,0 +1,284 @@
+---
+title: "The Simard Whisperer — lightweight Overseer→Simard steering"
+description: >
+  How the Overseer steers Simard (the main OODA loop) with a lightweight, advisory
+  "whisper" — a short steering note injected onto the existing meeting-handoff inbox
+  and folded into Simard's reasoner context at the start of her next cycle, without
+  taking the action for her. Covers the trigger conditions (looping, drift), the
+  reused delivery channel, the advisory-not-command guarantee, dedup/rate-limit,
+  distinct-identity anti-recursion, transparency, the config flag, and escalation to
+  a full meeting when a whisper is insufficient.
+last_updated: 2026-07-05
+review_schedule: as-needed
+owner: simard
+doc_type: concept
+status: design — not yet implemented
+related:
+  - ../design/overseer.md
+  - ../reference/simard-whisperer-api.md
+  - ../howto/configure-the-simard-whisperer.md
+  - ../concepts/steerable-ooda-daemon.md
+  - ../reference/meeting-handoff-schema.md
+  - ../architecture/ooda-meeting-handoff-integration.md
+---
+
+# The Simard Whisperer
+
+> **Status: design specification — not yet implemented (issue
+> [#2605](https://github.com/rysweet/Simard/issues/2605), open).**
+>
+> This document describes the **intended** design and the *why* behind it.
+> Nothing here ships yet: the `Intervention::Whisper` variant, the
+> `WhisperSink` capability and `src/overseer/whisper_ops.rs`, the
+> `ProblemKind::LoopDetected` / `ProblemKind::DriftCorrection` signals, the
+> `WhisperGate`, and the `SIMARD_OVERSEER_WHISPER` flag are all **planned, not
+> live**. The channel it rides on *does* exist today — the meeting-handoff
+> inbox ([`write_meeting_handoff`](../reference/meeting-handoff-schema.md),
+> `check_meeting_handoffs` at OODA cycle start) and the acting Overseer
+> co-process ([Overseer design](../design/overseer.md)) are already shipped —
+> so the Whisperer is a purely additive layer on proven mechanics. See the
+> [API reference](../reference/simard-whisperer-api.md) for the exact change map.
+
+The **Simard Whisperer** is a pattern in the [Overseer](../design/overseer.md) that
+lets the Overseer **steer** Simard — the authoritative OODA loop — without ever
+taking the action for her. When the Overseer observes Simard **looping**,
+**drifting from a goal's intent**, missing context the Overseer can see, or heading
+toward a known pitfall, it delivers a short, **advisory** *whisper*: a steering note
+injected onto the **same meeting-handoff inbox** Simard already scans at the start of
+every cycle. The note is folded into the reasoners' Observe context on Simard's next
+turn as *additional input* — the reasoners still decide.
+
+Whispering is the **lightweight default**. When a whisper is insufficient (the same
+condition recurs, or the Overseer flags it urgent), the Overseer **escalates** to a
+full meeting via the existing [`MeetingHost`](../design/overseer.md) capability — the
+pre-existing, heavier steering path — rather than whispering forever.
+
+!!! note "One brain, one steward"
+    Simard is **one brain**. The Overseer is her **steward**, not a second decision
+    maker. A whisper is *context*, never a command: it can add information or suggest
+    a correction, but it can never overwrite, fabricate, or fake one of Simard's
+    decisions or actions. See [Advisory, not command](#advisory-not-command).
+
+## Why a whisper (and not a meeting)
+
+The Overseer already had one way to steer Simard: **transfer a goal through a
+meeting** (`Intervention::TransferGoal` → `MeetingHost`). That path is deliberately
+heavy — it opens a meeting, produces a decision-bearing handoff, and can create or
+re-prioritise goals. It is the right tool for a *hand-off*, but far too heavy for a
+*nudge*.
+
+Most of the time the Overseer just needs to say a sentence into Simard's ear:
+
+- "You've taken no action for two cycles on goal `g-42` — reconsider or pick a
+  different sub-task."
+- "Your recent work looks unrelated to the stated goal intent — re-read the goal."
+- "There's a known pitfall here: the last three attempts at this failed on CI OOM."
+
+The whisper is that sentence. It is a **single lightweight handoff record** carrying
+only the note, delivered onto the channel Simard already reads, and consumed as
+advisory Observe context. No meeting, no new goal, no action taken on Simard's
+behalf.
+
+## Where a whisper rides — the reused channel
+
+The whisper does **not** invent a new channel. It rides the **existing**
+meeting-handoff inbox that Simard's OODA loop already scans at the **start** of every
+cycle:
+
+| Concern | Mechanism | Source |
+|---|---|---|
+| Inbox directory | `meeting_facilitator::default_handoff_dir()` → `<state_root>/meeting_handoffs/` | `src/meeting_facilitator/handoff/mod.rs` |
+| Writer | `write_meeting_handoff(dir, &MeetingHandoff)` → `handoff-<rfc3339>.json` | `src/meeting_facilitator/handoff/persistence.rs` |
+| Cycle-start ingest | `check_meeting_handoffs(...)` runs **before** Observe→Orient→Decide→Act | `src/ooda_loop/cycle.rs` |
+| Observe surfacing | `observe()` scans unprocessed handoffs and folds a handoff signal into the reasoner-facing `Observation` | `src/ooda_loop/observe.rs` |
+
+Because the whisper is written **during the Overseer's tick** and picked up at the
+**start of Simard's next cycle**, delivery is asynchronous by design: a whisper
+written at Overseer tick *T* appears in Simard's Observe context at cycle *T+1*.
+
+```mermaid
+flowchart LR
+  subgraph overseer["Overseer meta-OODA tick (isolated)"]
+    obs["Observe\nObservedState{ consecutive_no_action, drift }"] --> ori["Orient\nSignal::LoopDetected / DriftCorrection"]
+    ori --> dec["Decide\nProblem → Intervention::Whisper{ note, urgency }"]
+    dec --> gate["WhisperGate\n(identity fail-closed +\ndedup window + per-hour cap)"]
+    gate --> act["Act\nWhisperSink::deliver"]
+  end
+  act -->|write_meeting_handoff| inbox[("meeting_handoffs/\nhandoff-*.json\nthemes:[overseer-whisper]")]
+  inbox -->|next cycle START| simard["Simard OODA\ncheck_meeting_handoffs + observe()\n⇒ note in reasoner context (advisory)"]
+  act -.->|OperatorNotification| operator["Operator\n(email / Signal / dashboard)"]
+```
+
+!!! warning "Not the `.txt` goal-sink"
+    The Overseer's pre-existing `FileHandoffSink` writes `overseer-goal-*.txt`, which
+    the OODA ingest path **never parses**. A whisper written that way would silently
+    never reach Simard. The whisper therefore delivers a real
+    `handoff-<rfc3339>.json` through `write_meeting_handoff` — the exact artifact
+    Simard's inbox understands.
+
+## What triggers a whisper
+
+The Overseer's Observe step gains two additive readings of Simard's live state, and
+its Orient step turns them into two additive
+[`Signal`](../reference/simard-whisperer-api.md#signal)s that Decide routes to a
+whisper:
+
+### Looping — repeated no-action / no progress
+
+Simard's no-progress breaker counts a goal's **consecutive no-action** cycles and
+fires a hard breaker at `NO_PROGRESS_BREAKER_THRESHOLD` (**3**;
+`src/goal_curation/no_progress_breaker.rs`). The Whisperer nudges **before** the hard
+breaker: at **2** consecutive no-action cycles the Overseer emits
+`Signal::LoopDetected` → `ProblemKind::LoopDetected` → a whisper that names the loop
+and suggests reconsidering or switching sub-task. The whisper threshold is **strictly
+less than** the breaker threshold so the gentle nudge always precedes the blocking
+intervention.
+
+### Drift — work diverging from goal intent
+
+When Simard's recent activity looks unrelated to the stated intent of the active
+goal, the Overseer emits `Signal::DriftCorrection` → `ProblemKind::DriftCorrection` →
+a whisper that points back at the goal intent. Drift detection is a comparison the
+steward can make from outside the loop (active work vs. stated goal), so it is a
+natural whisper trigger.
+
+Both conditions compose a **concise corrective/additional instruction** — one or two
+sentences — never a rewritten plan.
+
+## Advisory, not command
+
+A whisper is **context**, not a decision. This is enforced structurally, not by
+convention:
+
+- The note is carried on the whisper handoff in a **non-promoting field**
+  (`open_questions` / `themes`), with **`decisions` empty** and **`action_items`
+  empty**. Simard's `check_meeting_handoffs` promotes `decisions` into goals and
+  `action_items` into backlog items — so an empty-decisions, empty-action-items
+  handoff **cannot fabricate a goal, backlog item, or planned action**.
+- The whisper handoff is tagged `themes: ["overseer-whisper"]` so the OODA Observe
+  path recognises it and folds its note into the **reasoner-facing Observe context**
+  as advisory input, then marks it processed.
+- Simard's reasoners run exactly as before. They read the whisper alongside every
+  other observation and **produce their own decision**. The whisper never overwrites
+  or forges a planned action or an outcome.
+
+The result: after a whisper, Simard's next decision is still *hers*. The whisper is
+present as one more input she may or may not act on.
+
+## Guardrails
+
+The Whisperer reuses the Overseer's existing guardrail patterns
+(`src/overseer/guardrails.rs`) rather than inventing new ones.
+
+### Dedup + rate-limit
+
+The Overseer must not re-inject the same whisper every cycle. A `WhisperGate`:
+
+- **Deduplicates** by a stable signature `(ProblemKind + goal_id + normalized_note)`
+  and **suppresses** an identical whisper within a **time window** (default **900 s**,
+  measured with an injected clock — the same pattern as `OverseerCadence::due`).
+- **Caps** whispers to a **per-period budget** (default **5 per hour** across all
+  signatures), in the spirit of `BudgetGate` / `ConflictSequencer`.
+
+A suppressed whisper is counted (`whispers_suppressed`) and traced, never silently
+dropped.
+
+### Distinct identity + anti-recursion
+
+The whisper is authored under the Overseer's **distinct steward identity**
+(`overseer_author_login()`, default `simard-overseer[bot]`) — never the human
+operator's login and never Simard's own. Two protections follow:
+
+- **No self-whisper.** Simard's Observe / the Overseer's `signals_from` **ignore
+  overseer-authored handoffs**, so the Overseer can never observe its own whisper and
+  whisper about it — no feedback loop.
+- **Fail-closed.** If the Overseer identity is unconfigured, `RecursionGuard` refuses
+  the whisper (nothing is delivered), exactly as it fails closed for PR/commit/goal
+  subjects today. A steward that cannot prove its own identity does not get to speak.
+
+### Transparent + traceable
+
+A whisper is **never a hidden side-channel**:
+
+- Every whisper emits a structured `tracing` event (`target: "overseer::whisper"`)
+  with `trigger`, `note`, `urgency`, `delivered`, `path`, `signature`, and
+  `suppressed` fields.
+- Each **delivered** whisper is surfaced to the operator as an `OperatorNotification`
+  (kind `"whisper"`) through the mandatory `DualChannelNotifier`, so it shows up on
+  the operator's channels and the dashboard.
+- The per-tick `OverseerTickReport` gains `whispers` and `whispers_suppressed`
+  counters.
+
+### Isolated + panic-safe
+
+The whisper capability runs **inside** the existing panic-isolated Overseer tick
+(`run_overseer_tick_isolated`'s `catch_unwind`). A whisper-sink error or panic is
+caught, reflected in the report (`errors` / `panicked`), and the daemon and OODA loop
+continue unaffected.
+
+## Escalation — keep the meeting path
+
+Whispering is the default, not the only tool. When a whisper is **insufficient**, the
+Overseer escalates to the pre-existing meeting path:
+
+- **Repeated:** the same-signature whisper has fired ≥ N times within the window
+  (default **N = 3**) without the condition clearing, **or**
+- **Urgent:** the whisper's `urgency` is `High`.
+
+On escalation the Overseer takes `Intervention::TransferGoal` through `MeetingHost` —
+a full meeting/handoff with Simard, exactly as before. The lightweight whisper remains
+the default path; escalation is the exception.
+
+## Configuration
+
+The Whisperer is gated by `SIMARD_OVERSEER_WHISPER`, following the Overseer's
+**opt-out** convention:
+
+| Value | Effect |
+|---|---|
+| unset / empty / truthy (`1`,`true`,`yes`,`on`) / unrecognised | **enabled** (default, when the Overseer is enabled) |
+| explicit falsey (`0`,`false`,`no`,`off`) | **disabled** — Decide emits no whisper |
+
+Because whispering only makes sense when the Overseer runs, the flag defaults to
+**enabled when the Overseer is enabled** and is disabled by an explicit falsey value —
+the same shape as `overseer_acting_enabled`. See
+[Configure the Simard Whisperer](../howto/configure-the-simard-whisperer.md).
+
+## Invariants
+
+- **Reused channel only.** A whisper is delivered *exclusively* by writing a
+  `handoff-<rfc3339>.json` into `meeting_handoffs/` via `write_meeting_handoff`. No
+  parallel channel exists.
+- **Advisory.** A whisper handoff carries empty `decisions` and empty `action_items`;
+  it can never create a goal, backlog item, planned action, or outcome.
+- **At most one identical whisper per window.** Dedup suppresses duplicates; the
+  per-hour cap bounds total whispers.
+- **Distinct authorship.** Every whisper is authored under the Overseer's steward
+  identity; overseer-authored handoffs are ignored by observation (no self-whisper).
+- **Fail-closed.** Unconfigured identity ⇒ refused, nothing delivered.
+- **Visible.** Every whisper is traced and every delivered whisper notifies the
+  operator.
+- **Default lightweight.** The whisper is the default; the meeting path is the
+  escalation.
+- **Isolated.** A whisper failure or panic is caught by the isolated tick; the daemon
+  continues.
+
+## Out of scope
+
+- **Renaming or replacing** any existing Overseer, meeting, or OODA concept. The
+  Whisperer is purely additive and contains no "Bridge" naming.
+- **Taking Simard's action for her.** The Overseer never executes Simard's decision;
+  it only adds context.
+- **A second decision channel.** There is exactly one steering inbox
+  (`meeting_handoffs/`); the whisper is a lightweight record on it.
+- **Synchronous, same-cycle delivery.** Whispers are picked up at the *next* cycle
+  start.
+
+## See also
+
+- Design: [Overseer — operator/observer co-process](../design/overseer.md)
+- API reference: [Simard Whisperer API](../reference/simard-whisperer-api.md)
+- How-to: [Configure the Simard Whisperer](../howto/configure-the-simard-whisperer.md)
+- Related: [Keeping the OODA Daemon Steerable](../concepts/steerable-ooda-daemon.md),
+  [Meeting Handoff Schema](../reference/meeting-handoff-schema.md),
+  [OODA Meeting-Handoff Integration](../architecture/ooda-meeting-handoff-integration.md)

--- a/docs/design/overseer.md
+++ b/docs/design/overseer.md
@@ -8,13 +8,16 @@ description: >
   modules, the guardrails (autonomy boundary, anti-recursion, budget/concurrency,
   conflict-avoidance), persisted state, the explicit boundary against Simard's own OODA, and a
   phased roadmap. Design + scaffolding only — no daemon runtime behavior change.
-last_updated: 2026-07-03
+last_updated: 2026-07-05
 review_schedule: as-needed
 owner: simard
 doc_type: design
 status: draft
 related:
   - ../concepts/operational-autonomy-model.md
+  - ../concepts/simard-whisperer.md
+  - ../reference/simard-whisperer-api.md
+  - ../howto/configure-the-simard-whisperer.md
   - ../reference/cognitive-thread-scheduling.md
   - ../howto/add-a-new-cognitive-thread.md
   - ../reference/status-snapshot-api.md

--- a/docs/howto/configure-the-simard-whisperer.md
+++ b/docs/howto/configure-the-simard-whisperer.md
@@ -1,0 +1,267 @@
+---
+title: Configure and observe the Simard Whisperer
+description: Operator guide for the Overseer's lightweight whisper steering — enabling/disabling with SIMARD_OVERSEER_WHISPER, tuning the dedup window, per-hour cap, and meeting-escalation threshold, reading whisper tracing and operator notifications, understanding how a whisper reaches Simard's next OODA cycle, confirming the advisory-not-command and fail-closed-identity guarantees, and verifying the feature end-to-end with injected fakes.
+last_updated: 2026-07-05
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../concepts/simard-whisperer.md
+  - ../reference/simard-whisperer-api.md
+  - ../design/overseer.md
+  - ./configure-self-quality-audit.md
+---
+
+# Configure and observe the Simard Whisperer
+
+> **Status: design specification — not yet implemented (issue
+> [#2605](https://github.com/rysweet/Simard/issues/2605), open).**
+>
+> This guide documents the **intended** operator surface. The
+> `SIMARD_OVERSEER_WHISPER*` environment variables, the `overseer::whisper`
+> traces, the `whisper` operator notifications, and the `cargo test` targets
+> below do **not** exist in a running daemon yet — they describe how the feature
+> will be configured and observed once the implementation PR lands. Until then,
+> setting these variables has no effect.
+
+The **Overseer** can steer Simard (the main OODA loop) with a lightweight,
+**advisory** *whisper* — a short steering note injected onto Simard's meeting-handoff
+inbox and folded into her reasoners' context at the start of her next cycle. Whispers
+fire when the Overseer sees Simard **looping** (repeated no-action) or **drifting**
+from a goal's intent. The whisper never takes the action for her; her reasoners still
+decide.
+
+This guide shows how to enable, tune, observe, and verify whispering. For the concept
+see [The Simard Whisperer](../concepts/simard-whisperer.md); for the API contract see
+the [Simard Whisperer API](../reference/simard-whisperer-api.md).
+
+!!! note "Activation requires a redeploy"
+    These knobs are read from the environment at daemon start. Set them **before**
+    launching (or relaunching) the daemon. After merging a Whisperer change, the
+    operator redeploys the binary to activate it — the running daemon does not pick up
+    new code until then.
+
+## When to use this
+
+Use this guide when:
+
+- You want to turn whispering on or off, independently of the rest of the Overseer
+- You want to change how aggressively the Overseer whispers (window, per-hour cap)
+- You want the Overseer to escalate to a full meeting sooner or later
+- The daemon emitted `overseer::whisper` traces, or you received a `[Overseer]
+  whisper: …` operator notification, and you want to understand it
+- You need to confirm a whisper actually reached Simard's next cycle
+- You need to verify the advisory / fail-closed guarantees
+
+## Enable, disable, and tune
+
+All knobs are environment variables, read once at daemon start.
+
+| Knob | Env var | Default | What it controls |
+| --- | --- | ---: | --- |
+| On/off | `SIMARD_OVERSEER_WHISPER` | enabled with Overseer | Master gate. Opt-**out**: explicit falsey disables. |
+| Dedup window | `SIMARD_OVERSEER_WHISPER_WINDOW_SECS` | `900` | Suppress an identical whisper seen within this many seconds. |
+| Per-hour cap | `SIMARD_OVERSEER_WHISPER_CAP_PER_HOUR` | `5` | Max whispers admitted per rolling hour across all signatures. |
+| Escalate after | `SIMARD_OVERSEER_WHISPER_ESCALATE_AFTER` | `3` | Same-signature whispers before escalating to a full meeting. |
+
+### On/off — opt-out semantics
+
+`SIMARD_OVERSEER_WHISPER` follows the same **opt-out** convention as the acting
+Overseer: it is **enabled by default whenever the Overseer is enabled**, and only an
+explicit falsey value disables it.
+
+```bash
+# Disable whispering (Overseer still runs, just never whispers)
+export SIMARD_OVERSEER_WHISPER=off      # or: 0 | false | no
+
+# Explicitly enable (default when the Overseer is enabled)
+export SIMARD_OVERSEER_WHISPER=on       # or: 1 | true | yes
+
+# Restore the default (enabled-with-Overseer) — just unset it
+unset SIMARD_OVERSEER_WHISPER
+```
+
+Recognised **falsey** values (case-insensitive, trimmed): `0`, `false`, `no`, `off`.
+Everything else — unset, empty, `1`, `true`, `yes`, `on`, or an unrecognised string —
+leaves whispering **enabled**, provided the Overseer itself is enabled
+(`SIMARD_OVERSEER_ENABLED` is not falsey). If the Overseer is disabled, whispering is
+disabled too, regardless of this flag.
+
+### Tuning aggressiveness
+
+```bash
+# Whisper about the same condition at most once every 30 min (less chatty)
+export SIMARD_OVERSEER_WHISPER_WINDOW_SECS=1800
+
+# Allow at most 3 whispers per hour total
+export SIMARD_OVERSEER_WHISPER_CAP_PER_HOUR=3
+
+# Escalate to a full meeting after 2 repeats instead of 3
+export SIMARD_OVERSEER_WHISPER_ESCALATE_AFTER=2
+```
+
+- **Window** larger ⇒ fewer repeated nudges about the same thing.
+- **Cap** smaller ⇒ a hard ceiling on total whispers per hour (dedup runs first, the
+  cap second).
+- **Escalate-after** smaller ⇒ the Overseer opens a full meeting sooner when a
+  condition will not clear. High-urgency whispers escalate immediately regardless of
+  this count.
+
+## How a whisper reaches Simard
+
+You do not deliver whispers manually — the Overseer composes and delivers them. The
+path is:
+
+1. **Overseer tick.** The Overseer observes `consecutive_no_action` and drift for the
+   active goal. At **2** consecutive no-action cycles (one below the no-progress
+   breaker at **3**), or on detected drift, it composes a one- or two-sentence note.
+2. **Gate.** The `WhisperGate` suppresses duplicates within the window and enforces
+   the per-hour cap; `RecursionGuard` refuses if the steward identity is unconfigured.
+3. **Deliver.** The whisper is written as a real
+   `<state_root>/meeting_handoffs/handoff-<rfc3339>.json` with `themes:
+   ["overseer-whisper"]`, the note in `open_questions`, and **empty** `decisions` /
+   `action_items`.
+4. **Pickup.** At the **start of Simard's next OODA cycle**, her inbox scan
+   (`check_meeting_handoffs` + `observe()`) folds the note into her reasoners' Observe
+   context as advisory input, then marks the handoff processed. Because the handoff
+   carries no decisions or action items, it **never becomes a goal or backlog item**.
+
+Delivery is asynchronous: a whisper written during Overseer tick *T* appears in
+Simard's context at cycle *T+1*.
+
+## Observe whispers
+
+### Structured tracing
+
+Every whisper emits one `tracing` event on target `overseer::whisper`:
+
+```
+INFO overseer::whisper trigger="loop_detected" note="No action for 2 cycles on g-42; reconsider or switch sub-task." urgency=Normal signature="loop:g-42:…" delivered=true suppressed="" path="…/meeting_handoffs/handoff-2026-07-05T15-40-12Z.json" overseer whisper
+```
+
+Key fields:
+
+- `trigger` — `loop_detected` or `drift_correction`
+- `note` — the exact steering text delivered
+- `urgency` — `Low` | `Normal` | `High`
+- `delivered` — `true` when written, `false` when suppressed/refused
+- `suppressed` — `""`, `duplicate`, or `cap`
+- `signature` — the dedup signature
+- `path` — the written handoff file (when delivered)
+
+The per-tick summary event (`overseer::tick`) additionally carries `whispers` and
+`whispers_suppressed` counts.
+
+### Operator notifications
+
+Each **delivered** whisper is surfaced to the operator through the mandatory
+dual-channel notifier as an `OperatorNotification` of kind `"whisper"`:
+
+- **Subject:** `[Overseer] whisper: <headline>`
+- **Body:** the steering note, the trigger, and the affected goal
+
+Suppressed whispers are traced but **not** notified, to keep the operator channels
+quiet.
+
+### On disk
+
+You can see pending whispers as handoff files in the inbox:
+
+```bash
+ls -1 "$SIMARD_STATE_ROOT/meeting_handoffs/"
+# handoff-2026-07-05T15-40-12Z.json   ← a whisper (themes: ["overseer-whisper"])
+
+# Inspect one:
+jq '{themes, decisions, action_items, open_questions, participants, processed}' \
+  "$SIMARD_STATE_ROOT/meeting_handoffs/handoff-2026-07-05T15-40-12Z.json"
+```
+
+A whisper handoff always shows `themes` containing `"overseer-whisper"`, **empty**
+`decisions` and `action_items`, the note in `open_questions`, and the Overseer's
+steward login in `participants`. Once Simard's next cycle consumes it, `processed`
+flips to `true`.
+
+## Confirm the guarantees
+
+### Advisory, not command
+
+A whisper cannot create work or fake a decision. Because the whisper handoff carries
+empty `decisions` and empty `action_items`, Simard's curation step
+(`check_meeting_handoffs`) has nothing to promote — it folds the note into context and
+marks the handoff processed without creating any goal, backlog item, or planned
+action. Simard's reasoners produce their **own** next decision with the whisper as one
+additional input.
+
+### Distinct identity and no self-whisper
+
+Whispers are authored under the Overseer's **steward login**
+(`SIMARD_OVERSEER_AUTHOR_LOGIN`, default `simard-overseer[bot]`) — never the operator's
+login and never Simard's. Simard's observation ignores overseer-authored handoffs, so
+the Overseer cannot observe its own whisper and whisper about it.
+
+If the steward identity is unconfigured, the whisper is **refused** (fail-closed) and
+nothing is written — you will see a trace with `delivered=false` and an
+`anti-recursion` refusal, and no `handoff-*.json` appears. To configure the identity:
+
+```bash
+export SIMARD_OVERSEER_AUTHOR_LOGIN="simard-overseer[bot]"
+```
+
+### Escalation to a meeting
+
+When the same condition keeps recurring (same-signature whispers reach
+`SIMARD_OVERSEER_WHISPER_ESCALATE_AFTER`) or a whisper is `High` urgency, the Overseer
+stops whispering and opens a **full meeting** with Simard via the existing
+`TransferGoal`/`MeetingHost` path — the heavier steering channel. The lightweight
+whisper remains the default; escalation is the exception. You will see the
+`overseer::tick` report show a goal transfer rather than a whisper for that cycle.
+
+## Verify
+
+The Whisperer is fully covered by tests that inject fakes for observed-state, the
+whisper sink, the clock, and the identity — **no network**. Run them with:
+
+```bash
+# Whisperer unit + integration tests
+cargo test -p simard overseer::whisper
+cargo test -p simard whisper
+```
+
+The suite proves, at minimum:
+
+- **Delivery reaches the next cycle.** A loop/drift condition produces a whisper
+  written as a real `handoff-*.json`; a subsequent OODA `observe()`/`check_meeting_handoffs`
+  finds the note in the next cycle's reasoner context (via a `tempfile` inbox).
+- **Advisory.** The delivered handoff has empty `decisions` and `action_items`; no
+  goal/backlog item/planned action is fabricated.
+- **Dedup + cap.** An identical whisper on the next tick is suppressed within the
+  window (single delivery); a 6th whisper in an hour is capped.
+- **Fail-closed identity.** With the steward identity unset, the whisper is refused
+  and the sink is never called.
+- **No self-whisper.** An overseer-authored handoff is ignored by `signals_from`.
+- **Escalation.** Repeated or `High`-urgency conditions transfer a goal via
+  `MeetingHost`; the default path stays a whisper.
+- **Config.** A falsey `SIMARD_OVERSEER_WHISPER` yields no whisper; the default yields
+  one when the condition holds.
+- **Isolation.** A whisper-sink error or panic is caught by the isolated tick; the
+  report records it (`errors` / `panicked`) and the daemon continues.
+- **Observability.** The tracing fields and the operator `whisper` notification are
+  emitted for each delivered whisper.
+
+## Troubleshoot
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| No whispers ever, condition clearly holds | `SIMARD_OVERSEER_WHISPER` falsey, or the Overseer disabled (`SIMARD_OVERSEER_ENABLED` falsey) | Unset the flag or set a truthy value; ensure the Overseer is enabled; redeploy. |
+| Trace shows `delivered=false`, `anti-recursion` refusal | Steward identity unconfigured | Set `SIMARD_OVERSEER_AUTHOR_LOGIN`; redeploy. |
+| Same whisper repeats every cycle | Window too small | Increase `SIMARD_OVERSEER_WHISPER_WINDOW_SECS`. |
+| Whispers stop after a few per hour | Per-hour cap reached | Increase `SIMARD_OVERSEER_WHISPER_CAP_PER_HOUR` (or accept the ceiling). |
+| Overseer opens meetings instead of whispering | Escalation threshold reached, or `High` urgency | Raise `SIMARD_OVERSEER_WHISPER_ESCALATE_AFTER` if you want more whispers before a meeting. |
+| A whisper became a goal/backlog item | Should be impossible — whisper handoffs carry empty `decisions`/`action_items` | File a bug: inspect the offending `handoff-*.json`; a non-empty `decisions`/`action_items` on an `overseer-whisper` handoff is the defect. |
+
+## See also
+
+- Concept: [The Simard Whisperer](../concepts/simard-whisperer.md)
+- API reference: [Simard Whisperer API](../reference/simard-whisperer-api.md)
+- Design: [Overseer — operator/observer co-process](../design/overseer.md)
+- Related: [Configure the monthly self-quality-audit](./configure-self-quality-audit.md)

--- a/docs/reference/simard-whisperer-api.md
+++ b/docs/reference/simard-whisperer-api.md
@@ -1,0 +1,589 @@
+---
+title: "Simard Whisperer API"
+description: >
+  Public surface of the Simard Whisperer: the Whisper intervention and urgency,
+  the WhisperSink trait and its real/fake implementations, the LoopDetected /
+  DriftCorrection problem kinds and signals, the WhisperGate dedup/rate-limit,
+  the SIMARD_OVERSEER_WHISPER config flag, the extended OverseerTickReport,
+  operator notification, and error variants.
+last_updated: 2026-07-05
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+status: design — not yet implemented
+related:
+  - ../concepts/simard-whisperer.md
+  - ../howto/configure-the-simard-whisperer.md
+  - ../design/overseer.md
+  - ../reference/meeting-handoff-schema.md
+---
+
+# Simard Whisperer API Reference
+
+> **Status: design specification — not yet implemented (issue
+> [#2605](https://github.com/rysweet/Simard/issues/2605), open).**
+>
+> This page specifies the **intended** public surface. None of the types,
+> traits, or functions below exist in `src/` yet — `whisper_ops.rs` is not
+> created, and no `Whisper` / `LoopDetected` / `DriftCorrection` symbols are
+> present. Signatures marked *(proposed)* are the design target for the
+> implementation PR, not a description of shipped code. The existing modules
+> they extend (`intervention.rs`, `signal.rs`, `guardrails.rs`,
+> `capabilities.rs`, `config.rs`, `wiring.rs`, `mod.rs`) are real; the additive
+> members described here are not.
+
+Module: `simard::overseer`
+Primary source: `src/overseer/whisper_ops.rs` (new) with additive edits to
+`intervention.rs`, `signal.rs`, `guardrails.rs`, `capabilities.rs`, `config.rs`,
+`wiring.rs`, and `mod.rs`.
+
+For the conceptual overview see
+[The Simard Whisperer](../concepts/simard-whisperer.md). For operator configuration
+see [Configure the Simard Whisperer](../howto/configure-the-simard-whisperer.md).
+
+The Whisperer is **purely additive**: it introduces new enum variants, one new
+module, and new report/notification fields. No existing type, function, or field is
+renamed or removed, and every existing Overseer test keeps passing unchanged.
+
+## Module layout
+
+```
+src/overseer/whisper_ops.rs      NEW: WhisperUrgency, WhisperRecord, WhisperSink,
+                                 MeetingHandoffWhisperSink, FakeWhisperSink,
+                                 compose_whisper_note, whisper_signature
+src/overseer/intervention.rs     + Intervention::Whisper { note, urgency } + label()
+src/overseer/signal.rs           + ProblemKind::{LoopDetected, DriftCorrection}
+                                 + Signal::{LoopDetected, DriftCorrection}
+                                 + signals_from arms (ignore overseer-authored)
+src/overseer/guardrails.rs       + WhisperGate (dedup window + per-hour cap);
+                                 + classify() arm; RecursionGuard reuse (fail-closed)
+src/overseer/capabilities.rs     + ObservedState.{consecutive_no_action, drift_*}
+                                 + ActOutcome::{Whispered, WhisperSuppressed}
+src/overseer/config.rs           + SIMARD_OVERSEER_WHISPER + whisper_enabled_from()
+src/overseer/wiring.rs           + OverseerTickReport.{whispers, whispers_suppressed}
+                                 + assemble MeetingHandoffWhisperSink + notify
+src/overseer/notify.rs           + OperatorNotification::whisper(...) (kind "whisper")
+```
+
+## `Intervention::Whisper`
+
+```rust
+// src/overseer/intervention.rs
+pub enum Intervention {
+    // ...existing variants...
+
+    /// Inject a short, ADVISORY steering note onto Simard's meeting-handoff inbox,
+    /// to be folded into her reasoners' Observe context at the start of her NEXT
+    /// cycle. The lightweight default steering action.
+    /// Capability: `WhisperSink::deliver`.
+    Whisper { note: String, urgency: WhisperUrgency },
+}
+```
+
+`label()` gains one arm:
+
+```rust
+Intervention::Whisper { .. } => "whisper",
+```
+
+The label `"whisper"` is the stable key used in gate messages, tracing, dedup, and
+the tick report.
+
+### `WhisperUrgency`
+
+```rust
+// src/overseer/whisper_ops.rs
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum WhisperUrgency {
+    Low,
+    #[default]
+    Normal,
+    High,
+}
+```
+
+`High` feeds the [escalation](#escalation) trigger. `Normal` is the default for
+composed whispers.
+
+### Risk classification
+
+```rust
+// src/overseer/guardrails.rs — classify()
+Intervention::Whisper { .. } => RiskClass::Routine,
+```
+
+A whisper is **`Routine`**: it takes no action on Simard's behalf, spends no LLM
+budget, and merely adds advisory context. It is admitted by the default
+`AutonomyGate` without any HIGH-RISK or merge opt-in. (The gating that *does* apply to
+whispers — dedup, rate-limit, identity — lives in [`WhisperGate`](#whispergate) and
+`RecursionGuard`, not in the autonomy gate.)
+
+A whisper is **not** cost-bearing: `is_cost_bearing(Intervention::Whisper { .. })`
+is `false`, so it is never counted against the per-cycle launch cap or the
+`BudgetGate`.
+
+## Problem kinds and signals
+
+### `ProblemKind`
+
+```rust
+// src/overseer/signal.rs
+pub enum ProblemKind {
+    // ...existing variants...
+    /// Simard is looping: repeated no-action / no-progress on a goal.
+    LoopDetected,
+    /// Simard's recent work is drifting from the active goal's stated intent.
+    DriftCorrection,
+}
+```
+
+These are **explicit additive variants**, not overloads of `ProcessHealth` /
+`GoalHygiene`, so Decide can route them independently and they are independently
+testable.
+
+### `Signal`
+
+```rust
+// src/overseer/signal.rs
+pub enum Signal {
+    // ...existing variants...
+
+    /// Consecutive no-action cycles observed for `goal_id`
+    /// (`ObservedState.consecutive_no_action`). Emitted at the whisper loop
+    /// threshold (2), strictly below `NO_PROGRESS_BREAKER_THRESHOLD` (3).
+    LoopDetected { goal_id: String, consecutive_no_action: u32 },
+
+    /// Recent work diverging from the active goal's stated intent
+    /// (`ObservedState.drift_detail`).
+    DriftCorrection { goal_id: String, detail: String },
+}
+```
+
+### `ObservedState` additions
+
+```rust
+// src/overseer/capabilities.rs — additive fields on ObservedState
+pub struct ObservedState {
+    // ...existing fields...
+
+    /// Consecutive no-action cycles for the active goal, mirrored from Simard's
+    /// no-progress breaker (`goal_curation::NoProgressBreaker::record_no_action`).
+    /// `None` when unavailable.
+    pub consecutive_no_action: Option<u32>,
+
+    /// The active goal id the loop/drift readings pertain to. `None` when idle.
+    pub active_goal_id: Option<String>,
+
+    /// Non-empty when the Overseer detects recent work drifting from the active
+    /// goal's stated intent; carries a short human-readable reason.
+    pub drift_detail: Option<String>,
+}
+```
+
+### `signals_from` behaviour
+
+`signals_from(&ObservedState)` gains two arms (thresholds are illustrative env-tunable
+defaults, mirroring the existing sketch constants):
+
+```rust
+// WHISPER_LOOP_THRESHOLD = 2  (< NO_PROGRESS_BREAKER_THRESHOLD = 3)
+if let (Some(n), Some(goal)) = (state.consecutive_no_action, state.active_goal_id.clone())
+    && n >= WHISPER_LOOP_THRESHOLD
+{
+    out.push(Signal::LoopDetected { goal_id: goal, consecutive_no_action: n });
+}
+if let (Some(detail), Some(goal)) = (state.drift_detail.clone(), state.active_goal_id.clone()) {
+    out.push(Signal::DriftCorrection { goal_id: goal, detail });
+}
+```
+
+!!! important "No self-whisper"
+    The Observe adapter that fills `ObservedState` **ignores handoffs authored by the
+    Overseer** (`author == overseer_author_login()` or
+    `themes` contains `"overseer-whisper"`). The Overseer therefore never observes its
+    own whisper and can never whisper about it.
+
+### Orient / Decide routing
+
+`classify_signal` maps the new signals:
+
+```rust
+Signal::LoopDetected { goal_id, consecutive_no_action } => (
+    ProblemKind::LoopDetected,
+    Priority::High,
+    format!("loop:{goal_id}"),
+    format!("no action for {consecutive_no_action} cycles on {goal_id}"),
+),
+Signal::DriftCorrection { goal_id, detail } => (
+    ProblemKind::DriftCorrection,
+    Priority::Normal,
+    format!("drift:{goal_id}"),
+    format!("work drifting from goal {goal_id}: {detail}"),
+),
+```
+
+`decide` routes both problem kinds to a **whisper by default**, and to a **meeting
+transfer on escalation**:
+
+```rust
+ProblemKind::LoopDetected | ProblemKind::DriftCorrection => {
+    if escalate {                       // see “Escalation” below
+        Intervention::TransferGoal { goal: /* GoalBrief from problem */ }
+    } else {
+        Intervention::Whisper {
+            note: compose_whisper_note(problem, observed),
+            urgency: /* Normal, or High when the condition is acute */,
+        }
+    }
+}
+```
+
+## `WhisperSink`
+
+The injectable delivery seam. Production writes a real meeting handoff; tests capture
+records in memory.
+
+```rust
+// src/overseer/whisper_ops.rs
+
+/// A composed whisper ready for delivery.
+pub struct WhisperRecord {
+    pub note: String,
+    pub urgency: WhisperUrgency,
+    pub problem: ProblemKind,
+    pub goal_id: Option<String>,
+    /// The Overseer's distinct steward login (overseer_author_login()).
+    pub author: String,
+    /// Stable dedup signature: (problem + goal_id + normalized note).
+    pub signature: String,
+}
+
+/// Deliver a whisper by writing an ADVISORY meeting handoff onto the inbox that
+/// Simard's OODA loop scans at cycle start.
+pub trait WhisperSink {
+    /// Build a `MeetingHandoff` with the note in a NON-PROMOTING field
+    /// (`open_questions` / `themes`), `decisions` EMPTY, `action_items` EMPTY,
+    /// `processed: false`, `themes` containing `"overseer-whisper"`, authored under
+    /// `rec.author`; persist it via `write_meeting_handoff`. Returns the written path.
+    fn deliver(&self, rec: &WhisperRecord) -> Result<PathBuf, OverseerError>;
+}
+```
+
+### `MeetingHandoffWhisperSink` (production)
+
+```rust
+pub struct MeetingHandoffWhisperSink {
+    dir: PathBuf,   // meeting_facilitator::default_handoff_dir()
+}
+
+impl MeetingHandoffWhisperSink {
+    /// Construct against the default `<state_root>/meeting_handoffs/` inbox.
+    pub fn from_env() -> Self;
+    /// Construct against an explicit directory (used by wiring and tests).
+    pub fn new(dir: PathBuf) -> Self;
+}
+```
+
+`deliver` constructs the handoff and calls
+`crate::meeting_facilitator::write_meeting_handoff(&self.dir, &handoff)`, producing a
+`handoff-<rfc3339>.json`. It never touches the `.txt` `FileHandoffSink` path.
+
+The written handoff is shaped so Simard's `check_meeting_handoffs` cannot promote it
+into a goal or backlog item:
+
+| Field | Value |
+|---|---|
+| `decisions` | `[]` (empty — cannot become a goal) |
+| `action_items` | `[]` (empty — cannot become a backlog item) |
+| `open_questions` | one entry carrying the whisper note (advisory context) |
+| `themes` | `["overseer-whisper"]` (recognition tag) |
+| `next_owner` | `Some("ooda-observe")` |
+| `participants` | `[author]` (the Overseer's steward login) |
+| `processed` | `false` |
+| `topic` | `"overseer whisper"` |
+
+See the [Meeting Handoff Schema](../reference/meeting-handoff-schema.md) for the full
+struct.
+
+### Ingestion contract (OODA side)
+
+Delivery is only half of the channel; Simard's cycle-start ingest must **fold the
+whisper note into the reasoner-facing Observe context** rather than drop it. This is a
+small additive branch in the OODA handoff ingest (`check_meeting_handoffs` /
+`observe()` in `src/ooda_loop/`):
+
+- A handoff whose `themes` contains `"overseer-whisper"` is a **whisper**, recognised
+  before the generic empty-handoff fast-mark path. (Today, a handoff with empty
+  `decisions` **and** empty `action_items` is fast-marked `processed` and otherwise
+  ignored — which would silently drop a whisper. The whisper branch runs first.)
+- The whisper's note (`open_questions` / `themes`) is appended to the Observe context
+  the reasoners read this cycle — as **advisory context only**.
+- The handoff is then marked `processed: true`. Because it carries **no** `decisions`
+  and **no** `action_items`, it never creates a goal, backlog item, or planned action.
+
+This ordering guarantee is what makes the whisper both *visible to the reasoners* and
+*incapable of fabricating work*. It is asserted by the integration test
+([Verify](../howto/configure-the-simard-whisperer.md#verify)).
+
+### `FakeWhisperSink` (test-only)
+
+```rust
+#[cfg(any(test, feature = "test-utils"))]
+pub struct FakeWhisperSink {
+    /// Every delivered record, in order.
+    pub delivered: RefCell<Vec<WhisperRecord>>,
+    /// When set, `deliver` returns this error instead of capturing (isolation test).
+    pub fail_with: Option<OverseerError>,
+    /// When true, `deliver` panics (panic-isolation test).
+    pub panic_on_deliver: bool,
+}
+```
+
+`FakeWhisperSink` lets tests assert *what* was whispered, *how many times*, and the
+window/cap behaviour without any filesystem or network I/O. An
+`InMemoryWhisperSink` variant that writes to a `tempfile::tempdir()` is used by the
+integration test that proves the note reaches the next OODA cycle through a real
+`handoff-*.json`.
+
+### Note composer and signature
+
+```rust
+/// Compose a concise (1–2 sentence) corrective/additional instruction from the
+/// problem and the observed state. Deterministic; no I/O.
+pub fn compose_whisper_note(problem: &Problem, state: &ObservedState) -> String;
+
+/// Stable dedup signature = hash of (problem kind + goal_id + normalized note).
+/// `normalize` lowercases, trims, and collapses whitespace so trivially-different
+/// renderings of the same whisper collapse to one signature.
+pub fn whisper_signature(kind: ProblemKind, goal_id: Option<&str>, note: &str) -> String;
+```
+
+## `WhisperGate`
+
+Dedup + rate-limit, in the style of `BudgetGate` / `ConflictSequencer`, with an
+injected clock so it is unit-testable with a virtual clock.
+
+```rust
+// src/overseer/guardrails.rs
+pub struct WhisperGate {
+    /// Suppress an identical signature seen within this many seconds. Default 900.
+    window_secs: u64,
+    /// Max whispers admitted per rolling hour across all signatures. Default 5.
+    cap_per_hour: usize,
+    // internal: seen-signature ledger with timestamps; rolling per-hour counter
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WhisperDecision {
+    /// Admit and record the whisper for delivery.
+    Deliver,
+    /// Suppress: identical signature seen within the window.
+    SuppressDuplicate,
+    /// Suppress: the per-hour cap is reached.
+    SuppressCapReached,
+}
+
+impl WhisperGate {
+    pub fn new(window_secs: u64, cap_per_hour: usize) -> Self;
+    /// Defaults: 900 s window, 5/hour cap.
+    pub fn from_env() -> Self;
+    /// Decide whether to admit `signature` at `now_secs`. Records the timestamp on
+    /// `Deliver`. Pure w.r.t. the injected clock — no wall-clock reads.
+    pub fn admit(&mut self, signature: &str, now_secs: u64) -> WhisperDecision;
+}
+```
+
+Both knobs are env-tunable: `SIMARD_OVERSEER_WHISPER_WINDOW_SECS` and
+`SIMARD_OVERSEER_WHISPER_CAP_PER_HOUR` (see [Config](#configuration)).
+
+### Fail-closed identity
+
+The Whisperer reuses the existing `RecursionGuard`. Before any whisper is delivered,
+the Overseer requires a configured steward identity:
+
+```rust
+// unconfigured identity ⇒ refuse; nothing delivered
+if overseer_author_login_is_default_only_and_required_unset() {
+    return Err(OverseerError::Recursion {
+        subject: "unconfigured-identity: whisper".to_string(),
+    });
+}
+```
+
+In practice the whisper path calls `RecursionGuard::admit` with the whisper's author
+subject; an unconfigured guard fails closed exactly as it does for PR/commit/goal
+subjects (see `src/overseer/guardrails.rs`). A refused whisper never calls
+`WhisperSink::deliver`.
+
+## Escalation
+
+Escalation reuses the pre-existing meeting path — `Intervention::TransferGoal` →
+`MeetingHost::transfer_goal` — with **no change** to that capability. The Overseer
+escalates instead of whispering when **either**:
+
+- the same-signature whisper has been admitted **≥ N times** within the window
+  (default **N = 3**, `SIMARD_OVERSEER_WHISPER_ESCALATE_AFTER`) without the condition
+  clearing, **or**
+- the composed whisper's `urgency == WhisperUrgency::High`.
+
+Otherwise the Overseer emits the lightweight whisper. The default path is always the
+whisper.
+
+## `ActOutcome`
+
+```rust
+// src/overseer/mod.rs
+pub enum ActOutcome {
+    // ...existing variants...
+    /// A whisper was delivered onto the inbox; carries the written path.
+    Whispered { path: PathBuf },
+    /// A whisper was suppressed by the WhisperGate (dedup or cap).
+    WhisperSuppressed { reason: &'static str },
+}
+```
+
+`act` dispatches `Intervention::Whisper` through the `WhisperGate` and, when admitted,
+the `WhisperSink`:
+
+```rust
+Intervention::Whisper { note, urgency } => {
+    let rec = /* WhisperRecord: author, signature, ... */;
+    match self.whisper_gate.admit(&rec.signature, now_secs) {
+        WhisperDecision::Deliver => {
+            let path = self.caps.whisper.deliver(&rec)?;
+            Ok(ActOutcome::Whispered { path })
+        }
+        WhisperDecision::SuppressDuplicate =>
+            Ok(ActOutcome::WhisperSuppressed { reason: "duplicate" }),
+        WhisperDecision::SuppressCapReached =>
+            Ok(ActOutcome::WhisperSuppressed { reason: "cap" }),
+    }
+}
+```
+
+## `OverseerTickReport` additions
+
+```rust
+// src/overseer/wiring.rs
+pub struct OverseerTickReport {
+    // ...existing fields...
+    /// Advisory whispers delivered onto Simard's steering inbox this tick.
+    pub whispers: usize,
+    /// Whispers suppressed by the WhisperGate (dedup/cap) this tick.
+    pub whispers_suppressed: usize,
+}
+```
+
+`tally_outcome` increments `whispers` on `ActOutcome::Whispered` and
+`whispers_suppressed` on `ActOutcome::WhisperSuppressed`. The per-tick `tracing::info!`
+event gains `whispers` and `whispers_suppressed` keys alongside the existing counters.
+
+## Operator notification
+
+```rust
+// src/overseer/notify.rs
+impl OperatorNotification {
+    /// Build a whisper notification (kind "whisper"). `note` is the steering text,
+    /// `trigger` names the condition (loop/drift), `urgency` the composed urgency.
+    pub fn whisper(note: &str, trigger: &str, urgency: WhisperUrgency, goal_id: &str) -> Self;
+}
+```
+
+Each **delivered** whisper is surfaced through the mandatory `DualChannelNotifier`
+(`notify(&OperatorNotification)`), so whispers appear on the operator's channels and
+the dashboard. Suppressed whispers are traced but not notified (to avoid channel
+noise); they still increment `whispers_suppressed`.
+
+## Structured tracing
+
+Every whisper emits one event:
+
+```rust
+tracing::info!(
+    target: "overseer::whisper",
+    trigger,                 // "loop_detected" | "drift_correction"
+    note,                    // the composed steering text
+    urgency = ?urgency,      // Low | Normal | High
+    signature,               // dedup signature
+    delivered,               // bool
+    suppressed,              // "" | "duplicate" | "cap"
+    path,                    // written handoff path, when delivered
+    "overseer whisper"
+);
+```
+
+No `println!` / `eprintln!` is added; operator-facing lines continue to use the
+existing `"[simard] ..."` convention only where that convention already lives.
+
+## Configuration
+
+All Whisperer knobs are pure and env-**injectable** (`impl Fn(&str) -> Option<String>`),
+mirroring the existing `config.rs` pattern (no `std::env` mutation in tests).
+
+| Env var | Meaning | Default |
+|---|---|---|
+| `SIMARD_OVERSEER_WHISPER` | Enable/disable the Whisperer (opt-out). | enabled when Overseer enabled |
+| `SIMARD_OVERSEER_WHISPER_WINDOW_SECS` | Dedup window for identical whispers. | `900` |
+| `SIMARD_OVERSEER_WHISPER_CAP_PER_HOUR` | Max whispers per rolling hour. | `5` |
+| `SIMARD_OVERSEER_WHISPER_ESCALATE_AFTER` | Same-signature whispers before escalating to a meeting. | `3` |
+
+```rust
+// src/overseer/config.rs
+pub const SIMARD_OVERSEER_WHISPER_ENV: &str = "SIMARD_OVERSEER_WHISPER";
+
+/// Opt-out gate: enabled unless an explicit falsey value is set, AND only when the
+/// Overseer itself is enabled. Mirrors `overseer_acting_enabled_from`.
+pub fn whisper_enabled_from(lookup: impl Fn(&str) -> Option<String>) -> bool {
+    if !overseer_acting_enabled_from(&lookup) {
+        return false; // whispering only makes sense when the Overseer runs
+    }
+    !matches!(
+        lookup(SIMARD_OVERSEER_WHISPER_ENV).as_deref().map(str::trim),
+        Some(v) if is_falsey(v)
+    )
+}
+
+/// Production entry point: read the real process environment.
+pub fn whisper_enabled() -> bool {
+    whisper_enabled_from(|k| std::env::var(k).ok())
+}
+```
+
+Truthy/falsey recognition reuses the existing `is_truthy` / `is_falsey` helpers, so
+`0`/`false`/`no`/`off` disable and everything else (unset, empty, `1`, `true`, `yes`,
+`on`, or garbage) leaves it enabled — provided the Overseer is enabled.
+
+## Error variants
+
+The Whisperer reuses the existing `OverseerError` enum
+(`src/overseer/capabilities.rs`); no new error type is introduced.
+
+| Variant | When |
+|---|---|
+| `OverseerError::Recursion { subject }` | Whisper refused: unconfigured steward identity (fail-closed), or the subject is the Overseer's own work. |
+| `OverseerError::Capability { what, detail }` | `write_meeting_handoff` failed (e.g. I/O error) while delivering the whisper. |
+
+A whisper never produces `Gated`, `Budget`, or `Conflict` errors: it is `Routine` and
+non-cost-bearing. Suppression is **not** an error — it is an `ActOutcome`, counted and
+traced.
+
+## Test surface
+
+Test-only re-exports from `overseer::whisper_ops`:
+
+```rust
+#[cfg(any(test, feature = "test-utils"))]
+pub use whisper_ops::{FakeWhisperSink, InMemoryWhisperSink};
+```
+
+The Whisperer is fully testable with injected fakes (observed-state, whisper sink,
+clock, identity) and **no network**. See
+[Configure the Simard Whisperer › Verify](../howto/configure-the-simard-whisperer.md#verify)
+for the end-to-end scenarios.
+
+## See also
+
+- Concept: [The Simard Whisperer](../concepts/simard-whisperer.md)
+- How-to: [Configure the Simard Whisperer](../howto/configure-the-simard-whisperer.md)
+- Design: [Overseer — operator/observer co-process](../design/overseer.md)
+- Reference: [Meeting Handoff Schema](../reference/meeting-handoff-schema.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
     - Goal-Fact Dedup in Preparation: concepts/goal-fact-dedup-in-preparation.md
     - Compound-Objective Search in Preparation: concepts/preparation-compound-objective-search.md
     - Goal Stewardship Mode: concepts/stewardship-mode.md
+    - The Simard Whisperer: concepts/simard-whisperer.md
     - Automated Disk-Health Management: concepts/automated-disk-health.md
     - Update-Check Design: concepts/update-check-design.md
     - The amplihack Freshness Gate: concepts/amplihack-freshness-gate.md
@@ -165,6 +166,7 @@ nav:
     - Inspect Improvement Curation State: howto/inspect-improvement-curation-state.md
     - Inspect the Procedural-Learning Loop: howto/inspect-the-procedural-learning-loop.md
     - File Stewardship Issues from Orchestrator Runs: howto/file-stewardship-issues-from-orchestrator-runs.md
+    - Configure the Simard Whisperer: howto/configure-the-simard-whisperer.md
     - Configure the Monthly Self-Quality-Audit: howto/configure-self-quality-audit.md
     - Configure the Disk-Health Check: howto/configure-disk-health-check.md
     - Reclaim Disk Space (Low-Space Rust Builds): howto/reclaim-disk-space-and-run-low-space-rust-builds.md
@@ -239,6 +241,7 @@ nav:
     - Goal Coverage Allocation: reference/goal-coverage-allocation.md
     - spawn_agent_for_goal API: reference/spawn-agent-for-goal.md
     - Stewardship API: reference/stewardship-api.md
+    - Simard Whisperer API: reference/simard-whisperer-api.md
     - Maximum Safe Parallelism: reference/maximum-safe-parallelism.md
     - Concurrent Engineer Dispatch: reference/concurrent-engineer-dispatch.md
     - Engineer Copilot Permissions: reference/engineer-copilot-permissions.md

--- a/src/ooda_loop/curate.rs
+++ b/src/ooda_loop/curate.rs
@@ -365,6 +365,95 @@ pub fn reap_old_handoffs(handoff_dir: &std::path::Path) -> SimardResult<u32> {
     Ok(deleted)
 }
 
+/// Drain unprocessed **Overseer whisper** handoffs from `handoff_dir`, folding
+/// each advisory steering note into the caller's next-cycle context and marking
+/// the handoff processed so it is never re-injected on a later cycle.
+///
+/// This is the OODA-side ingest of the Simard Whisperer: whispers are delivered
+/// (by [`crate::overseer::whisper_ops::MeetingHandoffWhisperSink`]) as advisory
+/// `handoff-*.json` files tagged with
+/// [`crate::overseer::whisper_ops::WHISPER_THEME`] and carrying the note in
+/// `open_questions`. Called at cycle start (Observe/Orient), it returns the notes
+/// in FIFO order so the reasoners see them as ADDITIONAL context — they still
+/// decide; a whisper never becomes a goal (its empty `decisions`/`action_items`
+/// mean the normal [`check_meeting_handoffs`] path could only fast-mark it).
+///
+/// Non-whisper handoffs are left untouched for the normal curate path.
+pub fn drain_overseer_whispers(handoff_dir: &Path) -> SimardResult<Vec<String>> {
+    let whisper_theme = crate::overseer::whisper_ops::WHISPER_THEME;
+    let mut notes: Vec<String> = Vec::new();
+
+    // Collect timestamped handoff files (FIFO by lexicographically-sortable name).
+    let mut files: Vec<std::path::PathBuf> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(handoff_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with("handoff-") && name.ends_with(".json") {
+                files.push(entry.path());
+            }
+        }
+    }
+    files.sort();
+
+    for path in files {
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "drain_overseer_whispers: skipping unreadable handoff"
+                );
+                continue;
+            }
+        };
+        let mut handoff: crate::meeting_facilitator::MeetingHandoff =
+            match serde_json::from_str(&raw) {
+                Ok(h) => h,
+                Err(e) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %e,
+                        "drain_overseer_whispers: skipping malformed handoff JSON"
+                    );
+                    continue;
+                }
+            };
+
+        // Only unprocessed whisper handoffs; leave everything else for curate.
+        if handoff.processed || !handoff.themes.iter().any(|t| t == whisper_theme) {
+            continue;
+        }
+
+        for q in &handoff.open_questions {
+            notes.push(q.text.clone());
+        }
+
+        // Mark processed so the whisper is folded exactly once (never re-injected).
+        handoff.processed = true;
+        let json = serde_json::to_string_pretty(&handoff).map_err(|e| {
+            crate::error::SimardError::ArtifactIo {
+                path: path.clone(),
+                reason: format!("serializing whisper handoff: {e}"),
+            }
+        })?;
+        std::fs::write(&path, &json).map_err(|e| crate::error::SimardError::ArtifactIo {
+            path: path.clone(),
+            reason: format!("writing whisper handoff: {e}"),
+        })?;
+
+        tracing::info!(
+            target: "overseer::whisper",
+            path = %path.display(),
+            notes = handoff.open_questions.len(),
+            "OODA folded an overseer whisper into the next cycle's context"
+        );
+    }
+
+    Ok(notes)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -58,8 +58,8 @@ mod tests_pr_c_procedures;
 // Re-export all public items so `crate::ooda_loop::X` still works.
 pub use bridge_factory::{bridges_from_state_root, connect_memory};
 pub use curate::{
-    check_meeting_handoffs, load_tombstones, promote_from_backlog, reap_old_handoffs,
-    tombstone_goals,
+    check_meeting_handoffs, drain_overseer_whispers, load_tombstones, promote_from_backlog,
+    reap_old_handoffs, tombstone_goals,
 };
 pub use decide::{decide, decide_with_brain};
 pub use observe::{gather_environment, observe};

--- a/src/overseer/capabilities.rs
+++ b/src/overseer/capabilities.rs
@@ -86,6 +86,16 @@ pub struct ObservedState {
     pub ready_prs: Vec<PrRef>,
     /// CI-failure clusters observed across recent runs.
     pub ci_failures: Vec<CiFailure>,
+    /// Consecutive OODA cycles the active goal has produced no action / no
+    /// progress. Mirrors the OODA no-progress tracker; drives the loop-whisper.
+    /// `None` when unknown (e.g. no active goal).
+    pub consecutive_no_action: Option<u32>,
+    /// The goal Simard is currently working, if any — the subject a whisper
+    /// steers. `None` when idle.
+    pub active_goal_id: Option<String>,
+    /// A short description of observed drift from the active goal's intent, when
+    /// the Overseer can see it. `None` when no drift is observed.
+    pub drift_detail: Option<String>,
 }
 
 /// A `(repo, pr)` pair. `repo` is an `owner/name` slug.

--- a/src/overseer/config.rs
+++ b/src/overseer/config.rs
@@ -28,6 +28,13 @@ pub const DAILY_BUDGET_ENV: &str = "SIMARD_DAILY_BUDGET_USD";
 /// self-tuning (M4) can never drive the observer into a hot loop.
 pub const OVERSEER_INTERVAL_ENV: &str = "SIMARD_OVERSEER_INTERVAL_SECS";
 
+/// Opt-out flag for the **Simard Whisperer**. The Overseer's lightweight
+/// steering channel is ON by default whenever the acting Overseer runs; an
+/// explicit falsey value (`0`/`false`/`no`/`off`) disables it. Whispering only
+/// makes sense while the Overseer runs, so a disabled Overseer forces the
+/// whisperer off regardless of this flag.
+pub const SIMARD_OVERSEER_WHISPER_ENV: &str = "SIMARD_OVERSEER_WHISPER";
+
 /// GitHub login the acting Overseer authors its own workstreams under. Sourced
 /// here so the daemon and the merge/recursion path agree on ONE stable, DISTINCT
 /// identity (never the human operator's login). Defaults to
@@ -86,6 +93,28 @@ pub fn overseer_acting_enabled_from(lookup: impl Fn(&str) -> Option<String>) -> 
 /// Production entry point: read the real process environment.
 pub fn overseer_acting_enabled() -> bool {
     overseer_acting_enabled_from(|k| std::env::var(k).ok())
+}
+
+/// Resolve whether the **Simard Whisperer** is enabled, with **default ON**
+/// opt-out semantics consistent with the acting Overseer. The whisperer is
+/// enabled UNLESS [`SIMARD_OVERSEER_WHISPER_ENV`] is an explicit falsey value —
+/// AND only while the acting Overseer itself is enabled (an explicitly-disabled
+/// Overseer forces the whisperer off regardless of the whisper flag).
+pub fn whisper_enabled_from(lookup: impl Fn(&str) -> Option<String>) -> bool {
+    // No Overseer ⇒ no whisperer.
+    if !overseer_acting_enabled_from(&lookup) {
+        return false;
+    }
+    // Opt-out: enabled unless an explicit falsey value is set.
+    !matches!(
+        lookup(SIMARD_OVERSEER_WHISPER_ENV).as_deref().map(str::trim),
+        Some(v) if is_falsey(v)
+    )
+}
+
+/// Production entry point: read the real process environment.
+pub fn whisper_enabled() -> bool {
+    whisper_enabled_from(|k| std::env::var(k).ok())
 }
 
 /// Resolve the Overseer's DISTINCT author login. Falls back to

--- a/src/overseer/guardrails.rs
+++ b/src/overseer/guardrails.rs
@@ -42,6 +42,10 @@ pub fn classify(iv: &Intervention) -> RiskClass {
         Intervention::Escalate { .. } => RiskClass::HighRisk,
         // Merge authority is opt-in until proven (crusty risk #1).
         Intervention::VerifyAndMergePr { .. } => RiskClass::MergeAuthority,
+        // A whisper takes NO action on Simard's behalf and spends no budget — it
+        // is advisory context only. Routine; its own dedup/identity gates
+        // ([`WhisperGate`] / [`RecursionGuard`]) apply in the act path.
+        Intervention::Whisper { .. } => RiskClass::Routine,
         _ => RiskClass::Routine,
     }
 }
@@ -245,6 +249,84 @@ impl ConflictSequencer {
     /// Release a sequence group when its sweep completes.
     pub fn release(&mut self, group: &str) {
         self.active_groups.retain(|a| a != group);
+    }
+}
+
+/// A whisper gate's decision: deliver the whisper, or suppress it as a duplicate
+/// (same signature within the dedup window) or because the per-hour cap is spent.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WhisperDecision {
+    Deliver,
+    SuppressDuplicate,
+    SuppressCapReached,
+}
+
+/// Dedup + rate-limit gate for whispers (mirrors the [`BudgetGate`] /
+/// [`ConflictSequencer`] guardrail style). Two limits, both on an INJECTED clock
+/// (`now_secs`) so the daemon uses wall-clock while tests drive a virtual clock:
+///
+/// 1. **Dedup window** — the same whisper signature is suppressed while it is
+///    within `window_secs` of its last delivery, so a persistent condition is
+///    not re-injected every cycle.
+/// 2. **Per-hour cap** — at most `cap_per_hour` whispers are delivered within any
+///    rolling hour, so a noisy Overseer cannot flood Simard's inbox.
+///
+/// Only DELIVERED whispers count toward either limit; a suppressed whisper is
+/// never recorded. [`admit`](WhisperGate::admit) is the combined decide+commit
+/// used in unit tests; the act path peeks then commits only on a successful
+/// delivery so a failed/panicking sink does not consume the dedup slot.
+#[derive(Clone, Debug)]
+pub struct WhisperGate {
+    window_secs: i64,
+    cap_per_hour: usize,
+    last_delivered: std::collections::HashMap<String, i64>,
+    deliveries: Vec<i64>,
+}
+
+impl WhisperGate {
+    /// A gate with a `window_secs` dedup window and a `cap_per_hour` rolling-hour
+    /// delivery cap.
+    pub fn new(window_secs: i64, cap_per_hour: usize) -> Self {
+        Self {
+            window_secs,
+            cap_per_hour,
+            last_delivered: std::collections::HashMap::new(),
+            deliveries: Vec::new(),
+        }
+    }
+
+    /// Decide WITHOUT recording — the act path uses this so it can commit only
+    /// after a successful delivery.
+    pub fn peek(&self, signature: &str, now_secs: i64) -> WhisperDecision {
+        if let Some(&last) = self.last_delivered.get(signature)
+            && now_secs - last < self.window_secs
+        {
+            return WhisperDecision::SuppressDuplicate;
+        }
+        let hour_ago = now_secs - 3600;
+        let recent = self.deliveries.iter().filter(|&&t| t > hour_ago).count();
+        if recent >= self.cap_per_hour {
+            return WhisperDecision::SuppressCapReached;
+        }
+        WhisperDecision::Deliver
+    }
+
+    /// Record a successful delivery of `signature` at `now_secs` (updates the
+    /// dedup window and the rolling-hour budget, pruning stale entries).
+    pub fn commit(&mut self, signature: &str, now_secs: i64) {
+        self.last_delivered.insert(signature.to_string(), now_secs);
+        self.deliveries.push(now_secs);
+        let hour_ago = now_secs - 3600;
+        self.deliveries.retain(|&t| t > hour_ago);
+    }
+
+    /// Decide and, on `Deliver`, record the delivery in one call.
+    pub fn admit(&mut self, signature: &str, now_secs: i64) -> WhisperDecision {
+        let decision = self.peek(signature, now_secs);
+        if decision == WhisperDecision::Deliver {
+            self.commit(signature, now_secs);
+        }
+        decision
     }
 }
 

--- a/src/overseer/intervention.rs
+++ b/src/overseer/intervention.rs
@@ -4,6 +4,7 @@
 //! variants are gated by `guardrails::classify`.
 
 use crate::overseer::capabilities::{AuditScope, GoalBrief, OrchestratorRunBrief, RecipeBrief};
+use crate::overseer::whisper_ops::WhisperUrgency;
 
 /// A single action the Overseer can take. Each variant names the capability it
 /// dispatches through; see the trait doc comments for the exact reused function.
@@ -36,6 +37,15 @@ pub enum Intervention {
     RunAudit { scope: AuditScope },
     /// Surface a HIGH-RISK or low-confidence decision to the human operator.
     Escalate { reason: String },
+    /// Inject a lightweight ADVISORY steering note ("whisper") into Simard's OODA
+    /// loop — additional/corrective context she picks up at the start of her next
+    /// cycle, WITHOUT the Overseer taking the action for her. Delivered onto the
+    /// existing meeting-handoff inbox as an advisory (non-promoting) handoff.
+    /// Capability: `whisper_ops::WhisperSink`.
+    Whisper {
+        note: String,
+        urgency: WhisperUrgency,
+    },
 }
 
 impl Intervention {
@@ -51,6 +61,7 @@ impl Intervention {
             Self::Report => "report",
             Self::RunAudit { .. } => "run_audit",
             Self::Escalate { .. } => "escalate",
+            Self::Whisper { .. } => "whisper",
         }
     }
 }

--- a/src/overseer/mod.rs
+++ b/src/overseer/mod.rs
@@ -61,12 +61,15 @@ pub mod pr_verify;
 pub mod sensor;
 pub mod signal;
 pub mod tuning;
+pub mod whisper_ops;
 pub mod wiring;
 
 #[cfg(test)]
 mod tests_m1;
 #[cfg(test)]
 mod tests_m2;
+#[cfg(test)]
+mod tests_whisper;
 
 pub use capabilities::{
     Auditor, Deployer, GoalCurator, IssueFiler, MeetingHost, ObservedState, OrchestratorRunBrief,
@@ -76,7 +79,8 @@ pub use config::{
     daily_budget_usd, overseer_acting_enabled, overseer_author_login, overseer_enabled,
 };
 pub use guardrails::{
-    AutonomyGate, BudgetGate, ConflictSequencer, RecursionGuard, RiskClass, Subject, classify,
+    AutonomyGate, BudgetGate, ConflictSequencer, RecursionGuard, RiskClass, Subject,
+    WhisperDecision, WhisperGate, classify,
 };
 pub use intervention::{Intervention, PlannedIntervention};
 pub use observer::{StewardshipIssueFiler, decide_read_only, is_m1_permitted};
@@ -85,13 +89,19 @@ pub use sensor::{
     in_flight_from_board, observed_from_snapshot, run_observer_cycle,
 };
 pub use signal::{Priority, Problem, ProblemKind, Signal, signals_from};
+pub use whisper_ops::{
+    MeetingHandoffWhisperSink, WhisperRecord, WhisperSink, WhisperUrgency, compose_whisper_note,
+    note_signature, whisper_signature,
+};
 pub use wiring::{
     BoardGoalCurator, OverseerCadence, OverseerTickReport, RefuseDeployer, assemble_capabilities,
     build_overseer, overseer_identity, overseer_tick, overseer_tick_interval_secs,
     run_overseer_tick_isolated,
 };
 
+use crate::goal_curation::no_progress_breaker::NO_PROGRESS_BREAKER_THRESHOLD;
 use capabilities::{DeployReport, GoalBrief, InFlightItem, IssueOutcome, WorkstreamHandle};
+use std::path::PathBuf;
 
 /// The capability handles the Overseer acts through — one per reused Simard
 /// subsystem. Grouping them keeps the `Overseer` constructor to a single
@@ -118,6 +128,14 @@ pub struct Overseer {
     /// Cap on how many cost-bearing launches one cycle may plan (concurrency
     /// bound layered on top of the AIMD engineer cap the launcher already obeys).
     max_launches_per_cycle: usize,
+    /// The Simard Whisperer's delivery seam (advisory steering notes onto the
+    /// meeting-handoff inbox). `None` until wired; whispers require it.
+    whisper_sink: Option<Box<dyn WhisperSink>>,
+    /// Dedup + rate-limit gate for whispers (shared across ticks).
+    whisper_gate: WhisperGate,
+    /// Whether the whisperer is enabled (config opt-out). When off, whispers are
+    /// held (never delivered) even if the observed condition holds.
+    whisper_enabled: bool,
 }
 
 /// The result of one meta-OODA turn. Side-effect free: it reports what was
@@ -143,6 +161,16 @@ pub enum ActOutcome {
     Reported,
     Audited,
     Escalated,
+    /// A lightweight advisory whisper was delivered into Simard's OODA inbox.
+    Whispered {
+        path: PathBuf,
+        signature: String,
+    },
+    /// A whisper was suppressed by the [`WhisperGate`] (duplicate within the
+    /// dedup window, or the per-hour cap was reached) — not re-injected.
+    WhisperSuppressed {
+        reason: &'static str,
+    },
 }
 
 impl Overseer {
@@ -155,7 +183,24 @@ impl Overseer {
             budget: BudgetGate::default(),
             sequencer: ConflictSequencer::default(),
             max_launches_per_cycle: 2,
+            whisper_sink: None,
+            // 15-minute dedup window; at most 5 whispers per rolling hour.
+            whisper_gate: WhisperGate::new(900, 5),
+            whisper_enabled: false,
         }
+    }
+
+    /// Wire the Simard Whisperer's delivery seam (advisory steering notes).
+    pub fn with_whisper_sink(mut self, sink: Box<dyn WhisperSink>) -> Self {
+        self.whisper_sink = Some(sink);
+        self
+    }
+
+    /// Enable/disable the whisperer (config opt-out). Off by default; the daemon
+    /// sets this from [`config::whisper_enabled`].
+    pub fn with_whisper_enabled(mut self, enabled: bool) -> Self {
+        self.whisper_enabled = enabled;
+        self
     }
 
     /// Opt into autonomous HIGH-RISK execution (deploy / conflict-resolution).
@@ -216,6 +261,16 @@ impl Overseer {
         observed: &ObservedState,
         launches: &mut usize,
     ) -> PlannedIntervention {
+        // Whisper opt-out: when the whisperer is disabled, hold the whisper (it
+        // is never delivered) even though the observed condition holds.
+        if matches!(iv, Intervention::Whisper { .. }) && !self.whisper_enabled {
+            return PlannedIntervention {
+                intervention: iv.clone(),
+                admitted: false,
+                note: "held: whisper disabled (SIMARD_OVERSEER_WHISPER)".to_string(),
+            };
+        }
+
         // Autonomy: HIGH-RISK requires opt-in, else it is escalated (held).
         if let Err(e) = self.autonomy.admit(iv) {
             return PlannedIntervention {
@@ -300,8 +355,106 @@ impl Overseer {
                 Ok(ActOutcome::Audited)
             }
             Intervention::Escalate { .. } => Ok(ActOutcome::Escalated),
+            Intervention::Whisper { note, urgency } => self.act_whisper(note, *urgency),
         }
     }
+
+    /// Deliver an advisory whisper: fail CLOSED without a distinct steward
+    /// identity (anti-recursion — the Overseer must never whisper without a
+    /// configured DISTINCT identity, and never about its own whisper), dedup +
+    /// rate-limit via the [`WhisperGate`], then deliver through the sink. The
+    /// dedup slot is consumed only on a SUCCESSFUL delivery, so a failed or
+    /// panicking sink never silently swallows a future whisper.
+    fn act_whisper(
+        &mut self,
+        note: &str,
+        urgency: WhisperUrgency,
+    ) -> Result<ActOutcome, OverseerError> {
+        // Fail closed: a whisper requires the Overseer's DISTINCT steward
+        // identity (RecursionGuard). An unconfigured guard REFUSES the whisper.
+        if !self.recursion.is_configured() {
+            return Err(OverseerError::Recursion {
+                subject: format!("whisper (unconfigured steward identity): {note}"),
+            });
+        }
+
+        let signature = note_signature(note);
+        let now = now_secs();
+        match self.whisper_gate.peek(&signature, now) {
+            WhisperDecision::Deliver => {
+                let sink = self
+                    .whisper_sink
+                    .as_ref()
+                    .ok_or(OverseerError::Capability {
+                        what: "whisper.sink",
+                        detail: "no whisper sink configured".to_string(),
+                    })?;
+                let rec = WhisperRecord {
+                    note: note.to_string(),
+                    urgency,
+                    // The originating problem is not carried on the intervention;
+                    // the note itself encodes the goal + trigger. Kept generic
+                    // here — the delivered note carries the specifics.
+                    problem: ProblemKind::LoopDetected,
+                    goal_id: None,
+                    author: self.recursion.author_login.clone(),
+                    signature: signature.clone(),
+                };
+                let path = sink.deliver(&rec)?;
+                // Consume the dedup slot only after a successful delivery.
+                self.whisper_gate.commit(&signature, now);
+                tracing::info!(
+                    target: "overseer::whisper",
+                    trigger = "overseer-decide",
+                    note = %note,
+                    urgency = urgency.label(),
+                    delivered = true,
+                    signature = %signature,
+                    path = %path.display(),
+                    "overseer delivered an advisory whisper into Simard's OODA inbox"
+                );
+                Ok(ActOutcome::Whispered { path, signature })
+            }
+            WhisperDecision::SuppressDuplicate => {
+                tracing::debug!(
+                    target: "overseer::whisper",
+                    note = %note,
+                    urgency = urgency.label(),
+                    delivered = false,
+                    signature = %signature,
+                    reason = "duplicate",
+                    "overseer suppressed a duplicate whisper within the dedup window"
+                );
+                Ok(ActOutcome::WhisperSuppressed {
+                    reason: "duplicate",
+                })
+            }
+            WhisperDecision::SuppressCapReached => {
+                tracing::debug!(
+                    target: "overseer::whisper",
+                    note = %note,
+                    urgency = urgency.label(),
+                    delivered = false,
+                    signature = %signature,
+                    reason = "cap_reached",
+                    "overseer suppressed a whisper: per-hour cap reached"
+                );
+                Ok(ActOutcome::WhisperSuppressed {
+                    reason: "cap_reached",
+                })
+            }
+        }
+    }
+}
+
+/// Current wall-clock time in whole seconds since the Unix epoch, for the
+/// whisper dedup/rate-limit clock. Monotonic enough for windowing; tests drive
+/// the [`WhisperGate`] directly with a virtual clock.
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
 }
 
 /// True for interventions that spend LLM budget / spawn work.
@@ -415,6 +568,21 @@ fn classify_signal(s: &Signal) -> (ProblemKind, Priority, String, String) {
             format!("anomaly:{detail}"),
             format!("telemetry anomaly: {detail}"),
         ),
+        Signal::LoopDetected {
+            goal_id,
+            consecutive_no_action,
+        } => (
+            ProblemKind::LoopDetected,
+            Priority::High,
+            format!("loop:{goal_id}"),
+            format!("goal {goal_id} looping — no progress for {consecutive_no_action} cycles"),
+        ),
+        Signal::DriftCorrection { goal_id, detail } => (
+            ProblemKind::DriftCorrection,
+            Priority::Normal,
+            format!("drift:{goal_id}"),
+            format!("goal {goal_id} drifting from intent: {detail}"),
+        ),
     }
 }
 
@@ -475,6 +643,44 @@ pub fn decide(problem: &Problem) -> Intervention {
                 priority: 3,
                 target_repo: "rysweet/Simard".to_string(),
             },
+        },
+        // A looping goal is steered with a LIGHTWEIGHT whisper by default. Only
+        // once the loop reaches Simard's no-progress breaker threshold (the
+        // whisper was insufficient) does the Overseer escalate to a full meeting
+        // via the existing MeetingHost/TransferGoal path.
+        ProblemKind::LoopDetected => {
+            let consecutive = problem.evidence.iter().find_map(|s| match s {
+                Signal::LoopDetected {
+                    consecutive_no_action,
+                    ..
+                } => Some(*consecutive_no_action),
+                _ => None,
+            });
+            let acute = consecutive
+                .map(|n| n >= NO_PROGRESS_BREAKER_THRESHOLD)
+                .unwrap_or(false);
+            if acute {
+                Intervention::TransferGoal {
+                    goal: GoalBrief {
+                        title: problem.summary.clone(),
+                        rationale: "repeated no-progress loop — a lightweight whisper was \
+                                    insufficient; escalate to a meeting with Simard"
+                            .to_string(),
+                        priority: 2,
+                        target_repo: "rysweet/Simard".to_string(),
+                    },
+                }
+            } else {
+                Intervention::Whisper {
+                    note: compose_whisper_note(problem, &ObservedState::default()),
+                    urgency: WhisperUrgency::Normal,
+                }
+            }
+        }
+        // Drift is always steered with an advisory whisper.
+        ProblemKind::DriftCorrection => Intervention::Whisper {
+            note: compose_whisper_note(problem, &ObservedState::default()),
+            urgency: WhisperUrgency::Normal,
         },
     }
 }

--- a/src/overseer/notify.rs
+++ b/src/overseer/notify.rs
@@ -24,6 +24,7 @@
 use std::sync::Mutex;
 
 use crate::conversation_channel::{ConversationChannel, OutKind, Outbound};
+use crate::overseer::whisper_ops::WhisperUrgency;
 
 // ─────────────────────────── notification content ──────────────────────────
 
@@ -119,6 +120,24 @@ impl OperatorNotification {
             problem: format!("Deployed {commit} (previous {previous}); {gate_summary}"),
             link: None,
             repo: repo.to_string(),
+            autonomous: true,
+        }
+    }
+
+    /// Build a whisper notification: surfaces an advisory steering note the
+    /// Overseer injected into Simard's loop so whispers are TRANSPARENT to the
+    /// operator (never a hidden side-channel). `trigger` is the observed problem
+    /// (e.g. `"loop_detected"`); `goal_id` is the goal being steered.
+    pub fn whisper(note: &str, trigger: &str, urgency: WhisperUrgency, goal_id: &str) -> Self {
+        Self {
+            kind: "whisper",
+            headline: format!(
+                "steering goal {goal_id} ({trigger}, {} urgency)",
+                urgency.label()
+            ),
+            problem: note.to_string(),
+            link: None,
+            repo: "rysweet/Simard".to_string(),
             autonomous: true,
         }
     }

--- a/src/overseer/observer.rs
+++ b/src/overseer/observer.rs
@@ -134,8 +134,13 @@ pub fn decide_read_only(problem: &Problem) -> Intervention {
         },
         // Transient resource pressure / positive delivery signals — report, do
         // not file. Filing per-cycle issues for e.g. momentary budget pressure
-        // would be noise; the value is in the rolled-up Report.
-        ProblemKind::ResourcePressure | ProblemKind::DeliveryReady => Intervention::Report,
+        // would be noise; the value is in the rolled-up Report. Loop/drift
+        // conditions are advisory: the read-only sensor surfaces them in the
+        // Report (the acting Overseer whispers; M1 does not).
+        ProblemKind::ResourcePressure
+        | ProblemKind::DeliveryReady
+        | ProblemKind::LoopDetected
+        | ProblemKind::DriftCorrection => Intervention::Report,
     }
 }
 
@@ -178,6 +183,8 @@ fn kind_step_label(kind: ProblemKind) -> &'static str {
         ProblemKind::QualityRegression => "quality_regression",
         ProblemKind::GoalHygiene => "goal_hygiene",
         ProblemKind::CrossCutting => "cross_cutting",
+        ProblemKind::LoopDetected => "loop_detected",
+        ProblemKind::DriftCorrection => "drift_correction",
     }
 }
 
@@ -224,6 +231,8 @@ fn signal_kind_label(s: &Signal) -> &'static str {
         Signal::PrReadyToMerge { .. } => "PrReadyToMerge",
         Signal::StaleGoal { .. } => "StaleGoal",
         Signal::Anomaly { .. } => "Anomaly",
+        Signal::LoopDetected { .. } => "LoopDetected",
+        Signal::DriftCorrection { .. } => "DriftCorrection",
     }
 }
 

--- a/src/overseer/sensor.rs
+++ b/src/overseer/sensor.rs
@@ -121,6 +121,14 @@ pub fn observed_from_snapshot(snap: &StatusSnapshot) -> ObservedState {
         anomalies: telemetry.map(|t| t.anomalies.clone()).unwrap_or_default(),
         ready_prs: Vec::new(),
         ci_failures: Vec::new(),
+        // Loop/drift are surfaced from the OODA no-progress tracker, which the
+        // read-only status snapshot does not yet expose. Left `None` here so the
+        // adapter stays additive; a follow-up enriches this from the goal board's
+        // progress state to activate production whispers (the daemon is not
+        // redeployed by this change).
+        consecutive_no_action: None,
+        active_goal_id: None,
+        drift_detail: None,
     }
 }
 

--- a/src/overseer/signal.rs
+++ b/src/overseer/signal.rs
@@ -32,6 +32,17 @@ pub enum Signal {
     StaleGoal { goal_id: String },
     /// A free-form anomaly surfaced by `TelemetrySignals.anomalies[]`.
     Anomaly { detail: String },
+    /// A live goal has gone `consecutive_no_action` cycles without progress —
+    /// the primary lightweight-whisper trigger. Fires strictly BELOW Simard's
+    /// no-progress breaker so the Overseer can nudge before the hard breaker
+    /// trips. From `ObservedState.{consecutive_no_action, active_goal_id}`.
+    LoopDetected {
+        goal_id: String,
+        consecutive_no_action: u32,
+    },
+    /// Active work appears to be drifting from a goal's stated intent. From
+    /// `ObservedState.{drift_detail, active_goal_id}`.
+    DriftCorrection { goal_id: String, detail: String },
 }
 
 /// Coarse relative importance. `Ord` sorts ascending so `Critical` comes first,
@@ -59,6 +70,10 @@ pub enum ProblemKind {
     GoalHygiene,
     /// Naming/architecture sweeps, terminology cleanups, cross-repo initiatives.
     CrossCutting,
+    /// A live goal looping without progress — steered by a lightweight whisper.
+    LoopDetected,
+    /// Active work drifting from a goal's intent — nudged by an advisory whisper.
+    DriftCorrection,
 }
 
 /// A classified, deduplicated, prioritised problem — the output of Orient and the
@@ -82,6 +97,12 @@ const DISTILL_FAIL_PCT_THRESHOLD: f64 = 20.0;
 const RESTART_CHURN_THRESHOLD: u64 = 3;
 const BUDGET_PRESSURE_FRACTION: f64 = 0.8;
 const ENGINEER_SPAWN_THRESHOLD: u32 = 8;
+
+/// Consecutive no-action cycles at (or above) which the Overseer whispers a
+/// loop-correction. Deliberately BELOW
+/// [`crate::goal_curation::no_progress_breaker::NO_PROGRESS_BREAKER_THRESHOLD`]
+/// so the lightweight whisper nudges Simard before the hard breaker escalates.
+pub const WHISPER_LOOP_THRESHOLD: u32 = 2;
 
 /// Pure Observe→Signal derivation. No I/O; unit-testable with a hand-built
 /// `ObservedState`. Real thresholds would be env-tunable.
@@ -134,6 +155,26 @@ pub fn signals_from(state: &ObservedState) -> Vec<Signal> {
     }
     for detail in &state.anomalies {
         out.push(Signal::Anomaly {
+            detail: detail.clone(),
+        });
+    }
+
+    // A live goal looping without progress: whisper trigger. Requires an active
+    // goal (idle churn with no goal is not a goal loop to steer).
+    if let (Some(n), Some(goal_id)) = (state.consecutive_no_action, state.active_goal_id.as_ref())
+        && n >= WHISPER_LOOP_THRESHOLD
+    {
+        out.push(Signal::LoopDetected {
+            goal_id: goal_id.clone(),
+            consecutive_no_action: n,
+        });
+    }
+    // Active work drifting from a goal's intent: advisory whisper trigger.
+    if let (Some(detail), Some(goal_id)) =
+        (state.drift_detail.as_ref(), state.active_goal_id.as_ref())
+    {
+        out.push(Signal::DriftCorrection {
+            goal_id: goal_id.clone(),
             detail: detail.clone(),
         });
     }

--- a/src/overseer/tests_whisper.rs
+++ b/src/overseer/tests_whisper.rs
@@ -1,0 +1,914 @@
+//! TDD tests (written FIRST) for the **Simard Whisperer** — the Overseer's
+//! lightweight steering channel (issue #2605).
+//!
+//! These tests specify the *contract* for a feature that does not yet exist;
+//! they are the red half of the TDD cycle and pin down the public surface the
+//! implementation must provide:
+//!
+//! - `overseer::whisper_ops`: [`WhisperUrgency`], [`WhisperRecord`],
+//!   [`WhisperSink`], [`MeetingHandoffWhisperSink`], [`compose_whisper_note`],
+//!   [`whisper_signature`].
+//! - `Intervention::Whisper { note, urgency }` + `label()` + `classify` = Routine.
+//! - `ProblemKind::{LoopDetected, DriftCorrection}` + matching `Signal`s and
+//!   `signals_from` arms (loop threshold 2, strictly below the no-progress
+//!   breaker threshold 3).
+//! - `ObservedState.{consecutive_no_action, active_goal_id, drift_detail}`.
+//! - `guardrails::{WhisperGate, WhisperDecision}` (dedup window + per-hour cap,
+//!   injected clock).
+//! - `config::{whisper_enabled_from, SIMARD_OVERSEER_WHISPER_ENV}` (opt-out gate,
+//!   off whenever the Overseer itself is off).
+//! - `Overseer::{with_whisper_sink, with_whisper_enabled}`, `act(Whisper)`,
+//!   `ActOutcome::{Whispered, WhisperSuppressed}`, and `OverseerTickReport
+//!   .{whispers, whispers_suppressed}`.
+//! - `notify::OperatorNotification::whisper(...)`.
+//! - OODA ingest: `ooda_loop::drain_overseer_whispers` folds the note into
+//!   Simard's next-cycle context and marks the handoff processed; a whisper is
+//!   never turned into a goal by `check_meeting_handoffs` (advisory only).
+//!
+//! Everything is exercised with injected fakes (observed-state, whisper sink,
+//! clock, identity) and a `tempfile` inbox — no network, no `~/.simard`.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use crate::goal_curation::GoalBoard;
+use crate::goal_curation::no_progress_breaker::NO_PROGRESS_BREAKER_THRESHOLD;
+use crate::meeting_facilitator::load_meeting_handoff;
+
+use crate::overseer::capabilities::{
+    AuditReport, AuditScope, Auditor, DeployReport, Deployer, GoalBrief, GoalCurator, InFlightItem,
+    IssueOutcome, MeetingHost, ObservedState, OrchestratorRunBrief, OverseerError, PrOps,
+    RecipeBrief, RecipeLauncher, StatusReader, VerifyReport, WorkstreamHandle, WorkstreamStatus,
+};
+use crate::overseer::config::{
+    SIMARD_OVERSEER_WHISPER_ENV, overseer_author_login, whisper_enabled_from,
+};
+use crate::overseer::guardrails::{
+    AutonomyGate, RiskClass, WhisperDecision, WhisperGate, classify,
+};
+use crate::overseer::intervention::Intervention;
+use crate::overseer::notify::{
+    ChannelDelivery, DualChannelNotifier, NotifyChannel, OperatorNotification,
+};
+use crate::overseer::signal::{
+    Priority, Problem, ProblemKind, Signal, WHISPER_LOOP_THRESHOLD, signals_from,
+};
+use crate::overseer::whisper_ops::{
+    MeetingHandoffWhisperSink, WhisperRecord, WhisperSink, WhisperUrgency, compose_whisper_note,
+    whisper_signature,
+};
+use crate::overseer::wiring::{overseer_identity, overseer_tick, run_overseer_tick_isolated};
+use crate::overseer::{ActOutcome, Capabilities, Overseer, decide};
+
+// ─────────────────────────── capability fakes ──────────────────────────────
+
+struct FakeStatus(ObservedState);
+impl StatusReader for FakeStatus {
+    fn snapshot(&self) -> Result<ObservedState, OverseerError> {
+        Ok(self.0.clone())
+    }
+}
+
+struct FakeRecipes;
+impl RecipeLauncher for FakeRecipes {
+    fn launch(&self, _b: &RecipeBrief) -> Result<WorkstreamHandle, OverseerError> {
+        Ok(WorkstreamHandle {
+            id: "ws-1".to_string(),
+        })
+    }
+    fn poll(&self, _h: &WorkstreamHandle) -> Result<WorkstreamStatus, OverseerError> {
+        Ok(WorkstreamStatus::Running)
+    }
+}
+
+struct FakePrs;
+impl PrOps for FakePrs {
+    fn verify(&self, _r: &str, _p: u32) -> Result<VerifyReport, OverseerError> {
+        Ok(VerifyReport {
+            ready: false,
+            checks: vec![],
+        })
+    }
+    fn merge(&self, _r: &str, _p: u32) -> Result<(), OverseerError> {
+        Ok(())
+    }
+    fn resolve_conflict(&self, _r: &str, _p: u32) -> Result<(), OverseerError> {
+        Ok(())
+    }
+}
+
+struct FakeDeployer;
+impl Deployer for FakeDeployer {
+    fn deploy(&self, commit: &str) -> Result<DeployReport, OverseerError> {
+        Ok(DeployReport {
+            deployed_commit: commit.to_string(),
+            gates_passed: true,
+        })
+    }
+    fn deployed_commit(&self) -> Result<String, OverseerError> {
+        Ok("deadbeef".to_string())
+    }
+}
+
+struct FakeIssues;
+impl crate::overseer::capabilities::IssueFiler for FakeIssues {
+    fn file(&self, _run: &OrchestratorRunBrief) -> Result<IssueOutcome, OverseerError> {
+        Ok(IssueOutcome::FiledNew {
+            url: "https://example/issues/1".to_string(),
+        })
+    }
+}
+
+struct FakeGoals(Vec<InFlightItem>);
+impl GoalCurator for FakeGoals {
+    fn propose(&self, _g: &GoalBrief) -> Result<(), OverseerError> {
+        Ok(())
+    }
+    fn in_flight(&self) -> Result<Vec<InFlightItem>, OverseerError> {
+        Ok(self.0.clone())
+    }
+}
+
+struct FakeAuditor;
+impl Auditor for FakeAuditor {
+    fn run_audit(&self, scope: &AuditScope) -> Result<AuditReport, OverseerError> {
+        Ok(AuditReport {
+            scope: scope.clone(),
+            passed: true,
+            findings: vec![],
+        })
+    }
+}
+
+/// Records every goal handed to the meeting host so escalation is observable
+/// without a REPL or filesystem — the shared log is returned alongside so a test
+/// can inspect it after the recorder is boxed into the Overseer.
+struct RecordingMeetings {
+    log: Arc<Mutex<Vec<GoalBrief>>>,
+}
+impl RecordingMeetings {
+    fn new() -> (Self, Arc<Mutex<Vec<GoalBrief>>>) {
+        let log: Arc<Mutex<Vec<GoalBrief>>> = Arc::new(Mutex::new(vec![]));
+        (Self { log: log.clone() }, log)
+    }
+}
+impl MeetingHost for RecordingMeetings {
+    fn transfer_goal(&self, g: &GoalBrief) -> Result<(), OverseerError> {
+        self.log.lock().unwrap().push(g.clone());
+        Ok(())
+    }
+}
+
+/// Captures delivered whisper records; can be told to fail or panic so the
+/// panic-isolated tick can be proven to survive a bad whisper capability.
+struct RecordingWhisperSink {
+    log: Arc<Mutex<Vec<WhisperRecord>>>,
+    fail: bool,
+    panic: bool,
+}
+impl RecordingWhisperSink {
+    fn new() -> (Self, Arc<Mutex<Vec<WhisperRecord>>>) {
+        let log: Arc<Mutex<Vec<WhisperRecord>>> = Arc::new(Mutex::new(vec![]));
+        (
+            Self {
+                log: log.clone(),
+                fail: false,
+                panic: false,
+            },
+            log,
+        )
+    }
+    fn failing() -> Self {
+        Self {
+            log: Arc::new(Mutex::new(vec![])),
+            fail: true,
+            panic: false,
+        }
+    }
+    fn panicking() -> Self {
+        Self {
+            log: Arc::new(Mutex::new(vec![])),
+            fail: false,
+            panic: true,
+        }
+    }
+}
+impl WhisperSink for RecordingWhisperSink {
+    fn deliver(&self, rec: &WhisperRecord) -> Result<PathBuf, OverseerError> {
+        if self.panic {
+            panic!("boom: whisper sink blew up mid-deliver");
+        }
+        if self.fail {
+            return Err(OverseerError::Capability {
+                what: "whisper.deliver",
+                detail: "inbox unwritable".to_string(),
+            });
+        }
+        let mut log = self.log.lock().unwrap();
+        log.push(rec.clone());
+        Ok(PathBuf::from(format!("/tmp/whisper-{}.json", log.len())))
+    }
+}
+
+/// A notify channel that records every notification and always reports `Sent`.
+struct RecordingChannel {
+    name: String,
+    seen: Mutex<Vec<OperatorNotification>>,
+}
+impl RecordingChannel {
+    fn sent(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            seen: Mutex::new(vec![]),
+        }
+    }
+}
+impl NotifyChannel for RecordingChannel {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn deliver(&self, n: &OperatorNotification) -> ChannelDelivery {
+        self.seen.lock().unwrap().push(n.clone());
+        ChannelDelivery::Sent
+    }
+}
+
+fn caps(observed: ObservedState, meetings: Box<dyn MeetingHost>) -> Capabilities {
+    Capabilities {
+        status: Box::new(FakeStatus(observed)),
+        recipes: Box::new(FakeRecipes),
+        prs: Box::new(FakePrs),
+        deployer: Box::new(FakeDeployer),
+        meetings,
+        issues: Box::new(FakeIssues),
+        goals: Box::new(FakeGoals(vec![])),
+        auditor: Box::new(FakeAuditor),
+    }
+}
+
+/// An `ObservedState` with a live goal looping for `n` consecutive no-action
+/// cycles — the primary whisper trigger.
+fn looping(n: u32) -> ObservedState {
+    ObservedState {
+        consecutive_no_action: Some(n),
+        active_goal_id: Some("g1".to_string()),
+        ..ObservedState::default()
+    }
+}
+
+// ─────────────────── 1. Signal derivation (Observe → Signal) ────────────────
+
+#[test]
+fn loop_signal_fires_at_and_above_the_whisper_threshold_only() {
+    // The whisper must intervene BEFORE Simard's no-progress breaker trips. This
+    // is a compile-time relationship between two constants; the assertion
+    // documents and pins the invariant (clippy would otherwise flag it as a
+    // constant assertion).
+    #[allow(clippy::assertions_on_constants)]
+    {
+        assert!(
+            WHISPER_LOOP_THRESHOLD < NO_PROGRESS_BREAKER_THRESHOLD,
+            "the whisper loop threshold ({WHISPER_LOOP_THRESHOLD}) must sit strictly below the breaker ({NO_PROGRESS_BREAKER_THRESHOLD})"
+        );
+    }
+
+    // One below the fence: no loop signal.
+    let below = looping(1);
+    assert!(
+        !signals_from(&below)
+            .iter()
+            .any(|s| matches!(s, Signal::LoopDetected { .. })),
+        "one no-action cycle is below the whisper fence"
+    );
+
+    // Exactly at the fence: a loop signal carrying the goal + count.
+    let at = looping(2);
+    let found = signals_from(&at).into_iter().find_map(|s| match s {
+        Signal::LoopDetected {
+            goal_id,
+            consecutive_no_action,
+        } => Some((goal_id, consecutive_no_action)),
+        _ => None,
+    });
+    assert_eq!(found, Some(("g1".to_string(), 2)));
+}
+
+#[test]
+fn loop_signal_needs_an_active_goal() {
+    // No active goal ⇒ nothing to steer, so no loop whisper even if the counter
+    // is high (idle churn is not a goal loop).
+    let idle = ObservedState {
+        consecutive_no_action: Some(5),
+        active_goal_id: None,
+        ..ObservedState::default()
+    };
+    assert!(
+        !signals_from(&idle)
+            .iter()
+            .any(|s| matches!(s, Signal::LoopDetected { .. }))
+    );
+}
+
+#[test]
+fn drift_signal_fires_when_drift_detail_present() {
+    let drifting = ObservedState {
+        drift_detail: Some("editing unrelated module Y".to_string()),
+        active_goal_id: Some("g1".to_string()),
+        ..ObservedState::default()
+    };
+    let found = signals_from(&drifting).into_iter().find_map(|s| match s {
+        Signal::DriftCorrection { goal_id, detail } => Some((goal_id, detail)),
+        _ => None,
+    });
+    let (goal_id, detail) = found.expect("a drift signal must fire");
+    assert_eq!(goal_id, "g1");
+    assert!(detail.contains("unrelated"));
+}
+
+#[test]
+fn a_default_snapshot_emits_no_whisper_signals() {
+    let sigs = signals_from(&ObservedState::default());
+    assert!(
+        !sigs.iter().any(|s| matches!(
+            s,
+            Signal::LoopDetected { .. } | Signal::DriftCorrection { .. }
+        )),
+        "an idle Overseer never whispers"
+    );
+}
+
+// ─────────────────── 2. Decide routing: whisper by default ──────────────────
+
+fn loop_problem(n: u32) -> Problem {
+    Problem {
+        kind: ProblemKind::LoopDetected,
+        priority: Priority::High,
+        dedup_key: "loop:g1".to_string(),
+        summary: format!("no action for {n} cycles on g1"),
+        evidence: vec![Signal::LoopDetected {
+            goal_id: "g1".to_string(),
+            consecutive_no_action: n,
+        }],
+    }
+}
+
+#[test]
+fn decide_routes_a_mild_loop_to_a_lightweight_whisper() {
+    // Default steward action: a whisper, not a meeting, not a launch.
+    match decide(&loop_problem(2)) {
+        Intervention::Whisper { note, urgency } => {
+            assert!(!note.is_empty(), "the whisper must carry a steering note");
+            assert_eq!(
+                urgency,
+                WhisperUrgency::Normal,
+                "a mild loop is a Normal-urgency whisper"
+            );
+        }
+        other => panic!("expected a Whisper for a mild loop, got {other:?}"),
+    }
+}
+
+#[test]
+fn decide_routes_drift_to_a_lightweight_whisper() {
+    let drift = Problem {
+        kind: ProblemKind::DriftCorrection,
+        priority: Priority::Normal,
+        dedup_key: "drift:g1".to_string(),
+        summary: "work drifting from goal g1".to_string(),
+        evidence: vec![Signal::DriftCorrection {
+            goal_id: "g1".to_string(),
+            detail: "editing unrelated module Y".to_string(),
+        }],
+    };
+    assert!(
+        matches!(decide(&drift), Intervention::Whisper { .. }),
+        "drift correction is delivered as an advisory whisper"
+    );
+}
+
+#[test]
+fn decide_escalates_an_acute_repeated_loop_to_a_meeting_transfer() {
+    // Repeated/urgent: once the loop reaches the breaker threshold the whisper
+    // was insufficient, so the Overseer escalates via the existing meeting path
+    // (TransferGoal → MeetingHost), NOT another lightweight whisper.
+    let acute = loop_problem(NO_PROGRESS_BREAKER_THRESHOLD + 1);
+    assert!(
+        matches!(decide(&acute), Intervention::TransferGoal { .. }),
+        "an acute/repeated loop escalates to a meeting transfer"
+    );
+}
+
+// ───────────────── 3. Intervention identity, label, risk class ──────────────
+
+#[test]
+fn whisper_intervention_has_a_stable_label() {
+    let iv = Intervention::Whisper {
+        note: "steer".to_string(),
+        urgency: WhisperUrgency::Normal,
+    };
+    assert_eq!(
+        iv.label(),
+        "whisper",
+        "the stable label the gate/tracing/dedup depend on"
+    );
+}
+
+#[test]
+fn a_whisper_is_routine_and_admitted_by_the_default_autonomy_gate() {
+    let iv = Intervention::Whisper {
+        note: "steer".to_string(),
+        urgency: WhisperUrgency::Normal,
+    };
+    // A whisper takes no action on Simard's behalf and spends no budget, so it
+    // is Routine: no HIGH-RISK / merge opt-in required.
+    assert_eq!(classify(&iv), RiskClass::Routine);
+    assert!(
+        AutonomyGate::default().admit(&iv).is_ok(),
+        "a whisper is admitted by the default gate (its own dedup/identity gates apply elsewhere)"
+    );
+}
+
+// ─────────────────── 4. WhisperGate: dedup window + per-hour cap ────────────
+
+#[test]
+fn whisper_gate_suppresses_an_identical_whisper_within_the_window() {
+    // 900s dedup window, generous cap.
+    let mut gate = WhisperGate::new(900, 5);
+    assert_eq!(gate.admit("sig-a", 0), WhisperDecision::Deliver);
+    assert_eq!(
+        gate.admit("sig-a", 300),
+        WhisperDecision::SuppressDuplicate,
+        "same signature 300s later is a duplicate"
+    );
+    assert_eq!(
+        gate.admit("sig-a", 899),
+        WhisperDecision::SuppressDuplicate,
+        "still inside the 900s window"
+    );
+    assert_eq!(
+        gate.admit("sig-a", 901),
+        WhisperDecision::Deliver,
+        "past the window the same signature may be re-delivered"
+    );
+    // A different signature is never a duplicate of the first.
+    assert_eq!(gate.admit("sig-b", 902), WhisperDecision::Deliver);
+}
+
+#[test]
+fn whisper_gate_caps_whispers_per_rolling_hour() {
+    // Distinct signatures (so dedup never fires) exercise the per-hour cap of 3.
+    let mut gate = WhisperGate::new(900, 3);
+    assert_eq!(gate.admit("s1", 0), WhisperDecision::Deliver);
+    assert_eq!(gate.admit("s2", 10), WhisperDecision::Deliver);
+    assert_eq!(gate.admit("s3", 20), WhisperDecision::Deliver);
+    assert_eq!(
+        gate.admit("s4", 30),
+        WhisperDecision::SuppressCapReached,
+        "the 4th whisper within the hour is capped"
+    );
+    // After the rolling hour fully elapses, the budget frees.
+    assert_eq!(
+        gate.admit("s5", 7200),
+        WhisperDecision::Deliver,
+        "a new hour re-opens the whisper budget"
+    );
+}
+
+// ─────────────────── 5. whisper_ops helpers: note + signature ───────────────
+
+#[test]
+fn whisper_signature_is_stable_under_trivial_note_differences() {
+    let a = whisper_signature(
+        ProblemKind::LoopDetected,
+        Some("g1"),
+        "Steer   TOWARD the goal intent",
+    );
+    let b = whisper_signature(
+        ProblemKind::LoopDetected,
+        Some("g1"),
+        "steer toward the goal intent",
+    );
+    assert_eq!(a, b, "case + whitespace normalise to one dedup signature");
+
+    // A different goal or a different problem kind is a different whisper.
+    let other_goal = whisper_signature(
+        ProblemKind::LoopDetected,
+        Some("g2"),
+        "steer toward the goal intent",
+    );
+    let other_kind = whisper_signature(
+        ProblemKind::DriftCorrection,
+        Some("g1"),
+        "steer toward the goal intent",
+    );
+    assert_ne!(a, other_goal, "goal id discriminates the signature");
+    assert_ne!(a, other_kind, "problem kind discriminates the signature");
+}
+
+#[test]
+fn compose_whisper_note_is_deterministic_and_references_the_goal() {
+    let problem = loop_problem(2);
+    let state = looping(2);
+    let note = compose_whisper_note(&problem, &state);
+    assert!(!note.is_empty());
+    assert!(
+        note.contains("g1"),
+        "a steering note identifies the goal it is steering: {note:?}"
+    );
+    assert_eq!(
+        note,
+        compose_whisper_note(&problem, &state),
+        "note composition is pure/deterministic"
+    );
+}
+
+// ─────────── 6. MeetingHandoffWhisperSink: advisory handoff on the inbox ─────
+
+#[test]
+fn whisper_sink_writes_an_advisory_handoff_on_the_shared_inbox() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sink = MeetingHandoffWhisperSink::new(dir.path().to_path_buf());
+    let note = "Focus on the failing assertion in module X before broadening scope.";
+    let rec = WhisperRecord {
+        note: note.to_string(),
+        urgency: WhisperUrgency::Normal,
+        problem: ProblemKind::LoopDetected,
+        goal_id: Some("g1".to_string()),
+        author: overseer_author_login(),
+        signature: whisper_signature(ProblemKind::LoopDetected, Some("g1"), note),
+    };
+
+    let path = sink.deliver(&rec).expect("deliver a whisper");
+    assert!(path.exists(), "the handoff file is written");
+    let name = path.file_name().unwrap().to_string_lossy().into_owned();
+    assert!(
+        name.starts_with("handoff-") && name.ends_with(".json"),
+        "delivered through the same handoff-*.json channel observe.rs scans: {name}"
+    );
+    assert!(
+        path.starts_with(dir.path()),
+        "written under the injected inbox dir, never elsewhere"
+    );
+
+    // The handoff is shaped so Simard's curate step can NEVER promote it into a
+    // goal or backlog item — it is advisory context only.
+    let h = load_meeting_handoff(dir.path())
+        .expect("load handoff")
+        .expect("a handoff exists");
+    assert!(
+        h.decisions.is_empty(),
+        "no decisions ⇒ a whisper can never become a goal"
+    );
+    assert!(
+        h.action_items.is_empty(),
+        "no action items ⇒ a whisper can never become a backlog item"
+    );
+    assert!(
+        h.open_questions
+            .iter()
+            .any(|q| q.text.contains("Focus on the failing assertion")),
+        "the steering note rides in a non-promoting field"
+    );
+    assert!(
+        h.themes.iter().any(|t| t == "overseer-whisper"),
+        "tagged for recognition (and self-whisper skip)"
+    );
+    assert!(
+        !h.processed,
+        "delivered unprocessed so the OODA inbox scan folds it in"
+    );
+    assert!(
+        h.participants.iter().any(|p| p == &overseer_author_login()),
+        "authored under the Overseer's DISTINCT steward identity"
+    );
+}
+
+// ─────────── 7. Overseer.act(Whisper): deliver, dedup, fail-closed ──────────
+
+#[test]
+fn act_delivers_a_whisper_then_dedups_an_identical_one() {
+    let (sink, log) = RecordingWhisperSink::new();
+    let (meetings, _t) = RecordingMeetings::new();
+    let mut ov = Overseer::new(caps(ObservedState::default(), Box::new(meetings)))
+        .with_identity(overseer_identity())
+        .with_whisper_sink(Box::new(sink));
+
+    let iv = Intervention::Whisper {
+        note: "Re-read the goal intent, then narrow to one file.".to_string(),
+        urgency: WhisperUrgency::Normal,
+    };
+
+    let first = ov.act(&iv).expect("first act");
+    assert!(
+        matches!(first, ActOutcome::Whispered { .. }),
+        "the first whisper is delivered"
+    );
+
+    let second = ov.act(&iv).expect("second act");
+    assert!(
+        matches!(second, ActOutcome::WhisperSuppressed { .. }),
+        "an identical whisper within the window is suppressed, not re-injected"
+    );
+
+    assert_eq!(
+        log.lock().unwrap().len(),
+        1,
+        "the sink is touched exactly once for a deduped whisper"
+    );
+}
+
+#[test]
+fn act_fails_closed_when_the_steward_identity_is_unconfigured() {
+    // No `.with_identity(...)` ⇒ the default RecursionGuard is unconfigured, so
+    // the whisper must be REFUSED (fail closed) and the sink never called — the
+    // Overseer can never whisper without a distinct steward identity.
+    let (sink, log) = RecordingWhisperSink::new();
+    let (meetings, _t) = RecordingMeetings::new();
+    let mut ov = Overseer::new(caps(ObservedState::default(), Box::new(meetings)))
+        .with_whisper_sink(Box::new(sink));
+
+    let iv = Intervention::Whisper {
+        note: "steer".to_string(),
+        urgency: WhisperUrgency::Normal,
+    };
+    let out = ov.act(&iv);
+    assert!(
+        matches!(out, Err(OverseerError::Recursion { .. })),
+        "unconfigured identity refuses the whisper (anti-recursion, fail closed): {out:?}"
+    );
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "a refused whisper never reaches the sink"
+    );
+}
+
+// ───────────────── 8. Tick: emit, dedup, escalate, config, isolate ──────────
+
+#[test]
+fn a_loop_condition_delivers_exactly_one_whisper_this_tick() {
+    let (sink, log) = RecordingWhisperSink::new();
+    let (meetings, transfers) = RecordingMeetings::new();
+    let mut ov = Overseer::new(caps(looping(2), Box::new(meetings)))
+        .with_identity(overseer_identity())
+        .with_whisper_sink(Box::new(sink))
+        .with_whisper_enabled(true);
+
+    let report = overseer_tick(&mut ov);
+    assert_eq!(report.whispers, 1, "one advisory whisper delivered");
+    assert_eq!(report.whispers_suppressed, 0);
+    assert_eq!(report.errors, 0);
+    assert!(!report.panicked);
+
+    let delivered = log.lock().unwrap();
+    assert_eq!(delivered.len(), 1);
+    assert!(
+        delivered[0].note.contains("g1"),
+        "the delivered note steers the looping goal"
+    );
+    assert!(
+        transfers.lock().unwrap().is_empty(),
+        "the default path is a lightweight whisper, not a meeting"
+    );
+}
+
+#[test]
+fn an_identical_whisper_is_suppressed_on_the_next_tick() {
+    let (sink, log) = RecordingWhisperSink::new();
+    let (meetings, _t) = RecordingMeetings::new();
+    let mut ov = Overseer::new(caps(looping(2), Box::new(meetings)))
+        .with_identity(overseer_identity())
+        .with_whisper_sink(Box::new(sink))
+        .with_whisper_enabled(true);
+
+    let first = overseer_tick(&mut ov);
+    assert_eq!(first.whispers, 1);
+
+    // Same observed condition ⇒ same whisper ⇒ suppressed by the dedup window.
+    let second = overseer_tick(&mut ov);
+    assert_eq!(second.whispers, 0, "no re-injection every cycle");
+    assert_eq!(second.whispers_suppressed, 1, "the duplicate is counted");
+
+    assert_eq!(
+        log.lock().unwrap().len(),
+        1,
+        "delivered once across two ticks"
+    );
+}
+
+#[test]
+fn an_acute_loop_escalates_to_a_meeting_instead_of_whispering() {
+    let observed = looping(NO_PROGRESS_BREAKER_THRESHOLD + 1);
+    let (sink, log) = RecordingWhisperSink::new();
+    let (meetings, transfers) = RecordingMeetings::new();
+    let mut ov = Overseer::new(caps(observed, Box::new(meetings)))
+        .with_identity(overseer_identity())
+        .with_whisper_sink(Box::new(sink))
+        .with_whisper_enabled(true);
+
+    let report = overseer_tick(&mut ov);
+    assert_eq!(
+        report.whispers, 0,
+        "an acute/repeated loop escalates rather than whispering"
+    );
+    assert_eq!(
+        transfers.lock().unwrap().len(),
+        1,
+        "escalation transfers a goal via the existing meeting host"
+    );
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "no lightweight whisper is delivered when escalating"
+    );
+}
+
+#[test]
+fn a_disabled_whisperer_emits_nothing_even_when_the_condition_holds() {
+    let (sink, log) = RecordingWhisperSink::new();
+    let (meetings, _t) = RecordingMeetings::new();
+    let mut ov = Overseer::new(caps(looping(2), Box::new(meetings)))
+        .with_identity(overseer_identity())
+        .with_whisper_sink(Box::new(sink))
+        .with_whisper_enabled(false);
+
+    let report = overseer_tick(&mut ov);
+    assert_eq!(
+        report.whispers, 0,
+        "SIMARD_OVERSEER_WHISPER disabled ⇒ no whisper emitted"
+    );
+    assert!(log.lock().unwrap().is_empty(), "the sink is never called");
+}
+
+#[test]
+fn a_panicking_whisper_sink_is_isolated_and_the_overseer_survives() {
+    let mut ov = Overseer::new(caps(looping(2), Box::new(RecordingMeetings::new().0)))
+        .with_identity(overseer_identity())
+        .with_whisper_sink(Box::new(RecordingWhisperSink::panicking()))
+        .with_whisper_enabled(true);
+
+    let report = run_overseer_tick_isolated(&mut ov);
+    assert!(
+        report.panicked,
+        "a panic in the whisper capability is caught by the isolated tick"
+    );
+    // The daemon keeps ticking: a second isolated tick also survives.
+    let report2 = run_overseer_tick_isolated(&mut ov);
+    assert!(report2.panicked);
+}
+
+#[test]
+fn a_whisper_sink_error_is_counted_not_fatal() {
+    let mut ov = Overseer::new(caps(looping(2), Box::new(RecordingMeetings::new().0)))
+        .with_identity(overseer_identity())
+        .with_whisper_sink(Box::new(RecordingWhisperSink::failing()))
+        .with_whisper_enabled(true);
+
+    let report = overseer_tick(&mut ov);
+    assert!(!report.panicked, "an error is not a panic");
+    assert!(
+        report.errors >= 1,
+        "a failed whisper delivery is counted, not propagated"
+    );
+    assert_eq!(report.whispers, 0, "nothing was delivered");
+}
+
+// ─────────────────── 9. Config: opt-out gate, off when Overseer off ─────────
+
+fn env_of(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+    let map: std::collections::HashMap<String, String> = pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect();
+    move |k: &str| map.get(k).cloned()
+}
+
+#[test]
+fn whisper_enabled_by_default_when_the_overseer_is_enabled() {
+    // Unset everything: the acting Overseer defaults ON, so the whisperer does too.
+    assert!(whisper_enabled_from(env_of(&[])));
+    // Explicit truthy / garbage / empty leaves it ON (opt-out, not opt-in).
+    for v in ["1", "true", "yes", "on", "", "maybe"] {
+        assert!(
+            whisper_enabled_from(env_of(&[(SIMARD_OVERSEER_WHISPER_ENV, v)])),
+            "{v:?} must leave the whisperer enabled"
+        );
+    }
+}
+
+#[test]
+fn whisper_disabled_by_explicit_falsey_flag() {
+    for v in ["0", "false", "no", "off", "  off  "] {
+        assert!(
+            !whisper_enabled_from(env_of(&[(SIMARD_OVERSEER_WHISPER_ENV, v)])),
+            "{v:?} must disable the whisperer"
+        );
+    }
+}
+
+#[test]
+fn whisper_disabled_whenever_the_overseer_itself_is_disabled() {
+    // Whispering only makes sense while the Overseer runs: an explicitly-disabled
+    // Overseer forces the whisperer off regardless of the whisper flag.
+    let disabled_overseer = env_of(&[
+        ("SIMARD_OVERSEER_ENABLED", "false"),
+        (SIMARD_OVERSEER_WHISPER_ENV, "true"),
+    ]);
+    assert!(
+        !whisper_enabled_from(disabled_overseer),
+        "no Overseer ⇒ no whisperer, even with the whisper flag on"
+    );
+}
+
+// ─────────────────── 10. Operator notification (observability) ──────────────
+
+#[test]
+fn a_delivered_whisper_is_surfaced_to_the_operator() {
+    let n = OperatorNotification::whisper(
+        "Re-read the goal intent before broadening scope.",
+        "loop_detected",
+        WhisperUrgency::Normal,
+        "g1",
+    );
+    assert_eq!(n.kind, "whisper", "a distinct notification kind");
+    assert!(
+        n.problem.contains("Re-read the goal intent"),
+        "the steering note is carried to the operator"
+    );
+    assert!(
+        n.subject().contains("whisper"),
+        "the subject names the whisper: {}",
+        n.subject()
+    );
+    assert!(n.plain_text().contains("Re-read the goal intent"));
+
+    // Surfaced through the MANDATORY dual channel — never a hidden side-channel.
+    let notifier = DualChannelNotifier::new(vec![
+        Box::new(RecordingChannel::sent("email")),
+        Box::new(RecordingChannel::sent("signal")),
+    ]);
+    let report = notifier.notify(&n);
+    assert!(report.dispatched(), "the whisper notification fires");
+    assert!(report.all_sent());
+}
+
+// ─────────── 11. Integration: the whisper reaches Simard's next cycle ───────
+
+#[test]
+fn a_delivered_whisper_is_folded_into_the_next_ooda_cycle_once() {
+    // Deliver a real whisper handoff onto a tempfile inbox …
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sink = MeetingHandoffWhisperSink::new(dir.path().to_path_buf());
+    let note = "Prefer the smallest reproduction; stop re-running the full suite.";
+    let rec = WhisperRecord {
+        note: note.to_string(),
+        urgency: WhisperUrgency::Normal,
+        problem: ProblemKind::LoopDetected,
+        goal_id: Some("g1".to_string()),
+        author: overseer_author_login(),
+        signature: whisper_signature(ProblemKind::LoopDetected, Some("g1"), note),
+    };
+    sink.deliver(&rec).expect("deliver");
+
+    // … the OODA cycle-start ingest folds the note into the reasoner-facing
+    // context (the inbox observe.rs scans) and marks it processed.
+    let notes = crate::ooda_loop::drain_overseer_whispers(dir.path()).expect("drain whispers");
+    assert_eq!(notes.len(), 1, "the note reaches the next cycle's context");
+    assert!(notes[0].contains("smallest reproduction"));
+
+    // A whisper is folded exactly once — never re-injected every cycle.
+    let again = crate::ooda_loop::drain_overseer_whispers(dir.path()).expect("drain again");
+    assert!(
+        again.is_empty(),
+        "the whisper is processed after ingest, not re-injected"
+    );
+}
+
+#[test]
+fn a_whisper_is_advisory_and_never_becomes_a_goal() {
+    // Curate must never promote a whisper into a goal or backlog item: reasoners
+    // still decide; the whisper is only additional context.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sink = MeetingHandoffWhisperSink::new(dir.path().to_path_buf());
+    let note = "Consider whether the goal is already satisfied by PR #42.";
+    let rec = WhisperRecord {
+        note: note.to_string(),
+        urgency: WhisperUrgency::Normal,
+        problem: ProblemKind::DriftCorrection,
+        goal_id: Some("g1".to_string()),
+        author: overseer_author_login(),
+        signature: whisper_signature(ProblemKind::DriftCorrection, Some("g1"), note),
+    };
+    sink.deliver(&rec).expect("deliver");
+
+    let mut board = GoalBoard::new();
+    let created = crate::ooda_loop::check_meeting_handoffs(&mut board, dir.path(), dir.path())
+        .expect("curate handoffs");
+    assert_eq!(created, 0, "a whisper fabricates no goal / backlog item");
+    assert!(
+        board.active.is_empty(),
+        "no active goal created from a whisper"
+    );
+    assert!(
+        board.backlog.is_empty(),
+        "no backlog item created from a whisper"
+    );
+}

--- a/src/overseer/whisper_ops.rs
+++ b/src/overseer/whisper_ops.rs
@@ -1,0 +1,221 @@
+//! The **Simard Whisperer** — the Overseer's lightweight steering channel.
+//!
+//! A *whisper* is a short, advisory steering note the Overseer injects into
+//! Simard's OODA loop when it observes her looping without progress or drifting
+//! from a goal's intent. Unlike the meeting/handoff escalation path (which hands
+//! a goal to Simard), a whisper is **advisory context only**: it rides onto the
+//! SAME `meeting_handoffs` inbox `src/ooda_loop/observe.rs` already scans, shaped
+//! so Simard's curate step can never promote it into a goal or backlog item
+//! (empty `decisions` + empty `action_items`). Simard's reasoners still decide;
+//! the whisper is only additional input folded into the next cycle's context.
+//!
+//! Delivery reuses [`crate::meeting_facilitator::write_meeting_handoff`] — no new
+//! parallel channel is introduced. The note is carried in `open_questions` (a
+//! non-promoting field), tagged with the [`WHISPER_THEME`] so the OODA ingest
+//! ([`crate::ooda_loop::drain_overseer_whispers`]) recognises it and so the
+//! Overseer never whispers about its own whisper, and authored under the
+//! Overseer's DISTINCT steward identity ([`crate::overseer::config::overseer_author_login`]).
+
+use std::path::PathBuf;
+
+use crate::meeting_facilitator::{MeetingHandoff, OpenQuestion, write_meeting_handoff};
+use crate::overseer::capabilities::{ObservedState, OverseerError};
+use crate::overseer::signal::{Problem, ProblemKind, Signal};
+
+/// Theme tag stamped on every whisper handoff. The OODA whisper-drain scans for
+/// it, and Observe/`signals_from` ignore handoffs carrying it so the Overseer
+/// never re-triggers on (whispers about) its own whisper.
+pub const WHISPER_THEME: &str = "overseer-whisper";
+
+/// How urgently a whisper should be treated. `High` feeds the escalation
+/// decision (a repeated/urgent condition escalates to a full meeting instead of
+/// a lightweight whisper); `Normal` is the default steering note.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum WhisperUrgency {
+    Low,
+    #[default]
+    Normal,
+    High,
+}
+
+impl WhisperUrgency {
+    /// Stable lower-case label for tracing/notification fields.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Normal => "normal",
+            Self::High => "high",
+        }
+    }
+}
+
+/// A single advisory whisper, as delivered to a [`WhisperSink`]. Carries the
+/// note plus enough metadata for transparent tracing and dedup.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WhisperRecord {
+    /// The advisory steering note folded into Simard's next-cycle context.
+    pub note: String,
+    pub urgency: WhisperUrgency,
+    /// The observed problem that triggered the whisper.
+    pub problem: ProblemKind,
+    /// The goal being steered, if known.
+    pub goal_id: Option<String>,
+    /// The Overseer's DISTINCT steward login (never the operator's).
+    pub author: String,
+    /// Stable dedup signature (see [`whisper_signature`]).
+    pub signature: String,
+}
+
+/// The delivery seam for a whisper. Production writes a `handoff-*.json` onto the
+/// shared meeting-handoff inbox; tests inject a fake that records/fails/panics.
+pub trait WhisperSink: Send + Sync {
+    /// Deliver one whisper, returning the path it was written to. A failure is
+    /// surfaced as an [`OverseerError`] (counted by the isolated tick, never
+    /// fatal); a panic is caught by the panic-isolated tick.
+    fn deliver(&self, rec: &WhisperRecord) -> Result<PathBuf, OverseerError>;
+}
+
+/// Production [`WhisperSink`]: writes the whisper as an advisory `MeetingHandoff`
+/// onto the SAME `meeting_handoffs` directory `observe.rs` scans, via the reused
+/// [`write_meeting_handoff`]. The handoff has empty `decisions`/`action_items`
+/// (so curate can never promote it to a goal), the note in `open_questions`, the
+/// [`WHISPER_THEME`] tag, and the Overseer author in `participants`.
+pub struct MeetingHandoffWhisperSink {
+    dir: PathBuf,
+}
+
+impl MeetingHandoffWhisperSink {
+    /// Deliver whispers into `dir` (the `<state_root>/meeting_handoffs` inbox).
+    pub fn new(dir: PathBuf) -> Self {
+        Self { dir }
+    }
+}
+
+impl WhisperSink for MeetingHandoffWhisperSink {
+    fn deliver(&self, rec: &WhisperRecord) -> Result<PathBuf, OverseerError> {
+        let handoff = whisper_handoff(rec);
+        write_meeting_handoff(&self.dir, &handoff).map_err(|e| OverseerError::Capability {
+            what: "whisper.deliver",
+            detail: format!("writing whisper handoff: {e}"),
+        })?;
+        // `write_meeting_handoff` derives its filename deterministically from
+        // `closed_at`; mirror that derivation so we can return the exact path.
+        let ts = handoff.closed_at.replace(':', "-").replace('+', "_");
+        Ok(self.dir.join(format!("handoff-{ts}.json")))
+    }
+}
+
+/// Build the advisory handoff that carries a whisper. Empty `decisions` and
+/// `action_items` guarantee `check_meeting_handoffs` fast-marks it processed
+/// without ever creating a goal or backlog item — the note is pure context.
+fn whisper_handoff(rec: &WhisperRecord) -> MeetingHandoff {
+    let now = chrono::Utc::now().to_rfc3339();
+    MeetingHandoff {
+        schema_version: 2,
+        meeting_id: String::new(),
+        topic: format!("overseer whisper ({})", rec.problem_label()),
+        started_at: now.clone(),
+        closed_at: now,
+        // Advisory-only: no decisions, no action items ⇒ never promoted.
+        decisions: Vec::new(),
+        action_items: Vec::new(),
+        // The steering note rides in a non-promoting field.
+        open_questions: vec![OpenQuestion {
+            text: rec.note.clone(),
+            explicit: true,
+        }],
+        // Delivered UNPROCESSED so the OODA inbox scan folds it into context.
+        processed: false,
+        duration_secs: None,
+        transcript: Vec::new(),
+        transcript_path: None,
+        // Authored under the Overseer's DISTINCT steward identity.
+        participants: vec![rec.author.clone()],
+        // Tagged for recognition + self-whisper skip.
+        themes: vec![WHISPER_THEME.to_string()],
+        next_owner: Some("ooda-observe".to_string()),
+        artifacts: Vec::new(),
+        goal: rec.goal_id.clone(),
+        next_actor: None,
+        applied_templates: Vec::new(),
+        history_truncated_count: 0,
+        partial_reason: None,
+        risks: Vec::new(),
+        disagreements: Vec::new(),
+    }
+}
+
+impl WhisperRecord {
+    fn problem_label(&self) -> &'static str {
+        match self.problem {
+            ProblemKind::LoopDetected => "loop_detected",
+            ProblemKind::DriftCorrection => "drift_correction",
+            _ => "steering",
+        }
+    }
+}
+
+/// A deterministic, pure steering note for a problem. References the goal being
+/// steered so the note is actionable in Simard's context. Never performs I/O.
+pub fn compose_whisper_note(problem: &Problem, state: &ObservedState) -> String {
+    let goal = whisper_goal_id(problem)
+        .or_else(|| state.active_goal_id.clone())
+        .unwrap_or_else(|| "the active goal".to_string());
+    match problem.kind {
+        ProblemKind::LoopDetected => format!(
+            "Overseer steering note for goal {goal}: this goal appears to be looping \
+             without progress ({}). Re-read its stated intent, then take the single \
+             smallest next step; if it is already satisfied, close it.",
+            problem.summary
+        ),
+        ProblemKind::DriftCorrection => format!(
+            "Overseer steering note for goal {goal}: work appears to be drifting from \
+             the goal's intent ({}). Refocus on the stated outcome before broadening \
+             scope.",
+            problem.summary
+        ),
+        _ => format!(
+            "Overseer steering note for goal {goal}: {}",
+            problem.summary
+        ),
+    }
+}
+
+/// Pull the goal id out of a whisper-triggering problem's evidence.
+fn whisper_goal_id(problem: &Problem) -> Option<String> {
+    problem.evidence.iter().find_map(|s| match s {
+        Signal::LoopDetected { goal_id, .. } | Signal::DriftCorrection { goal_id, .. } => {
+            Some(goal_id.clone())
+        }
+        _ => None,
+    })
+}
+
+/// Stable dedup signature for a whisper. Case- and whitespace-insensitive on the
+/// note (so trivially-different phrasings collapse to one signature) and
+/// discriminated by problem kind + goal so a loop and a drift on the same goal,
+/// or the same problem on two goals, are distinct whispers.
+pub fn whisper_signature(kind: ProblemKind, goal_id: Option<&str>, note: &str) -> String {
+    format!(
+        "{:?}|{}|{}",
+        kind,
+        goal_id.unwrap_or("-"),
+        normalize_note(note)
+    )
+}
+
+/// Note-only dedup signature used by [`crate::overseer::Overseer::act`], which
+/// receives an `Intervention::Whisper { note, .. }` without the originating
+/// problem. Identical notes collapse to one signature so the same whisper is not
+/// re-injected every cycle.
+pub fn note_signature(note: &str) -> String {
+    normalize_note(note)
+}
+
+/// Collapse whitespace runs and lower-case so trivially-different notes dedup.
+fn normalize_note(note: &str) -> String {
+    note.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}

--- a/src/overseer/wiring.rs
+++ b/src/overseer/wiring.rs
@@ -39,7 +39,7 @@ use crate::overseer::audit::SelfQualityAuditor;
 use crate::overseer::capabilities::{
     DeployReport, Deployer, GoalBrief, GoalCurator, InFlightItem, OverseerError,
 };
-use crate::overseer::config::{overseer_author_login, overseer_interval_secs};
+use crate::overseer::config::{overseer_author_login, overseer_interval_secs, whisper_enabled};
 use crate::overseer::deploy::GuardedDeployer;
 use crate::overseer::guardrails::RecursionGuard;
 use crate::overseer::launch::SmartOrchestratorLauncher;
@@ -112,6 +112,10 @@ pub struct OverseerTickReport {
     pub escalations: usize,
     /// Interventions the gates held (autonomy/budget/conflict).
     pub held: usize,
+    /// Advisory whispers delivered into Simard's OODA inbox this tick.
+    pub whispers: usize,
+    /// Whispers suppressed by the dedup window / per-hour cap this tick.
+    pub whispers_suppressed: usize,
     /// Capability errors encountered while acting (isolated, never fatal).
     pub errors: usize,
     /// Set when the tick itself panicked and was isolated by
@@ -176,6 +180,8 @@ pub fn overseer_tick(overseer: &mut Overseer) -> OverseerTickReport {
         deploys = report.deploys,
         escalations = report.escalations,
         held = report.held,
+        whispers = report.whispers,
+        whispers_suppressed = report.whispers_suppressed,
         errors = report.errors,
         duration_ms = report.duration_ms,
         "overseer tick complete"
@@ -214,6 +220,8 @@ fn tally_outcome(report: &mut OverseerTickReport, outcome: &ActOutcome) {
         ActOutcome::Deployed(_) => report.deploys += 1,
         ActOutcome::IssueFiled(_) => report.issues_filed += 1,
         ActOutcome::Escalated => report.escalations += 1,
+        ActOutcome::Whispered { .. } => report.whispers += 1,
+        ActOutcome::WhisperSuppressed { .. } => report.whispers_suppressed += 1,
         ActOutcome::ConflictResolved
         | ActOutcome::GoalTransferred
         | ActOutcome::Reported
@@ -378,6 +386,16 @@ pub fn build_overseer(
         .with_verify_merge_autonomy(true)
         .with_high_risk_autonomy(true)
         .with_identity(overseer_identity())
+        // The Simard Whisperer: advisory steering notes onto the SAME
+        // meeting-handoff inbox the OODA observe step scans. Enabled by default
+        // (opt-out via SIMARD_OVERSEER_WHISPER), consistent with the acting
+        // Overseer's opt-out gate.
+        .with_whisper_enabled(whisper_enabled())
+        .with_whisper_sink(Box::new(
+            crate::overseer::whisper_ops::MeetingHandoffWhisperSink::new(
+                crate::meeting_facilitator::default_handoff_dir(),
+            ),
+        ))
 }
 
 /// Resolve the acting Overseer's tick cadence (seconds), clamped to the config


### PR DESCRIPTION
## Summary

Adds a **Simard Whisperer** pattern to the Overseer (#2605): when the Overseer
observes Simard (the main OODA loop) **looping without progress** or **drifting
from a goal's intent**, it injects a short **advisory steering note** ("whisper")
into her OODA loop — steering Simard *without taking the action for her*.

The whisper is the **primary, lightweight** mechanism. It is delivered onto the
**existing** meeting-handoff inbox (`write_meeting_handoff` →
`<state_root>/meeting_handoffs/`, the same directory `src/ooda_loop/observe.rs`
already scans) as an **advisory** handoff and folded into the next cycle's
reasoner context. Simard's reasoners still decide — the whisper is *additional
input only*. The existing meeting path is retained as an **escalation** when a
loop is acute/repeated.

No new parallel channel, no renames, purely additive Rust.

## How it works

- **Observe → Signal → Problem → Decide → Act** (the Overseer's own meta-OODA):
  - New `Signal::{LoopDetected, DriftCorrection}` derived from new
    `ObservedState.{consecutive_no_action, active_goal_id, drift_detail}` fields.
    Loop threshold is **2**, strictly below the no-progress breaker (**3**), so
    the whisper nudges *before* the hard breaker trips.
  - New `ProblemKind::{LoopDetected, DriftCorrection}`.
  - `decide` routes a mild loop / drift → `Intervention::Whisper { note, urgency }`
    (default, lightweight); an **acute** loop (≥ breaker threshold) → escalates via
    the existing `MeetingHost`/`TransferGoal`.
- **Delivery** (`overseer::whisper_ops`): `WhisperSink` +
  `MeetingHandoffWhisperSink` write a `handoff-*.json` with **empty
  `decisions`/`action_items`** (so `check_meeting_handoffs` can only fast-mark it
  — it can never become a goal/backlog item), the note in `open_questions`, the
  `overseer-whisper` theme tag, and the Overseer's DISTINCT steward login in
  `participants`.
- **OODA ingest**: `ooda_loop::drain_overseer_whispers` folds each whisper note
  into the next cycle's context **exactly once** and marks it processed.

## Guardrails (reuse `guardrails.rs` patterns)

- **Dedup + rate-limit**: `WhisperGate`/`WhisperDecision` suppress an identical
  whisper within a window and cap whispers per rolling hour (injected clock). A
  slot is consumed only on a *successful* delivery.
- **Fail-closed identity + anti-recursion**: a whisper requires the Overseer's
  configured DISTINCT steward identity (`RecursionGuard`); an unconfigured
  identity **refuses** the whisper, and theme-tagged handoffs are ignored on
  ingest so the Overseer never whispers about its own whisper.
- **Transparent**: structured `tracing` for every whisper
  (`trigger`/`note`/`urgency`/`delivered`), `OverseerTickReport.{whispers,
  whispers_suppressed}`, and `OperatorNotification::whisper` (dual-channel).
- **Config**: `SIMARD_OVERSEER_WHISPER` opt-out (on by default when the Overseer
  is on; forced off when the Overseer is off). Isolated + panic-safe like the
  rest of the overseer tick.

## Tests (28, TDD)

Signal derivation, decide routing (whisper vs. escalate), label/risk class,
`WhisperGate` dedup + per-hour cap, note/signature helpers, advisory-handoff
shape on the shared inbox, `act` deliver/dedup/fail-closed, tick emit/dedup/
escalate/disabled/panic-isolated/error-counted, config opt-out, operator
notification, and the integration path (whisper reaches the next OODA cycle once
and never becomes a goal). Fakes for observed-state, sink, clock, and identity;
no network.

## Policy / activation

- Purely additive Rust; no `Bridge` naming; existing concepts unchanged; reuses
  the existing steering/inbox + meeting + guardrail mechanisms.
- Green pre-commit locally **without `--no-verify`**; all required CI must pass;
  merge-ready **without `gh pr merge --admin`**.
- The live daemon / `~/.simard` are **not** touched. The production observation
  adapter (`observed_from_snapshot`) leaves the new loop/drift fields `None` for
  now (a follow-up enriches them from the goal board's progress state).
  **The operator redeploys after merge to activate.**

Closes #2605
