### PR TITLE
feat(creative-ideas): design spike + typed foundation for the Creative Ideas thread (#2419)

### DIFF
--- a/docs/design/creative-ideas-thread.md
+++ b/docs/design/creative-ideas-thread.md
@@ -1,0 +1,692 @@
+---
+title: "Creative Ideas background thread — an idea-generation subsystem (design spike)"
+description: >
+  Design spike (#2419) for a "Creative Ideas" background thread: an idea-generation
+  subsystem that primes a backlog of new ideas for improving Simard's capabilities
+  and her ability to self-regulate, self-assess, and self-improve. All Rust, maximal
+  reuse of Simard's existing subsystems: the cognitive-memory prospective type, the
+  Mind cognitive-thread scheduler (#2531), the goal store, the stewardship gh client,
+  and existing agent/skill invocation. Covers the CreativeIdea prospective-memory
+  data model, the status state-machine, the generator thread inputs, the four-reviewer
+  pipeline, the routing (idea→goal, idea→issue, idea-PR human-review gate), the safety
+  model, and a phased roadmap. Design + typed foundation + tests only — gated OFF by
+  default; no autonomous behavior; the operator redeploys after merge.
+last_updated: 2026-07-05
+review_schedule: as-needed
+owner: simard
+doc_type: design
+status: draft
+related:
+  - overseer.md
+  - ../reference/creative-ideas-api.md
+  - ../howto/configure-creative-ideas-thread.md
+  - ../concepts/operational-autonomy-model.md
+  - ../reference/cognitive-thread-scheduling.md
+  - ../howto/add-a-new-cognitive-thread.md
+  - ../reference/stewardship-api.md
+---
+
+# Creative Ideas background thread — an idea-generation subsystem (design spike)
+
+!!! note "Status — design + typed foundation + tests only (#2419), gated OFF"
+    This is a **design spike**. It ships this design document plus additive,
+    tested Rust **scaffolding** (`src/creative_ideas/`, `src/cognitive_memory/creative_idea.rs`,
+    `src/cognitive_threads/threads/creative_ideas.rs`) that is `#![allow(dead_code)]`
+    and **not wired into `main`** or the daemon loop. Nothing constructs or schedules
+    the thread, and the subsystem is **OFF by default** behind
+    `SIMARD_CREATIVE_IDEAS_ENABLED`. The generator does not act autonomously: reviewer
+    adapters and the real gh/PR wiring are **fakes/stubs** with clearly-marked
+    `// FUTURE:` seams. The goal is to fix the data model, the state machine, the
+    reviewer/routing contracts, and the safety guardrails so a later milestone can
+    wire them behind the flag without redesigning. **The operator redeploys after
+    merge.**
+
+## Problem statement
+
+Simard improves herself by pursuing goals, distilling episodic memory into facts and
+procedures, and letting the Overseer watch her process (see
+[Overseer](overseer.md)). What she lacks is a **deliberate, always-on source of new
+ideas** — a divergent-thinking process that periodically stands back from the current
+work, surveys where she is, and proposes *diverse* candidate improvements before any
+of them is committed to as a goal.
+
+Today idea generation is implicit and reactive: an idea appears because a human
+suggested it, a failure forced it, or an OODA cycle stumbled onto it. There is no
+durable **pool of prospective ideas**, no structured **review** of an idea's
+feasibility/necessity/measurability, and no **safe routing** from "interesting idea"
+to "goal" or "human-gated change." This spike designs that subsystem.
+
+The design must satisfy three constraints that shaped every decision below:
+
+1. **One brain.** This is not a new service or a "Bridge." It is a **cognitive thread**
+   plus a set of **reviewers** inside the single Simard brain, reusing the Mind
+   scheduler and existing memory/goal/gh subsystems.
+2. **Safe by construction.** The subsystem is OFF by default; high-risk or
+   irreversible ideas *always* route to human review; PRs born from creative ideas are
+   **blocked from merge** (draft + label + owner review-required) until a human
+   approves — enforced **without** `--admin` or `--no-verify`.
+3. **Measured, not vibes.** Every accepted idea carries a concrete **success metric**
+   (tied where possible to existing self-metrics) and only reaches
+   `ImplementationCompleted` when that metric is met.
+
+## Goals and non-goals
+
+**Goals (this spike):**
+
+- A durable design (this document): data model, status state-machine, thread inputs,
+  reviewer pipeline, routing, safety, and future milestones.
+- Typed, tested Rust scaffolding for: the `CreativeIdea` prospective-memory type +
+  status state-machine + store/retrieve; the generator-thread skeleton (typed inputs,
+  pluggable idea-source, gated OFF); the reviewer-pipeline trait + four adapters +
+  synthesis (interfaces + fakes); the routing interfaces (idea→goal, idea→issue+owner,
+  idea-PR draft+label+owner-review gate) as typed functions with fakes.
+- Tests with **no network** (fakes for reviewers / goal-store / issue-filer / gh /
+  clock).
+
+**Non-goals (explicitly future work):**
+
+- Wiring the thread into the Mind scheduler / daemon `main` (no runtime behavior
+  change).
+- A production LLM idea-source (the spike ships a pluggable trait + a deterministic
+  fake).
+- Real reviewer execution against the `crusty-old-engineer` skill / `philosophy-guardian`
+  agent (the spike ships adapters that shape the invocation but run through fakes in
+  tests).
+- Extending `GhClient` with real label/assignee/draft/review-request subprocess calls
+  (the spike defines the seam and tests it with a fake; the real `gh` calls are a
+  marked `// FUTURE:` stub).
+- A native "links" edge type in prospective memory (see Decision 1 — links are carried
+  in the payload for now).
+
+## Key decisions (resolved ambiguities)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Model `CreativeIdea` as a typed struct that **round-trips to/from** a `CognitiveProspective` node. Store `status`, `context`, and typed `links` as a JSON payload in `action_on_trigger`; `description` = the idea text; `status` mirrored into the prospective `status: String`. A thin `CreativeIdeaStore` seam wraps `store_prospective` / `list_all_prospective`. | Zero schema change to prospective memory; fully round-trippable; marks a native links field as future work. |
+| 2 | Reuse **`ThreadKind::BackgroundThought`** for the generator thread; do not add an enum variant. | The variant is already reserved for "idle associative background thought"; avoids touching the enum and its exhaustive matches. |
+| 3 | New top-level **`src/creative_ideas/`** owns the reviewer-pipeline trait, the four adapters, synthesis, routing, dedup/portfolio, and the config flag. The prospective type lives in `src/cognitive_memory/creative_idea.rs`; the generator thread in `src/cognitive_threads/threads/creative_ideas.rs`. | Respects "prospective type in `cognitive_memory`, thread in `cognitive_threads`" while keeping pipeline/routing cohesive and independently testable. |
+| 4 | Do **not** mutate the live `gh` tooling. Define an `IdeaGhClient` **extension seam** (labeled+assigned issue creation; PR draft/label/owner-review-request) with a fake for tests; the real subprocess wiring is a marked `// FUTURE:` stub. Reuse the existing `GhClient` (`src/stewardship/gh_client.rs`) pattern; never `--admin` / `--no-verify`. | The existing `GhClient` has only `search_issues` / `create_issue`; the gate needs labels/assignees/draft/review. Extending it live would touch the daemon; the seam keeps the spike additive and testable. |
+
+## Reuse map (what this design builds on — no duplication)
+
+| Concern | Existing surface (reused) | This spike adds |
+|---------|---------------------------|-----------------|
+| Prospective memory | `CognitiveProspective` (`src/memory_cognitive.rs`); `CognitiveMemoryOps::store_prospective` / `list_all_prospective` / `check_triggers` / `resolve_prospective` (`src/cognitive_memory/mod.rs`) | `CreativeIdea` + `CreativeIdeaStore` seam that (de)serializes to a prospective node |
+| Thread scheduling | `CognitiveThread` trait, `ThreadKind::BackgroundThought`, `SchedulePolicy`, `Priority`, `ThreadContext`, `ThreadOutcome` (`src/cognitive_threads/thread.rs`); the `Mind` scheduler (#2531) | `CreativeIdeasThread` implementing `CognitiveThread` (gated `enabled()`) |
+| Goals | `GoalStore` trait, `GoalRecord`, `GoalStatus`, `GoalUpdate`, `goal_slug` (`src/goals/`) | `route_idea_to_goal(...)` producing a `Proposed` goal |
+| GitHub issues | `GhClient` trait + `RealGhClient` (`src/stewardship/gh_client.rs`); `StewardshipIssueFiler` (`src/overseer/observer.rs`) | `IdeaGhClient` extension seam for labeled+assigned issues and PR gate |
+| Reviewers | Existing agent/skill invocation (amplihack bin via `SIMARD_AMPLIHACK_BIN`; `AgentRole` in `src/agent_roles.rs`) | `Reviewer` trait + 4 adapters (skill/agent/synthesis) |
+| Cross-pollination | Overseer observations (`src/overseer/`); the daily Journal (OODA observe/cycle) | Read-only inputs into the generator's observation window |
+| Self-metrics | `recall_precision_at_k` (`RECALL_PRECISION_METRIC`, `src/cognitive_memory/metrics.rs`), distill fact-yield, reasoner-reliability | Measurability reviewer ties idea success metrics to these |
+| Budget | `SIMARD_DAILY_BUDGET_USD`, `cost_tracking.rs` | Generator rate-limit + budget check before an expensive tick |
+
+## Data model
+
+### `CreativeIdea`
+
+A `CreativeIdea` is the **prospective-memory** representation of one candidate
+improvement. It is a typed struct that round-trips to a single `CognitiveProspective`
+node (Decision 1).
+
+```rust
+// src/cognitive_memory/creative_idea.rs  (sketch)
+
+/// A candidate self-improvement idea, stored as a prospective-memory node.
+pub struct CreativeIdea {
+    pub node_id: String,          // prospective node_id ("" until stored)
+    pub idea: String,             // the idea text  -> prospective.description
+    pub status: IdeaStatus,       // -> mirrored into prospective.status (String)
+    pub context: IdeaContext,     // why/when/where it came from  -> payload
+    pub links: Vec<MemoryLink>,   // supporting semantic/episodic/procedural nodes -> payload
+    pub reviews: Vec<ReviewRecord>, // accumulated reviewer output -> payload
+    pub success_metric: Option<SuccessMetric>, // set by measurability reviewer -> payload
+    pub created_epoch: u64,       // injected clock -> payload
+}
+
+/// Typed edge to another memory node that supports/resources this idea.
+pub struct MemoryLink {
+    pub kind: MemoryLinkKind,     // Semantic | Episodic | Procedural
+    pub node_id: String,
+}
+
+pub enum MemoryLinkKind { Semantic, Episodic, Procedural }
+
+/// Provenance + situational context captured at generation time.
+pub struct IdeaContext {
+    pub source: String,           // e.g. "creative-ideas-thread"
+    pub goals_snapshot: Vec<String>,
+    pub observation_digest: String, // hash/summary of the >=24h window used
+    pub rationale: String,
+}
+```
+
+**Prospective mapping (round-trip):**
+
+| `CognitiveProspective` field | `CreativeIdea` mapping |
+|------------------------------|------------------------|
+| `description` | `idea` (the idea text) |
+| `status` | `status.as_str()` (mirrored `IdeaStatus`) |
+| `trigger_condition` | fixed sentinel `"creative-idea"` (marks the node type for retrieval filtering) |
+| `action_on_trigger` | JSON payload: `{ context, links, reviews, success_metric, created_epoch }` |
+| `priority` | derived from portfolio/risk (higher = more urgent to review) |
+
+The sentinel `trigger_condition = "creative-idea"` lets `CreativeIdeaStore` filter
+`list_all_prospective(...)` down to creative-idea nodes without a schema change. The
+payload is versioned (`payload_version`) so a future native-links migration can detect
+old rows.
+
+### Status state-machine
+
+`IdeaStatus` is the lifecycle of an idea. Transitions are **explicit and validated**:
+`CreativeIdea::try_transition(to)` returns `Err` for any disallowed edge, and every
+transition is the *only* way `status` changes.
+
+```rust
+pub enum IdeaStatus {
+    New,                     // freshly generated, not yet reviewed
+    NeedsRevision,           // synthesis asked for a rewrite before acceptance
+    NeedsHumanReview,        // high-risk / flagged: a human must decide
+    AcceptedForImplementation,
+    Rejected,                // terminal
+    Deferred,                // parked; may be reconsidered later
+    ImplementationStarted,   // a goal/PR is in flight
+    ImplementationCompleted, // terminal; ONLY when success_metric is met
+}
+```
+
+**Allowed transitions** (anything not listed is rejected):
+
+| From | To |
+|------|----|
+| `New` | `AcceptedForImplementation`, `Rejected`, `Deferred`, `NeedsRevision`, `NeedsHumanReview` |
+| `NeedsRevision` | `New` (re-enter review after rewrite), `Rejected`, `Deferred` |
+| `NeedsHumanReview` | `AcceptedForImplementation`, `Rejected`, `Deferred` |
+| `Deferred` | `New`, `Rejected` |
+| `AcceptedForImplementation` | `ImplementationStarted`, `Deferred`, `Rejected` |
+| `ImplementationStarted` | `ImplementationCompleted`, `NeedsRevision`, `Rejected` |
+| `Rejected` | *(terminal — no outgoing)* |
+| `ImplementationCompleted` | *(terminal — no outgoing)* |
+
+```mermaid
+stateDiagram-v2
+    [*] --> New
+    New --> AcceptedForImplementation
+    New --> Rejected
+    New --> Deferred
+    New --> NeedsRevision
+    New --> NeedsHumanReview
+    NeedsRevision --> New
+    NeedsRevision --> Rejected
+    NeedsRevision --> Deferred
+    NeedsHumanReview --> AcceptedForImplementation
+    NeedsHumanReview --> Rejected
+    NeedsHumanReview --> Deferred
+    Deferred --> New
+    Deferred --> Rejected
+    AcceptedForImplementation --> ImplementationStarted
+    AcceptedForImplementation --> Deferred
+    AcceptedForImplementation --> Rejected
+    ImplementationStarted --> ImplementationCompleted
+    ImplementationStarted --> NeedsRevision
+    ImplementationStarted --> Rejected
+    Rejected --> [*]
+    ImplementationCompleted --> [*]
+```
+
+Invariant enforced in code and tested: **`ImplementationCompleted` is reachable only
+from `ImplementationStarted`, and the router refuses to complete an idea whose
+`success_metric` has not been marked met.**
+
+### `CreativeIdeaStore` seam
+
+```rust
+pub trait CreativeIdeaStore {
+    fn store(&self, idea: &CreativeIdea) -> SimardResult<String>; // -> node_id
+    fn update(&self, idea: &CreativeIdea) -> SimardResult<()>;    // re-serialize payload/status
+    fn list(&self, limit: u32) -> SimardResult<Vec<CreativeIdea>>;
+    fn get(&self, node_id: &str) -> SimardResult<Option<CreativeIdea>>;
+}
+
+/// Production adapter over CognitiveMemoryOps (thin; no new backend).
+pub struct ProspectiveCreativeIdeaStore<'a> { mem: &'a dyn CognitiveMemoryOps }
+```
+
+`list` calls `list_all_prospective`, keeps rows whose `trigger_condition ==
+"creative-idea"`, and deserializes the payload. Tests use an in-memory
+`FakeCreativeIdeaStore` **and** a round-trip test through a fake `CognitiveMemoryOps`.
+
+## The generator thread
+
+`CreativeIdeasThread` implements `CognitiveThread` (`src/cognitive_threads/threads/creative_ideas.rs`).
+
+- **`kind()`** → `ThreadKind::BackgroundThought` (Decision 2).
+- **`policy()`** → `SchedulePolicy::Interval(24h)` by default (a large observation
+  window; configurable). Reserved to become `Adaptive` later.
+- **`priority()`** → `Priority::Low` (never competes with OODA).
+- **`enabled()`** → reads `SIMARD_CREATIVE_IDEAS_ENABLED` → **`false` by default**.
+  A disabled thread never ticks (scheduler contract), so the subsystem is inert unless
+  explicitly turned on.
+- **`tick()`** → best-effort, self-contained (returns `ThreadOutcome::failed` rather
+  than panicking), uses `ctx.now_epoch` (injected clock) and may `block_on`
+  `ctx.runtime` for the idea-source and reviewers. It honors the two `ThreadContext`
+  safety fields: it bails early when `ctx.shutdown` is set (cooperative cancellation)
+  and performs **no destructive side-effect** (no goal/issue/PR writes) when
+  `ctx.dry_run` is true.
+
+### Thread inputs (the observation window)
+
+The thread assembles a typed `GenerationInputs` from **read-only** sources:
+
+```rust
+pub struct GenerationInputs {
+    pub current_goals: Vec<String>,          // GoalStore active/proposed
+    pub recent_activity: ActivityWindow,     // >= 24h of progress & behavior (Journal/OODA)
+    pub episodic_summaries: Vec<String>,      // cognitive-memory episodic digests
+    pub works_in_progress: Vec<String>,       // open goals/PRs/sessions
+    pub overseer_observations: Vec<String>,   // src/overseer (cross-pollination)
+    pub conversation_insights: Vec<String>,   // extracted from meetings/conversations
+    pub previous_ideas: Vec<CreativeIdea>,    // for dedup/novelty (store.list)
+}
+```
+
+### Pluggable idea source
+
+```rust
+pub trait IdeaSource {
+    /// Produce up to `n` diverse raw idea candidates from the inputs.
+    fn generate(&self, inputs: &GenerationInputs, n: usize) -> SimardResult<Vec<RawIdea>>;
+}
+```
+
+- **Spike:** a deterministic `FakeIdeaSource` (used by tests) + a marked `// FUTURE:`
+  `LlmIdeaSource` stub. The thread targets **ten** ideas per run (the design's fixed
+  batch), then applies dedup/portfolio filtering (below).
+- Each surviving `RawIdea` becomes a `CreativeIdea { status: New, links, context }`,
+  is persisted via `CreativeIdeaStore`, and (in the wired future) enqueued for review.
+
+## Reviewer pipeline
+
+Each new idea is reviewed by a fixed set of reviewers, then a synthesis step sets the
+status. The pipeline is a trait so reviewers are pluggable and independently testable.
+
+```rust
+pub struct ReviewContext<'a> {
+    pub idea: &'a CreativeIdea,
+    pub inputs: &'a GenerationInputs,
+}
+
+pub struct Review {
+    pub reviewer: &'static str,       // stable id for telemetry
+    pub verdict: ReviewVerdict,       // Support | Concern | Block | NeedsHuman
+    pub notes: String,
+    pub flags: ReviewFlags,           // high_risk, irreversible, needs_human, ...
+    pub proposed_metric: Option<SuccessMetric>, // measurability reviewer only
+}
+
+pub trait Reviewer {
+    fn id(&self) -> &'static str;
+    fn review(&self, ctx: &ReviewContext<'_>) -> SimardResult<Review>;
+}
+```
+
+The four reviewers (run in order; all four contribute before synthesis):
+
+1. **`crusty-old-engineer` (skill adapter).** Reviews **scope, feasibility, necessity,
+   utility, inventiveness, RISK, need-for-human-review, practicality**. Sets
+   `flags.high_risk` / `flags.needs_human` when warranted. Adapter shapes the amplihack
+   skill invocation; tests use a fake.
+2. **`philosophy-guardian` (agent adapter).** "Do we need this? Will it be an
+   interesting enhancement?" — **explicitly, a user signal is NOT required to justify
+   an idea; exploratory ideas are OK/encouraged.** The adapter therefore treats absence
+   of a user signal as neutral, never as a `Block`.
+3. **`measurability` (NEW reviewer agent).** Enhances the idea's **measurability**: how
+   will we know it is effective / successful / actually improving Simard? It emits a
+   concrete `SuccessMetric`, tied where relevant to existing self-metrics
+   (`recall_precision_at_k`, distill fact-yield, reasoner-reliability). This metric is
+   the *only* thing that can later move the idea to `ImplementationCompleted`.
+4. **`idea-feedback-synthesis` (synthesis step).** Reads **all** reviews + the idea
+   context, summarizes **next steps**, and **sets the status** per the state-machine.
+
+```rust
+pub struct SuccessMetric {
+    pub name: String,           // e.g. "recall_precision_at_k"
+    pub baseline: Option<f64>,
+    pub target: String,         // e.g. ">= +0.05 over 7-day baseline"
+    pub how_measured: String,
+}
+
+pub trait FeedbackSynthesizer {
+    /// Fold all reviews into a next-status + human-readable next steps.
+    fn synthesize(&self, ctx: &ReviewContext<'_>, reviews: &[Review])
+        -> SimardResult<SynthesisOutcome>;
+}
+
+pub struct SynthesisOutcome {
+    pub next_status: IdeaStatus,   // MUST be a legal transition from idea.status
+    pub next_steps: String,
+    pub set_metric: Option<SuccessMetric>,
+}
+```
+
+**Synthesis policy (default, deterministic fake mirrors it for tests):**
+
+- Any reviewer sets `flags.irreversible` **or** `flags.high_risk` **or**
+  `flags.needs_human` → `NeedsHumanReview`.
+- Any `Block` (non-philosophy) with no human flag → `Rejected` or `NeedsRevision`
+  depending on whether the block is fatal or fixable.
+- No metric produced → `NeedsRevision` (an idea with no way to measure success is not
+  acceptable).
+- Otherwise, sufficient support + a metric → `AcceptedForImplementation`.
+
+The pipeline runner applies `try_transition` so an illegal synthesis verdict is a hard
+error, not a silent corruption.
+
+## Routing of reviewed ideas
+
+Routing consumes an idea whose synthesis has set a terminal-ish status and dispatches
+it. All routing functions are **typed, side-effect-via-seam, and fake-tested**.
+
+### 1. Accepted, not flagged → a Goal
+
+```rust
+pub fn route_idea_to_goal(idea: &CreativeIdea, goals: &dyn GoalStore, now_epoch: u64)
+    -> SimardResult<GoalRecord>;
+```
+
+Produces a `GoalRecord` (status `Proposed`, `slug = goal_slug(idea.idea)`), tagged in
+its evidence/label with the originating `idea.node_id` so the goal is traceable back to
+the idea. The idea transitions `AcceptedForImplementation → ImplementationStarted` when
+the goal is created. Time is supplied as `now_epoch: u64` (unix-epoch seconds) — the
+same injected-clock convention the thread's `tick` uses via `ctx.now_epoch`, rather than
+a bespoke clock trait — so routing is deterministic in tests.
+
+### 2. Accepted but flagged → a GitHub Issue tagging the owner
+
+```rust
+pub fn route_idea_to_issue(idea: &CreativeIdea, gh: &dyn IdeaGhClient, repo: &str)
+    -> SimardResult<GhIssue>;
+```
+
+Creates an issue with a **specific label** (`creative-idea`) and **assigns the repo
+owner (`rysweet`)**. Applies only to ideas in `NeedsHumanReview`. The issue body embeds
+`idea.node_id` (traceability) and the synthesized next steps.
+
+### 3. Idea-PR human-review gate
+
+A PR that arises from a creative-idea goal must be **blocked from merge** until a human
+approves — enforced by three mechanisms, **never** by `--admin` / `--no-verify`:
+
+```rust
+pub struct IdeaPrGate {
+    pub draft: bool,                 // always true: kept as DRAFT
+    pub blocking_label: &'static str, // "creative-idea-needs-human-review"
+    pub review_requested_from: Vec<String>, // ["rysweet"] — owner review required
+    pub originating_idea: String,    // idea.node_id (link back)
+}
+
+pub fn mark_idea_pr(pr_number: u64, idea: &CreativeIdea, gh: &dyn IdeaGhClient, repo: &str)
+    -> SimardResult<IdeaPrGate>;
+```
+
+Enforcement model (all standard GitHub mechanisms, no privilege bypass). `repo`
+(`owner/name`) is threaded through so the call reaches the correct repository — every
+`IdeaGhClient` PR method requires it:
+
+- **Draft** — a draft PR cannot be merged by anyone until marked ready.
+- **Blocking label** — `creative-idea-needs-human-review`; branch-protection /
+  required-status can key off this label to keep the merge button disabled.
+- **Owner review-required** — `request-review` from `rysweet`; the PR needs the owner's
+  approving review. Simard **requests** the review; she never approves her own gate.
+- **Link-back** — the PR body carries `originating-idea: <node_id>` and the issue/goal
+  carry the PR URL, closing the traceability loop (idea ↔ goal ↔ issue ↔ PR).
+
+The idea only reaches `ImplementationCompleted` when (a) the PR merges through the
+normal gate **and** (b) the idea's `success_metric` is marked met — both required.
+
+### `IdeaGhClient` extension seam
+
+```rust
+pub trait IdeaGhClient {
+    fn create_labeled_issue(&self, repo: &str, title: &str, body: &str,
+        labels: &[&str], assignees: &[&str]) -> SimardResult<GhIssue>;
+    fn set_pr_draft(&self, repo: &str, pr: u64, draft: bool) -> SimardResult<()>;
+    fn add_pr_label(&self, repo: &str, pr: u64, label: &str) -> SimardResult<()>;
+    fn request_pr_review(&self, repo: &str, pr: u64, reviewer: &str) -> SimardResult<()>;
+}
+```
+
+- **Spike:** `FakeIdeaGhClient` records calls for assertions; the real subprocess impl
+  (`gh issue create --label ... --assignee ...`, `gh pr ready --undo`, `gh pr edit
+  --add-label`, `gh pr edit --add-reviewer`) is a marked `// FUTURE:` stub that reuses
+  the `RealGhClient` subprocess pattern from `src/stewardship/gh_client.rs`.
+- **Never** emits `--admin` or `--no-verify`; a unit test asserts the constructed
+  argument vectors contain neither flag.
+
+## API contracts
+
+This subsystem has **no HTTP/REST/GraphQL surface** — it is an in-process Rust
+library. Its "API" is therefore the set of **public trait methods and free
+functions** (the module "studs"). The equivalences to a network API are:
+
+| Network concept | This subsystem |
+|-----------------|----------------|
+| Endpoint | A public trait method / routing free function |
+| Request schema | The owned input struct(s) passed in |
+| Response schema | The `Ok` payload of the returned `SimardResult<T>` |
+| HTTP error / status | A typed `SimardError` variant |
+| API version | On-disk payload version + stable env/GitHub identifiers (below) |
+
+All fallible operations return the crate-wide `SimardResult<T>`
+(`= Result<T, SimardError>`, `src/error/mod.rs`). No new `Result` alias, no
+`anyhow`, no `Box<dyn Error>`, and no `unwrap()`/`expect()` on the runtime path
+(tests may `expect`).
+
+### Operation surface (the "endpoints")
+
+| Operation | Request (input) | Response (`Ok`) | Primary error variants |
+|-----------|-----------------|-----------------|------------------------|
+| `CreativeIdeaStore::store` | `&CreativeIdea` | `String` (node_id) | `InvalidCreativeIdeaRecord`, `PersistentStoreIo`, `StoragePoisoned` |
+| `CreativeIdeaStore::update` | `&CreativeIdea` | `()` | `InvalidCreativeIdeaRecord`, `PersistentStoreIo`, `StoragePoisoned` |
+| `CreativeIdeaStore::list` | `limit: u32` | `Vec<CreativeIdea>` | `InvalidCreativeIdeaRecord` (payload parse), `StoragePoisoned` |
+| `CreativeIdeaStore::get` | `&str` (node_id) | `Option<CreativeIdea>` | `InvalidCreativeIdeaRecord`, `StoragePoisoned` |
+| `CreativeIdea::try_transition` | `to: IdeaStatus` | `()` | `InvalidIdeaTransition { from, to }` |
+| `IdeaSource::generate` | `&GenerationInputs, n: usize` | `Vec<RawIdea>` | `ReviewUnavailable`, `BudgetExceeded` |
+| `Reviewer::review` | `&ReviewContext` | `Review` | `ReviewUnavailable` |
+| `FeedbackSynthesizer::synthesize` | `&ReviewContext, &[Review]` | `SynthesisOutcome` | `ReviewBlocked`, `InvalidIdeaTransition` (illegal `next_status`) |
+| `route_idea_to_goal` | `&CreativeIdea, &dyn GoalStore, now_epoch: u64` | `GoalRecord` | `InvalidGoalRecord`, `InvalidIdeaTransition` |
+| `route_idea_to_issue` | `&CreativeIdea, &dyn IdeaGhClient, repo: &str` | `GhIssue` | `ActionExecutionFailed`, `GitCommandFailed`, `CommandTimeout` |
+| `mark_idea_pr` | `pr: u64, &CreativeIdea, &dyn IdeaGhClient, repo: &str` | `IdeaPrGate` | `ActionExecutionFailed`, `GitCommandFailed`, `CommandTimeout` |
+| `IdeaGhClient::*` | (see seam above) | per method | `ActionExecutionFailed`, `GitCommandFailed`, `CommandTimeout` |
+| `CreativeIdeasThread::tick` | `&mut ThreadContext` | `ThreadOutcome` | **never `Err`** — folds internal errors into `ThreadOutcome::failed` |
+
+The request/response *schemas* are the structs already defined above
+(`CreativeIdea`, `GenerationInputs`, `RawIdea`, `ReviewContext`, `Review`,
+`SynthesisOutcome`, `SuccessMetric`, `IdeaPrGate`, `GhIssue`, `GoalRecord`).
+Each is owned, `Clone + Debug`, and serde-serializable so it round-trips
+through prospective memory and is trivially asserted in tests.
+
+### Error-handling patterns
+
+Errors reuse the crate `SimardError` (structured, named-field variants;
+`Clone + Debug + Eq + PartialEq`). The design adds **exactly two** new
+variants — a single, reviewed touch to the shared enum — each mirroring an
+existing shape:
+
+```rust
+// src/error/mod.rs (the ONLY additions to the shared enum)
+InvalidIdeaTransition {          // mirrors InvalidRuntimeTransition / InvalidSessionTransition
+    from: IdeaStatus,
+    to: IdeaStatus,
+},
+InvalidCreativeIdeaRecord {      // mirrors InvalidGoalRecord / InvalidImprovementRecord
+    field: String,
+    reason: String,
+},
+```
+
+Everything else reuses existing variants — **no bespoke error machinery**:
+
+- **Serialization** — `serde_json` (de)serialize failures fold into
+  `InvalidCreativeIdeaRecord { field, reason }` via `map_err`, exactly as
+  `goals::cognitive_memory_store` maps serde errors into `InvalidGoalRecord`.
+- **State machine** — every illegal edge (from `try_transition` *and* from an
+  illegal synthesis `next_status`) is `InvalidIdeaTransition { from, to }`.
+- **Budget / rate limit** — the `tick` budget guard returns the existing
+  `BudgetExceeded { period, spent, limit }` (or short-circuits to a skipped
+  outcome when merely over cadence).
+- **GitHub / routing** — the future real `IdeaGhClient` maps non-zero `gh`
+  exits to `GitCommandFailed`/`ActionExecutionFailed` and hangs to
+  `CommandTimeout`; fakes return `Ok`.
+- **Reviewer adapters** — an unreachable skill/agent returns
+  `ReviewUnavailable { reason }`; a fatal synthesis block surfaces as
+  `ReviewBlocked { summary }`.
+- **Fail-closed deserialization** — an unknown `IdeaStatus`, `ReviewVerdict`,
+  or `MemoryLinkKind` string, or a `payload_version` newer than the reader
+  understands, yields `InvalidCreativeIdeaRecord` — **never** a silent default.
+  A newer on-disk row is a hard, visible error on an older binary, never
+  misinterpreted.
+- **Total `tick`** — `CreativeIdeasThread::tick` is infallible by contract:
+  every internal `Err` is caught, `tracing::warn!`-logged with the stable
+  `creative_ideas` thread id, and returned as `ThreadOutcome::failed(reason, elapsed)`.
+  A single idea's failure never aborts the batch or the daemon.
+
+### Versioning strategy
+
+With no wire protocol, the only externally-observable contracts that must
+remain stable are three; each has an explicit version discipline:
+
+| Contract | Stability rule | Version mechanism |
+|----------|----------------|-------------------|
+| **On-disk prospective payload** (`action_on_trigger` JSON) | Additive-only within a major version; any rename/removal requires a bump + migration | `payload_version: u16` (starts at `1`). Reader: `== known` parse; `> known` → `InvalidCreativeIdeaRecord`; missing → assume `1` |
+| **Node-type sentinel** (`trigger_condition = "creative-idea"`) | Never renamed — it is the retrieval key for already-stored rows | Literal `const CREATIVE_IDEA_TRIGGER`; a rename is a breaking migration, not an edit |
+| **Operator / automation surface** (`SIMARD_CREATIVE_IDEAS_*` env vars; labels `creative-idea`, `creative-idea-needs-human-review`; assignee `rysweet`) | Names are the operator + GitHub-automation contract; treated as stable identifiers | Centralized as `const`s in `CreativeIdeasConfig`; changes are documented, breaking changes |
+
+- **Trait/type API** — during the spike the Rust surface is `#![allow(dead_code)]`
+  and carries **no** semver promise yet. The `Reviewer`, `FeedbackSynthesizer`,
+  `IdeaSource`, and `IdeaGhClient` traits are the intended long-term extension
+  seams, so future capability is added via **new adapter impls** or **new
+  trait methods with defaults**, never by changing an existing method signature.
+- **Enum evolution** — adding an `IdeaStatus`/`ReviewVerdict` state is
+  backward-compatible for *writers*, but per the fail-closed rule an older
+  *reader* rejects an unknown state rather than guessing. Such a change
+  therefore ships **reader-first** (deploy the reader that understands the new
+  state before any writer emits it).
+- **Forward-migration hook** (`// FUTURE:`) — promoting `links` from the JSON
+  payload to native prospective edges bumps `payload_version` to `2`; a
+  one-shot migration reads v1 rows, writes native edges, and rewrites the
+  payload. It is safe precisely because v1 rows are self-identifying via
+  `payload_version`.
+
+## Safety — "more interesting, yet safe"
+
+| Guardrail | Design | Scaffold hook |
+|-----------|--------|---------------|
+| **Dedup / novelty** | Reject a new idea that is a near-duplicate of a prior idea (token/shingle similarity over `previous_ideas`, threshold configurable). | `dedup::is_near_duplicate(new, prior, threshold)`; tested to reject a near-duplicate. |
+| **Diversity / portfolio** | Keep a balanced portfolio: mix incremental/exploratory and low/high risk; the batch of ten is filtered to spread across risk/novelty buckets. | `portfolio::select_balanced(candidates, budget)`. |
+| **Rate-limiting + budget** | The thread checks a per-day cap and `SIMARD_DAILY_BUDGET_USD` (via `cost_tracking`) before an expensive tick; over budget → skip. | `budget::within_budget(now, cfg)`; thread `tick` short-circuits. |
+| **High-risk → human** | Any idea flagged high-risk/irreversible **always** routes to `NeedsHumanReview` (synthesis policy above); it can never auto-become a goal. | Enforced in `FeedbackSynthesizer` + `try_transition`. |
+| **Cross-pollination** | Feed the Overseer's observations and the daily Journal into `GenerationInputs` (read-only). | `overseer_observations`, `recent_activity` fields. |
+| **Outcome feedback** | Measured outcomes update idea status; `ImplementationCompleted` only when the idea's own `success_metric` is met. | `route::mark_completed(idea, metric_met)` refuses if `!metric_met`. |
+| **OFF by default** | Whole subsystem gated behind `SIMARD_CREATIVE_IDEAS_ENABLED` (default false); thread `enabled()` returns false. | Config flag + test asserting default-off. |
+| **Dry-run honored** | The global `ThreadContext.dry_run` switch suppresses every destructive side-effect (goal/issue/PR writes); a dry-run tick still generates, reviews, and logs but writes nothing external. | `tick` checks `ctx.dry_run` before routing; routing seams are skipped. |
+| **Cooperative shutdown** | The thread observes `ThreadContext.shutdown` (the scheduler's cancellation flag) and returns promptly between pipeline stages instead of blocking a daemon stop. | `tick` polls `ctx.shutdown` between generate → review → route. |
+
+## Configuration & gating
+
+| Env var | Default | Effect |
+|---------|---------|--------|
+| `SIMARD_CREATIVE_IDEAS_ENABLED` | `false` | Master switch; when false the thread never ticks and nothing is generated/routed. |
+| `SIMARD_CREATIVE_IDEAS_INTERVAL_SECS` | `86400` | Generator cadence (large observation window ≥ 24h). |
+| `SIMARD_CREATIVE_IDEAS_BATCH` | `10` | Ideas targeted per run. |
+| `SIMARD_DAILY_BUDGET_USD` | *(existing)* | Reused for budget-awareness. |
+
+`CreativeIdeasConfig::from_env()` centralizes parsing and is the single source of truth
+for gating; a test asserts a default-constructed config is **disabled**.
+
+## Observability
+
+Structured `tracing` only (no `println!`/`eprintln!` beyond the `[simard] …` prefix
+convention). Spans/metrics keyed on the stable thread id `creative_ideas` and reviewer
+ids (`crusty_old_engineer`, `philosophy_guardian`, `measurability`,
+`idea_feedback_synthesis`): ideas generated, deduped, per-verdict counts, routed→goal /
+routed→issue / pr-gated, and status-transition events. These reuse the existing
+cognitive-thread telemetry surface (`src/cognitive_threads/telemetry.rs`).
+
+## Module layout & scaffold-vs-future
+
+```
+src/cognitive_memory/creative_idea.rs      # CreativeIdea, IdeaStatus (+ try_transition),
+                                           # MemoryLink, CreativeIdeaStore + Prospective adapter
+src/cognitive_threads/threads/creative_ideas.rs  # CreativeIdeasThread (CognitiveThread, gated OFF),
+                                           # GenerationInputs, IdeaSource trait + FakeIdeaSource
+src/creative_ideas/
+  mod.rs        # CreativeIdeasConfig::from_env (gating)
+  reviewers.rs  # Reviewer trait, Review, 4 adapters (skill/agent/measurability), fakes
+  synthesis.rs  # FeedbackSynthesizer, default policy, SynthesisOutcome
+  routing.rs    # route_idea_to_goal / route_idea_to_issue / mark_idea_pr, IdeaGhClient + fake
+  dedup.rs      # near-duplicate + portfolio + budget helpers
+  tests.rs      # unit tests (all fakes, no network)
+
+src/error/mod.rs                           # + InvalidIdeaTransition { from, to },
+                                           #   InvalidCreativeIdeaRecord { field, reason }
+```
+
+**Scaffolded (real, tested this spike):** the types, the `IdeaStatus` state-machine +
+`try_transition`, the two new `SimardError` variants (`InvalidIdeaTransition`,
+`InvalidCreativeIdeaRecord`), the `CreativeIdeaStore` prospective round-trip (with
+`payload_version`), the thread skeleton +
+`enabled()` gating, the `Reviewer`/`FeedbackSynthesizer`/routing **traits** with fakes,
+dedup/portfolio/budget helpers, and all the tests below.
+
+**Marked `// FUTURE:` (stubs, not wired):** the `LlmIdeaSource`; real
+`crusty-old-engineer`/`philosophy-guardian` skill/agent execution; the real
+`IdeaGhClient` `gh` subprocess impl; registering `CreativeIdeasThread` with the `Mind`
+scheduler in `main`; native prospective "links" edges.
+
+## Test plan (no network; all fakes)
+
+1. **State-machine** — `IdeaStatus::try_transition` allows only the edges in the table
+   above; every disallowed edge returns `Err`; terminal states have no outgoing edges;
+   `ImplementationCompleted` reachable only from `ImplementationStarted`.
+2. **Persistence/retrieval** — a generated idea persists as a prospective node with its
+   `links` and `context`, and is retrievable via `CreativeIdeaStore` (round-trip through
+   a fake `CognitiveMemoryOps`, asserting `trigger_condition == "creative-idea"` and
+   payload fidelity).
+3. **Pipeline** — the runner invokes **all four** reviewers (fakes) and the synthesis
+   step sets a status that is a legal transition from `New`.
+4. **Routing — goal** — an `AcceptedForImplementation` (non-flagged) idea produces a
+   `Proposed` goal in a fake `GoalStore`, tagged with the originating `node_id`.
+5. **Routing — issue** — a `NeedsHumanReview` idea produces an issue via a fake
+   `IdeaGhClient` with label `creative-idea` and assignee `rysweet`.
+6. **Routing — PR gate** — `mark_idea_pr` marks the PR **draft**, adds label
+   `creative-idea-needs-human-review`, and requests review from `rysweet`; a test
+   asserts the constructed gh args contain **no** `--admin` / `--no-verify`.
+7. **Dedup** — a near-duplicate of a prior idea is rejected.
+8. **Off-by-default** — a default `CreativeIdeasConfig` is disabled and the thread's
+   `enabled()` returns `false`.
+9. **Error contracts** — an illegal `try_transition` returns
+   `InvalidIdeaTransition { from, to }`; a payload that fails to parse (bad JSON, or a
+   `payload_version` newer than the reader) returns `InvalidCreativeIdeaRecord`, and an
+   unknown `IdeaStatus`/`ReviewVerdict` string is rejected (fail-closed), never defaulted.
+10. **Tick is total** — a `tick` whose idea source/reviewer returns `Err` yields
+   `ThreadOutcome::failed` (not a panic, not `Err`), leaving the daemon unaffected.
+
+## Phased roadmap (future milestones)
+
+- **M1 — this spike:** design + typed foundation + tests, gated OFF, nothing wired.
+- **M2 — wire the store + thread (still OFF):** register `CreativeIdeasThread` with the
+  `Mind` scheduler behind `SIMARD_CREATIVE_IDEAS_ENABLED`; real `IdeaSource` producing
+  ideas into prospective memory; no routing side-effects yet (dry-run).
+- **M3 — real reviewers:** connect the four adapters to the real
+  `crusty-old-engineer` skill / `philosophy-guardian` agent / measurability agent /
+  synthesis; persist reviews on the idea.
+- **M4 — routing side-effects:** enable idea→goal and idea→issue (labeled + owner-tagged)
+  behind the flag; land the real `IdeaGhClient` `gh` impl (no `--admin`/`--no-verify`).
+- **M5 — PR gate + outcome loop:** enforce the draft + blocking-label + owner-review
+  gate on creative-idea PRs; feed measured outcomes back so `ImplementationCompleted`
+  fires only on a met `success_metric`.
+- **M6 — tuning:** adaptive cadence, richer portfolio balancing, novelty scoring,
+  cross-pollination weighting from the Overseer/Journal.
+
+Each milestone is independently shippable and keeps the subsystem inert until the
+operator explicitly turns it on and redeploys.

--- a/docs/howto/configure-creative-ideas-thread.md
+++ b/docs/howto/configure-creative-ideas-thread.md
@@ -1,0 +1,326 @@
+---
+title: Configure and operate the Creative Ideas thread
+description: >
+  Operator + developer guide for Simard's Creative Ideas background thread
+  (#2419) — what it is, how to turn it on with SIMARD_CREATIVE_IDEAS_ENABLED,
+  tuning the cadence / batch / budget knobs, what one generation tick does
+  (generate → dedup/portfolio → persist → four-reviewer pipeline → synthesis →
+  route), how the human-review gate keeps creative-idea PRs unmergeable (draft +
+  blocking label + owner review, never --admin/--no-verify), tracing an idea
+  through goal ↔ issue ↔ PR, monitoring the telemetry, extending it with a
+  custom IdeaSource or Reviewer, and testing with the built-in fakes. The
+  subsystem is OFF by default.
+last_updated: 2026-07-05
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../reference/creative-ideas-api.md
+  - ../design/creative-ideas-thread.md
+  - ./add-a-new-cognitive-thread.md
+  - ./configure-cognitive-thread-scheduling.md
+  - ../reference/goal-board-api.md
+---
+
+# Configure and operate the Creative Ideas thread
+
+!!! note "Status — typed foundation + tests, OFF by default (#2419)"
+    The Creative Ideas subsystem ships as **tested scaffolding**, gated OFF
+    behind `SIMARD_CREATIVE_IDEAS_ENABLED` and **not yet registered** with the
+    `Mind` scheduler. Its reviewer and `gh` adapters run through **fakes** in
+    tests; the production idea-source, real skill/agent reviewers, and the real
+    `gh` PR/issue wiring are marked `// FUTURE:` and land across milestones
+    M2–M6 (see the
+    [design roadmap](../design/creative-ideas-thread.md#phased-roadmap-future-milestones)).
+    This guide documents the surface as built so you can enable, tune, extend,
+    and test it. For the exact Rust API, see the
+    [Creative Ideas API reference](../reference/creative-ideas-api.md).
+
+## What the Creative Ideas thread is
+
+The Creative Ideas thread is a **background cognitive thread** — one scheduled
+mental process among many that the `Mind` runs alongside OODA (see
+[Cognitive-thread scheduling](./configure-cognitive-thread-scheduling.md)). On a
+long cadence (≥ 24 h by default) it stands back from the current work, surveys
+where Simard is, and proposes a **diverse batch of ten candidate
+self-improvement ideas**. Each idea is stored as a **prospective-memory** node,
+reviewed by a four-reviewer pipeline, and then routed safely — to a goal, to a
+human-review issue, or parked.
+
+It is a divergent-thinking *source of new ideas*, not an executor. Nothing is
+committed to without review, high-risk ideas always go to a human, and any PR
+born from a creative idea is **blocked from merge** until the owner approves —
+enforced with plain GitHub mechanisms, **never** `--admin` or `--no-verify`.
+
+## When to use this
+
+- You want to **turn the subsystem on** in a non-production checkout and watch it
+  generate and review ideas.
+- You want to **tune** how often it runs, how many ideas it targets, or its
+  budget ceiling.
+- You are **extending** it with a real idea source or a new reviewer.
+- You need to understand the **human-review gate** on creative-idea PRs.
+
+If instead you want to add an unrelated scheduled process, see
+[Add a new cognitive thread](./add-a-new-cognitive-thread.md). To change
+*engineer* concurrency, that is the AIMD action-slot scaler
+(`SIMARD_MAX_CONCURRENT_ACTIONS`), not this thread.
+
+## Turn it on
+
+The subsystem is OFF by default. `CreativeIdeasConfig::from_env()` is the single
+gate; a default config is disabled and the thread's `enabled()` returns `false`,
+so it never ticks.
+
+!!! warning "Do not enable on the live daemon or against `~/.simard`"
+    This is a spike. Enable it only in a disposable checkout with an isolated
+    state root. The thread is also not registered with the `Mind` yet, so on the
+    current build turning the flag on has no runtime effect until the M2 wiring
+    milestone lands.
+
+```bash
+# Master switch (default: false)
+export SIMARD_CREATIVE_IDEAS_ENABLED=1
+
+# Optional tuning (defaults shown)
+export SIMARD_CREATIVE_IDEAS_INTERVAL_SECS=86400   # cadence: >= 24h observation window
+export SIMARD_CREATIVE_IDEAS_BATCH=10              # ideas targeted per run
+export SIMARD_DAILY_BUDGET_USD=5.00                # reused budget ceiling (existing knob)
+```
+
+| Env var | Default | Effect |
+|---------|---------|--------|
+| `SIMARD_CREATIVE_IDEAS_ENABLED` | `false` | Master switch. False ⇒ no generation, no routing, no side effects. |
+| `SIMARD_CREATIVE_IDEAS_INTERVAL_SECS` | `86400` | Generator cadence. Keep it large — this is a reflective pass, not a hot loop. |
+| `SIMARD_CREATIVE_IDEAS_BATCH` | `10` | Ideas targeted per run before dedup/portfolio filtering. |
+| `SIMARD_DAILY_BUDGET_USD` | *(existing)* | Reused: the thread skips an expensive tick when over budget. |
+
+The truthiness check mirrors `overseer_acting_enabled()` — `1`, `true`, `yes`,
+etc. count as on; unset or `0` is off.
+
+## What one generation tick does
+
+When enabled and due, `CreativeIdeasThread::tick` runs this pipeline. It is
+best-effort and total: any internal error is logged and folded into
+`ThreadOutcome::failed(reason, elapsed)` — it never panics and never aborts the
+daemon.
+
+```mermaid
+flowchart TD
+    A["tick (due + enabled + within budget)"] --> B[Assemble GenerationInputs<br/>goals, >=24h activity, episodics,<br/>WIP, overseer, meeting insights, prior ideas]
+    B --> C["IdeaSource.generate(inputs, 10)"]
+    C --> D[Dedup vs previous_ideas<br/>+ portfolio balancing]
+    D --> E[Persist survivors as<br/>CreativeIdea status=New]
+    E --> F[Four-reviewer pipeline<br/>crusty · philosophy · measurability]
+    F --> G[Synthesis sets next_status<br/>via try_transition]
+    G -->|AcceptedForImplementation,<br/>not flagged| H[route_idea_to_goal → Proposed goal]
+    G -->|NeedsHumanReview| I[route_idea_to_issue → issue<br/>label=creative-idea, assignee=rysweet]
+    G -->|Rejected / Deferred / NeedsRevision| J[Persist status; park or re-enter]
+```
+
+Budget/cadence guards short-circuit before any expensive work: over budget or
+merely not-yet-due ⇒ a **skipped** outcome with no side effects.
+
+## The four reviewers
+
+Every new idea is reviewed in order; then a synthesis step sets its status.
+
+| Reviewer | What it judges |
+|----------|----------------|
+| **crusty-old-engineer** (skill) | Scope, feasibility, necessity, utility, inventiveness, **risk**, need-for-human-review, practicality. Raises the `high_risk` / `needs_human` flags. |
+| **philosophy-guardian** (agent) | "Do we need this? Will it be interesting?" — but a **user signal is not required**; exploratory ideas are encouraged, so absence of a user request is never a block. |
+| **measurability** (agent, new) | Attaches a concrete **success metric** — tied where relevant to existing self-metrics like `recall_precision_at_k`, distill fact-yield, or reasoner-reliability. Without a metric, the idea cannot be accepted. |
+| **idea-feedback-synthesis** | Reads all reviews, writes next steps, and **sets the status** per the state machine. |
+
+**Synthesis policy** (default, deterministic):
+
+- Any `high_risk` / `irreversible` / `needs_human` flag ⇒ **NeedsHumanReview**.
+- A fatal block from a **non-philosophy reviewer** ⇒ **Rejected**; a fixable block ⇒ **NeedsRevision**. (A philosophy-guardian "no user signal" is never a block — exploratory ideas are encouraged.)
+- No success metric ⇒ **NeedsRevision** (unmeasurable ideas are not accepted).
+- Otherwise, enough support + a metric ⇒ **AcceptedForImplementation**.
+
+## Where reviewed ideas go (routing)
+
+| Synthesis result | Route | Effect |
+|------------------|-------|--------|
+| `AcceptedForImplementation`, not flagged | `route_idea_to_goal` | A `Proposed` goal on the goal board, tagged with the originating idea `node_id`. The idea moves to `ImplementationStarted`. |
+| `NeedsHumanReview` | `route_idea_to_issue` | A GitHub issue labelled `creative-idea` and **assigned to `rysweet`**, body embeds the idea `node_id` + next steps. |
+| `Rejected` / `Deferred` / `NeedsRevision` | *(none)* | Status persisted; parked or re-entered on a later pass. |
+
+## The human-review gate on creative-idea PRs
+
+A PR that arises from a creative-idea goal is tracked specially and **cannot be
+merged** until a human approves. `mark_idea_pr(pr, idea, gh, repo)` applies three
+standard GitHub mechanisms and returns an `IdeaPrGate` describing them (`repo` is
+`owner/name`, required because the underlying `gh` PR calls are repo-scoped):
+
+- **Draft** — the PR is kept as a draft; a draft PR is unmergeable by anyone
+  until explicitly marked ready.
+- **Blocking label** — `creative-idea-needs-human-review`; branch protection /
+  required status can key off this label to disable the merge button.
+- **Owner review-required** — review is *requested* from `rysweet`. Simard
+  never approves her own gate.
+- **Link-back** — the PR body carries `originating-idea: <node_id>`, so the
+  idea ↔ goal ↔ issue ↔ PR chain is fully traceable.
+
+!!! danger "Never bypass the gate"
+    The gate is enforced entirely with ordinary GitHub features. Simard
+    **never** runs `gh pr merge --admin` or `git --no-verify`, and a unit test
+    asserts the constructed `gh` argument vectors contain neither flag. An idea
+    reaches `ImplementationCompleted` only when **both** the PR merges through
+    the normal gate **and** its success metric is met.
+
+## Trace an idea end to end
+
+Every hop carries the originating idea `node_id`, so you can follow one idea
+through the whole system:
+
+1. **Idea** — a prospective node with `trigger_condition = "creative-idea"`.
+   List creative ideas via `CreativeIdeaStore::list` (or inspect prospective
+   memory with the [memory CLI](../reference/simard-memory-cli.md)).
+2. **Goal** — its `GoalRecord` evidence/label contains the idea `node_id`
+   (see the [Goal board API](../reference/goal-board-api.md)).
+3. **Issue** — for human-review ideas, the `creative-idea` issue assigned to
+   `rysweet` embeds the `node_id`.
+4. **PR** — its body carries `originating-idea: <node_id>`, and it stays a
+   labelled draft with an owner review requested until approved.
+
+## Monitor it
+
+Everything emits through the existing cognitive-thread telemetry facade
+(`src/cognitive_threads/telemetry.rs`; see
+[Telemetry metrics](../reference/telemetry-metrics.md)) keyed on the stable
+thread id `creative_ideas` and the reviewer ids `crusty_old_engineer`,
+`philosophy_guardian`, `measurability`, `idea_feedback_synthesis`:
+
+- ideas generated / deduped per run,
+- per-reviewer verdict counts,
+- routed→goal / routed→issue / pr-gated counts,
+- status-transition events.
+
+Output is structured `tracing` only — no `println!`/`eprintln!` beyond the
+`[simard] …` prefix convention.
+
+## Safety knobs
+
+| Guardrail | Knob / hook | Behavior |
+|-----------|-------------|----------|
+| Dedup / novelty | `dedup::is_near_duplicate(new, prior, threshold)` | Rejects a near-duplicate of a prior idea (token/shingle similarity). |
+| Diversity / portfolio | `portfolio::select_balanced(candidates, budget)` | Spreads the batch across risk/novelty buckets. |
+| Rate-limit / budget | `budget::within_budget(now, cfg)` + `SIMARD_DAILY_BUDGET_USD` | Skips an expensive tick when over budget. |
+| High-risk → human | synthesis policy + `try_transition` | High-risk/irreversible ideas can never auto-become a goal. |
+| Outcome feedback | `route::mark_completed(idea, metric_met)` | Refuses `ImplementationCompleted` unless the success metric is met. |
+| OFF by default | `SIMARD_CREATIVE_IDEAS_ENABLED` | Whole subsystem inert unless explicitly enabled. |
+| Dry-run | `ThreadContext.dry_run` | When set, `tick` still generates/reviews/logs but performs **no** destructive side-effect (no goal, issue, or PR writes). |
+| Cooperative shutdown | `ThreadContext.shutdown` | `tick` observes the scheduler's cancellation flag and returns promptly between pipeline stages, so a daemon stop is never blocked mid-generation. |
+
+## Extend it
+
+### Add a custom idea source
+
+Implement `IdeaSource`. The thread targets ten diverse candidates, then applies
+dedup + portfolio filtering.
+
+```rust
+use simard::cognitive_threads::threads::creative_ideas::{GenerationInputs, IdeaSource, RawIdea};
+use simard::error::SimardResult;
+
+struct MyIdeaSource;
+
+impl IdeaSource for MyIdeaSource {
+    fn generate(&self, inputs: &GenerationInputs, n: usize) -> SimardResult<Vec<RawIdea>> {
+        // Derive candidates from the read-only observation window.
+        let ideas = inputs
+            .current_goals
+            .iter()
+            .take(n)
+            .map(|g| RawIdea {
+                idea: format!("Improve tooling around: {g}"),
+                links: Vec::new(),
+                rationale: "derived from an active goal".into(),
+            })
+            .collect();
+        Ok(ideas)
+    }
+}
+```
+
+### Add or swap a reviewer
+
+Implement `Reviewer`. Keep the id stable (it keys telemetry) and only raise
+`needs_human` when a human genuinely must decide.
+
+```rust
+use simard::creative_ideas::reviewers::{Review, ReviewContext, ReviewFlags, ReviewVerdict, Reviewer};
+use simard::error::SimardResult;
+
+struct SecuritySmellReviewer;
+
+impl Reviewer for SecuritySmellReviewer {
+    fn id(&self) -> &'static str { "security_smell" }
+
+    fn review(&self, ctx: &ReviewContext<'_>) -> SimardResult<Review> {
+        let risky = ctx.idea.idea.to_lowercase().contains("disable auth");
+        Ok(Review {
+            reviewer: self.id(),
+            verdict: if risky { ReviewVerdict::NeedsHuman } else { ReviewVerdict::Support },
+            notes: "checked for auth/secret smells".into(),
+            flags: ReviewFlags { high_risk: risky, irreversible: false, needs_human: risky },
+            proposed_metric: None,
+        })
+    }
+}
+```
+
+Production reviewer adapters invoke an amplihack skill/agent through the
+`invoke_agent(prompt) -> String` seam; the prompt bodies are marked `// FUTURE:`
+until the real reviewers are wired (M3).
+
+## Test it (no network, all fakes)
+
+Every unit test runs with fakes and an injected clock — no network, no sleeps.
+
+```rust
+// Routing: an accepted, non-flagged idea produces a Proposed goal.
+let mut idea = CreativeIdea::new("index episodic recall by recency");
+idea.try_transition(IdeaStatus::AcceptedForImplementation).expect("legal edge");
+
+let goals = FakeGoalStore::default();
+let now_epoch = 1_700_000_000_u64;                 // injected clock (unix epoch seconds)
+let goal = route_idea_to_goal(&idea, &goals, now_epoch).expect("routes to goal");
+
+assert_eq!(goal.status, GoalStatus::Proposed);
+assert!(goal.evidence_contains(&idea.node_id));   // traceable back to the idea
+
+// PR gate: draft + blocking label + owner review, and NO privilege bypass.
+let gh = FakeIdeaGhClient::default();
+let gate = mark_idea_pr(42, &idea, &gh, "rysweet/Simard").expect("gate applied");
+assert!(gate.draft);
+assert_eq!(gate.blocking_label, "creative-idea-needs-human-review");
+assert_eq!(gate.review_requested_from, vec!["rysweet".to_string()]);
+assert!(gh.recorded_args().iter().all(|a| a != "--admin" && a != "--no-verify"));
+```
+
+The design's [test plan](../design/creative-ideas-thread.md#test-plan-no-network-all-fakes)
+covers the full set: valid/invalid `try_transition` edges, persist+retrieve with
+links, the four-reviewer pipeline + synthesis, all three routing paths, dedup
+rejection, off-by-default, the two error contracts, and a total `tick`.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Thread never runs | `SIMARD_CREATIVE_IDEAS_ENABLED` unset/`0`, or (current build) not registered with the `Mind` | Set the flag in a disposable checkout; runtime wiring lands in M2. |
+| No ideas generated but tick ran | Over budget or not yet due | Check `SIMARD_DAILY_BUDGET_USD` and `SIMARD_CREATIVE_IDEAS_INTERVAL_SECS`; a skipped tick has no side effects. |
+| An idea stuck in `NeedsRevision` | Measurability reviewer produced no success metric | Ensure the idea admits a concrete metric; unmeasurable ideas are intentionally not accepted. |
+| `InvalidIdeaTransition` in logs | Synthesis proposed an illegal `next_status` | Expected hard error — the runner rejects illegal edges rather than corrupting status. |
+| `InvalidCreativeIdeaRecord` on read | Bad JSON payload or a `payload_version` newer than this binary | Fail-closed by design — do not downgrade-read; upgrade the reader (reader-first rollout). |
+| A creative-idea PR looks mergeable | Draft/label/owner-review not applied | Re-run `mark_idea_pr`; never work around it with `--admin`/`--no-verify`. |
+
+## See also
+
+- [Creative Ideas subsystem API reference](../reference/creative-ideas-api.md)
+- [Creative Ideas background thread — design](../design/creative-ideas-thread.md)
+- [Configure and monitor cognitive-thread scheduling](./configure-cognitive-thread-scheduling.md)
+- [Add a new cognitive thread](./add-a-new-cognitive-thread.md)
+- [Goal board API](../reference/goal-board-api.md)

--- a/docs/reference/creative-ideas-api.md
+++ b/docs/reference/creative-ideas-api.md
@@ -1,0 +1,623 @@
+---
+title: Creative Ideas subsystem API reference
+description: >
+  Rust API reference for the Creative Ideas background thread (#2419) — the
+  CreativeIdea prospective-memory type and its IdeaStatus state machine
+  (try_transition), the CreativeIdeaStore prospective round-trip seam, the
+  CreativeIdeasThread generator and its GenerationInputs / IdeaSource, the
+  four-reviewer pipeline (Reviewer, Review, FeedbackSynthesizer,
+  SynthesisOutcome, SuccessMetric), the routing functions (route_idea_to_goal,
+  route_idea_to_issue, mark_idea_pr) with the IdeaGhClient seam, the two new
+  SimardError variants, configuration (SIMARD_CREATIVE_IDEAS_*), telemetry, and
+  the test fakes. Subsystem is gated OFF by default.
+last_updated: 2026-07-05
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+status: spike — typed foundation + tests (OFF by default)
+related:
+  - ../design/creative-ideas-thread.md
+  - ../howto/configure-creative-ideas-thread.md
+  - ./cognitive-thread-scheduling.md
+  - ./goal-board-api.md
+  - ./stewardship-api.md
+  - ./telemetry-metrics.md
+---
+
+# Creative Ideas subsystem API reference
+
+Modules:
+`simard::cognitive_memory::creative_idea`,
+`simard::cognitive_threads::threads::creative_ideas`,
+`simard::creative_ideas`.
+
+This page documents the public Rust surface of the **Creative Ideas** idea-
+generation subsystem: a cognitive thread plus a four-reviewer pipeline that
+primes a pool of candidate self-improvement ideas inside the single Simard
+brain. For the motivation, decision log, safety model, and roadmap, see
+[Creative Ideas background thread (design)](../design/creative-ideas-thread.md).
+To turn it on and operate it, see
+[Configure and operate the Creative Ideas thread](../howto/configure-creative-ideas-thread.md).
+
+!!! note "Status — typed foundation + tests, gated OFF (#2419)"
+    The types, the `IdeaStatus` state machine, the `CreativeIdeaStore`
+    prospective round-trip, the generator-thread skeleton, the reviewer /
+    synthesis / routing traits, and the dedup/portfolio/budget helpers **exist
+    and are unit-tested**. The subsystem is **OFF by default** behind
+    `SIMARD_CREATIVE_IDEAS_ENABLED`, is **not registered** with the `Mind`
+    scheduler, and its reviewer + `gh` adapters run through **fakes** in tests.
+    The production `LlmIdeaSource`, real skill/agent reviewer execution, and the
+    real `IdeaGhClient` `gh` subprocess impl are marked `// FUTURE:` seams. This
+    reference describes the surface exactly as it is built; the
+    [design roadmap](../design/creative-ideas-thread.md#phased-roadmap-future-milestones)
+    tracks the wiring milestones (M2–M6). No type or module contains the word
+    `Bridge` (operator preference).
+
+## Module layout
+
+```
+src/cognitive_memory/creative_idea.rs   # CreativeIdea, IdeaStatus (+ try_transition),
+                                         # MemoryLink/MemoryLinkKind, IdeaContext,
+                                         # CreativeIdeaStore + ProspectiveCreativeIdeaStore,
+                                         # FakeCreativeIdeaStore (cfg(test))
+src/cognitive_threads/threads/creative_ideas.rs
+                                         # CreativeIdeasThread (impl CognitiveThread, gated),
+                                         # GenerationInputs, ActivityWindow, RawIdea,
+                                         # IdeaSource trait + FakeIdeaSource, register(&mut Mind)
+src/creative_ideas/
+  mod.rs         # CreativeIdeasConfig::from_env (gating), const identifiers, re-exports
+  reviewers.rs   # Reviewer, Review, ReviewVerdict, ReviewFlags, 4 adapters, fakes
+  synthesis.rs   # FeedbackSynthesizer, DefaultSynthesizer, SynthesisOutcome, SuccessMetric
+  routing.rs     # route_idea_to_goal / route_idea_to_issue / mark_idea_pr,
+                 # IdeaGhClient + FakeIdeaGhClient, IdeaPrGate
+  dedup.rs       # is_near_duplicate, select_balanced, within_budget
+  tests.rs       # unit tests (all fakes, no network)
+src/error/mod.rs # + InvalidIdeaTransition, InvalidCreativeIdeaRecord
+```
+
+All fallible operations return the crate-wide
+`SimardResult<T> = Result<T, SimardError>` (`src/error/mod.rs`). There is no new
+`Result` alias, no `anyhow`, and no `unwrap()`/`expect()` on the runtime path
+(tests may `expect`). Every public struct is `Clone + Debug` and serde-
+serializable so it round-trips through prospective memory and is trivially
+asserted in tests.
+
+## Configuration
+
+`CreativeIdeasConfig::from_env()` is the single source of truth for gating and
+cadence. A default-constructed config is **disabled**.
+
+| Env var | Default | Effect |
+|---------|---------|--------|
+| `SIMARD_CREATIVE_IDEAS_ENABLED` | `false` | Master switch. When false the thread never ticks and nothing is generated or routed. |
+| `SIMARD_CREATIVE_IDEAS_INTERVAL_SECS` | `86400` | Generator cadence — a large (≥ 24 h) observation window. |
+| `SIMARD_CREATIVE_IDEAS_BATCH` | `10` | Ideas targeted per run (the design's fixed batch of ten). |
+| `SIMARD_DAILY_BUDGET_USD` | *(existing)* | Reused for budget-awareness before an expensive tick. |
+
+```rust
+pub struct CreativeIdeasConfig {
+    pub enabled: bool,        // SIMARD_CREATIVE_IDEAS_ENABLED (default false)
+    pub interval_secs: u64,   // SIMARD_CREATIVE_IDEAS_INTERVAL_SECS (default 86_400)
+    pub batch: usize,         // SIMARD_CREATIVE_IDEAS_BATCH (default 10)
+}
+
+impl CreativeIdeasConfig {
+    /// Parse from the environment. Truthy check mirrors overseer_acting_enabled().
+    pub fn from_env() -> Self;
+    /// True only when the master switch is truthy.
+    pub fn enabled(&self) -> bool;
+}
+```
+
+Stable operator/automation identifiers are centralized as `const`s so they are
+treated as a contract (see [Versioning](#versioning)):
+
+| Const | Value | Used for |
+|-------|-------|----------|
+| `CREATIVE_IDEA_TRIGGER` | `"creative-idea"` | Prospective node-type sentinel (retrieval key) and the issue label |
+| `CREATIVE_IDEA_PR_LABEL` | `"creative-idea-needs-human-review"` | The merge-blocking PR label |
+| `CREATIVE_IDEA_OWNER` | `"rysweet"` | Issue assignee / PR reviewer for the human gate |
+
+## Data model
+
+### `CreativeIdea`
+
+A `CreativeIdea` is the prospective-memory representation of one candidate
+improvement. It is a typed struct that round-trips to a single
+`CognitiveProspective` node.
+
+```rust
+pub struct CreativeIdea {
+    pub node_id: String,                       // prospective node_id ("" until stored)
+    pub idea: String,                          // idea text  -> prospective.description
+    pub status: IdeaStatus,                    // -> mirrored into prospective.status (String)
+    pub context: IdeaContext,                  // provenance/situation  -> payload
+    pub links: Vec<MemoryLink>,                // supporting memory nodes -> payload
+    pub reviews: Vec<Review>,                  // accumulated reviewer output -> payload
+    pub success_metric: Option<SuccessMetric>, // set by the measurability reviewer -> payload
+    pub created_epoch: u64,                    // injected clock -> payload
+}
+
+pub struct MemoryLink {
+    pub kind: MemoryLinkKind,                  // Semantic | Episodic | Procedural
+    pub node_id: String,
+}
+
+pub enum MemoryLinkKind { Semantic, Episodic, Procedural }
+
+pub struct IdeaContext {
+    pub source: String,                        // e.g. "creative-ideas-thread"
+    pub goals_snapshot: Vec<String>,
+    pub observation_digest: String,            // hash/summary of the >=24h window used
+    pub rationale: String,
+}
+```
+
+**Prospective mapping (round-trip).** The store (de)serializes a `CreativeIdea`
+to/from one `CognitiveProspective` node without any schema change to
+prospective memory:
+
+| `CognitiveProspective` field | `CreativeIdea` mapping |
+|------------------------------|------------------------|
+| `description` | `idea` (the idea text) |
+| `status` | `status.as_str()` (mirrored `IdeaStatus`) |
+| `trigger_condition` | fixed sentinel `CREATIVE_IDEA_TRIGGER` (`"creative-idea"`) — the retrieval filter |
+| `action_on_trigger` | JSON payload `{ payload_version, context, links, reviews, success_metric, created_epoch }` |
+| `priority` | derived from portfolio/risk (higher = more urgent to review) |
+
+The payload is versioned (`payload_version: u16`, starts at `1`) so a future
+native-links migration can detect old rows. A row whose `payload_version` is
+newer than the reader understands is a hard `InvalidCreativeIdeaRecord`, never a
+silent default.
+
+### `IdeaStatus` state machine
+
+`IdeaStatus` is the lifecycle of an idea. `status` changes **only** through
+`CreativeIdea::try_transition`, which validates the edge and returns
+`InvalidIdeaTransition { from, to }` for anything not in the table below.
+
+```rust
+pub enum IdeaStatus {
+    New,                     // freshly generated, not yet reviewed
+    NeedsRevision,           // synthesis asked for a rewrite before acceptance
+    NeedsHumanReview,        // high-risk / flagged: a human must decide
+    AcceptedForImplementation,
+    Rejected,                // terminal
+    Deferred,                // parked; may be reconsidered later
+    ImplementationStarted,   // a goal/PR is in flight
+    ImplementationCompleted, // terminal; ONLY when success_metric is met
+}
+
+impl CreativeIdea {
+    /// Validate and apply a status transition. Returns InvalidIdeaTransition on
+    /// any edge not in the allowed table.
+    pub fn try_transition(&mut self, to: IdeaStatus) -> SimardResult<()>;
+}
+
+impl IdeaStatus {
+    pub fn as_str(&self) -> &'static str;
+    pub fn is_terminal(&self) -> bool;               // Rejected | ImplementationCompleted
+    pub fn can_transition_to(&self, to: IdeaStatus) -> bool;
+}
+
+// Parsing is via the standard `FromStr` trait (fail-closed: an unknown string
+// yields `InvalidCreativeIdeaRecord`, never a silent default):
+impl std::str::FromStr for IdeaStatus {
+    type Err = SimardError;
+    fn from_str(s: &str) -> SimardResult<Self>;      // unknown -> InvalidCreativeIdeaRecord
+}
+```
+
+**Allowed transitions** (anything not listed is rejected):
+
+| From | To |
+|------|----|
+| `New` | `AcceptedForImplementation`, `Rejected`, `Deferred`, `NeedsRevision`, `NeedsHumanReview` |
+| `NeedsRevision` | `New`, `Rejected`, `Deferred` |
+| `NeedsHumanReview` | `AcceptedForImplementation`, `Rejected`, `Deferred` |
+| `Deferred` | `New`, `Rejected` |
+| `AcceptedForImplementation` | `ImplementationStarted`, `Deferred`, `Rejected` |
+| `ImplementationStarted` | `ImplementationCompleted`, `NeedsRevision`, `Rejected` |
+| `Rejected` | *(terminal — no outgoing)* |
+| `ImplementationCompleted` | *(terminal — no outgoing)* |
+
+```mermaid
+stateDiagram-v2
+    [*] --> New
+    New --> AcceptedForImplementation
+    New --> Rejected
+    New --> Deferred
+    New --> NeedsRevision
+    New --> NeedsHumanReview
+    NeedsRevision --> New
+    NeedsRevision --> Rejected
+    NeedsRevision --> Deferred
+    NeedsHumanReview --> AcceptedForImplementation
+    NeedsHumanReview --> Rejected
+    NeedsHumanReview --> Deferred
+    Deferred --> New
+    Deferred --> Rejected
+    AcceptedForImplementation --> ImplementationStarted
+    AcceptedForImplementation --> Deferred
+    AcceptedForImplementation --> Rejected
+    ImplementationStarted --> ImplementationCompleted
+    ImplementationStarted --> NeedsRevision
+    ImplementationStarted --> Rejected
+    Rejected --> [*]
+    ImplementationCompleted --> [*]
+```
+
+**Enforced invariants** (tested):
+
+- `ImplementationCompleted` is reachable **only** from `ImplementationStarted`.
+- The router refuses to complete an idea whose `success_metric` has not been
+  marked met — see [`mark_completed`](#outcome-feedback).
+- Any idea flagged high-risk/irreversible must pass through `NeedsHumanReview`
+  before it can reach `AcceptedForImplementation` (enforced by the synthesis
+  policy, below).
+
+### `CreativeIdeaStore` seam
+
+```rust
+pub trait CreativeIdeaStore {
+    fn store(&self, idea: &CreativeIdea) -> SimardResult<String>; // -> node_id
+    fn update(&self, idea: &CreativeIdea) -> SimardResult<()>;    // re-serialize payload/status
+    fn list(&self, limit: u32) -> SimardResult<Vec<CreativeIdea>>;
+    fn get(&self, node_id: &str) -> SimardResult<Option<CreativeIdea>>;
+}
+
+/// Production adapter over CognitiveMemoryOps (thin; no new backend).
+pub struct ProspectiveCreativeIdeaStore<'a> { /* mem: &'a dyn CognitiveMemoryOps */ }
+```
+
+`store`/`update` call `store_prospective`; `list` calls `list_all_prospective`,
+keeps rows whose `trigger_condition == CREATIVE_IDEA_TRIGGER`, and deserializes
+the payload; `get` filters `list` by `node_id`. Tests use an in-memory
+`FakeCreativeIdeaStore` **and** a round-trip test through a fake
+`CognitiveMemoryOps` that asserts `trigger_condition == "creative-idea"` and
+payload fidelity (`links`, `context`, `success_metric`).
+
+## The generator thread
+
+`CreativeIdeasThread` implements the `CognitiveThread` trait
+(see [Cognitive-thread scheduling](./cognitive-thread-scheduling.md)).
+
+| Method | Value | Notes |
+|--------|-------|-------|
+| `kind()` | `ThreadKind::BackgroundThought` | Reuses the reserved variant; no enum change. |
+| `policy()` | `SchedulePolicy::Interval(Duration::from_secs(interval_secs))` | Default 24 h; reserved to become `Adaptive` later. |
+| `priority()` | `Priority::Low` | Never competes with OODA. |
+| `enabled()` | `config.enabled()` → **`false` by default** | A disabled thread never ticks (scheduler contract), so the subsystem is inert unless explicitly turned on. |
+| `tick(&mut ThreadContext)` | `ThreadOutcome` | **Never returns `Err`** — internal errors are folded into `ThreadOutcome::failed(reason, elapsed)`. Uses `ctx.now_epoch` (injected clock) and may `block_on` `ctx.runtime`. Honors `ctx.shutdown` (returns promptly between stages) and `ctx.dry_run` (performs no goal/issue/PR side-effect). |
+
+```rust
+/// Register the thread with the Mind scheduler. NOT called from the live
+/// daemon during the spike; the call site is a marked `// FUTURE:` seam.
+pub fn register(mind: &mut Mind, config: CreativeIdeasConfig);
+```
+
+### Thread inputs (the observation window)
+
+`tick` assembles a typed `GenerationInputs` from **read-only** sources:
+
+```rust
+pub struct GenerationInputs {
+    pub current_goals: Vec<String>,          // GoalStore active/proposed
+    pub recent_activity: ActivityWindow,     // >= 24h of progress & behavior (Journal/OODA)
+    pub episodic_summaries: Vec<String>,     // cognitive-memory episodic digests
+    pub works_in_progress: Vec<String>,      // open goals/PRs/sessions
+    pub overseer_observations: Vec<String>,  // src/overseer (cross-pollination)
+    pub conversation_insights: Vec<String>,  // extracted from meetings/conversations
+    pub previous_ideas: Vec<CreativeIdea>,   // for dedup/novelty (store.list)
+}
+```
+
+### Pluggable idea source
+
+```rust
+pub struct RawIdea { pub idea: String, pub links: Vec<MemoryLink>, pub rationale: String }
+
+pub trait IdeaSource {
+    /// Produce up to `n` diverse raw idea candidates from the inputs.
+    fn generate(&self, inputs: &GenerationInputs, n: usize) -> SimardResult<Vec<RawIdea>>;
+}
+```
+
+- **Available now:** `FakeIdeaSource` (deterministic; used by tests).
+- **`// FUTURE:`** `LlmIdeaSource` (the production generator).
+
+The thread targets **ten** ideas per run, applies dedup + portfolio filtering
+(below), then persists each survivor as `CreativeIdea { status: New, links,
+context }` via `CreativeIdeaStore` and (in the wired future) enqueues it for
+review.
+
+## Reviewer pipeline
+
+Each new idea is reviewed by four reviewers in order; a synthesis step then sets
+the status. Reviewers are a trait so they are pluggable and independently
+testable.
+
+```rust
+pub struct ReviewContext<'a> {
+    pub idea: &'a CreativeIdea,
+    pub inputs: &'a GenerationInputs,
+}
+
+pub enum ReviewVerdict { Support, Concern, Block, NeedsHuman }
+
+pub struct ReviewFlags {
+    pub high_risk: bool,
+    pub irreversible: bool,
+    pub needs_human: bool,
+}
+
+pub struct Review {
+    pub reviewer: &'static str,                 // stable id for telemetry
+    pub verdict: ReviewVerdict,
+    pub notes: String,
+    pub flags: ReviewFlags,
+    pub proposed_metric: Option<SuccessMetric>, // measurability reviewer only
+}
+
+pub trait Reviewer {
+    fn id(&self) -> &'static str;
+    fn review(&self, ctx: &ReviewContext<'_>) -> SimardResult<Review>;
+}
+```
+
+The four reviewers and their stable ids:
+
+| Order | Reviewer id | Kind | Responsibility |
+|-------|-------------|------|----------------|
+| 1 | `crusty_old_engineer` | skill adapter | Scope, feasibility, necessity, utility, inventiveness, **RISK**, need-for-human-review, practicality. Sets `high_risk`/`needs_human` when warranted. |
+| 2 | `philosophy_guardian` | agent adapter | "Do we need this? Will it be an interesting enhancement?" **A user signal is NOT required** — absence of one is neutral, never a `Block`; exploratory ideas are encouraged. |
+| 3 | `measurability` | agent adapter (NEW) | Emits a concrete `SuccessMetric`, tied where relevant to existing self-metrics (`recall_precision_at_k`, distill fact-yield, reasoner-reliability). This metric is the only thing that can later move the idea to `ImplementationCompleted`. |
+| 4 | `idea_feedback_synthesis` | synthesis step | Reads **all** reviews + context, summarizes next steps, and **sets the status** per the state machine. |
+
+Production adapters shape an amplihack skill/agent invocation via the
+`invoke_agent(prompt) -> String` seam (the prompt bodies are marked `// FUTURE:`
+stubs); all tests inject deterministic fakes.
+
+### Synthesis
+
+```rust
+pub struct SuccessMetric {
+    pub name: String,           // e.g. "recall_precision_at_k"
+    pub baseline: Option<f64>,
+    pub target: String,         // e.g. ">= +0.05 over 7-day baseline"
+    pub how_measured: String,
+}
+
+pub struct SynthesisOutcome {
+    pub next_status: IdeaStatus,        // MUST be a legal transition from idea.status
+    pub next_steps: String,
+    pub set_metric: Option<SuccessMetric>,
+}
+
+pub trait FeedbackSynthesizer {
+    /// Fold all reviews into a next-status + human-readable next steps.
+    fn synthesize(&self, ctx: &ReviewContext<'_>, reviews: &[Review])
+        -> SimardResult<SynthesisOutcome>;
+}
+
+pub struct DefaultSynthesizer; // deterministic policy below; the test fake mirrors it
+```
+
+**Default synthesis policy** (deterministic; the test fake mirrors it):
+
+1. Any reviewer sets `irreversible` **or** `high_risk` **or** `needs_human`
+   → `NeedsHumanReview`.
+2. Any `Block` (from a non-philosophy reviewer) with no human flag →
+   `Rejected` (fatal) or `NeedsRevision` (fixable).
+3. No metric produced → `NeedsRevision` (an idea with no way to measure success
+   is not acceptable).
+4. Otherwise, sufficient support + a metric → `AcceptedForImplementation`.
+
+The pipeline runner applies `try_transition` to `next_status`, so an illegal
+synthesis verdict is a hard `InvalidIdeaTransition`, not a silent corruption.
+
+## Routing
+
+Routing consumes an idea whose synthesis has set a status and dispatches it. All
+routing functions are typed, produce side effects only through an injected seam,
+and are fake-tested.
+
+### 1. Accepted, not flagged → a Goal
+
+```rust
+pub fn route_idea_to_goal(idea: &CreativeIdea, goals: &dyn GoalStore, now_epoch: u64)
+    -> SimardResult<GoalRecord>;
+```
+
+Produces a `GoalRecord` with status `Proposed` and `slug = goal_slug(idea.idea)`,
+tagged in its evidence/label with the originating `idea.node_id` for
+traceability. The idea transitions `AcceptedForImplementation →
+ImplementationStarted` when the goal is created. Time is passed as
+`now_epoch: u64` (unix-epoch seconds) — the same injected-clock convention as
+`ctx.now_epoch` in `tick`, so there is no separate `Clock` trait to depend on
+and timestamps are deterministic under test.
+
+### 2. Accepted but flagged → a GitHub Issue tagging the owner
+
+```rust
+pub fn route_idea_to_issue(idea: &CreativeIdea, gh: &dyn IdeaGhClient, repo: &str)
+    -> SimardResult<GhIssue>;
+```
+
+Applies only to ideas in `NeedsHumanReview`. Creates an issue with label
+`creative-idea` and assignee `rysweet` (`CREATIVE_IDEA_OWNER`). The body embeds
+`idea.node_id` and the synthesized next steps.
+
+### 3. Idea-PR human-review gate
+
+```rust
+pub struct IdeaPrGate {
+    pub draft: bool,                        // always true: kept as DRAFT
+    pub blocking_label: &'static str,       // "creative-idea-needs-human-review"
+    pub review_requested_from: Vec<String>, // ["rysweet"] — owner review required
+    pub originating_idea: String,           // idea.node_id (link back)
+}
+
+pub fn mark_idea_pr(pr_number: u64, idea: &CreativeIdea, gh: &dyn IdeaGhClient, repo: &str)
+    -> SimardResult<IdeaPrGate>;
+```
+
+A PR arising from a creative-idea goal is blocked from merge by three standard
+GitHub mechanisms — **never** `--admin` or `--no-verify`. `repo` (`owner/name`)
+is required because every `IdeaGhClient` PR method (`set_pr_draft`,
+`add_pr_label`, `request_pr_review`) is repo-scoped:
+
+- **Draft** — a draft PR cannot be merged by anyone until marked ready.
+- **Blocking label** — `creative-idea-needs-human-review`; branch protection /
+  required status can key off it to keep the merge button disabled.
+- **Owner review-required** — `request-review` from `rysweet`. Simard
+  *requests* the review; she never approves her own gate.
+- **Link-back** — the PR body carries `originating-idea: <node_id>`, closing
+  the idea ↔ goal ↔ issue ↔ PR traceability loop.
+
+A unit test asserts the constructed `gh` argument vectors contain neither
+`--admin` nor `--no-verify`.
+
+### `IdeaGhClient` extension seam
+
+```rust
+pub trait IdeaGhClient {
+    fn create_labeled_issue(&self, repo: &str, title: &str, body: &str,
+        labels: &[&str], assignees: &[&str]) -> SimardResult<GhIssue>;
+    fn set_pr_draft(&self, repo: &str, pr: u64, draft: bool) -> SimardResult<()>;
+    fn add_pr_label(&self, repo: &str, pr: u64, label: &str) -> SimardResult<()>;
+    fn request_pr_review(&self, repo: &str, pr: u64, reviewer: &str) -> SimardResult<()>;
+}
+```
+
+- **Available now:** `FakeIdeaGhClient` records calls for assertions.
+- **`// FUTURE:`** the real subprocess impl (`gh issue create --label …
+  --assignee …`, `gh pr ready --undo`, `gh pr edit --add-label`, `gh pr edit
+  --add-reviewer`) reusing the `RealGhClient` pattern from
+  `src/stewardship/gh_client.rs`. See the [Stewardship API](./stewardship-api.md)
+  for that pattern.
+
+### Outcome feedback
+
+```rust
+/// Move an idea to ImplementationCompleted — refuses unless metric_met is true.
+pub fn mark_completed(idea: &mut CreativeIdea, metric_met: bool) -> SimardResult<()>;
+```
+
+`mark_completed` returns `InvalidIdeaTransition` if the idea is not in
+`ImplementationStarted`, and refuses (does not transition) when `!metric_met`.
+`ImplementationCompleted` therefore fires only when **both** the PR merges
+through the normal gate and the idea's `success_metric` is met.
+
+## Error handling
+
+The subsystem reuses the crate `SimardError` (structured, named-field variants;
+`Clone + Debug + Eq + PartialEq`) and adds **exactly two** new variants:
+
+```rust
+// src/error/mod.rs — the ONLY additions to the shared enum
+InvalidIdeaTransition {          // mirrors InvalidRuntimeTransition / InvalidSessionTransition
+    from: IdeaStatus,
+    to: IdeaStatus,
+},
+InvalidCreativeIdeaRecord {      // mirrors InvalidGoalRecord / InvalidImprovementRecord
+    field: String,
+    reason: String,
+},
+```
+
+Everything else reuses existing variants — no bespoke error machinery:
+
+| Source | Variant |
+|--------|---------|
+| serde (de)serialize failure | `InvalidCreativeIdeaRecord { field, reason }` (via `map_err`) |
+| Illegal `try_transition` / illegal synthesis `next_status` | `InvalidIdeaTransition { from, to }` |
+| Over budget / rate limit | `BudgetExceeded { period, spent, limit }` (or a skipped outcome when merely over cadence) |
+| `gh` non-zero exit / hang (future real impl) | `GitCommandFailed` / `ActionExecutionFailed` / `CommandTimeout` |
+| Unreachable skill/agent | `ReviewUnavailable { reason }` |
+| Fatal synthesis block | `ReviewBlocked { summary }` |
+| Unknown `IdeaStatus`/`ReviewVerdict`/`MemoryLinkKind` string, or too-new `payload_version` | `InvalidCreativeIdeaRecord` — **fail-closed**, never a silent default |
+
+`CreativeIdeasThread::tick` is infallible by contract: every internal `Err` is
+caught, `tracing::warn!`-logged with the stable `creative_ideas` thread id, and
+returned as `ThreadOutcome::failed(reason, elapsed)`. A single idea's failure
+never aborts the batch or the daemon.
+
+## Operation surface (the "endpoints")
+
+This subsystem has no HTTP/REST/GraphQL surface — it is an in-process Rust
+library, so its "API" is its public trait methods and free functions.
+
+| Operation | Request (input) | Response (`Ok`) | Primary error variants |
+|-----------|-----------------|-----------------|------------------------|
+| `CreativeIdeaStore::store` | `&CreativeIdea` | `String` (node_id) | `InvalidCreativeIdeaRecord`, `PersistentStoreIo`, `StoragePoisoned` |
+| `CreativeIdeaStore::update` | `&CreativeIdea` | `()` | `InvalidCreativeIdeaRecord`, `PersistentStoreIo`, `StoragePoisoned` |
+| `CreativeIdeaStore::list` | `limit: u32` | `Vec<CreativeIdea>` | `InvalidCreativeIdeaRecord`, `StoragePoisoned` |
+| `CreativeIdeaStore::get` | `&str` (node_id) | `Option<CreativeIdea>` | `InvalidCreativeIdeaRecord`, `StoragePoisoned` |
+| `CreativeIdea::try_transition` | `to: IdeaStatus` | `()` | `InvalidIdeaTransition { from, to }` |
+| `IdeaSource::generate` | `&GenerationInputs, n: usize` | `Vec<RawIdea>` | `ReviewUnavailable`, `BudgetExceeded` |
+| `Reviewer::review` | `&ReviewContext` | `Review` | `ReviewUnavailable` |
+| `FeedbackSynthesizer::synthesize` | `&ReviewContext, &[Review]` | `SynthesisOutcome` | `ReviewBlocked`, `InvalidIdeaTransition` |
+| `route_idea_to_goal` | `&CreativeIdea, &dyn GoalStore, now_epoch: u64` | `GoalRecord` | `InvalidGoalRecord`, `InvalidIdeaTransition` |
+| `route_idea_to_issue` | `&CreativeIdea, &dyn IdeaGhClient, repo: &str` | `GhIssue` | `ActionExecutionFailed`, `GitCommandFailed`, `CommandTimeout` |
+| `mark_idea_pr` | `pr: u64, &CreativeIdea, &dyn IdeaGhClient, repo: &str` | `IdeaPrGate` | `ActionExecutionFailed`, `GitCommandFailed`, `CommandTimeout` |
+| `mark_completed` | `&mut CreativeIdea, metric_met: bool` | `()` | `InvalidIdeaTransition` |
+| `CreativeIdeasThread::tick` | `&mut ThreadContext` | `ThreadOutcome` | **never `Err`** — folds into `ThreadOutcome::failed` |
+
+## Versioning
+
+With no wire protocol, three externally-observable contracts must remain stable:
+
+| Contract | Stability rule | Version mechanism |
+|----------|----------------|-------------------|
+| On-disk prospective payload (`action_on_trigger` JSON) | Additive-only within a major version; rename/removal needs a bump + migration | `payload_version: u16` (starts at `1`). Reader: `== known` parse; `> known` → `InvalidCreativeIdeaRecord`; missing → assume `1` |
+| Node-type sentinel (`trigger_condition = "creative-idea"`) | Never renamed — it is the retrieval key for stored rows | Literal `const CREATIVE_IDEA_TRIGGER`; a rename is a breaking migration |
+| Operator / automation surface (`SIMARD_CREATIVE_IDEAS_*`, labels, assignee) | Stable identifiers | Centralized `const`s in `CreativeIdeasConfig` |
+
+- **Trait/type API** — during the spike the Rust surface is
+  `#![allow(dead_code)]` and carries no semver promise. `Reviewer`,
+  `FeedbackSynthesizer`, `IdeaSource`, and `IdeaGhClient` are the long-term
+  extension seams: extend via new impls or new trait methods with defaults,
+  never by changing an existing signature.
+- **Enum evolution** — adding an `IdeaStatus`/`ReviewVerdict` state is
+  backward-compatible for writers, but per the fail-closed rule an older reader
+  rejects an unknown state. Ship such a change **reader-first**.
+- **Forward-migration hook (`// FUTURE:`)** — promoting `links` to native
+  prospective edges bumps `payload_version` to `2`; a one-shot migration reads
+  v1 rows, writes native edges, and rewrites the payload.
+
+## Observability
+
+Structured `tracing` only (no `println!`/`eprintln!` beyond the `[simard] …`
+prefix convention). Spans/metrics are keyed on the stable thread id
+`creative_ideas` and the reviewer ids (`crusty_old_engineer`,
+`philosophy_guardian`, `measurability`, `idea_feedback_synthesis`): ideas
+generated, deduped, per-verdict counts, routed→goal / routed→issue / pr-gated,
+and status-transition events. These reuse the existing cognitive-thread
+telemetry surface (`src/cognitive_threads/telemetry.rs`) documented in
+[Telemetry metrics](./telemetry-metrics.md).
+
+## Test fakes
+
+All tests run with no network and an injected clock. The following fakes are
+part of the module surface (`cfg(test)` where applicable):
+
+| Fake | Replaces | Used by |
+|------|----------|---------|
+| `FakeIdeaSource` | `IdeaSource` | pipeline / dedup tests |
+| `FakeCreativeIdeaStore` | `CreativeIdeaStore` | persistence tests (plus a fake `CognitiveMemoryOps` round-trip) |
+| Fake reviewers + fake `FeedbackSynthesizer` | `Reviewer` / `FeedbackSynthesizer` | pipeline / synthesis tests |
+| `FakeGoalStore` | `GoalStore` | `route_idea_to_goal` |
+| `FakeIdeaGhClient` | `IdeaGhClient` | `route_idea_to_issue`, `mark_idea_pr` (asserts no `--admin`/`--no-verify`) |
+| Injected `now_epoch: u64` | wall clock | deterministic timestamps (no `Clock` trait) |
+
+See the [design test plan](../design/creative-ideas-thread.md#test-plan-no-network-all-fakes)
+for the full list of assertions.
+
+## See also
+
+- [Creative Ideas background thread — design](../design/creative-ideas-thread.md)
+- [Configure and operate the Creative Ideas thread](../howto/configure-creative-ideas-thread.md)
+- [Cognitive-thread scheduling](./cognitive-thread-scheduling.md)
+- [Add a new cognitive thread](../howto/add-a-new-cognitive-thread.md)
+- [Goal board API](./goal-board-api.md) · [Stewardship API](./stewardship-api.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
     - Implementation Plan: architecture/implementation-plan.md
   - Design:
     - "Overseer — operator/observer co-process (spike)": design/overseer.md
+    - "Creative Ideas background thread (spike)": design/creative-ideas-thread.md
     - "Eliminate deterministic fallbacks": design/eliminate-deterministic-fallbacks.md
   - Concepts:
     - Operational Autonomy Model: concepts/operational-autonomy-model.md
@@ -179,6 +180,7 @@ nav:
     - Read Simard Status: howto/simard-status.md
     - Configure Cognitive-Thread Scheduling: howto/configure-cognitive-thread-scheduling.md
     - Add a New Cognitive Thread: howto/add-a-new-cognitive-thread.md
+    - Configure the Creative Ideas Thread: howto/configure-creative-ideas-thread.md
   - Reference:
     - CLI Reference: reference/simard-cli.md
     - Telemetry Metrics: reference/telemetry-metrics.md
@@ -278,6 +280,7 @@ nav:
     - Release Integrity (SBOM + Signing): reference/release-integrity.md
     - Distill Raw-Capture on Parse Failure: reference/distill-raw-capture-on-parse-failure.md
     - Cognitive-Thread Scheduling: reference/cognitive-thread-scheduling.md
+    - Creative Ideas Subsystem API: reference/creative-ideas-api.md
   - Operations:
     - Overview: operations/index.md
     - Verified Backups of the Live Store: operations/verified-backups.md

--- a/src/cognitive_memory/creative_idea.rs
+++ b/src/cognitive_memory/creative_idea.rs
@@ -1,0 +1,442 @@
+//! `CreativeIdea` — the prospective-memory representation of one candidate
+//! self-improvement idea (design spike #2419).
+//!
+//! A [`CreativeIdea`] is a typed struct that **round-trips to/from** a single
+//! [`CognitiveProspective`] node (Decision 1 of the design doc) with **no schema
+//! change** to prospective memory:
+//!
+//! | `CognitiveProspective` field | `CreativeIdea` mapping |
+//! |------------------------------|------------------------|
+//! | `description` | [`CreativeIdea::idea`] (the idea text) |
+//! | `trigger_condition` | the sentinel [`CREATIVE_IDEA_TRIGGER`] (retrieval key) |
+//! | `action_on_trigger` | JSON payload (versioned) with status/context/links/reviews/metric |
+//! | `priority` | derived from portfolio/risk |
+//!
+//! The subsystem is a **spike**: this file is real, tested typed foundation but
+//! nothing here is wired into the daemon and the generator is gated OFF (see
+//! [`crate::creative_ideas`]). `status` changes **only** through
+//! [`CreativeIdea::try_transition`], which validates every edge.
+#![allow(dead_code)]
+
+use serde::{Deserialize, Serialize};
+
+use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::creative_ideas::reviewers::{Review, ReviewFlags, ReviewVerdict, reviewer_id_from_str};
+use crate::creative_ideas::synthesis::SuccessMetric;
+use crate::error::{SimardError, SimardResult};
+use crate::memory_cognitive::CognitiveProspective;
+
+/// Prospective node-type sentinel written to `trigger_condition`. This is the
+/// retrieval key for every stored creative-idea row, so it is a **stable
+/// identifier** — renaming it is a breaking migration, not an edit.
+pub const CREATIVE_IDEA_TRIGGER: &str = "creative-idea";
+
+/// On-disk payload schema version. A row whose `payload_version` is **newer**
+/// than the reader understands is a hard [`SimardError::InvalidCreativeIdeaRecord`]
+/// (fail-closed), never a silent default. Starts at `1`; a future native-links
+/// migration bumps it to `2`.
+pub const CREATIVE_IDEA_PAYLOAD_VERSION: u16 = 1;
+
+/// The lifecycle status of a creative idea.
+///
+/// `status` changes only through [`CreativeIdea::try_transition`]; see
+/// [`IdeaStatus::can_transition_to`] for the allowed edges.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum IdeaStatus {
+    /// Freshly generated, not yet reviewed.
+    New,
+    /// Synthesis asked for a rewrite before acceptance.
+    NeedsRevision,
+    /// High-risk / flagged: a human must decide.
+    NeedsHumanReview,
+    /// Reviewed and accepted; may be promoted to a goal.
+    AcceptedForImplementation,
+    /// Terminal: rejected.
+    Rejected,
+    /// Parked; may be reconsidered later.
+    Deferred,
+    /// A goal/PR is in flight.
+    ImplementationStarted,
+    /// Terminal: completed — reachable ONLY when the success metric is met.
+    ImplementationCompleted,
+}
+
+impl IdeaStatus {
+    /// Stable string form (matches the serde variant names) used both in the
+    /// mirrored prospective `status` field and in the JSON payload.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::New => "New",
+            Self::NeedsRevision => "NeedsRevision",
+            Self::NeedsHumanReview => "NeedsHumanReview",
+            Self::AcceptedForImplementation => "AcceptedForImplementation",
+            Self::Rejected => "Rejected",
+            Self::Deferred => "Deferred",
+            Self::ImplementationStarted => "ImplementationStarted",
+            Self::ImplementationCompleted => "ImplementationCompleted",
+        }
+    }
+
+    /// Terminal states have no outgoing transitions.
+    #[must_use]
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Rejected | Self::ImplementationCompleted)
+    }
+
+    /// Whether `self -> to` is an allowed edge of the state machine.
+    ///
+    /// The full table (anything not listed is rejected):
+    ///
+    /// | From | To |
+    /// |------|----|
+    /// | `New` | `AcceptedForImplementation`, `Rejected`, `Deferred`, `NeedsRevision`, `NeedsHumanReview` |
+    /// | `NeedsRevision` | `New`, `Rejected`, `Deferred` |
+    /// | `NeedsHumanReview` | `AcceptedForImplementation`, `Rejected`, `Deferred` |
+    /// | `Deferred` | `New`, `Rejected` |
+    /// | `AcceptedForImplementation` | `ImplementationStarted`, `Deferred`, `Rejected` |
+    /// | `ImplementationStarted` | `ImplementationCompleted`, `NeedsRevision`, `Rejected` |
+    /// | `Rejected` / `ImplementationCompleted` | *(terminal)* |
+    #[must_use]
+    pub fn can_transition_to(&self, to: Self) -> bool {
+        use IdeaStatus::{
+            AcceptedForImplementation, Deferred, ImplementationCompleted, ImplementationStarted,
+            NeedsHumanReview, NeedsRevision, New, Rejected,
+        };
+        matches!(
+            (self, to),
+            (New, AcceptedForImplementation)
+                | (New, Rejected)
+                | (New, Deferred)
+                | (New, NeedsRevision)
+                | (New, NeedsHumanReview)
+                | (NeedsRevision, New)
+                | (NeedsRevision, Rejected)
+                | (NeedsRevision, Deferred)
+                | (NeedsHumanReview, AcceptedForImplementation)
+                | (NeedsHumanReview, Rejected)
+                | (NeedsHumanReview, Deferred)
+                | (Deferred, New)
+                | (Deferred, Rejected)
+                | (AcceptedForImplementation, ImplementationStarted)
+                | (AcceptedForImplementation, Deferred)
+                | (AcceptedForImplementation, Rejected)
+                | (ImplementationStarted, ImplementationCompleted)
+                | (ImplementationStarted, NeedsRevision)
+                | (ImplementationStarted, Rejected)
+        )
+    }
+}
+
+impl std::str::FromStr for IdeaStatus {
+    type Err = SimardError;
+
+    /// Parse a status string. **Fail-closed**: an unknown value yields
+    /// [`SimardError::InvalidCreativeIdeaRecord`] rather than a silent default.
+    fn from_str(s: &str) -> SimardResult<Self> {
+        match s {
+            "New" => Ok(Self::New),
+            "NeedsRevision" => Ok(Self::NeedsRevision),
+            "NeedsHumanReview" => Ok(Self::NeedsHumanReview),
+            "AcceptedForImplementation" => Ok(Self::AcceptedForImplementation),
+            "Rejected" => Ok(Self::Rejected),
+            "Deferred" => Ok(Self::Deferred),
+            "ImplementationStarted" => Ok(Self::ImplementationStarted),
+            "ImplementationCompleted" => Ok(Self::ImplementationCompleted),
+            other => Err(SimardError::InvalidCreativeIdeaRecord {
+                field: "status".to_string(),
+                reason: format!("unknown idea status '{other}'"),
+            }),
+        }
+    }
+}
+
+impl std::fmt::Display for IdeaStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The kind of memory node a [`MemoryLink`] points at.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum MemoryLinkKind {
+    /// A distilled semantic fact.
+    Semantic,
+    /// An autobiographical episode.
+    Episodic,
+    /// A reusable procedure.
+    Procedural,
+}
+
+/// A typed edge from a [`CreativeIdea`] to another memory node that
+/// supports/resources it.
+///
+/// FUTURE: promote links to native prospective edges (payload_version 2).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct MemoryLink {
+    pub kind: MemoryLinkKind,
+    pub node_id: String,
+}
+
+/// Provenance + situational context captured at generation time.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct IdeaContext {
+    /// e.g. `"creative-ideas-thread"`.
+    pub source: String,
+    /// The active/proposed goals when the idea was generated.
+    pub goals_snapshot: Vec<String>,
+    /// Hash/summary of the >=24h observation window used.
+    pub observation_digest: String,
+    /// Free-text rationale for why this idea surfaced.
+    pub rationale: String,
+}
+
+/// A candidate self-improvement idea, stored as a prospective-memory node.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct CreativeIdea {
+    /// Prospective `node_id` (`""` until stored).
+    pub node_id: String,
+    /// The idea text (-> prospective `description`).
+    pub idea: String,
+    /// Lifecycle status; mutate only via [`CreativeIdea::try_transition`].
+    pub status: IdeaStatus,
+    /// Provenance/situational context (-> payload).
+    pub context: IdeaContext,
+    /// Supporting semantic/episodic/procedural nodes (-> payload).
+    pub links: Vec<MemoryLink>,
+    /// Accumulated reviewer output (-> payload).
+    pub reviews: Vec<Review>,
+    /// Set by the measurability reviewer; the ONLY thing that can later move the
+    /// idea to `ImplementationCompleted` (-> payload).
+    pub success_metric: Option<SuccessMetric>,
+    /// Injected unix-epoch (seconds) at generation time (-> payload).
+    pub created_epoch: u64,
+}
+
+impl CreativeIdea {
+    /// Build a fresh `New` idea with no reviews/metric yet.
+    #[must_use]
+    pub fn new(idea: impl Into<String>, context: IdeaContext, created_epoch: u64) -> Self {
+        Self {
+            node_id: String::new(),
+            idea: idea.into(),
+            status: IdeaStatus::New,
+            context,
+            links: Vec::new(),
+            reviews: Vec::new(),
+            success_metric: None,
+            created_epoch,
+        }
+    }
+
+    /// Validate and apply a status transition. The **only** way `status`
+    /// changes. Returns [`SimardError::InvalidIdeaTransition`] on any edge not
+    /// in the allowed table.
+    pub fn try_transition(&mut self, to: IdeaStatus) -> SimardResult<()> {
+        if self.status.can_transition_to(to) {
+            self.status = to;
+            Ok(())
+        } else {
+            Err(SimardError::InvalidIdeaTransition {
+                from: self.status,
+                to,
+            })
+        }
+    }
+
+    /// Priority written to the prospective node (higher = more urgent to
+    /// review). Derived from risk flags on the accumulated reviews.
+    #[must_use]
+    pub fn priority(&self) -> i64 {
+        let flagged = self
+            .reviews
+            .iter()
+            .any(|r| r.flags.high_risk || r.flags.irreversible || r.flags.needs_human);
+        if flagged { 5 } else { 3 }
+    }
+
+    /// Serialize the versioned JSON payload written to `action_on_trigger`.
+    pub fn to_action_payload(&self) -> SimardResult<String> {
+        let payload = StoredPayload {
+            payload_version: CREATIVE_IDEA_PAYLOAD_VERSION,
+            status: self.status,
+            context: self.context.clone(),
+            links: self.links.clone(),
+            reviews: self
+                .reviews
+                .iter()
+                .map(PersistedReview::from_review)
+                .collect(),
+            success_metric: self.success_metric.clone(),
+            created_epoch: self.created_epoch,
+        };
+        serde_json::to_string(&payload).map_err(|e| SimardError::InvalidCreativeIdeaRecord {
+            field: "action_on_trigger".to_string(),
+            reason: format!("failed to serialize payload: {e}"),
+        })
+    }
+
+    /// Reconstruct a `CreativeIdea` from a stored [`CognitiveProspective`] node.
+    ///
+    /// Fail-closed: a wrong sentinel, unparseable payload, too-new
+    /// `payload_version`, or unknown enum string is a hard
+    /// [`SimardError::InvalidCreativeIdeaRecord`].
+    pub fn from_prospective(node: &CognitiveProspective) -> SimardResult<Self> {
+        if node.trigger_condition != CREATIVE_IDEA_TRIGGER {
+            return Err(SimardError::InvalidCreativeIdeaRecord {
+                field: "trigger_condition".to_string(),
+                reason: format!(
+                    "expected sentinel '{CREATIVE_IDEA_TRIGGER}', got '{}'",
+                    node.trigger_condition
+                ),
+            });
+        }
+        let payload: StoredPayload =
+            serde_json::from_str(&node.action_on_trigger).map_err(|e| {
+                SimardError::InvalidCreativeIdeaRecord {
+                    field: "action_on_trigger".to_string(),
+                    reason: format!("failed to parse payload: {e}"),
+                }
+            })?;
+        if payload.payload_version > CREATIVE_IDEA_PAYLOAD_VERSION {
+            return Err(SimardError::InvalidCreativeIdeaRecord {
+                field: "payload_version".to_string(),
+                reason: format!(
+                    "on-disk row version {} is newer than reader version {CREATIVE_IDEA_PAYLOAD_VERSION}",
+                    payload.payload_version
+                ),
+            });
+        }
+        let reviews = payload
+            .reviews
+            .into_iter()
+            .map(PersistedReview::into_review)
+            .collect::<SimardResult<Vec<_>>>()?;
+        Ok(Self {
+            node_id: node.node_id.clone(),
+            idea: node.description.clone(),
+            status: payload.status,
+            context: payload.context,
+            links: payload.links,
+            reviews,
+            success_metric: payload.success_metric,
+            created_epoch: payload.created_epoch,
+        })
+    }
+}
+
+/// The versioned JSON payload persisted in `action_on_trigger`.
+#[derive(Serialize, Deserialize)]
+struct StoredPayload {
+    payload_version: u16,
+    status: IdeaStatus,
+    context: IdeaContext,
+    links: Vec<MemoryLink>,
+    reviews: Vec<PersistedReview>,
+    success_metric: Option<SuccessMetric>,
+    created_epoch: u64,
+}
+
+/// On-disk form of a [`Review`]. [`Review::reviewer`] is a `&'static str`
+/// (a stable telemetry id) which cannot be `Deserialize`d directly, so the
+/// payload stores the id as a `String` and [`Self::into_review`] maps it back
+/// to a known static id — **fail-closed** on an unknown reviewer.
+#[derive(Serialize, Deserialize)]
+struct PersistedReview {
+    reviewer: String,
+    verdict: ReviewVerdict,
+    notes: String,
+    flags: ReviewFlags,
+    proposed_metric: Option<SuccessMetric>,
+}
+
+impl PersistedReview {
+    fn from_review(review: &Review) -> Self {
+        Self {
+            reviewer: review.reviewer.to_string(),
+            verdict: review.verdict,
+            notes: review.notes.clone(),
+            flags: review.flags,
+            proposed_metric: review.proposed_metric.clone(),
+        }
+    }
+
+    fn into_review(self) -> SimardResult<Review> {
+        let reviewer = reviewer_id_from_str(&self.reviewer).ok_or_else(|| {
+            SimardError::InvalidCreativeIdeaRecord {
+                field: "reviews.reviewer".to_string(),
+                reason: format!("unknown reviewer id '{}'", self.reviewer),
+            }
+        })?;
+        Ok(Review {
+            reviewer,
+            verdict: self.verdict,
+            notes: self.notes,
+            flags: self.flags,
+            proposed_metric: self.proposed_metric,
+        })
+    }
+}
+
+/// A thin persistence seam for creative ideas over prospective memory.
+///
+/// The production adapter is [`ProspectiveCreativeIdeaStore`]; tests use an
+/// in-memory fake. No new storage backend is introduced.
+pub trait CreativeIdeaStore {
+    /// Persist a new idea; returns its prospective `node_id`.
+    fn store(&self, idea: &CreativeIdea) -> SimardResult<String>;
+    /// Re-serialize an existing idea's payload/status.
+    fn update(&self, idea: &CreativeIdea) -> SimardResult<()>;
+    /// List up to `limit` stored creative ideas (filtered by the sentinel).
+    fn list(&self, limit: u32) -> SimardResult<Vec<CreativeIdea>>;
+    /// Fetch one idea by `node_id`.
+    fn get(&self, node_id: &str) -> SimardResult<Option<CreativeIdea>>;
+}
+
+/// Production [`CreativeIdeaStore`] over [`CognitiveMemoryOps`] — thin, no new
+/// backend. `list` keeps only rows whose `trigger_condition` is the sentinel.
+pub struct ProspectiveCreativeIdeaStore<'a> {
+    mem: &'a dyn CognitiveMemoryOps,
+}
+
+impl<'a> ProspectiveCreativeIdeaStore<'a> {
+    /// Wrap a live cognitive-memory handle.
+    #[must_use]
+    pub fn new(mem: &'a dyn CognitiveMemoryOps) -> Self {
+        Self { mem }
+    }
+}
+
+impl CreativeIdeaStore for ProspectiveCreativeIdeaStore<'_> {
+    fn store(&self, idea: &CreativeIdea) -> SimardResult<String> {
+        let action = idea.to_action_payload()?;
+        self.mem
+            .store_prospective(&idea.idea, CREATIVE_IDEA_TRIGGER, &action, idea.priority())
+    }
+
+    fn update(&self, idea: &CreativeIdea) -> SimardResult<()> {
+        // FUTURE (M2): a real upsert-by-node_id in the memory layer. During the
+        // spike `store_prospective` is the only write seam, so `update`
+        // re-persists the payload; callers treat ideas as append-only for now.
+        let action = idea.to_action_payload()?;
+        self.mem
+            .store_prospective(&idea.idea, CREATIVE_IDEA_TRIGGER, &action, idea.priority())?;
+        Ok(())
+    }
+
+    fn list(&self, limit: u32) -> SimardResult<Vec<CreativeIdea>> {
+        let nodes = self.mem.list_all_prospective(limit)?;
+        nodes
+            .iter()
+            .filter(|n| n.trigger_condition == CREATIVE_IDEA_TRIGGER)
+            .map(CreativeIdea::from_prospective)
+            .collect()
+    }
+
+    fn get(&self, node_id: &str) -> SimardResult<Option<CreativeIdea>> {
+        Ok(self
+            .list(u32::MAX)?
+            .into_iter()
+            .find(|idea| idea.node_id == node_id))
+    }
+}

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -747,6 +747,11 @@ pub trait CognitiveMemoryOps: Send + Sync {
 const EXACT_NAME_RECALL_LIMIT: u32 = 16;
 pub mod metrics;
 
+// Issue #2419 (design spike): the `CreativeIdea` prospective-memory type + its
+// `IdeaStatus` state machine + `CreativeIdeaStore` round-trip seam. Additive;
+// no schema change to prospective memory. Gated OFF at the subsystem level.
+pub mod creative_idea;
+
 // De-fork Phase 2b (issue #2307): the library-backed `CognitiveMemoryOps`
 // adapter is now the sole cognitive-memory backend. Re-exported at the
 // module root so callers reference `cognitive_memory::LibraryCognitiveMemory`.

--- a/src/cognitive_threads/threads/creative_ideas.rs
+++ b/src/cognitive_threads/threads/creative_ideas.rs
@@ -1,0 +1,333 @@
+//! The Creative Ideas generator thread (design spike #2419).
+//!
+//! `CreativeIdeasThread` implements [`CognitiveThread`] and reuses
+//! [`ThreadKind::BackgroundThought`] (Decision 2). It is **gated OFF by
+//! default** (`enabled()` reads [`CreativeIdeasConfig::enabled`], default
+//! `false`), so the scheduler never ticks it unless explicitly turned on. It is
+//! **not registered** with the `Mind` during the spike — [`register`] is a
+//! marked `// FUTURE:` seam.
+//!
+//! `tick` is **total by contract**: every internal `Err` is caught,
+//! `tracing::warn!`-logged with the stable `creative_ideas` id, and returned as
+//! [`ThreadOutcome::failed`] — a single idea's failure never aborts the batch or
+//! the daemon. It honors `ctx.shutdown` (cooperative cancellation) and
+//! `ctx.dry_run` (no external side-effect).
+#![allow(dead_code)]
+
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+
+use super::super::mind::Mind;
+use super::super::thread::{
+    CognitiveThread, Priority, SchedulePolicy, ThreadContext, ThreadHealth, ThreadKind,
+    ThreadOutcome,
+};
+use crate::cognitive_memory::creative_idea::{
+    CreativeIdea, CreativeIdeaStore, IdeaContext, MemoryLink, ProspectiveCreativeIdeaStore,
+};
+use crate::creative_ideas::CreativeIdeasConfig;
+use crate::creative_ideas::dedup;
+use crate::error::{SimardError, SimardResult};
+
+/// Stable telemetry id.
+pub const CREATIVE_IDEAS_ID: &str = "creative_ideas";
+
+/// A >= 24h window of recent progress & behavior (from the Journal / OODA).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ActivityWindow {
+    /// The window size actually covered, in seconds.
+    pub window_secs: u64,
+    /// Digested activity entries (newest first).
+    pub entries: Vec<String>,
+}
+
+/// Typed, read-only inputs assembled by the generator's observation window.
+#[derive(Clone, Debug, Default)]
+pub struct GenerationInputs {
+    /// Active/proposed goals.
+    pub current_goals: Vec<String>,
+    /// >= 24h of progress & behavior.
+    pub recent_activity: ActivityWindow,
+    /// Cognitive-memory episodic digests.
+    pub episodic_summaries: Vec<String>,
+    /// Open goals/PRs/sessions.
+    pub works_in_progress: Vec<String>,
+    /// Overseer observations (cross-pollination).
+    pub overseer_observations: Vec<String>,
+    /// Insights extracted from meetings/conversations.
+    pub conversation_insights: Vec<String>,
+    /// Previously-generated ideas (for dedup/novelty).
+    pub previous_ideas: Vec<CreativeIdea>,
+}
+
+/// A raw idea candidate produced by an [`IdeaSource`], before review.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RawIdea {
+    /// The idea text.
+    pub idea: String,
+    /// Supporting memory links.
+    pub links: Vec<MemoryLink>,
+    /// Why this idea surfaced.
+    pub rationale: String,
+}
+
+/// Produces raw idea candidates from the observation window.
+pub trait IdeaSource: Send {
+    /// Produce up to `n` diverse raw idea candidates from `inputs`.
+    fn generate(&self, inputs: &GenerationInputs, n: usize) -> SimardResult<Vec<RawIdea>>;
+}
+
+/// Deterministic idea source for tests (no network).
+#[derive(Clone, Debug, Default)]
+pub struct FakeIdeaSource {
+    ideas: Vec<RawIdea>,
+    fail: bool,
+}
+
+impl FakeIdeaSource {
+    /// Build a source that yields the given ideas (truncated to `n`).
+    #[must_use]
+    pub fn with_ideas(ideas: Vec<RawIdea>) -> Self {
+        Self { ideas, fail: false }
+    }
+
+    /// Build a source whose `generate` always fails (drives the tick-is-total
+    /// test).
+    #[must_use]
+    pub fn failing() -> Self {
+        Self {
+            ideas: Vec::new(),
+            fail: true,
+        }
+    }
+}
+
+impl IdeaSource for FakeIdeaSource {
+    fn generate(&self, _inputs: &GenerationInputs, n: usize) -> SimardResult<Vec<RawIdea>> {
+        if self.fail {
+            return Err(SimardError::ReviewUnavailable {
+                reason: "fake idea source configured to fail".to_string(),
+            });
+        }
+        Ok(self.ideas.iter().take(n).cloned().collect())
+    }
+}
+
+/// Production idea source — a marked `// FUTURE:` stub for the spike.
+///
+/// FUTURE (M2): the real LLM-backed generator producing diverse ideas from the
+/// observation window. Until then `generate` returns
+/// [`SimardError::ReviewUnavailable`]; the thread is gated OFF so it never runs.
+#[derive(Clone, Debug, Default)]
+pub struct LlmIdeaSource;
+
+impl IdeaSource for LlmIdeaSource {
+    fn generate(&self, _inputs: &GenerationInputs, _n: usize) -> SimardResult<Vec<RawIdea>> {
+        Err(SimardError::ReviewUnavailable {
+            reason: "LlmIdeaSource is not wired during the spike (M2)".to_string(),
+        })
+    }
+}
+
+/// The Creative Ideas generator cognitive thread.
+pub struct CreativeIdeasThread {
+    cfg: CreativeIdeasConfig,
+    source: Box<dyn IdeaSource>,
+    last_run_epoch: Option<u64>,
+    next_run_epoch: Option<u64>,
+    last_success: Option<bool>,
+    consecutive_errors: u32,
+}
+
+impl CreativeIdeasThread {
+    /// Build the thread from an explicit config + idea source (test seam).
+    #[must_use]
+    pub fn new(cfg: CreativeIdeasConfig, source: Box<dyn IdeaSource>) -> Self {
+        Self {
+            cfg,
+            source,
+            last_run_epoch: None,
+            next_run_epoch: None,
+            last_success: None,
+            consecutive_errors: 0,
+        }
+    }
+
+    /// Build from the environment with the production (FUTURE) idea source.
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self::new(CreativeIdeasConfig::from_env(), Box::new(LlmIdeaSource))
+    }
+
+    /// The core, fallible tick body. `tick` wraps this and folds any `Err` into
+    /// a [`ThreadOutcome::failed`] so the public contract stays infallible.
+    fn run_tick(&mut self, ctx: &mut ThreadContext<'_>) -> SimardResult<GenerationReport> {
+        let inputs = self.assemble_inputs(ctx);
+
+        let raw = self.source.generate(&inputs, self.cfg.batch)?;
+        let generated = raw.len();
+
+        let deduped =
+            dedup::reject_duplicates(raw, &inputs.previous_ideas, dedup::DEFAULT_DEDUP_THRESHOLD);
+        let selected = dedup::select_balanced(deduped, self.cfg.batch);
+        let surviving = selected.len();
+
+        let mut persisted = 0usize;
+        if !ctx.dry_run {
+            let store = ProspectiveCreativeIdeaStore::new(ctx.memory);
+            for raw_idea in &selected {
+                if ctx.shutdown.load(Ordering::Relaxed) {
+                    break;
+                }
+                let idea = raw_to_creative_idea(raw_idea, &inputs, ctx.now_epoch);
+                store.store(&idea)?;
+                persisted += 1;
+            }
+        }
+
+        Ok(GenerationReport {
+            generated,
+            surviving,
+            persisted,
+            dry_run: ctx.dry_run,
+        })
+    }
+
+    /// Assemble the (read-only) observation window.
+    ///
+    /// FUTURE (M2): populate from the goal store / Journal / OODA / Overseer /
+    /// conversation insights / previous ideas. During the spike this is empty
+    /// so the gated-OFF thread has no external reads.
+    fn assemble_inputs(&self, _ctx: &ThreadContext<'_>) -> GenerationInputs {
+        GenerationInputs::default()
+    }
+
+    fn record_success(&mut self, now_epoch: u64) {
+        self.last_run_epoch = Some(now_epoch);
+        self.next_run_epoch = Some(now_epoch.saturating_add(self.cfg.interval_secs));
+        self.last_success = Some(true);
+        self.consecutive_errors = 0;
+    }
+
+    fn record_failure(&mut self, now_epoch: u64) {
+        self.last_run_epoch = Some(now_epoch);
+        self.next_run_epoch = Some(now_epoch.saturating_add(self.cfg.interval_secs));
+        self.last_success = Some(false);
+        self.consecutive_errors = self.consecutive_errors.saturating_add(1);
+    }
+}
+
+/// Structured result of one successful generation tick.
+struct GenerationReport {
+    generated: usize,
+    surviving: usize,
+    persisted: usize,
+    dry_run: bool,
+}
+
+impl CognitiveThread for CreativeIdeasThread {
+    fn id(&self) -> &str {
+        CREATIVE_IDEAS_ID
+    }
+
+    fn kind(&self) -> ThreadKind {
+        ThreadKind::BackgroundThought
+    }
+
+    fn policy(&self) -> SchedulePolicy {
+        SchedulePolicy::Interval(Duration::from_secs(self.cfg.interval_secs))
+    }
+
+    fn priority(&self) -> Priority {
+        Priority::Low
+    }
+
+    fn enabled(&self) -> bool {
+        self.cfg.enabled()
+    }
+
+    fn tick(&mut self, ctx: &mut ThreadContext<'_>) -> ThreadOutcome {
+        let start = Instant::now();
+
+        // Gated OFF: never do work unless explicitly enabled.
+        if !self.cfg.enabled() {
+            return ThreadOutcome::skipped();
+        }
+        // Cooperative cancellation: bail promptly on shutdown.
+        if ctx.shutdown.load(Ordering::Relaxed) {
+            return ThreadOutcome::skipped();
+        }
+
+        match self.run_tick(ctx) {
+            Ok(report) => {
+                self.record_success(ctx.now_epoch);
+                let verb = if report.dry_run {
+                    "generated (dry-run)"
+                } else {
+                    "generated"
+                };
+                let summary = format!(
+                    "creative_ideas: {verb} {} idea(s), {} survived dedup, {} persisted",
+                    report.generated, report.surviving, report.persisted,
+                );
+                let detail = json!({
+                    "generated": report.generated,
+                    "surviving": report.surviving,
+                    "persisted": report.persisted,
+                    "dry_run": report.dry_run,
+                });
+                ThreadOutcome::ok(summary, start.elapsed()).with_detail(detail)
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "creative_ideas",
+                    error = %error,
+                    "[simard] creative-ideas tick failed"
+                );
+                self.record_failure(ctx.now_epoch);
+                ThreadOutcome::failed(
+                    format!("creative-ideas tick failed: {error}"),
+                    start.elapsed(),
+                )
+            }
+        }
+    }
+
+    fn health(&self) -> ThreadHealth {
+        ThreadHealth {
+            id: CREATIVE_IDEAS_ID.to_string(),
+            enabled: self.cfg.enabled(),
+            last_run_epoch: self.last_run_epoch,
+            next_run_epoch: self.next_run_epoch,
+            last_success: self.last_success,
+            consecutive_errors: self.consecutive_errors,
+            backoff_until_epoch: None,
+        }
+    }
+}
+
+/// Convert a raw idea into a `New` [`CreativeIdea`] carrying its links + context.
+fn raw_to_creative_idea(raw: &RawIdea, inputs: &GenerationInputs, now_epoch: u64) -> CreativeIdea {
+    let context = IdeaContext {
+        source: CREATIVE_IDEAS_ID.to_string(),
+        goals_snapshot: inputs.current_goals.clone(),
+        observation_digest: format!("entries={}", inputs.recent_activity.entries.len()),
+        rationale: raw.rationale.clone(),
+    };
+    let mut idea = CreativeIdea::new(raw.idea.clone(), context, now_epoch);
+    idea.links = raw.links.clone();
+    idea
+}
+
+/// Register the thread with the `Mind` scheduler.
+///
+/// FUTURE (M2): call site in the daemon `main`, still behind
+/// `SIMARD_CREATIVE_IDEAS_ENABLED`. **NOT** called during the spike; the
+/// production idea source ([`LlmIdeaSource`]) is itself a not-wired stub, so a
+/// registered-but-enabled thread would only ever emit `ThreadOutcome::failed`.
+pub fn register(mind: &mut Mind, config: CreativeIdeasConfig) {
+    let thread = CreativeIdeasThread::new(config, Box::new(LlmIdeaSource));
+    mind.register(Box::new(thread));
+}

--- a/src/cognitive_threads/threads/mod.rs
+++ b/src/cognitive_threads/threads/mod.rs
@@ -8,6 +8,12 @@ pub mod engineer_log_analysis;
 pub mod maintenance;
 pub mod ooda;
 
+// Issue #2419 (design spike): the Creative Ideas generator thread — reuses
+// `ThreadKind::BackgroundThought`, gated OFF by default, not registered with
+// the `Mind` during the spike.
+pub mod creative_ideas;
+
+pub use creative_ideas::CreativeIdeasThread;
 pub use engineer_log_analysis::{EngineerLogAnalysisConfig, EngineerLogAnalysisThread};
 pub use maintenance::{MaintenanceConfig, MaintenanceThread};
 pub use ooda::OodaThread;

--- a/src/creative_ideas/dedup.rs
+++ b/src/creative_ideas/dedup.rs
@@ -1,0 +1,81 @@
+//! Dedup / novelty, portfolio balancing, and budget helpers (design spike #2419).
+//!
+//! These are the safety "make it more interesting, yet safe" hooks:
+//! - [`is_near_duplicate`] / [`reject_duplicates`] keep the pool novel;
+//! - [`select_balanced`] keeps a bounded, balanced portfolio;
+//! - [`within_budget`] gates an expensive generation tick.
+//!
+//! The similarity metric is a deterministic word-set Jaccard so tests are
+//! reproducible with no network. FUTURE (M6): richer shingle/embedding novelty
+//! scoring and risk/novelty-bucketed portfolio selection.
+#![allow(dead_code)]
+
+use std::collections::BTreeSet;
+
+use crate::cognitive_memory::creative_idea::CreativeIdea;
+use crate::cognitive_threads::threads::creative_ideas::RawIdea;
+
+/// Default Jaccard threshold at or above which two ideas are "near-duplicates".
+pub const DEFAULT_DEDUP_THRESHOLD: f64 = 0.6;
+
+/// Whether `candidate` is a near-duplicate of `prior` at `threshold`
+/// (word-set Jaccard similarity `>= threshold`).
+#[must_use]
+pub fn is_near_duplicate(candidate: &str, prior: &str, threshold: f64) -> bool {
+    jaccard(candidate, prior) >= threshold
+}
+
+/// Keep only candidates that are **not** a near-duplicate of any previous idea.
+#[must_use]
+pub fn reject_duplicates(
+    candidates: Vec<RawIdea>,
+    previous: &[CreativeIdea],
+    threshold: f64,
+) -> Vec<RawIdea> {
+    candidates
+        .into_iter()
+        .filter(|c| {
+            !previous
+                .iter()
+                .any(|p| is_near_duplicate(&c.idea, &p.idea, threshold))
+        })
+        .collect()
+}
+
+/// Select a bounded portfolio of at most `budget` candidates.
+///
+/// FUTURE (M6): spread across risk/novelty buckets. For the spike this simply
+/// truncates to the budget while preserving order.
+#[must_use]
+pub fn select_balanced(mut candidates: Vec<RawIdea>, budget: usize) -> Vec<RawIdea> {
+    candidates.truncate(budget);
+    candidates
+}
+
+/// Whether an expensive generation tick is within the daily budget.
+#[must_use]
+pub fn within_budget(spent_usd: f64, limit_usd: f64) -> bool {
+    spent_usd < limit_usd
+}
+
+fn tokenize(text: &str) -> BTreeSet<String> {
+    text.split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .map(|t| t.to_ascii_lowercase())
+        .collect()
+}
+
+fn jaccard(a: &str, b: &str) -> f64 {
+    let sa = tokenize(a);
+    let sb = tokenize(b);
+    if sa.is_empty() && sb.is_empty() {
+        return 1.0;
+    }
+    let intersection = sa.intersection(&sb).count();
+    let union = sa.union(&sb).count();
+    if union == 0 {
+        0.0
+    } else {
+        intersection as f64 / union as f64
+    }
+}

--- a/src/creative_ideas/mod.rs
+++ b/src/creative_ideas/mod.rs
@@ -1,0 +1,118 @@
+//! Creative Ideas subsystem (design spike #2419) — an idea-generation subsystem
+//! that primes a pool of candidate self-improvement ideas inside the single
+//! Simard brain.
+//!
+//! **Status: design + typed foundation + tests, gated OFF.** This module owns
+//! the reviewer-pipeline trait and adapters ([`reviewers`]), the synthesis step
+//! ([`synthesis`]), the routing functions ([`routing`]), the dedup/portfolio/
+//! budget helpers ([`dedup`]), and the config flag ([`CreativeIdeasConfig`]).
+//! The `CreativeIdea` prospective type lives in
+//! [`crate::cognitive_memory::creative_idea`] and the generator thread in
+//! [`crate::cognitive_threads::threads::creative_ideas`]. Nothing here is wired
+//! into the daemon; the generator is OFF by default behind
+//! `SIMARD_CREATIVE_IDEAS_ENABLED`. The operator redeploys after merge.
+//!
+//! No type or module contains the word "Bridge" — this is one brain with
+//! cognitive threads and reviewers, not a separate service.
+#![allow(dead_code)]
+
+pub mod dedup;
+pub mod reviewers;
+pub mod routing;
+pub mod synthesis;
+
+#[cfg(test)]
+mod tests;
+
+/// Master switch env var. When falsey/unset the thread never ticks and nothing
+/// is generated or routed.
+pub const ENABLED_ENV: &str = "SIMARD_CREATIVE_IDEAS_ENABLED";
+/// Generator cadence env var (seconds); a large (>= 24h) observation window.
+pub const INTERVAL_SECS_ENV: &str = "SIMARD_CREATIVE_IDEAS_INTERVAL_SECS";
+/// Ideas targeted per run env var.
+pub const BATCH_ENV: &str = "SIMARD_CREATIVE_IDEAS_BATCH";
+
+/// Default cadence: 24 hours.
+pub const DEFAULT_INTERVAL_SECS: u64 = 86_400;
+/// Default batch: ten ideas per run (the design's fixed batch).
+pub const DEFAULT_BATCH: usize = 10;
+
+/// Issue label applied to a human-review issue minted from an idea.
+pub const CREATIVE_IDEA_ISSUE_LABEL: &str = "creative-idea";
+/// Merge-blocking PR label for a creative-idea PR (human-review gate).
+pub const CREATIVE_IDEA_PR_LABEL: &str = "creative-idea-needs-human-review";
+/// Repo owner tagged as issue assignee / PR reviewer for the human gate.
+pub const CREATIVE_IDEA_OWNER: &str = "rysweet";
+
+/// Configuration + gating for the Creative Ideas subsystem.
+///
+/// A default-constructed config is **disabled**. [`Self::from_env`] is the
+/// single source of truth for gating and cadence.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CreativeIdeasConfig {
+    /// `SIMARD_CREATIVE_IDEAS_ENABLED` (default `false`).
+    pub enabled: bool,
+    /// `SIMARD_CREATIVE_IDEAS_INTERVAL_SECS` (default `86_400`).
+    pub interval_secs: u64,
+    /// `SIMARD_CREATIVE_IDEAS_BATCH` (default `10`).
+    pub batch: usize,
+}
+
+impl Default for CreativeIdeasConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_secs: DEFAULT_INTERVAL_SECS,
+            batch: DEFAULT_BATCH,
+        }
+    }
+}
+
+impl CreativeIdeasConfig {
+    /// Parse the config from the real process environment.
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self::from_lookup(|k| std::env::var(k).ok())
+    }
+
+    /// Parse from an arbitrary env resolver (test seam).
+    ///
+    /// The truthy check mirrors the Overseer's gate: only an explicit truthy
+    /// value enables the subsystem; unset/empty/garbage leaves it OFF.
+    #[must_use]
+    pub fn from_lookup(lookup: impl Fn(&str) -> Option<String>) -> Self {
+        let enabled = lookup(ENABLED_ENV)
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(is_truthy);
+        let interval_secs = lookup(INTERVAL_SECS_ENV)
+            .as_deref()
+            .map(str::trim)
+            .and_then(|s| s.parse::<u64>().ok())
+            .filter(|v| *v > 0)
+            .unwrap_or(DEFAULT_INTERVAL_SECS);
+        let batch = lookup(BATCH_ENV)
+            .as_deref()
+            .map(str::trim)
+            .and_then(|s| s.parse::<usize>().ok())
+            .filter(|v| *v > 0)
+            .unwrap_or(DEFAULT_BATCH);
+        Self {
+            enabled,
+            interval_secs,
+            batch,
+        }
+    }
+
+    /// True only when the master switch is truthy.
+    #[must_use]
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+}
+
+/// Recognise an explicit truthy env value (case-insensitive; trimmed). Anything
+/// else — including `0`/`false`/empty/unset — is falsey.
+fn is_truthy(v: &str) -> bool {
+    matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+}

--- a/src/creative_ideas/reviewers.rs
+++ b/src/creative_ideas/reviewers.rs
@@ -1,0 +1,256 @@
+//! The reviewer pipeline — four reviewers vet each new idea (design spike #2419).
+//!
+//! Each new [`CreativeIdea`] is reviewed by a fixed set of reviewers, then the
+//! [`FeedbackSynthesizer`] sets the next status. The pipeline is expressed as a
+//! trait so reviewers are pluggable and independently testable; production
+//! adapters shape an amplihack skill/agent invocation through the
+//! [`AgentInvoker`] seam (their prompt bodies are marked `// FUTURE:` stubs),
+//! and all tests inject deterministic fakes.
+//!
+//! The four reviewers, in order:
+//! 1. `crusty_old_engineer` — scope/feasibility/necessity/utility/RISK/practicality.
+//! 2. `philosophy_guardian` — "do we need this?"; a user signal is NOT required.
+//! 3. `measurability` — emits a concrete [`SuccessMetric`].
+//! 4. `idea_feedback_synthesis` — the synthesis step (see [`super::synthesis`]).
+#![allow(dead_code)]
+
+use serde::{Deserialize, Serialize};
+
+use crate::cognitive_memory::creative_idea::CreativeIdea;
+use crate::cognitive_threads::threads::creative_ideas::GenerationInputs;
+use crate::creative_ideas::synthesis::{FeedbackSynthesizer, SuccessMetric, SynthesisOutcome};
+use crate::error::{SimardError, SimardResult};
+
+/// Stable telemetry id — crusty-old-engineer skill reviewer.
+pub const CRUSTY_OLD_ENGINEER_ID: &str = "crusty_old_engineer";
+/// Stable telemetry id — philosophy-guardian agent reviewer.
+pub const PHILOSOPHY_GUARDIAN_ID: &str = "philosophy_guardian";
+/// Stable telemetry id — the new measurability reviewer agent.
+pub const MEASURABILITY_ID: &str = "measurability";
+
+/// Map a persisted reviewer-id string back to its stable `&'static str` id.
+///
+/// **Fail-closed**: an unknown id yields `None` so the caller can raise
+/// [`SimardError::InvalidCreativeIdeaRecord`] rather than silently defaulting.
+#[must_use]
+pub fn reviewer_id_from_str(s: &str) -> Option<&'static str> {
+    match s {
+        CRUSTY_OLD_ENGINEER_ID => Some(CRUSTY_OLD_ENGINEER_ID),
+        PHILOSOPHY_GUARDIAN_ID => Some(PHILOSOPHY_GUARDIAN_ID),
+        MEASURABILITY_ID => Some(MEASURABILITY_ID),
+        crate::creative_ideas::synthesis::IDEA_FEEDBACK_SYNTHESIS_ID => {
+            Some(crate::creative_ideas::synthesis::IDEA_FEEDBACK_SYNTHESIS_ID)
+        }
+        _ => None,
+    }
+}
+
+/// A reviewer's overall verdict.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum ReviewVerdict {
+    /// The idea is worth pursuing.
+    Support,
+    /// Reservations, but not a blocker.
+    Concern,
+    /// The idea should not proceed as written.
+    Block,
+    /// A human must decide.
+    NeedsHuman,
+}
+
+/// Risk flags a reviewer can raise; any of these routes the idea to human review.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ReviewFlags {
+    /// High blast-radius / risky change.
+    pub high_risk: bool,
+    /// Irreversible change (data loss, deploy, external side-effect).
+    pub irreversible: bool,
+    /// Explicitly requires a human decision.
+    pub needs_human: bool,
+}
+
+/// Immutable inputs handed to each reviewer.
+pub struct ReviewContext<'a> {
+    /// The idea under review.
+    pub idea: &'a CreativeIdea,
+    /// The generation inputs (observation window) that produced it.
+    pub inputs: &'a GenerationInputs,
+}
+
+/// One reviewer's structured output.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct Review {
+    /// Stable reviewer id (for telemetry).
+    pub reviewer: &'static str,
+    /// The verdict.
+    pub verdict: ReviewVerdict,
+    /// Free-text notes.
+    pub notes: String,
+    /// Risk flags.
+    pub flags: ReviewFlags,
+    /// A proposed success metric (the measurability reviewer only).
+    pub proposed_metric: Option<SuccessMetric>,
+}
+
+/// A pluggable reviewer.
+pub trait Reviewer {
+    /// Stable telemetry id.
+    fn id(&self) -> &'static str;
+    /// Review the idea in `ctx`.
+    fn review(&self, ctx: &ReviewContext<'_>) -> SimardResult<Review>;
+}
+
+/// The amplihack skill/agent invocation seam.
+///
+/// FUTURE (M3): the real implementation shells out to the amplihack binary
+/// (`SIMARD_AMPLIHACK_BIN`) to run the `crusty-old-engineer` skill /
+/// `philosophy-guardian` agent / measurability agent. During the spike the
+/// production adapters below build the prompt and call this seam, but do not
+/// interpret the response; all tests inject fakes.
+pub trait AgentInvoker {
+    /// Invoke an agent/skill with `prompt` and return its raw text response.
+    fn invoke(&self, prompt: &str) -> SimardResult<String>;
+}
+
+/// Production adapter for the `crusty-old-engineer` skill.
+///
+/// FUTURE (M3): parse the skill response into a [`Review`]. Until then
+/// `review` returns [`SimardError::ReviewUnavailable`]; the spike drives the
+/// pipeline through fakes.
+pub struct CrustyOldEngineerReviewer<I: AgentInvoker> {
+    invoker: I,
+}
+
+impl<I: AgentInvoker> CrustyOldEngineerReviewer<I> {
+    /// Wrap an agent invoker.
+    pub fn new(invoker: I) -> Self {
+        Self { invoker }
+    }
+
+    fn build_prompt(_ctx: &ReviewContext<'_>) -> String {
+        // FUTURE (M3): render the real crusty-old-engineer skill prompt from
+        // the idea + observation window (scope/feasibility/necessity/utility/
+        // inventiveness/RISK/need-for-human-review/practicality).
+        String::from("FUTURE: crusty-old-engineer review prompt")
+    }
+}
+
+impl<I: AgentInvoker> Reviewer for CrustyOldEngineerReviewer<I> {
+    fn id(&self) -> &'static str {
+        CRUSTY_OLD_ENGINEER_ID
+    }
+    fn review(&self, ctx: &ReviewContext<'_>) -> SimardResult<Review> {
+        let prompt = Self::build_prompt(ctx);
+        let _raw = self.invoker.invoke(&prompt)?;
+        Err(SimardError::ReviewUnavailable {
+            reason: "crusty-old-engineer reviewer is not wired during the spike (M3)".to_string(),
+        })
+    }
+}
+
+/// Production adapter for the `philosophy-guardian` agent.
+///
+/// Explicitly, **a user signal is NOT required** to justify an idea; absence of
+/// one is neutral, never a `Block`. FUTURE (M3): parse the agent response.
+pub struct PhilosophyGuardianReviewer<I: AgentInvoker> {
+    invoker: I,
+}
+
+impl<I: AgentInvoker> PhilosophyGuardianReviewer<I> {
+    /// Wrap an agent invoker.
+    pub fn new(invoker: I) -> Self {
+        Self { invoker }
+    }
+
+    fn build_prompt(_ctx: &ReviewContext<'_>) -> String {
+        // FUTURE (M3): "do we need this? will it be an interesting
+        // enhancement?" — treat missing user signal as neutral.
+        String::from("FUTURE: philosophy-guardian review prompt")
+    }
+}
+
+impl<I: AgentInvoker> Reviewer for PhilosophyGuardianReviewer<I> {
+    fn id(&self) -> &'static str {
+        PHILOSOPHY_GUARDIAN_ID
+    }
+    fn review(&self, ctx: &ReviewContext<'_>) -> SimardResult<Review> {
+        let prompt = Self::build_prompt(ctx);
+        let _raw = self.invoker.invoke(&prompt)?;
+        Err(SimardError::ReviewUnavailable {
+            reason: "philosophy-guardian reviewer is not wired during the spike (M3)".to_string(),
+        })
+    }
+}
+
+/// Production adapter for the new `measurability` reviewer agent.
+///
+/// FUTURE (M3): parse the agent response into a concrete [`SuccessMetric`]
+/// tied where relevant to existing self-metrics.
+pub struct MeasurabilityReviewer<I: AgentInvoker> {
+    invoker: I,
+}
+
+impl<I: AgentInvoker> MeasurabilityReviewer<I> {
+    /// Wrap an agent invoker.
+    pub fn new(invoker: I) -> Self {
+        Self { invoker }
+    }
+
+    fn build_prompt(_ctx: &ReviewContext<'_>) -> String {
+        // FUTURE (M3): ask for a concrete metric (name/baseline/target/
+        // how_measured), preferring recall_precision_at_k / distill fact-yield
+        // / reasoner-reliability where relevant.
+        String::from("FUTURE: measurability review prompt")
+    }
+}
+
+impl<I: AgentInvoker> Reviewer for MeasurabilityReviewer<I> {
+    fn id(&self) -> &'static str {
+        MEASURABILITY_ID
+    }
+    fn review(&self, ctx: &ReviewContext<'_>) -> SimardResult<Review> {
+        let prompt = Self::build_prompt(ctx);
+        let _raw = self.invoker.invoke(&prompt)?;
+        Err(SimardError::ReviewUnavailable {
+            reason: "measurability reviewer is not wired during the spike (M3)".to_string(),
+        })
+    }
+}
+
+/// Run the full reviewer pipeline over one idea and apply the synthesized
+/// status.
+///
+/// Invokes every reviewer in `reviewers` (the three vetting reviewers; the
+/// `synthesizer` is the fourth step), folds their [`Review`]s through the
+/// synthesizer, attaches the accumulated reviews and any success metric to the
+/// idea, and applies the next status via
+/// [`CreativeIdea::try_transition`] — so an illegal synthesis verdict is a hard
+/// [`SimardError::InvalidIdeaTransition`], never a silent corruption.
+pub fn run_review_pipeline(
+    idea: &mut CreativeIdea,
+    inputs: &GenerationInputs,
+    reviewers: &[&dyn Reviewer],
+    synthesizer: &dyn FeedbackSynthesizer,
+) -> SimardResult<SynthesisOutcome> {
+    // Collect reviews under an immutable borrow, then release it before mutating.
+    let reviews: Vec<Review> = {
+        let ctx = ReviewContext { idea, inputs };
+        let mut acc = Vec::with_capacity(reviewers.len());
+        for reviewer in reviewers {
+            acc.push(reviewer.review(&ctx)?);
+        }
+        acc
+    };
+
+    let outcome = {
+        let ctx = ReviewContext { idea, inputs };
+        synthesizer.synthesize(&ctx, &reviews)?
+    };
+
+    idea.reviews = reviews;
+    if let Some(metric) = &outcome.set_metric {
+        idea.success_metric = Some(metric.clone());
+    }
+    idea.try_transition(outcome.next_status)?;
+    Ok(outcome)
+}

--- a/src/creative_ideas/routing.rs
+++ b/src/creative_ideas/routing.rs
@@ -1,0 +1,318 @@
+//! Routing of reviewed ideas (design spike #2419).
+//!
+//! Once synthesis has set an idea's status, routing dispatches it:
+//! - accepted + not flagged → a **goal** ([`route_idea_to_goal`]);
+//! - accepted but flagged → a **GitHub issue** tagging the owner
+//!   ([`route_idea_to_issue`]);
+//! - a PR arising from a creative-idea goal → the **human-review gate**
+//!   ([`mark_idea_pr`]): draft + blocking label + owner review-requested,
+//!   enforced by standard GitHub mechanisms — **never** `--admin`/`--no-verify`.
+//!
+//! All side effects go through the [`IdeaGhClient`] seam (a fake in tests). The
+//! real `gh` subprocess implementation is a marked `// FUTURE:` stub (M4).
+#![allow(dead_code)]
+
+use crate::cognitive_memory::creative_idea::{CreativeIdea, IdeaStatus};
+use crate::creative_ideas::{
+    CREATIVE_IDEA_ISSUE_LABEL, CREATIVE_IDEA_OWNER, CREATIVE_IDEA_PR_LABEL,
+};
+use crate::error::{SimardError, SimardResult};
+use crate::goals::{GoalRecord, GoalStatus, GoalStore, goal_slug};
+use crate::improvements::EvidenceRef;
+use crate::session::{SessionId, SessionPhase};
+use crate::stewardship::gh_client::GhIssue;
+
+/// Owner identity recorded on goals minted from creative ideas.
+const CREATIVE_IDEA_GOAL_OWNER_IDENTITY: &str = "simard";
+/// Default priority for a freshly proposed creative-idea goal.
+const CREATIVE_IDEA_GOAL_PRIORITY: u8 = 3;
+
+/// The `gh` extension seam needed by the human-review gate.
+///
+/// The live [`GhClient`](crate::stewardship::gh_client::GhClient) only exposes
+/// `search_issues`/`create_issue`; this seam adds labeled+assigned issue
+/// creation and the PR draft/label/review-request operations without mutating
+/// the daemon's `gh` tooling. FUTURE (M4): a real subprocess impl.
+pub trait IdeaGhClient {
+    /// Create an issue with labels and assignees.
+    fn create_labeled_issue(
+        &self,
+        repo: &str,
+        title: &str,
+        body: &str,
+        labels: &[&str],
+        assignees: &[&str],
+    ) -> SimardResult<GhIssue>;
+    /// Set (or clear) a PR's draft state.
+    fn set_pr_draft(&self, repo: &str, pr: u64, draft: bool) -> SimardResult<()>;
+    /// Add a label to a PR.
+    fn add_pr_label(&self, repo: &str, pr: u64, label: &str) -> SimardResult<()>;
+    /// Request a review from `reviewer` on a PR.
+    fn request_pr_review(&self, repo: &str, pr: u64, reviewer: &str) -> SimardResult<()>;
+}
+
+/// The human-review gate applied to a creative-idea PR.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IdeaPrGate {
+    /// Always `true`: the PR is kept as a DRAFT (cannot be merged until ready).
+    pub draft: bool,
+    /// The merge-blocking label.
+    pub blocking_label: &'static str,
+    /// Reviewers whose approval is required (the repo owner).
+    pub review_requested_from: Vec<String>,
+    /// The originating idea's `node_id` (link back).
+    pub originating_idea: String,
+}
+
+/// Accepted, not flagged → a Goal.
+///
+/// Produces a `Proposed` [`GoalRecord`] with `slug = goal_slug(idea.idea)`,
+/// tagged in its evidence with the originating `idea.node_id` (traceability).
+/// Preconditions: the idea must be in `AcceptedForImplementation`; otherwise
+/// [`SimardError::InvalidIdeaTransition`] (only accepted ideas become goals).
+/// `now_epoch` (unix seconds) is the injected-clock convention used by the
+/// thread's `tick`, so timestamps are deterministic in tests.
+pub fn route_idea_to_goal(
+    idea: &CreativeIdea,
+    goals: &dyn GoalStore,
+    now_epoch: u64,
+) -> SimardResult<GoalRecord> {
+    if idea.status != IdeaStatus::AcceptedForImplementation {
+        return Err(SimardError::InvalidIdeaTransition {
+            from: idea.status,
+            to: IdeaStatus::ImplementationStarted,
+        });
+    }
+
+    let evidence = vec![EvidenceRef::raw(format!(
+        "creative-idea:{}@epoch={now_epoch}",
+        idea.node_id
+    ))];
+    let record = GoalRecord {
+        slug: goal_slug(&idea.idea),
+        title: idea.idea.clone(),
+        rationale: creative_idea_rationale(idea),
+        status: GoalStatus::Proposed,
+        priority: CREATIVE_IDEA_GOAL_PRIORITY,
+        owner_identity: CREATIVE_IDEA_GOAL_OWNER_IDENTITY.to_string(),
+        source_session_id: creative_idea_session_id(),
+        updated_in: SessionPhase::Planning,
+        evidence,
+    };
+    goals.put(record.clone())?;
+    Ok(record)
+}
+
+/// Accepted but flagged → a GitHub Issue tagging the owner.
+///
+/// Applies to ideas in `NeedsHumanReview`. Creates an issue labeled
+/// [`CREATIVE_IDEA_ISSUE_LABEL`] and assigned to [`CREATIVE_IDEA_OWNER`]; the
+/// body embeds `idea.node_id` for traceability.
+pub fn route_idea_to_issue(
+    idea: &CreativeIdea,
+    gh: &dyn IdeaGhClient,
+    repo: &str,
+) -> SimardResult<GhIssue> {
+    let title = format!("[creative-idea] {}", idea.idea);
+    let body = format!(
+        "originating-idea: {node}\n\n{rationale}\n\nRouted for human review by the Creative Ideas thread (#2419).",
+        node = idea.node_id,
+        rationale = creative_idea_rationale(idea),
+    );
+    gh.create_labeled_issue(
+        repo,
+        &title,
+        &body,
+        &[CREATIVE_IDEA_ISSUE_LABEL],
+        &[CREATIVE_IDEA_OWNER],
+    )
+}
+
+/// Apply the human-review gate to a PR arising from a creative-idea goal.
+///
+/// Enforced by three standard GitHub mechanisms — **never** `--admin`/
+/// `--no-verify`: (1) keep the PR a **draft**, (2) add the merge-blocking
+/// label [`CREATIVE_IDEA_PR_LABEL`], (3) **request** the owner's review
+/// ([`CREATIVE_IDEA_OWNER`]). `repo` (`owner/name`) is required because each
+/// `IdeaGhClient` PR method is repo-scoped.
+pub fn mark_idea_pr(
+    pr_number: u64,
+    idea: &CreativeIdea,
+    gh: &dyn IdeaGhClient,
+    repo: &str,
+) -> SimardResult<IdeaPrGate> {
+    gh.set_pr_draft(repo, pr_number, true)?;
+    gh.add_pr_label(repo, pr_number, CREATIVE_IDEA_PR_LABEL)?;
+    gh.request_pr_review(repo, pr_number, CREATIVE_IDEA_OWNER)?;
+    Ok(IdeaPrGate {
+        draft: true,
+        blocking_label: CREATIVE_IDEA_PR_LABEL,
+        review_requested_from: vec![CREATIVE_IDEA_OWNER.to_string()],
+        originating_idea: idea.node_id.clone(),
+    })
+}
+
+/// Outcome feedback: move an idea to `ImplementationCompleted`.
+///
+/// Refuses (returns [`SimardError::InvalidIdeaTransition`]) unless the idea is
+/// in `ImplementationStarted` **and** `metric_met` is true — so completion
+/// fires only when both the PR merges through the normal gate and the idea's
+/// own `success_metric` is met.
+pub fn mark_completed(idea: &mut CreativeIdea, metric_met: bool) -> SimardResult<()> {
+    if idea.status != IdeaStatus::ImplementationStarted || !metric_met {
+        return Err(SimardError::InvalidIdeaTransition {
+            from: idea.status,
+            to: IdeaStatus::ImplementationCompleted,
+        });
+    }
+    idea.try_transition(IdeaStatus::ImplementationCompleted)
+}
+
+fn creative_idea_rationale(idea: &CreativeIdea) -> String {
+    if idea.context.rationale.is_empty() {
+        format!(
+            "Creative idea generated by the Creative Ideas thread: {}",
+            idea.idea
+        )
+    } else {
+        idea.context.rationale.clone()
+    }
+}
+
+/// A fixed sentinel session id for goals minted by the (non-interactive)
+/// Creative Ideas thread. The nil UUID marks "no originating interactive
+/// session"; traceability is carried by the evidence tag instead.
+fn creative_idea_session_id() -> SessionId {
+    SessionId::from_uuid(uuid::Uuid::nil())
+}
+
+// ── `gh` argument builders (pure; the real impl uses these at M4) ────────────
+//
+// Kept as pure functions so a unit test can assert the constructed argument
+// vectors contain **no** `--admin` / `--no-verify` without any subprocess.
+
+/// `gh issue create` argv for a labeled + assigned issue.
+#[must_use]
+pub fn gh_issue_create_argv(
+    repo: &str,
+    title: &str,
+    body: &str,
+    labels: &[&str],
+    assignees: &[&str],
+) -> Vec<String> {
+    let mut argv = vec![
+        "issue".to_string(),
+        "create".to_string(),
+        "-R".to_string(),
+        repo.to_string(),
+        "--title".to_string(),
+        title.to_string(),
+        "--body".to_string(),
+        body.to_string(),
+    ];
+    for label in labels {
+        argv.push("--label".to_string());
+        argv.push((*label).to_string());
+    }
+    for assignee in assignees {
+        argv.push("--assignee".to_string());
+        argv.push((*assignee).to_string());
+    }
+    argv
+}
+
+/// `gh pr ready --undo` argv (mark a PR back to draft).
+#[must_use]
+pub fn gh_pr_draft_argv(repo: &str, pr: u64) -> Vec<String> {
+    vec![
+        "pr".to_string(),
+        "ready".to_string(),
+        pr.to_string(),
+        "-R".to_string(),
+        repo.to_string(),
+        "--undo".to_string(),
+    ]
+}
+
+/// `gh pr edit --add-label` argv.
+#[must_use]
+pub fn gh_pr_add_label_argv(repo: &str, pr: u64, label: &str) -> Vec<String> {
+    vec![
+        "pr".to_string(),
+        "edit".to_string(),
+        pr.to_string(),
+        "-R".to_string(),
+        repo.to_string(),
+        "--add-label".to_string(),
+        label.to_string(),
+    ]
+}
+
+/// `gh pr edit --add-reviewer` argv.
+#[must_use]
+pub fn gh_pr_add_reviewer_argv(repo: &str, pr: u64, reviewer: &str) -> Vec<String> {
+    vec![
+        "pr".to_string(),
+        "edit".to_string(),
+        pr.to_string(),
+        "-R".to_string(),
+        repo.to_string(),
+        "--add-reviewer".to_string(),
+        reviewer.to_string(),
+    ]
+}
+
+/// Production [`IdeaGhClient`] — a marked `// FUTURE:` stub for the spike.
+///
+/// FUTURE (M4): run the real `gh` subprocess (reusing the
+/// [`RealGhClient`](crate::stewardship::gh_client::RealGhClient) pattern) using
+/// the pure argv builders above. It must **never** emit `--admin`/`--no-verify`.
+/// During the spike every method builds its argv and returns
+/// [`SimardError::ActionExecutionFailed`] (not-wired) so nothing touches the
+/// network; tests exercise [`super::routing`] through a fake instead.
+#[derive(Default)]
+pub struct RealIdeaGhClient;
+
+impl RealIdeaGhClient {
+    /// Construct the not-yet-wired production client.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl IdeaGhClient for RealIdeaGhClient {
+    fn create_labeled_issue(
+        &self,
+        repo: &str,
+        title: &str,
+        body: &str,
+        labels: &[&str],
+        assignees: &[&str],
+    ) -> SimardResult<GhIssue> {
+        let _argv = gh_issue_create_argv(repo, title, body, labels, assignees);
+        Err(not_wired("gh issue create"))
+    }
+
+    fn set_pr_draft(&self, repo: &str, pr: u64, _draft: bool) -> SimardResult<()> {
+        let _argv = gh_pr_draft_argv(repo, pr);
+        Err(not_wired("gh pr ready --undo"))
+    }
+
+    fn add_pr_label(&self, repo: &str, pr: u64, label: &str) -> SimardResult<()> {
+        let _argv = gh_pr_add_label_argv(repo, pr, label);
+        Err(not_wired("gh pr edit --add-label"))
+    }
+
+    fn request_pr_review(&self, repo: &str, pr: u64, reviewer: &str) -> SimardResult<()> {
+        let _argv = gh_pr_add_reviewer_argv(repo, pr, reviewer);
+        Err(not_wired("gh pr edit --add-reviewer"))
+    }
+}
+
+fn not_wired(action: &str) -> SimardError {
+    SimardError::ActionExecutionFailed {
+        action: action.to_string(),
+        reason: "creative-idea gh routing is not wired during the spike (M4)".to_string(),
+    }
+}

--- a/src/creative_ideas/synthesis.rs
+++ b/src/creative_ideas/synthesis.rs
@@ -1,0 +1,128 @@
+//! Feedback synthesis — the fourth reviewer step (design spike #2419).
+//!
+//! The `idea-feedback-synthesis` step reads **all** reviews plus the idea
+//! context, summarizes next steps, and **sets the next status** per the
+//! [`IdeaStatus`](crate::cognitive_memory::creative_idea::IdeaStatus) state
+//! machine. The pipeline runner applies the returned status through
+//! [`CreativeIdea::try_transition`](crate::cognitive_memory::creative_idea::CreativeIdea::try_transition),
+//! so an illegal `next_status` is a hard
+//! [`InvalidIdeaTransition`](crate::error::SimardError::InvalidIdeaTransition),
+//! never a silent corruption.
+#![allow(dead_code)]
+
+use serde::{Deserialize, Serialize};
+
+use crate::cognitive_memory::creative_idea::IdeaStatus;
+use crate::creative_ideas::reviewers::{Review, ReviewContext, ReviewVerdict};
+use crate::error::SimardResult;
+
+/// Stable telemetry id for the synthesis step (the fourth "reviewer").
+pub const IDEA_FEEDBACK_SYNTHESIS_ID: &str = "idea_feedback_synthesis";
+
+/// A concrete, measurable success criterion for an idea.
+///
+/// Emitted by the `measurability` reviewer and carried on the idea; it is the
+/// **only** thing that can later move the idea to `ImplementationCompleted`
+/// (see [`crate::creative_ideas::routing::mark_completed`]). Tied where relevant
+/// to existing self-metrics (`recall_precision_at_k`, distill fact-yield,
+/// reasoner-reliability).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SuccessMetric {
+    /// Metric name, e.g. `"recall_precision_at_k"`.
+    pub name: String,
+    /// Optional numeric baseline to improve on.
+    pub baseline: Option<f64>,
+    /// Target expression, e.g. `">= +0.05 over 7-day baseline"`.
+    pub target: String,
+    /// How the metric is measured.
+    pub how_measured: String,
+}
+
+/// The outcome of the synthesis step.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SynthesisOutcome {
+    /// The next status — MUST be a legal transition from the idea's current
+    /// status (enforced by the pipeline runner).
+    pub next_status: IdeaStatus,
+    /// Human-readable summary of the next steps.
+    pub next_steps: String,
+    /// A metric to attach to the idea (from the measurability reviewer).
+    pub set_metric: Option<SuccessMetric>,
+}
+
+/// Folds all reviews into a next-status decision plus next-steps text.
+pub trait FeedbackSynthesizer {
+    /// Stable telemetry id.
+    fn id(&self) -> &'static str {
+        IDEA_FEEDBACK_SYNTHESIS_ID
+    }
+    /// Decide the next status from the accumulated reviews.
+    fn synthesize(
+        &self,
+        ctx: &ReviewContext<'_>,
+        reviews: &[Review],
+    ) -> SimardResult<SynthesisOutcome>;
+}
+
+/// The default, deterministic synthesis policy (design doc §"Synthesis policy").
+///
+/// 1. Any reviewer sets `irreversible` **or** `high_risk` **or** `needs_human`
+///    → `NeedsHumanReview`.
+/// 2. Any `Block` (from a non-`philosophy_guardian` reviewer) with no human
+///    flag → `Rejected`.
+/// 3. No metric produced → `NeedsRevision` (an idea with no way to measure
+///    success is not acceptable).
+/// 4. Otherwise, sufficient support + a metric → `AcceptedForImplementation`.
+pub struct DefaultSynthesizer;
+
+impl FeedbackSynthesizer for DefaultSynthesizer {
+    fn synthesize(
+        &self,
+        _ctx: &ReviewContext<'_>,
+        reviews: &[Review],
+    ) -> SimardResult<SynthesisOutcome> {
+        let human_flagged = reviews
+            .iter()
+            .any(|r| r.flags.high_risk || r.flags.irreversible || r.flags.needs_human);
+
+        // The measurability reviewer's metric is the one that can later gate
+        // `ImplementationCompleted`.
+        let metric = reviews.iter().find_map(|r| r.proposed_metric.clone());
+
+        // A fatal block from any reviewer other than philosophy-guardian
+        // (whose absence-of-user-signal is never a `Block`).
+        let hard_block = reviews.iter().any(|r| {
+            matches!(r.verdict, ReviewVerdict::Block)
+                && r.reviewer != crate::creative_ideas::reviewers::PHILOSOPHY_GUARDIAN_ID
+        });
+
+        let (next_status, next_steps) = if human_flagged {
+            (
+                IdeaStatus::NeedsHumanReview,
+                "flagged high-risk/irreversible/needs-human by a reviewer; routing to human review"
+                    .to_string(),
+            )
+        } else if hard_block {
+            (
+                IdeaStatus::Rejected,
+                "blocked by a reviewer with no fixable path; rejected".to_string(),
+            )
+        } else if metric.is_none() {
+            (
+                IdeaStatus::NeedsRevision,
+                "no success metric produced; revise so effectiveness is measurable".to_string(),
+            )
+        } else {
+            (
+                IdeaStatus::AcceptedForImplementation,
+                "sufficient support and a success metric; accepted for implementation".to_string(),
+            )
+        };
+
+        Ok(SynthesisOutcome {
+            next_status,
+            next_steps,
+            set_metric: metric,
+        })
+    }
+}

--- a/src/creative_ideas/tests.rs
+++ b/src/creative_ideas/tests.rs
@@ -1,0 +1,786 @@
+//! Unit tests for the Creative Ideas subsystem (design spike #2419).
+//!
+//! Hermetic: no network, injected clock (`now_epoch`), and reused in-memory
+//! backends ([`LibraryCognitiveMemory::in_memory`], [`InMemoryGoalStore`]) plus
+//! deterministic fakes for the reviewers and the `gh` seam. These tests pin the
+//! data model, the state machine, the round-trip, the pipeline, the routing,
+//! the safety gates, and the OFF-by-default contract.
+
+use std::cell::RefCell;
+use std::str::FromStr;
+use std::sync::atomic::AtomicBool;
+
+use serde_json::Value;
+
+use crate::cognitive_memory::creative_idea::{
+    CREATIVE_IDEA_PAYLOAD_VERSION, CREATIVE_IDEA_TRIGGER, CreativeIdea, CreativeIdeaStore,
+    IdeaContext, IdeaStatus, MemoryLink, MemoryLinkKind, ProspectiveCreativeIdeaStore,
+};
+use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
+use crate::cognitive_threads::threads::creative_ideas::{
+    CreativeIdeasThread, FakeIdeaSource, GenerationInputs, RawIdea,
+};
+use crate::cognitive_threads::{CognitiveThread, ThreadContext, ThreadHealth, ThreadKind};
+use crate::error::{SimardError, SimardResult};
+use crate::goals::{GoalStatus, GoalStore, InMemoryGoalStore, goal_slug};
+use crate::memory_cognitive::CognitiveProspective;
+use crate::stewardship::gh_client::GhIssue;
+
+use super::dedup::{self, is_near_duplicate, reject_duplicates};
+use super::reviewers::{
+    CRUSTY_OLD_ENGINEER_ID, MEASURABILITY_ID, PHILOSOPHY_GUARDIAN_ID, Review, ReviewFlags,
+    ReviewVerdict, Reviewer, run_review_pipeline,
+};
+use super::routing::{
+    IdeaGhClient, gh_pr_add_label_argv, gh_pr_add_reviewer_argv, gh_pr_draft_argv, mark_completed,
+    mark_idea_pr, route_idea_to_goal, route_idea_to_issue,
+};
+use super::synthesis::{DefaultSynthesizer, SuccessMetric};
+use super::{
+    CREATIVE_IDEA_ISSUE_LABEL, CREATIVE_IDEA_OWNER, CREATIVE_IDEA_PR_LABEL, CreativeIdeasConfig,
+};
+
+// ---------------------------------------------------------------------------
+// Fixtures & fakes
+// ---------------------------------------------------------------------------
+
+const ALL_STATUSES: [IdeaStatus; 8] = [
+    IdeaStatus::New,
+    IdeaStatus::NeedsRevision,
+    IdeaStatus::NeedsHumanReview,
+    IdeaStatus::AcceptedForImplementation,
+    IdeaStatus::Rejected,
+    IdeaStatus::Deferred,
+    IdeaStatus::ImplementationStarted,
+    IdeaStatus::ImplementationCompleted,
+];
+
+/// The allowed edges of the state machine (must mirror `can_transition_to`).
+const ALLOWED_EDGES: &[(IdeaStatus, IdeaStatus)] = &[
+    (IdeaStatus::New, IdeaStatus::AcceptedForImplementation),
+    (IdeaStatus::New, IdeaStatus::Rejected),
+    (IdeaStatus::New, IdeaStatus::Deferred),
+    (IdeaStatus::New, IdeaStatus::NeedsRevision),
+    (IdeaStatus::New, IdeaStatus::NeedsHumanReview),
+    (IdeaStatus::NeedsRevision, IdeaStatus::New),
+    (IdeaStatus::NeedsRevision, IdeaStatus::Rejected),
+    (IdeaStatus::NeedsRevision, IdeaStatus::Deferred),
+    (
+        IdeaStatus::NeedsHumanReview,
+        IdeaStatus::AcceptedForImplementation,
+    ),
+    (IdeaStatus::NeedsHumanReview, IdeaStatus::Rejected),
+    (IdeaStatus::NeedsHumanReview, IdeaStatus::Deferred),
+    (IdeaStatus::Deferred, IdeaStatus::New),
+    (IdeaStatus::Deferred, IdeaStatus::Rejected),
+    (
+        IdeaStatus::AcceptedForImplementation,
+        IdeaStatus::ImplementationStarted,
+    ),
+    (IdeaStatus::AcceptedForImplementation, IdeaStatus::Deferred),
+    (IdeaStatus::AcceptedForImplementation, IdeaStatus::Rejected),
+    (
+        IdeaStatus::ImplementationStarted,
+        IdeaStatus::ImplementationCompleted,
+    ),
+    (IdeaStatus::ImplementationStarted, IdeaStatus::NeedsRevision),
+    (IdeaStatus::ImplementationStarted, IdeaStatus::Rejected),
+];
+
+fn sample_context() -> IdeaContext {
+    IdeaContext {
+        source: "creative-ideas-thread".to_string(),
+        goals_snapshot: vec!["improve recall".to_string()],
+        observation_digest: "digest-abc".to_string(),
+        rationale: "recall precision has plateaued for 3 days".to_string(),
+    }
+}
+
+fn sample_metric() -> SuccessMetric {
+    SuccessMetric {
+        name: "recall_precision_at_k".to_string(),
+        baseline: Some(0.71),
+        target: ">= +0.05 over 7-day baseline".to_string(),
+        how_measured: "nightly recall eval".to_string(),
+    }
+}
+
+fn support_review(reviewer: &'static str, metric: Option<SuccessMetric>) -> Review {
+    Review {
+        reviewer,
+        verdict: ReviewVerdict::Support,
+        notes: "looks reasonable".to_string(),
+        flags: ReviewFlags::default(),
+        proposed_metric: metric,
+    }
+}
+
+/// A deterministic [`Reviewer`] that returns a canned [`Review`].
+struct StubReviewer {
+    id: &'static str,
+    review: Review,
+}
+
+impl Reviewer for StubReviewer {
+    fn id(&self) -> &'static str {
+        self.id
+    }
+    fn review(&self, _ctx: &super::reviewers::ReviewContext<'_>) -> SimardResult<Review> {
+        Ok(self.review.clone())
+    }
+}
+
+/// A recording fake for the [`IdeaGhClient`] seam.
+#[derive(Default)]
+struct FakeIdeaGhClient {
+    issues: RefCell<Vec<RecordedIssue>>,
+    pr_ops: RefCell<Vec<String>>,
+}
+
+#[derive(Clone)]
+struct RecordedIssue {
+    labels: Vec<String>,
+    assignees: Vec<String>,
+    body: String,
+}
+
+impl IdeaGhClient for FakeIdeaGhClient {
+    fn create_labeled_issue(
+        &self,
+        _repo: &str,
+        title: &str,
+        body: &str,
+        labels: &[&str],
+        assignees: &[&str],
+    ) -> SimardResult<GhIssue> {
+        self.issues.borrow_mut().push(RecordedIssue {
+            labels: labels.iter().map(|s| (*s).to_string()).collect(),
+            assignees: assignees.iter().map(|s| (*s).to_string()).collect(),
+            body: body.to_string(),
+        });
+        Ok(GhIssue {
+            number: 4242,
+            url: "https://example.test/issues/4242".to_string(),
+            title: title.to_string(),
+            body: body.to_string(),
+        })
+    }
+
+    fn set_pr_draft(&self, _repo: &str, pr: u64, draft: bool) -> SimardResult<()> {
+        self.pr_ops
+            .borrow_mut()
+            .push(format!("set_pr_draft:{pr}:{draft}"));
+        Ok(())
+    }
+
+    fn add_pr_label(&self, _repo: &str, pr: u64, label: &str) -> SimardResult<()> {
+        self.pr_ops
+            .borrow_mut()
+            .push(format!("add_pr_label:{pr}:{label}"));
+        Ok(())
+    }
+
+    fn request_pr_review(&self, _repo: &str, pr: u64, reviewer: &str) -> SimardResult<()> {
+        self.pr_ops
+            .borrow_mut()
+            .push(format!("request_pr_review:{pr}:{reviewer}"));
+        Ok(())
+    }
+}
+
+/// Owns the borrowed resources a [`ThreadContext`] needs.
+struct TickEnv {
+    rt: tokio::runtime::Runtime,
+    mem: LibraryCognitiveMemory,
+    shutdown: AtomicBool,
+    tmp: tempfile::TempDir,
+}
+
+impl TickEnv {
+    fn new() -> Self {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build current-thread runtime");
+        let mem = LibraryCognitiveMemory::in_memory().expect("in-memory cognitive store");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        Self {
+            rt,
+            mem,
+            shutdown: AtomicBool::new(false),
+            tmp,
+        }
+    }
+
+    fn ctx(&self, now_epoch: u64, dry_run: bool) -> ThreadContext<'_> {
+        ThreadContext {
+            state_root: self.tmp.path(),
+            repo_root: self.tmp.path(),
+            memory: &self.mem as &dyn CognitiveMemoryOps,
+            runtime: self.rt.handle().clone(),
+            shutdown: &self.shutdown,
+            now_epoch,
+            dry_run,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. State machine — only valid transitions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn state_machine_allows_only_valid_transitions() {
+    for &from in &ALL_STATUSES {
+        for &to in &ALL_STATUSES {
+            let expected = ALLOWED_EDGES.contains(&(from, to));
+            assert_eq!(
+                from.can_transition_to(to),
+                expected,
+                "can_transition_to mismatch for {from} -> {to}"
+            );
+
+            let mut idea = CreativeIdea::new("x", sample_context(), 100);
+            idea.status = from;
+            let result = idea.try_transition(to);
+            if expected {
+                assert!(result.is_ok(), "expected {from} -> {to} to be allowed");
+                assert_eq!(idea.status, to);
+            } else {
+                assert!(
+                    matches!(result, Err(SimardError::InvalidIdeaTransition { from: f, to: t }) if f == from && t == to),
+                    "expected InvalidIdeaTransition for {from} -> {to}"
+                );
+                assert_eq!(
+                    idea.status, from,
+                    "status must not change on a rejected edge"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn terminal_states_have_no_outgoing_edges() {
+    for &terminal in &[IdeaStatus::Rejected, IdeaStatus::ImplementationCompleted] {
+        assert!(terminal.is_terminal());
+        for &to in &ALL_STATUSES {
+            assert!(
+                !terminal.can_transition_to(to),
+                "{terminal} is terminal but allowed -> {to}"
+            );
+        }
+    }
+}
+
+#[test]
+fn implementation_completed_only_from_implementation_started() {
+    for &from in &ALL_STATUSES {
+        let allowed = from.can_transition_to(IdeaStatus::ImplementationCompleted);
+        assert_eq!(
+            allowed,
+            from == IdeaStatus::ImplementationStarted,
+            "only ImplementationStarted may reach ImplementationCompleted (offender: {from})"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Persistence / retrieval — round-trip through prospective memory
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generated_idea_persists_as_prospective_node_and_round_trips() {
+    let mem = LibraryCognitiveMemory::in_memory().expect("in-memory store");
+    let store = ProspectiveCreativeIdeaStore::new(&mem);
+
+    let mut idea = CreativeIdea::new(
+        "add a nightly recall regression eval",
+        sample_context(),
+        1_700_000_000,
+    );
+    idea.links = vec![
+        MemoryLink {
+            kind: MemoryLinkKind::Semantic,
+            node_id: "sem_1".to_string(),
+        },
+        MemoryLink {
+            kind: MemoryLinkKind::Episodic,
+            node_id: "epi_9".to_string(),
+        },
+    ];
+    idea.success_metric = Some(sample_metric());
+    idea.reviews = vec![support_review(MEASURABILITY_ID, Some(sample_metric()))];
+
+    let node_id = store.store(&idea).expect("store idea");
+    assert!(!node_id.is_empty());
+
+    // The raw prospective node carries the retrieval sentinel.
+    let raw = mem.list_all_prospective(u32::MAX).expect("list raw");
+    let node = raw
+        .iter()
+        .find(|n| n.trigger_condition == CREATIVE_IDEA_TRIGGER)
+        .expect("a creative-idea node exists");
+    assert_eq!(
+        node.description, idea.idea,
+        "description mirrors the idea text"
+    );
+
+    // Round-trips with payload fidelity.
+    let listed = store.list(u32::MAX).expect("list ideas");
+    assert_eq!(listed.len(), 1);
+    let got = &listed[0];
+    assert_eq!(got.idea, idea.idea);
+    assert_eq!(got.status, IdeaStatus::New);
+    assert_eq!(got.links, idea.links);
+    assert_eq!(got.context, idea.context);
+    assert_eq!(got.success_metric, idea.success_metric);
+    assert_eq!(got.reviews, idea.reviews);
+
+    // `get` by node_id resolves the same idea.
+    let by_id = store.get(&got.node_id).expect("get").expect("some");
+    assert_eq!(by_id.idea, idea.idea);
+    assert_eq!(by_id.node_id, got.node_id);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Pipeline — all four reviewers + synthesis sets a legal status
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pipeline_runs_all_reviewers_and_synthesis_sets_status() {
+    let inputs = GenerationInputs::default();
+    let mut idea = CreativeIdea::new("cache distilled facts by concept", sample_context(), 200);
+
+    let crusty = StubReviewer {
+        id: CRUSTY_OLD_ENGINEER_ID,
+        review: support_review(CRUSTY_OLD_ENGINEER_ID, None),
+    };
+    let philosophy = StubReviewer {
+        id: PHILOSOPHY_GUARDIAN_ID,
+        review: support_review(PHILOSOPHY_GUARDIAN_ID, None),
+    };
+    let measurability = StubReviewer {
+        id: MEASURABILITY_ID,
+        review: support_review(MEASURABILITY_ID, Some(sample_metric())),
+    };
+    let reviewers: [&dyn Reviewer; 3] = [&crusty, &philosophy, &measurability];
+
+    let outcome = run_review_pipeline(&mut idea, &inputs, &reviewers, &DefaultSynthesizer)
+        .expect("pipeline runs");
+
+    // All three vetting reviewers ran (the synthesizer is the fourth step).
+    assert_eq!(idea.reviews.len(), 3);
+    // Synthesis set a status that is a legal transition from `New`.
+    assert!(IdeaStatus::New.can_transition_to(outcome.next_status));
+    assert_eq!(idea.status, outcome.next_status);
+    // Support + a metric with no risk flags => accepted, metric attached.
+    assert_eq!(idea.status, IdeaStatus::AcceptedForImplementation);
+    assert_eq!(idea.success_metric, Some(sample_metric()));
+}
+
+#[test]
+fn synthesis_routes_high_risk_idea_to_human_review() {
+    let inputs = GenerationInputs::default();
+    let mut idea = CreativeIdea::new("auto-delete stale worktrees", sample_context(), 200);
+
+    let mut risky = support_review(CRUSTY_OLD_ENGINEER_ID, None);
+    risky.verdict = ReviewVerdict::Concern;
+    risky.flags.high_risk = true;
+    risky.flags.irreversible = true;
+
+    let crusty = StubReviewer {
+        id: CRUSTY_OLD_ENGINEER_ID,
+        review: risky,
+    };
+    let measurability = StubReviewer {
+        id: MEASURABILITY_ID,
+        review: support_review(MEASURABILITY_ID, Some(sample_metric())),
+    };
+    let reviewers: [&dyn Reviewer; 2] = [&crusty, &measurability];
+
+    run_review_pipeline(&mut idea, &inputs, &reviewers, &DefaultSynthesizer).expect("pipeline");
+    assert_eq!(idea.status, IdeaStatus::NeedsHumanReview);
+}
+
+#[test]
+fn synthesis_needs_revision_when_no_metric() {
+    let inputs = GenerationInputs::default();
+    let mut idea = CreativeIdea::new("some idea with no measurable outcome", sample_context(), 1);
+    let crusty = StubReviewer {
+        id: CRUSTY_OLD_ENGINEER_ID,
+        review: support_review(CRUSTY_OLD_ENGINEER_ID, None),
+    };
+    let reviewers: [&dyn Reviewer; 1] = [&crusty];
+    run_review_pipeline(&mut idea, &inputs, &reviewers, &DefaultSynthesizer).expect("pipeline");
+    assert_eq!(idea.status, IdeaStatus::NeedsRevision);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Routing — accepted, not flagged => a proposed goal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn route_accepted_idea_produces_proposed_goal() {
+    let goals = InMemoryGoalStore::try_default().expect("goal store");
+    let mut idea = CreativeIdea::new(
+        "distill meeting transcripts into facts",
+        sample_context(),
+        5,
+    );
+    idea.node_id = "pro_idea_1".to_string();
+    idea.status = IdeaStatus::AcceptedForImplementation;
+
+    let record = route_idea_to_goal(&idea, &goals, 1_700_000_500).expect("route to goal");
+    assert_eq!(record.status, GoalStatus::Proposed);
+    assert_eq!(record.slug, goal_slug(&idea.idea));
+
+    // Traceability: the originating node id is in the goal evidence.
+    let ev = record
+        .evidence
+        .iter()
+        .map(|e| e.to_persisted_string())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        ev.contains("pro_idea_1"),
+        "evidence should tag the idea node id: {ev}"
+    );
+
+    // Persisted in the store.
+    let stored = goals.list().expect("list goals");
+    assert!(
+        stored
+            .iter()
+            .any(|g| g.slug == record.slug && g.status == GoalStatus::Proposed)
+    );
+}
+
+#[test]
+fn route_non_accepted_idea_to_goal_is_rejected() {
+    let goals = InMemoryGoalStore::try_default().expect("goal store");
+    let mut idea = CreativeIdea::new("premature idea", sample_context(), 5);
+    idea.status = IdeaStatus::New;
+    let result = route_idea_to_goal(&idea, &goals, 1);
+    assert!(matches!(
+        result,
+        Err(SimardError::InvalidIdeaTransition {
+            from: IdeaStatus::New,
+            to: IdeaStatus::ImplementationStarted
+        })
+    ));
+    assert!(goals.list().expect("list").is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// 5. Routing — NeedsHumanReview => issue tagging the owner
+// ---------------------------------------------------------------------------
+
+#[test]
+fn route_needs_human_idea_files_issue_tagging_owner() {
+    let gh = FakeIdeaGhClient::default();
+    let mut idea = CreativeIdea::new("risky exploratory refactor", sample_context(), 9);
+    idea.node_id = "pro_idea_hr".to_string();
+    idea.status = IdeaStatus::NeedsHumanReview;
+
+    let issue = route_idea_to_issue(&idea, &gh, "rysweet/Simard").expect("file issue");
+    assert!(issue.body.contains("pro_idea_hr"));
+
+    let recorded = gh.issues.borrow();
+    assert_eq!(recorded.len(), 1);
+    assert!(
+        recorded[0]
+            .labels
+            .iter()
+            .any(|l| l == CREATIVE_IDEA_ISSUE_LABEL)
+    );
+    assert!(
+        recorded[0]
+            .assignees
+            .iter()
+            .any(|a| a == CREATIVE_IDEA_OWNER)
+    );
+    assert!(recorded[0].body.contains("pro_idea_hr"));
+}
+
+// ---------------------------------------------------------------------------
+// 6. Routing — PR human-review gate (draft + label + owner review, no bypass)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mark_idea_pr_applies_full_gate_and_never_bypasses() {
+    let gh = FakeIdeaGhClient::default();
+    let mut idea = CreativeIdea::new("idea behind a PR", sample_context(), 11);
+    idea.node_id = "pro_idea_pr".to_string();
+
+    let gate = mark_idea_pr(77, &idea, &gh, "rysweet/Simard").expect("mark pr");
+    assert!(gate.draft);
+    assert_eq!(gate.blocking_label, CREATIVE_IDEA_PR_LABEL);
+    assert_eq!(
+        gate.review_requested_from,
+        vec![CREATIVE_IDEA_OWNER.to_string()]
+    );
+    assert_eq!(gate.originating_idea, "pro_idea_pr");
+
+    let ops = gh.pr_ops.borrow();
+    assert!(ops.contains(&"set_pr_draft:77:true".to_string()));
+    assert!(ops.contains(&format!("add_pr_label:77:{CREATIVE_IDEA_PR_LABEL}")));
+    assert!(ops.contains(&format!("request_pr_review:77:{CREATIVE_IDEA_OWNER}")));
+}
+
+#[test]
+fn constructed_gh_argv_never_contain_admin_or_no_verify() {
+    let argvs: Vec<Vec<String>> = vec![
+        gh_pr_draft_argv("rysweet/Simard", 77),
+        gh_pr_add_label_argv("rysweet/Simard", 77, CREATIVE_IDEA_PR_LABEL),
+        gh_pr_add_reviewer_argv("rysweet/Simard", 77, CREATIVE_IDEA_OWNER),
+        super::routing::gh_issue_create_argv(
+            "rysweet/Simard",
+            "t",
+            "b",
+            &[CREATIVE_IDEA_ISSUE_LABEL],
+            &[CREATIVE_IDEA_OWNER],
+        ),
+    ];
+
+    for argv in &argvs {
+        assert!(
+            !argv.iter().any(|a| a == "--admin"),
+            "no --admin in {argv:?}"
+        );
+        assert!(
+            !argv.iter().any(|a| a == "--no-verify"),
+            "no --no-verify in {argv:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 7. Dedup — rejects a near-duplicate of a prior idea
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dedup_rejects_near_duplicate_of_prior_idea() {
+    let prior = CreativeIdea::new(
+        "add a nightly recall regression eval for cognitive memory",
+        sample_context(),
+        1,
+    );
+
+    assert!(is_near_duplicate(
+        "add a nightly recall regression eval for cognitive memory please",
+        &prior.idea,
+        dedup::DEFAULT_DEDUP_THRESHOLD
+    ));
+    assert!(!is_near_duplicate(
+        "rewrite the dashboard styling",
+        &prior.idea,
+        dedup::DEFAULT_DEDUP_THRESHOLD
+    ));
+
+    let candidates = vec![
+        RawIdea {
+            idea: "add a nightly recall regression eval for cognitive memory".to_string(),
+            links: vec![],
+            rationale: String::new(),
+        },
+        RawIdea {
+            idea: "introduce a brand new sensory pre-processing thread".to_string(),
+            links: vec![],
+            rationale: String::new(),
+        },
+    ];
+    let kept = reject_duplicates(
+        candidates,
+        std::slice::from_ref(&prior),
+        dedup::DEFAULT_DEDUP_THRESHOLD,
+    );
+    assert_eq!(kept.len(), 1);
+    assert!(kept[0].idea.contains("sensory"));
+}
+
+// ---------------------------------------------------------------------------
+// 8. Off by default
+// ---------------------------------------------------------------------------
+
+#[test]
+fn subsystem_is_off_by_default() {
+    assert!(!CreativeIdeasConfig::default().enabled());
+    // An empty environment leaves it OFF.
+    assert!(!CreativeIdeasConfig::from_lookup(|_| None).enabled());
+    // A falsey value leaves it OFF.
+    assert!(
+        !CreativeIdeasConfig::from_lookup(|k| (k == super::ENABLED_ENV).then(|| "0".to_string()))
+            .enabled()
+    );
+    // Only an explicit truthy value enables it.
+    assert!(
+        CreativeIdeasConfig::from_lookup(|k| (k == super::ENABLED_ENV).then(|| "true".to_string()))
+            .enabled()
+    );
+
+    // The thread reports disabled by default and never ticks.
+    let thread = CreativeIdeasThread::new(
+        CreativeIdeasConfig::default(),
+        Box::new(FakeIdeaSource::default()),
+    );
+    assert!(!thread.enabled());
+    assert_eq!(thread.kind(), ThreadKind::BackgroundThought);
+}
+
+// ---------------------------------------------------------------------------
+// 9. Error contracts — fail-closed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn illegal_transition_returns_invalid_idea_transition() {
+    let mut idea = CreativeIdea::new("x", sample_context(), 1);
+    idea.status = IdeaStatus::Rejected; // terminal
+    let err = idea.try_transition(IdeaStatus::New).unwrap_err();
+    assert!(matches!(
+        err,
+        SimardError::InvalidIdeaTransition {
+            from: IdeaStatus::Rejected,
+            to: IdeaStatus::New
+        }
+    ));
+}
+
+#[test]
+fn unknown_status_string_is_rejected_not_defaulted() {
+    let err = IdeaStatus::from_str("Bogus").unwrap_err();
+    assert!(matches!(err, SimardError::InvalidCreativeIdeaRecord { .. }));
+    // A known one round-trips.
+    assert_eq!(
+        IdeaStatus::from_str("NeedsHumanReview").expect("known"),
+        IdeaStatus::NeedsHumanReview
+    );
+}
+
+#[test]
+fn bad_payload_and_wrong_sentinel_and_new_version_fail_closed() {
+    // Wrong sentinel.
+    let wrong = CognitiveProspective {
+        node_id: "pro_x".to_string(),
+        description: "d".to_string(),
+        trigger_condition: "not-a-creative-idea".to_string(),
+        action_on_trigger: "{}".to_string(),
+        status: "pending".to_string(),
+        priority: 3,
+    };
+    assert!(matches!(
+        CreativeIdea::from_prospective(&wrong),
+        Err(SimardError::InvalidCreativeIdeaRecord { .. })
+    ));
+
+    // Unparseable payload.
+    let bad_json = CognitiveProspective {
+        trigger_condition: CREATIVE_IDEA_TRIGGER.to_string(),
+        action_on_trigger: "{ not valid json".to_string(),
+        ..wrong.clone()
+    };
+    assert!(matches!(
+        CreativeIdea::from_prospective(&bad_json),
+        Err(SimardError::InvalidCreativeIdeaRecord { .. })
+    ));
+
+    // A too-new payload_version.
+    let mut idea = CreativeIdea::new("versioned", sample_context(), 1);
+    idea.reviews = vec![support_review(MEASURABILITY_ID, Some(sample_metric()))];
+    let payload = idea.to_action_payload().expect("payload");
+    let mut value: Value = serde_json::from_str(&payload).expect("json");
+    value["payload_version"] = Value::from(CREATIVE_IDEA_PAYLOAD_VERSION as u64 + 1);
+    let too_new = CognitiveProspective {
+        trigger_condition: CREATIVE_IDEA_TRIGGER.to_string(),
+        action_on_trigger: value.to_string(),
+        ..wrong.clone()
+    };
+    assert!(matches!(
+        CreativeIdea::from_prospective(&too_new),
+        Err(SimardError::InvalidCreativeIdeaRecord { .. })
+    ));
+
+    // An unknown reviewer id in the payload is fail-closed.
+    let mut value2: Value = serde_json::from_str(&payload).expect("json");
+    value2["reviews"][0]["reviewer"] = Value::from("totally_unknown_reviewer");
+    let unknown_reviewer = CognitiveProspective {
+        trigger_condition: CREATIVE_IDEA_TRIGGER.to_string(),
+        action_on_trigger: value2.to_string(),
+        ..wrong
+    };
+    assert!(matches!(
+        CreativeIdea::from_prospective(&unknown_reviewer),
+        Err(SimardError::InvalidCreativeIdeaRecord { .. })
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// 10. Tick is total
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tick_is_total_when_idea_source_errors() {
+    let env = TickEnv::new();
+    let cfg = CreativeIdeasConfig {
+        enabled: true, // turn on so tick reaches the (failing) source
+        ..CreativeIdeasConfig::default()
+    };
+    let mut thread = CreativeIdeasThread::new(cfg, Box::new(FakeIdeaSource::failing()));
+
+    let mut ctx = env.ctx(1_000, /* dry_run */ true);
+    let outcome = thread.tick(&mut ctx);
+
+    assert!(outcome.ran, "an enabled tick runs");
+    assert!(
+        !outcome.success,
+        "a failing source yields a failed outcome, not a panic/Err"
+    );
+    assert!(outcome.summary.contains("creative-ideas tick failed"));
+
+    let health: ThreadHealth = thread.health();
+    assert_eq!(health.consecutive_errors, 1);
+    assert_eq!(health.last_success, Some(false));
+}
+
+#[test]
+fn disabled_tick_is_skipped() {
+    let env = TickEnv::new();
+    let mut thread = CreativeIdeasThread::new(
+        CreativeIdeasConfig::default(),
+        Box::new(FakeIdeaSource::failing()),
+    );
+    let mut ctx = env.ctx(1_000, true);
+    let outcome = thread.tick(&mut ctx);
+    assert!(!outcome.ran, "a disabled thread does no work");
+    assert!(outcome.success);
+}
+
+// ---------------------------------------------------------------------------
+// 11. Outcome feedback — mark_completed gated on a met metric
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mark_completed_requires_started_and_metric_met() {
+    // Happy path.
+    let mut idea = CreativeIdea::new("done idea", sample_context(), 1);
+    idea.status = IdeaStatus::ImplementationStarted;
+    mark_completed(&mut idea, true).expect("complete");
+    assert_eq!(idea.status, IdeaStatus::ImplementationCompleted);
+
+    // Refuses when the metric is not met.
+    let mut idea2 = CreativeIdea::new("not-yet idea", sample_context(), 1);
+    idea2.status = IdeaStatus::ImplementationStarted;
+    assert!(matches!(
+        mark_completed(&mut idea2, false),
+        Err(SimardError::InvalidIdeaTransition { .. })
+    ));
+    assert_eq!(idea2.status, IdeaStatus::ImplementationStarted);
+
+    // Refuses when not in ImplementationStarted.
+    let mut idea3 = CreativeIdea::new("wrong state", sample_context(), 1);
+    idea3.status = IdeaStatus::New;
+    assert!(matches!(
+        mark_completed(&mut idea3, true),
+        Err(SimardError::InvalidIdeaTransition { .. })
+    ));
+}

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -38,6 +38,15 @@ impl Display for SimardError {
                 field: identity,
                 reason,
             } => fmt_field_reason(f, self, identity, reason),
+            Self::InvalidCreativeIdeaRecord { field, reason } => {
+                write!(f, "invalid creative-idea record field '{field}': {reason}")
+            }
+            Self::InvalidIdeaTransition { from, to } => {
+                write!(
+                    f,
+                    "invalid creative-idea transition from '{from}' to '{to}'"
+                )
+            }
             Self::InvalidSessionId { value, reason } => {
                 write!(f, "invalid session id '{value}': {reason}")
             }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -11,6 +11,7 @@ use std::error::Error;
 use std::path::PathBuf;
 
 use crate::base_types::BaseTypeCapability;
+use crate::cognitive_memory::creative_idea::IdeaStatus;
 use crate::runtime::{RuntimeState, RuntimeTopology};
 use crate::session::SessionPhase;
 
@@ -52,6 +53,20 @@ pub enum SimardError {
         reason: String,
     },
     InvalidImprovementRecord {
+        field: String,
+        reason: String,
+    },
+    /// Creative-ideas subsystem (#2419): an illegal `IdeaStatus` transition,
+    /// from `try_transition` or an illegal synthesis `next_status`. Mirrors
+    /// `InvalidRuntimeTransition` / `InvalidSessionTransition`.
+    InvalidIdeaTransition {
+        from: IdeaStatus,
+        to: IdeaStatus,
+    },
+    /// Creative-ideas subsystem (#2419): a malformed `CreativeIdea` record —
+    /// a serde (de)serialize failure, an unknown enum string, or a too-new
+    /// `payload_version`. Mirrors `InvalidGoalRecord` / `InvalidImprovementRecord`.
+    InvalidCreativeIdeaRecord {
         field: String,
         reason: String,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,12 @@ mod copilot_task_submit;
 // `MeetingBackend`; `SignalConversation` (feature-gated below) is a third.
 pub mod conversation_channel;
 pub mod cost_tracking;
+// Issue #2419 (design spike): the Creative Ideas subsystem — an idea-generation
+// cognitive thread + four-reviewer pipeline that primes a pool of candidate
+// self-improvement ideas. Typed foundation + tests only; gated OFF by default
+// (`SIMARD_CREATIVE_IDEAS_ENABLED`) and not wired into the daemon. See
+// `docs/design/creative-ideas-thread.md`.
+pub mod creative_ideas;
 pub mod disk_health;
 pub mod disk_pressure;
 pub mod engineer_loop;


### PR DESCRIPTION
## Summary

**Design spike (#2419) — gated OFF, nothing wired into the daemon.** Adds a
"Creative Ideas" idea-generation subsystem: a background **cognitive thread**
plus a **four-reviewer pipeline** that primes a pool of candidate
self-improvement ideas inside the single Simard brain (no "Bridge"; one brain,
cognitive threads + reviewers).

This PR delivers **(1)** a durable design doc and **(2)** additive, tested Rust
scaffolding for the core types, the generator thread, the reviewer pipeline, and
the routing seams — with clearly-marked `// FUTURE:` stubs where full wiring is
future work.

> ⚠️ **This is a gated-OFF spike.** The subsystem is OFF by default behind
> `SIMARD_CREATIVE_IDEAS_ENABLED`, is **not** registered with the `Mind`
> scheduler, and does **not** act autonomously. The production LLM idea-source,
> the real skill/agent reviewers, and the real `gh` PR/issue wiring are
> `// FUTURE:` stubs. **The operator redeploys after merge.**

## What's included

**Design doc**
- `docs/design/creative-ideas-thread.md` — full design: data model, `IdeaStatus`
  state-machine (+ mermaid), thread inputs, four-reviewer pipeline, routing,
  safety model, versioning, and a phased roadmap (M1–M6).
- `docs/howto/configure-creative-ideas-thread.md`, `docs/reference/creative-ideas-api.md`
  companion pages (added to mkdocs nav; `mkdocs build --strict` passes).

**Rust scaffolding**
- `src/cognitive_memory/creative_idea.rs` — `CreativeIdea` prospective type;
  `IdeaStatus` state-machine with a validated `try_transition` (fail-closed);
  `CreativeIdeaStore` round-trip over prospective memory — **no schema change**
  (payload in `action_on_trigger`, versioned via `payload_version`).
- `src/cognitive_threads/threads/creative_ideas.rs` — `CreativeIdeasThread`
  (`CognitiveThread`, reuses `ThreadKind::BackgroundThought`), gated OFF, pluggable
  `IdeaSource` (fake + `// FUTURE:` LLM stub), **total** `tick`.
- `src/creative_ideas/` — `Reviewer`/`FeedbackSynthesizer` traits + 4 adapters
  (crusty-old-engineer / philosophy-guardian / measurability / synthesis) with
  fakes; routing (`route_idea_to_goal`, `route_idea_to_issue`, `mark_idea_pr`)
  via an `IdeaGhClient` seam; dedup/portfolio/budget helpers; the config flag.
- `src/error/` — two new `SimardError` variants (`InvalidIdeaTransition`,
  `InvalidCreativeIdeaRecord`).

## Safety

- **OFF by default** behind `SIMARD_CREATIVE_IDEAS_ENABLED`; a default config is disabled.
- High-risk / irreversible ideas **always** route to `NeedsHumanReview`.
- Creative-idea PRs are gated: **draft + merge-blocking label + owner (`rysweet`)
  review-requested** — enforced with plain GitHub mechanisms, **never**
  `--admin` / `--no-verify` (a unit test asserts constructed `gh` argv contain neither).
- `ImplementationCompleted` is reachable only when the idea's own `success_metric` is met.

## Reuse (no duplication)

Cognitive-memory prospective type, the Mind cognitive-thread scheduler (#2531),
the goal store, the stewardship `gh` client pattern, and existing self-metrics
(`recall_precision_at_k`, distill fact-yield, reasoner-reliability).

## Tests

20 hermetic unit tests (no network; fakes for reviewers / goal-store /
issue-filer / gh / clock): state-machine valid-transitions, prospective
round-trip, full pipeline + synthesis, routing (goal / owner-tagged issue / PR
gate), dedup rejects near-duplicates, off-by-default, fail-closed error
contracts, and total-tick.

## Validation

- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓
- `cargo test --lib creative_ideas` → 20 passed ✓
- `mkdocs build --strict` ✓
- Pre-commit + pre-push hooks green on push (no `--no-verify`).

Branched off latest `origin/main`. Closes #2419.