### PR TITLE
feat(prompts,docs): encode three durable engineering guidelines (G1/G2/G3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ they are the same gates CI enforces.
 5. [Local Data Retention Disclosure](#local-data-retention-disclosure)
 6. [Pre-Existing Test Failure Disposition](#pre-existing-test-failure-disposition)
 7. [Real-Meeting & Dashboard E2E Verification](#real-meeting--dashboard-e2e-verification)
+8. [Engineering Guidelines (G1/G2/G3)](#engineering-guidelines-g1g2g3)
 
 ---
 
@@ -568,6 +569,192 @@ Dashboard rendering smoke tests caught only Unicode bugs; they could not
 detect (and did not detect) the WAL-checkpoint data-loss bug. Real E2E
 exercise on a live daemon is the only verification gate that catches
 durability and ingestion regressions before they reach production.
+
+---
+
+## Engineering Guidelines (G1/G2/G3)
+
+These are **durable engineering principles**, not a point-in-time
+snapshot. They apply to human contributors *and* to Simard's own OODA
+reasoners and engineer sessions. They are encoded declaratively in the
+hot-reloaded prompt assets under `prompt_assets/simard/` (mirrored into
+the recipe YAML the daemon runs), enforced as soft review gates in the
+merge-readiness judge and the code-review reasoner, and pinned by a
+presence test at
+[`tests/engineering_guidelines_prompts.rs`](tests/engineering_guidelines_prompts.rs).
+
+> **Why these three?** Each guideline is a lesson learned from a
+> specific merged PR where a change looked complete but left a durable
+> gap. The guidelines exist so the same class of gap is caught the next
+> time — by a reviewer, by the merge-judge, or by Simard herself while
+> planning the work.
+
+> **Terminology.** Simard runs a single **Brain** (the one-Brain
+> model). The interpretive reasoners named below — OODA Orient, Decide,
+> and the engineer-lifecycle brain — are phases of that one Brain, not a
+> separate "Bridge" reasoner. Do not introduce new "Bridge" naming for
+> the Brain or its OODA phases. (This is distinct from the existing
+> memory/knowledge *bridge adapters*, which keep their established
+> names.)
+
+### G1 — Prove gains on BOTH a fixed benchmark AND live self-measurement
+
+Cognition and self-improvement work must iterate toward proving its
+gains on **both**:
+
+1. a **fixed benchmark** — a stable corpus or regression baseline, and
+2. a **live self-measurement** — a production self-metric that Simard
+   emits about her own running behaviour, **trended over time**.
+
+A benchmark-corpus number, or a coarse proxy metric, is **not
+sufficient on its own**. The bar is a **hybrid benchmark + live**
+result: the improvement must also show up in a live self-metric drawn
+from the running daemon, not only on an offline corpus.
+
+This bar is enforced as a **soft advisory flag**, not a hard CI block —
+see [How the review gates read](#how-the-review-gates-read-soft-flags-not-hard-blocks)
+below. The imperative wording ("must", "not sufficient") describes what a
+reviewer or the merge-judge will flag, not a gate that fails the build.
+
+**Motivating context.** PR #2584 reported +86% on a fixed distillation
+corpus, and PR #2601 added `recall_precision_at_k` via a coarse
+substring proxy. Both proved gains on benchmarks/proxies — neither yet
+showed the gain in a live, trended self-metric. G1 closes that gap:
+benchmark **and** live, never either alone.
+
+**What "done" looks like for a G1-affected change:**
+
+- A fixed-benchmark result (corpus name, before/after, baseline commit).
+- A named live self-metric the daemon emits (for example a `*_at_k`
+  recall metric or equivalent), with a plan or link showing it is
+  **trended over time** in production — not a one-shot offline number.
+- If the live metric cannot yet move within the PR, the PR says so
+  explicitly and links the follow-up that will land the live
+  measurement.
+
+### G2 — Memory-architecture work belongs upstream in `amplihack-memory-lib`
+
+All memory-architecture work — distillation, recall, ranking, storage,
+WAL, forgetting — must land in **`rysweet/amplihack-memory-lib`** (the
+memory engine). Simard then **bumps** her pinned `amplihack-memory`
+dependency to pick it up.
+
+**Do not fork memory logic into Simard's own repo**
+(`src/memory_consolidation`, `src/cognitive_memory`). Where Simard-side
+memory logic already exists, **prefer migrating it upstream** over
+extending it locally.
+
+**Motivating context.** PR #2584 placed distillation fact-yield logic
+in Simard's repo instead of in the library. G2 routes that class of
+work to the engine repo so there is a single source of truth for the
+memory architecture, and Simard consumes it by bumping the pinned
+`amplihack-memory` git rev.
+
+**What "done" looks like for a G2-affected change:**
+
+- The memory-architecture change is a PR against
+  `rysweet/amplihack-memory-lib`.
+- Simard's PR is (or is immediately followed by) a **dependency bump**
+  of the pinned `amplihack-memory` git rev (the dependency is pinned by
+  commit SHA, not a semver range) — not a re-implementation under `src/`.
+- If a change touches `src/memory_consolidation` or
+  `src/cognitive_memory`, the PR justifies why it is a thin
+  consumer/adapter and not new engine logic that belongs upstream.
+
+### G3 — Prefer agentic steps over brittle parsing; prefer recipes/prompts over code
+
+Treat string/line parsing of LLM or tool output as a **brittle-parsing
+antipattern**. Whenever code parses or extracts model or tool output,
+stop and weigh the brittleness, and prefer an **agentic step** — a
+structured **JSON output contract** plus agent extraction — that is
+robust to rewording, reordering, and extra prose.
+
+More broadly: whenever a change or architecture improvement can be
+accomplished through **recipes + prompts** alone, that is the
+**preferred choice over writing code**. This guidelines document, and
+this whole change set, is itself an application of G3 — it moves policy
+into prompt assets rather than into new deterministic code.
+
+**Motivating context.** PR #2573 shipped a line-dropping parser in
+`src/recipe_output/extract.rs`. Line/substring parsers silently
+mis-handle output the moment the model reformats. G3 pushes extraction
+toward a structured contract read by an agent, and pushes new behaviour
+toward prompts/recipes before code.
+
+**What "done" looks like for a G3-affected change:**
+
+- New extraction of model/tool output uses a structured/JSON contract,
+  not ad-hoc line/substring slicing. (The merge-judge's `verdict` field
+  is the reference pattern: a machine-parseable field read through the
+  shared extractor that fails **closed** on a parse-miss, never
+  silently to `ready`.)
+- If new code parses output, the PR explains why an agentic step was
+  not viable.
+- If the same outcome was reachable via recipes/prompts, the change
+  uses recipes/prompts.
+
+**Scope.** G3 targets **new** brittle parsing. The existing shared
+extractor in `src/recipe_output/extract.rs` — which the merge-judge reads
+and which fails **closed** to `unclear` on a parse-miss — is the
+**sanctioned reference pattern**, not a G3 violation. Route new extraction
+of model/tool output through that same fail-closed, structured path rather
+than adding fresh line/substring slicing.
+
+### Where the guidelines are encoded
+
+| Layer | Assets | Effect |
+|---|---|---|
+| Engineer + OODA reasoner prompts | `engineer_system.md`, `engineer_planning.md`, `ooda_orient.md`, `ooda_decide.md`, `ooda_brain.md` (+ mirrored recipes `ooda-orient.yaml`, `ooda-decide.yaml`, `ooda-engineer-lifecycle.yaml`) | Simard's engineers and OODA Brain apply G1/G2/G3 while planning and doing cognition/memory/parsing work. |
+| Review gates (soft) | `merge_readiness_judge.md` (+ `merge-readiness-judge.yaml`), `review_pipeline.md`, `progress_assessment_reviewer.md` (+ `progress-assessment.yaml`) | Reviewers FLAG (a) cognition changes with no live self-measurement, (b) memory-arch changes in Simard's repo that belong in `amplihack-memory-lib`, (c) new/extended brittle output-parsing where an agentic step is cleaner. |
+| Goal framing | `goal_session_objective.md`, `goal_decomposition.md` (+ `goal-decomposition.yaml`), `goal_curator_system.md` | Standing cognition/self-improvement goals inherit G1 (hybrid benchmark + live) and G2 (route memory-arch upstream) in their success criteria. Those goals are **seeded at runtime into `~/.simard` state**, not stored as repo assets — so the presence test pins the G1/G2 framing in the goal *prompts*, not any specific goal slug. |
+| Durable doc | this section | Human-facing source of truth for G1/G2/G3. |
+| Presence test | `tests/engineering_guidelines_prompts.rs` | Pins keyword invariants so a future prompt edit cannot silently drop a guideline. |
+
+**Why not `AGENTS.md`?** `AGENTS.md` is regenerated amplihack boilerplate —
+its body is overwritten on each agent-context sync (the file even opens with
+a corrupted marker line). It is therefore **deliberately excluded** as a
+durable layer: a cross-reference added there would not survive regeneration.
+This `CONTRIBUTING.md` section is the single canonical, human-facing source
+of truth for G1/G2/G3, and no `AGENTS.md` edit is required for parity.
+
+**Hot reload.** The `prompt_assets/simard/` files hot-reload from
+`~/.simard/prompt_assets/`. After this PR merges, the operator syncs
+prompt assets / redeploys to activate the updated prompts on the running
+daemon — the merge alone does not change live behaviour.
+
+### How the review gates read (soft flags, not hard blocks)
+
+The review gates add **advisory flags** — they do not change the
+machine verdict enum (`ready` / `not_ready` / `unclear` for the
+merge-judge, and the severity scale for the code reviewer). A reviewer
+or the merge-judge raises a G1/G2/G3 flag as a finding or blocker with a
+`fix` suggestion; the author either addresses it or justifies why it
+does not apply. What fires a flag:
+
+- **G1 flag** — a PR that improves recall/distillation/ranking and
+  reports only a corpus or proxy number, with no live self-metric
+  trended over time.
+- **G2 flag** — a diff that adds distillation/recall/ranking/WAL logic
+  under `src/memory_consolidation` or `src/cognitive_memory` instead of
+  `amplihack-memory-lib` plus a dependency bump.
+- **G3 flag** — a new or extended line/substring parser over model/tool
+  output where a structured JSON contract + agent extraction would be
+  cleaner.
+
+### Verifying the guidelines are present
+
+```bash
+cargo test --test engineering_guidelines_prompts
+```
+
+The test reads the prompt assets, lowercases them, and asserts stable
+keyword invariants for each guideline (for example `live
+self-measurement` and `trended over time` for G1, `amplihack-memory-lib`
+for G2, `brittle parsing` and `agentic step` for G3), asserts each
+edited reasoner `.md` stays in parity with its recipe `.yaml` mirror,
+and asserts the edited reasoner regions do not rename the one-Brain
+OODA phases as a "Bridge". It asserts **keywords, not full sentences**,
+so ordinary rewording does not break it — deleting a guideline does.
 
 ---
 

--- a/prompt_assets/simard/engineer_planning.md
+++ b/prompt_assets/simard/engineer_planning.md
@@ -18,6 +18,22 @@ Decompose multi-paragraph or multi-task objectives into ATOMIC steps. Do NOT col
 
 If the objective cannot be decomposed into supported actions, return an empty array `[]` and the planner will report PlanningUnavailable.
 
+## Engineering guidelines (G1/G2/G3) — apply when planning cognition / memory / parsing work
+
+When the objective touches Simard's cognition, memory architecture, or parsing of
+model/tool output, thread these durable guidelines (canonical in `CONTRIBUTING.md`)
+into the plan steps and their `expected_outcome`s:
+
+- **G1** — a cognition / self-improvement plan must prove gains on **both** a
+  fixed **benchmark** and a **live self-measurement** (a production self-metric
+  **trended over time**), never a benchmark or coarse proxy alone.
+- **G2** — memory-architecture work (distillation, recall, ranking, storage, WAL,
+  forgetting) goes **upstream** in `amplihack-memory-lib` plus a pinned-dep bump;
+  do **not** fork it into `src/memory_consolidation` / `src/cognitive_memory`.
+- **G3** — prefer an **agentic step** (structured/JSON output contract + agent
+  extraction) over **brittle parsing** of model/tool output, and prefer
+  recipes/prompts over new code.
+
 Return ONLY the JSON array — no markdown fences, no prose preamble, no trailing commentary.
 
 Example for objective "verify issue 915 exists and read its body":

--- a/prompt_assets/simard/engineer_system.md
+++ b/prompt_assets/simard/engineer_system.md
@@ -493,6 +493,39 @@ The engineer-loop selection module (`src/engineer_loop/selection/`) already
 delegates to LLM planning (`engineer_plan::plan_objective`); the remaining
 deterministic helpers are *fallbacks* and should generally not be extended.
 
+## Engineering Guidelines (G1/G2/G3) — durable
+
+Three durable engineering guidelines govern all cognition, memory-architecture,
+and output-parsing work — yours and every engineer session's. Apply them while
+**planning and doing** the work, not only at review. The canonical, human-facing
+source of truth is `CONTRIBUTING.md`, section "Engineering Guidelines (G1/G2/G3)".
+
+- **G1 — Prove gains on BOTH a fixed benchmark AND live self-measurement.**
+  Cognition / self-improvement work must iterate toward proving its gains on
+  *both* a fixed **benchmark** corpus *and* a **live self-measurement** — a
+  production self-metric Simard emits about her own running behaviour,
+  **trended over time**. A benchmark-corpus number, or a coarse proxy, is
+  **not sufficient on its own**; the improvement must also move a live
+  self-metric. (Context: PRs
+  #2584 (+86% on a fixed corpus) and #2601 (`recall_precision_at_k` via a coarse
+  substring proxy) proved benchmark/proxy gains but not yet a live, trended one.)
+- **G2 — Memory-architecture work belongs upstream in `amplihack-memory-lib`.**
+  All memory-architecture work — distillation, recall, ranking, storage, WAL,
+  forgetting — must land in `rysweet/amplihack-memory-lib`, then Simard **bumps**
+  her pinned `amplihack-memory` dep to pick it up. Do **not** fork memory logic
+  into Simard's own repo (`src/memory_consolidation`, `src/cognitive_memory`);
+  where such Simard-side memory logic already exists, prefer **migrating it
+  upstream** over extending it locally. (Context: #2584 put distillation
+  fact-yield logic in Simard's repo instead of the library.)
+- **G3 — Prefer agentic steps over brittle parsing; prefer recipes/prompts over
+  code.** Treat string/line parsing of LLM or tool output as a **brittle parsing**
+  antipattern (e.g. #2573's line-dropping parser in `src/recipe_output/extract.rs`).
+  Whenever code parses/extracts model or tool output, prefer an **agentic step**
+  — a structured/JSON output contract plus agent extraction — that is robust to
+  rewording and reordering. And whenever a change or architecture improvement can
+  be accomplished through **recipes/prompts** alone, that is the preferred choice
+  over writing code. (This section itself is an application of G3.)
+
 ## Engineer Mode Boundaries
 
 - Prefer explicit repo-grounded actions over speculative narration.

--- a/prompt_assets/simard/goal_curator_system.md
+++ b/prompt_assets/simard/goal_curator_system.md
@@ -37,6 +37,20 @@ Goals come from multiple inputs — weigh them all during curation:
 - A goal is complete only with a merged PR, a closed linked issue, and — for changes to Simard's own running code — a verified deploy. Never archive a goal as complete on narrative alone; if any piece of that evidence is missing, keep the goal active and record the missing evidence as a blocker.
 - Goals must align with amplihack quality standards: ruthless simplicity, working code, evidence over narrative.
 
+## Durable engineering guidelines (G1/G2/G3)
+
+Two of Simard's durable engineering guidelines (canonical in `CONTRIBUTING.md`)
+shape the `done-when` criteria you write for cognition and memory goals:
+
+- **G1 — hybrid benchmark + live self-measurement.** A cognition /
+  self-improvement goal's `done-when` must require proving the gain on **both** a
+  fixed **benchmark** and a **live self-measurement** — a production self-metric
+  **trended over time** — never a benchmark-corpus number or coarse proxy alone.
+- **G2 — memory-architecture work routes upstream.** A memory-architecture goal
+  (distillation, recall, ranking, storage, WAL, forgetting) must land **upstream**
+  in `amplihack-memory-lib` and reach Simard via a pinned-dep bump, not be forked
+  into Simard's own repo.
+
 ## Open-ended goal hygiene
 
 Some goals are inherently **open-ended / unbounded** — there is no natural 100% (e.g. "increase test coverage across the ecosystem", "improve reliability", "keep dependencies current"). Left as-is, these never complete, never archive, and tend to park at a high completion-% forever while real work stalls.

--- a/prompt_assets/simard/goal_decomposition.md
+++ b/prompt_assets/simard/goal_decomposition.md
@@ -41,6 +41,19 @@ If the goal is already small and concrete enough that it cannot be honestly
 split into at least two bounded slices, still emit the two smallest real slices
 you can defend — do not pad with filler, and do not emit a single sub-goal.
 
+## Cognition & memory sub-goals — carry the engineering guidelines (G1/G2/G3)
+
+When you decompose a **cognition / self-improvement** or **memory-architecture**
+goal, encode the durable engineering guidelines (canonical in `CONTRIBUTING.md`)
+into the relevant `done_criterion`s:
+
+- **G1** — a cognition sub-goal's `done_criterion` must require a gain on a fixed
+  **benchmark** **and** a **live self-measurement** (a production self-metric
+  **trended over time**), not a benchmark or coarse proxy alone.
+- **G2** — a memory-architecture sub-goal (distillation, recall, ranking,
+  storage, WAL, forgetting) must land **upstream** in `amplihack-memory-lib` plus
+  a pinned-dep bump, never forked into Simard's own repo.
+
 ## Output
 
 Return a single JSON object, **no prose, no markdown fences**:

--- a/prompt_assets/simard/goal_session_objective.md
+++ b/prompt_assets/simard/goal_session_objective.md
@@ -212,6 +212,27 @@ of stalled, red, open PRs is a failure mode, not parallel progress — finish
 safe parallelism*: **start** in parallel on distinct issues, **don't loop**, and
 now **finish/land** each PR you own.
 
+# Cognition & self-improvement goals — hybrid benchmark + live measurement, memory-arch upstream (G1/G2)
+
+For any standing **cognition or self-improvement** goal (e.g.
+`continuously-research-and-improve-your-own-cognition*`), two durable success
+criteria apply — Simard's durable **engineering guidelines (G1/G2/G3)**,
+canonical in `CONTRIBUTING.md`:
+
+- **G1 — hybrid benchmark + live self-measurement.** A cognition improvement is
+  not done on a fixed **benchmark** corpus alone, nor on a coarse proxy: the
+  success criterion requires **both** a benchmark result **and** a **live
+  self-measurement** — a production self-metric Simard emits about her own
+  running behaviour, **trended over time**. Do **not** record such a goal as
+  complete on a benchmark/proxy number that has not also moved a live,
+  trended-over-time self-metric.
+- **G2 — memory-architecture work routes upstream.** When the goal's work is
+  memory-architecture (distillation, recall, ranking, storage, WAL, forgetting),
+  it must land **upstream** in `amplihack-memory-lib` and reach Simard's build
+  via a pinned-dep bump (see the dependency-pin done-gate above) — not be forked
+  into Simard's own repo. A memory-arch goal whose change lives only in Simard's
+  repo is not done.
+
 # Priority Order
 
 Triage existing PRs as a **quick first pass — not a perpetual gate.** Do it once

--- a/prompt_assets/simard/merge_readiness_judge.md
+++ b/prompt_assets/simard/merge_readiness_judge.md
@@ -41,6 +41,31 @@ referenced commit **is** substantive.
 You do **not** need to verify CI status, mergeability, or base branch — the deterministic
 gate has already done that before calling you. You are judging **evidence quality only**.
 
+## Engineering-guideline flags (G1/G2/G3) — advisory
+
+Beyond the six skill criteria, raise an **advisory flag** — a `blocker` entry with
+a `fix`, or a note in `rationale` — when a PR trips one of Simard's durable
+engineering guidelines (canonical in `CONTRIBUTING.md`, "Engineering Guidelines
+(G1/G2/G3)"). These are **soft**: they do not by themselves change the `verdict`
+enum (`ready` / `not_ready` / `unclear`); they surface a finding the author either
+addresses or justifies.
+
+- **G1 flag — benchmark without live self-measurement.** The PR improves cognition
+  (recall / distillation / ranking) and reports only a fixed **benchmark** corpus
+  number or a coarse proxy, with **no live self-measurement** — a production
+  self-metric **trended over time**. Flag it: the bar is benchmark **and** live,
+  not either alone.
+- **G2 flag — memory-arch forked into Simard's repo.** The diff adds
+  distillation / recall / ranking / WAL / forgetting logic under
+  `src/memory_consolidation` or `src/cognitive_memory` instead of landing it
+  upstream in `amplihack-memory-lib` plus a pinned-dep bump. Flag it: that class
+  of work belongs in `amplihack-memory-lib`.
+- **G3 flag — new brittle parsing where an agentic step is cleaner.** The diff
+  adds or extends line/substring **brittle parsing** of model or tool output where
+  a structured/JSON output contract read by an **agentic step** would be robust —
+  or writes new code where recipes/prompts would suffice. Flag it and point at the
+  agentic / prompt-first alternative.
+
 ## Inputs
 
 You receive:

--- a/prompt_assets/simard/ooda_brain.md
+++ b/prompt_assets/simard/ooda_brain.md
@@ -4,6 +4,14 @@
 
 You are the brain of Simard's OODA daemon. The Act phase is about to skip a goal because a live engineer worktree already exists for it. Before that skip happens, decide whether the engineer is genuinely making progress, is wedged, or warrants escalation. Output a single DECISION marker judgment the daemon will execute. Be conservative: prefer `continue_skipping` unless evidence clearly points elsewhere.
 
+> **Engineering guidelines (G1/G2/G3).** When the engineer's work touches
+> cognition, memory-architecture, or output-parsing, apply Simard's three durable
+> engineering guidelines (canonical in `CONTRIBUTING.md`): prove cognition gains
+> on a benchmark **and** a live, trended self-metric (G1); route
+> memory-architecture work upstream to `amplihack-memory-lib` (G2); and prefer
+> agentic extraction over brittle parsing, and recipes/prompts over code (G3).
+> This does not change your output contract below.
+
 ## CONTEXT
 
 - goal_id: {goal_id}

--- a/prompt_assets/simard/ooda_decide.md
+++ b/prompt_assets/simard/ooda_decide.md
@@ -22,6 +22,14 @@ issues, a completion-% parked high), still route to `advance_goal` (the action
 *kind* does not change), but name the suspected loop in your rationale so the
 goal-action brain re-scopes or executes rather than re-triaging the same state.
 
+> **Engineering guidelines (G1/G2/G3).** When routing cognition,
+> memory-architecture, or output-parsing work, apply Simard's three durable
+> engineering guidelines (canonical in `CONTRIBUTING.md`): prove cognition gains
+> on a benchmark **and** a live, trended self-metric (G1); route
+> memory-architecture work upstream to `amplihack-memory-lib` (G2); and prefer
+> agentic extraction over brittle parsing, and recipes/prompts over code (G3).
+> This does not change your output contract below.
+
 ## Done-gate guardrail
 
 Completion is evidence-gated, never narrative-gated. Do not propose STATUS: ACHIEVED without merged + closed + (if self-affecting) deployed evidence. A self-affecting change (Simard's own running code, or a bump to a dependency rev pinned in Simard's `Cargo.toml`) is not done until the new binary is built, deployed, and verified running — a merged PR alone does not make it ACHIEVED.

--- a/prompt_assets/simard/ooda_orient.md
+++ b/prompt_assets/simard/ooda_orient.md
@@ -23,6 +23,14 @@ Be conservative. The deterministic floor — `urgency − 0.2 × failure_count`,
 clamped to `[0, 1]` — exists for a reason: it is well-tuned and never
 escalates the goal. Deviate from it only when the context clearly warrants.
 
+> **Engineering guidelines (G1/G2/G3).** When your judgment touches cognition,
+> memory-architecture, or output-parsing work, apply Simard's three durable
+> engineering guidelines (canonical in `CONTRIBUTING.md`): prove cognition gains
+> on a benchmark **and** a live, trended self-metric (G1); route
+> memory-architecture work upstream to `amplihack-memory-lib` (G2); and prefer
+> agentic extraction over brittle parsing, and recipes/prompts over code (G3).
+> This does not change your output contract below.
+
 ## CONTEXT
 
 A single goal that has at least one consecutive failure recorded:

--- a/prompt_assets/simard/progress_assessment_reviewer.md
+++ b/prompt_assets/simard/progress_assessment_reviewer.md
@@ -107,6 +107,20 @@ When in genuine doubt, prefer **accept** with a cautionary rationale. The
 goal of this reviewer is to catch hallucinated jumps, not to gatekeep every
 small movement.
 
+### Cognition progress needs a live self-measurement, not just a benchmark (G1)
+
+Simard's durable **engineering guidelines (G1/G2/G3)** (canonical in
+`CONTRIBUTING.md`) add one progress-honesty rule here. When the `{problem}` /
+`{plan}` is a **cognition or self-improvement** goal (recall / distillation /
+ranking) and `{claimed_pct}` is at or near completion, a fixed **benchmark**
+corpus number or a coarse proxy is **not sufficient on its own**: the claim also
+needs a **live self-measurement** — a production self-metric Simard emits about
+her own running behaviour, **trended over time**. If the `{plan}` or
+`{wip_summary}` shows only a benchmark/proxy gain with **no** live, trended
+self-metric, treat a near-completion claim as not-yet-done and prefer **reject**
+with a rationale naming the missing live measurement. A modest in-flight delta on
+a benchmark gain is still fine.
+
 ## Output contract
 
 Return a single JSON object on a single line, no prose, no markdown fences:

--- a/prompt_assets/simard/recipes/goal-decomposition.yaml
+++ b/prompt_assets/simard/recipes/goal-decomposition.yaml
@@ -64,6 +64,19 @@ steps:
       real slices you can defend — do not pad with filler, and do not emit a
       single sub-goal.
 
+      ## Cognition & memory sub-goals — carry the engineering guidelines (G1/G2/G3)
+
+      When you decompose a cognition/self-improvement or memory-architecture goal,
+      encode the durable engineering guidelines (canonical in `CONTRIBUTING.md`) into
+      the relevant `done_criterion`s:
+
+      - **G1** — a cognition sub-goal's `done_criterion` must require a gain on a
+        fixed **benchmark** AND a **live self-measurement** (a production self-metric
+        **trended over time**), not a benchmark or coarse proxy alone.
+      - **G2** — a memory-architecture sub-goal (distillation, recall, ranking,
+        storage, WAL, forgetting) must land **upstream** in `amplihack-memory-lib`
+        plus a pinned-dep bump, never forked into Simard's own repo.
+
       ## Output
 
       Return a single JSON object, no prose, no markdown fences:

--- a/prompt_assets/simard/recipes/merge-readiness-judge.yaml
+++ b/prompt_assets/simard/recipes/merge-readiness-judge.yaml
@@ -53,6 +53,27 @@ steps:
       You do NOT need to verify CI status, mergeability, or base branch — the deterministic
       gate has already done that. You are judging evidence quality only.
 
+      ## Engineering-guideline flags (G1/G2/G3) — advisory
+
+      Beyond the six skill criteria, raise an advisory flag (a `blocker` entry with a
+      `fix`, or a note in `rationale`) when a PR trips one of Simard's durable
+      engineering guidelines (canonical in `CONTRIBUTING.md`, "Engineering Guidelines
+      (G1/G2/G3)"). These are soft — they do NOT by themselves change the `verdict`
+      enum (`ready`/`not_ready`/`unclear`); they surface a finding the author
+      addresses or justifies.
+
+      - **G1 flag** — the PR improves cognition (recall/distillation/ranking) and
+        reports only a fixed **benchmark** corpus number or a coarse proxy, with no
+        **live self-measurement** — a production self-metric **trended over time**.
+        The bar is benchmark AND live, not either alone.
+      - **G2 flag** — the diff adds distillation/recall/ranking/WAL/forgetting logic
+        under `src/memory_consolidation` or `src/cognitive_memory` instead of upstream
+        in `amplihack-memory-lib` plus a pinned-dep bump. That work belongs in
+        `amplihack-memory-lib`.
+      - **G3 flag** — the diff adds or extends line/substring **brittle parsing** of
+        model/tool output where a structured/JSON contract read by an **agentic step**
+        would be robust, or writes new code where recipes/prompts would suffice.
+
       ## Inputs
 
       PR_NUMBER: {{pr_number}}

--- a/prompt_assets/simard/recipes/ooda-decide.yaml
+++ b/prompt_assets/simard/recipes/ooda-decide.yaml
@@ -48,6 +48,14 @@ steps:
       rationale so the goal-action brain re-scopes or executes rather than
       re-triaging the same state.
 
+      **Engineering guidelines (G1/G2/G3).** When routing cognition,
+      memory-architecture, or output-parsing work, apply Simard's three durable
+      engineering guidelines (canonical in `CONTRIBUTING.md`): prove cognition
+      gains on a benchmark AND a live, trended self-metric (G1); route
+      memory-architecture work upstream to `amplihack-memory-lib` (G2); and prefer
+      agentic extraction over brittle parsing, and recipes/prompts over code (G3).
+      This does not change your output contract below.
+
       ## CONTEXT
 
       A single priority entry produced by the Orient phase:

--- a/prompt_assets/simard/recipes/ooda-engineer-lifecycle.yaml
+++ b/prompt_assets/simard/recipes/ooda-engineer-lifecycle.yaml
@@ -41,6 +41,14 @@ steps:
 
       You are the brain of Simard's OODA daemon. The Act phase is about to skip a goal because a live engineer worktree already exists for it. Before that skip happens, decide whether the engineer is genuinely making progress, is wedged, or warrants escalation. Output the variant name as the very first word of your response, followed by your rationale. Be conservative: prefer `continue_skipping` unless evidence clearly points elsewhere.
 
+      **Engineering guidelines (G1/G2/G3).** When the engineer's work touches
+      cognition, memory-architecture, or output-parsing, apply Simard's three
+      durable engineering guidelines (canonical in `CONTRIBUTING.md`): prove
+      cognition gains on a benchmark AND a live, trended self-metric (G1); route
+      memory-architecture work upstream to `amplihack-memory-lib` (G2); and prefer
+      agentic extraction over brittle parsing, and recipes/prompts over code (G3).
+      This does not change your output contract below.
+
       ## CONTEXT
 
       - goal_id: {{goal_id}}

--- a/prompt_assets/simard/recipes/ooda-orient.yaml
+++ b/prompt_assets/simard/recipes/ooda-orient.yaml
@@ -46,6 +46,14 @@ steps:
       clamped to `[0, 1]` — exists for a reason: it is well-tuned and never
       escalates the goal. Deviate from it only when the context clearly warrants.
 
+      **Engineering guidelines (G1/G2/G3).** When your judgment touches cognition,
+      memory-architecture, or output-parsing work, apply Simard's three durable
+      engineering guidelines (canonical in `CONTRIBUTING.md`): prove cognition
+      gains on a benchmark AND a live, trended self-metric (G1); route
+      memory-architecture work upstream to `amplihack-memory-lib` (G2); and prefer
+      agentic extraction over brittle parsing, and recipes/prompts over code (G3).
+      This does not change your output contract below.
+
       ## CONTEXT
 
       A single goal that has at least one consecutive failure recorded:

--- a/prompt_assets/simard/recipes/progress-assessment.yaml
+++ b/prompt_assets/simard/recipes/progress-assessment.yaml
@@ -105,6 +105,18 @@ steps:
 
       When in genuine doubt, prefer accept with a cautionary rationale.
 
+      ### Cognition progress needs a live self-measurement, not just a benchmark (G1)
+
+      Simard's durable **engineering guidelines (G1/G2/G3)** (canonical in
+      `CONTRIBUTING.md`) add one progress-honesty rule. When the problem/plan is a
+      **cognition or self-improvement** goal (recall/distillation/ranking) and
+      claimed_pct is at or near completion, a fixed **benchmark** corpus number or a
+      coarse proxy is not sufficient on its own: the claim also needs a **live
+      self-measurement** — a production self-metric **trended over time**. If the plan
+      or wip_summary shows only a benchmark/proxy gain with no live, trended
+      self-metric, treat a near-completion claim as not-yet-done and prefer reject,
+      naming the missing live measurement (a modest in-flight delta is still fine).
+
       ## Output
 
       Return a single JSON object, no prose, no markdown fences:

--- a/prompt_assets/simard/review_pipeline.md
+++ b/prompt_assets/simard/review_pipeline.md
@@ -22,6 +22,25 @@ You are Simard's automated code reviewer. Review the following diff against the 
 4. Test coverage: Are new public functions tested? Are edge cases covered?
 5. Simplicity: Could the change be achieved with fewer lines or less abstraction?
 
+## Engineering-guideline flags (G1/G2/G3)
+
+Beyond the priorities above, raise a finding (category `architecture`, severity
+usually `medium`) when a diff trips one of Simard's durable engineering guidelines
+(canonical in `CONTRIBUTING.md`, "Engineering Guidelines (G1/G2/G3)"). These are
+advisory — surface them with a concrete `fix`; they do not by themselves block a PR.
+
+- **G1** — a cognition change (recall / distillation / ranking) that reports only a
+  fixed **benchmark** or coarse proxy number with **no live self-measurement** (a
+  production self-metric **trended over time**). Flag the missing live half.
+- **G2** — memory-architecture logic (distillation, recall, ranking, WAL,
+  forgetting) added under `src/memory_consolidation` or `src/cognitive_memory`
+  instead of **upstream** in `amplihack-memory-lib` + a pinned-dep bump. Flag the
+  fork; that work belongs in `amplihack-memory-lib`.
+- **G3** — new or extended line/substring **brittle parsing** of model/tool output
+  where a structured/JSON contract read by an **agentic step** is cleaner, or new
+  code where recipes/prompts would do. Flag it and name the agentic / prompt-first
+  alternative.
+
 ## Output Format
 
 Output a JSON array of findings. Each finding:

--- a/tests/engineering_guidelines_prompts.rs
+++ b/tests/engineering_guidelines_prompts.rs
@@ -1,0 +1,432 @@
+//! Durable contract for the THREE engineering guidelines (G1/G2/G3) that
+//! Simard's OODA reasoners, engineers, and reviewers — and human
+//! contributors — must follow.
+//!
+//! G1 — HYBRID BENCHMARK + LIVE SELF-MEASUREMENT: cognition / self-improvement
+//!      work must prove gains on BOTH a fixed benchmark AND a live production
+//!      self-measurement trended over time — not just one.
+//! G2 — MEMORY-ARCH WORK BELONGS UPSTREAM: distillation / recall / ranking /
+//!      storage / WAL / forgetting must land in `rysweet/amplihack-memory-lib`
+//!      and Simard bumps her pinned dep — do NOT fork the memory logic into
+//!      Simard's own repo (`src/memory_consolidation`, `src/cognitive_memory`).
+//! G3 — PREFER AGENTIC STEPS OVER BRITTLE PARSING; PREFER RECIPES/PROMPTS OVER
+//!      CODE: treat line/substring parsing of model/tool output as a brittle
+//!      antipattern; prefer a structured-output contract + agentic extraction,
+//!      and prefer recipes/prompts over new code.
+//!
+//! TDD (Step 7 — write tests first): these are RED until the implementation
+//! step threads G1/G2/G3 into the engineer / OODA reasoner prompts, the review
+//! gates, and the goal-framing prompts (and their recipe `.yaml` mirrors). The
+//! `CONTRIBUTING.md` durable-doc assertions are the GREEN anchor — the human
+//! source of truth is already in place, so a regression that deletes it is
+//! also caught.
+//!
+//! The assertions pin STABLE keyword invariants (lowercased), not full-sentence
+//! snapshots, so ordinary rewording does not break them — deleting a guideline
+//! does. (Keyword invariants, not brittle snapshots, is itself G3.)
+
+use std::fs;
+use std::path::PathBuf;
+
+// --- asset readers -------------------------------------------------------
+
+fn prompt(name: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("prompt_assets/simard")
+        .join(name);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read prompt asset {}: {e}", path.display()))
+}
+
+fn recipe(name: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("prompt_assets/simard/recipes")
+        .join(name);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read recipe asset {}: {e}", path.display()))
+}
+
+fn repo_file(name: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(name);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read repo file {}: {e}", path.display()))
+}
+
+fn prompt_lc(name: &str) -> String {
+    prompt(name).to_lowercase()
+}
+
+// --- assertion helpers ---------------------------------------------------
+
+fn contains_any(haystack_lc: &str, needles: &[&str]) -> bool {
+    needles
+        .iter()
+        .any(|n| haystack_lc.contains(&n.to_lowercase()))
+}
+
+fn assert_contains(haystack_lc: &str, needle: &str, file: &str, what: &str) {
+    assert!(
+        haystack_lc.contains(&needle.to_lowercase()),
+        "{file} must express {what} (expected keyword {needle:?})"
+    );
+}
+
+fn assert_contains_any(haystack_lc: &str, needles: &[&str], file: &str, what: &str) {
+    assert!(
+        contains_any(haystack_lc, needles),
+        "{file} must express {what} (expected one of {needles:?})"
+    );
+}
+
+fn assert_absent(haystack_lc: &str, needle: &str, file: &str, why: &str) {
+    assert!(
+        !haystack_lc.contains(&needle.to_lowercase()),
+        "{file} must not contain {needle:?} ({why})"
+    );
+}
+
+// --- canonical guideline keyword vocabulary ------------------------------
+//
+// One shared, stable vocabulary so every reasoner / gate / doc pins the SAME
+// anchors. Rewording the surrounding prose is fine; dropping a guideline is
+// what these catch.
+
+/// Shared label that threads every guideline-bearing asset back to the durable
+/// `CONTRIBUTING.md` section. Absent everywhere before Step 8, so it is the
+/// universal RED discriminator.
+const MARKER: &str = "g1/g2/g3";
+
+/// G1 — the live-self-measurement half (the benchmark half alone is NOT
+/// sufficient; that is the whole point of the guideline).
+const G1_LIVE: &[&str] = &[
+    "live self-measurement",
+    "live self-metric",
+    "live production self-measurement",
+];
+const G1_TREND: &[&str] = &["trended over time", "trend over time"];
+
+/// G2 — the anti-fork half: memory-arch logic must NOT be forked into Simard's
+/// own repo under these paths; it belongs in `amplihack-memory-lib`.
+const G2_ANTIFORK: &[&str] = &["src/memory_consolidation", "src/cognitive_memory"];
+const MEMORY_LIB: &str = "amplihack-memory-lib";
+
+/// G3 — brittle-parsing antipattern vs. agentic extraction, and prefer
+/// recipes/prompts over code.
+const G3_AGENTIC: &[&str] = &["agentic step", "agentic extraction"];
+const G3_OVER_CODE: &[&str] = &[
+    "over code",
+    "prefer recipes",
+    "prefer prompts",
+    "recipes and prompts over",
+    "recipes/prompts",
+];
+
+// Composite guideline assertions ------------------------------------------
+
+fn assert_g1(lc: &str, file: &str) {
+    assert_contains_any(
+        lc,
+        G1_LIVE,
+        file,
+        "G1: a LIVE production self-measurement (not just a fixed benchmark)",
+    );
+    assert_contains_any(
+        lc,
+        G1_TREND,
+        file,
+        "G1: the self-metric is trended over time",
+    );
+    assert_contains(
+        lc,
+        "benchmark",
+        file,
+        "G1: a fixed benchmark as the other half of the hybrid bar",
+    );
+}
+
+fn assert_g2_full(lc: &str, file: &str) {
+    assert_contains(
+        lc,
+        MEMORY_LIB,
+        file,
+        "G2: memory-arch work routes to amplihack-memory-lib",
+    );
+    assert_contains_any(
+        lc,
+        G2_ANTIFORK,
+        file,
+        "G2: do NOT fork memory logic into Simard's own repo \
+         (src/memory_consolidation / src/cognitive_memory)",
+    );
+}
+
+fn assert_g2_framing(lc: &str, file: &str) {
+    // Goal-framing prompts express G2 as a routing/success criterion rather
+    // than naming Simard-internal src paths.
+    assert_contains(
+        lc,
+        MEMORY_LIB,
+        file,
+        "G2: standing goals route memory-arch work to amplihack-memory-lib",
+    );
+    assert_contains_any(
+        lc,
+        &["upstream", G2_ANTIFORK[0], G2_ANTIFORK[1]],
+        file,
+        "G2: memory-arch work lands upstream, not forked into Simard's repo",
+    );
+}
+
+fn assert_g3(lc: &str, file: &str) {
+    assert_contains(
+        lc,
+        "brittle parsing",
+        file,
+        "G3: name line/substring parsing of model/tool output as a brittle antipattern",
+    );
+    assert_contains_any(
+        lc,
+        G3_AGENTIC,
+        file,
+        "G3: prefer an agentic step (structured output + agent extraction)",
+    );
+    assert_contains_any(
+        lc,
+        G3_OVER_CODE,
+        file,
+        "G3: prefer recipes/prompts over new code",
+    );
+}
+
+fn assert_marker(lc: &str, file: &str) {
+    assert_contains(
+        lc,
+        MARKER,
+        file,
+        "a reference to the durable engineering guidelines (G1/G2/G3)",
+    );
+}
+
+// --- Layer A: engineer + planning reasoner prompts (full G1+G2+G3) --------
+
+#[test]
+fn engineer_system_threads_all_three_guidelines() {
+    let lc = prompt_lc("engineer_system.md");
+    assert_marker(&lc, "engineer_system.md");
+    assert_g1(&lc, "engineer_system.md");
+    assert_g2_full(&lc, "engineer_system.md");
+    assert_g3(&lc, "engineer_system.md");
+}
+
+#[test]
+fn engineer_planning_threads_all_three_guidelines() {
+    let lc = prompt_lc("engineer_planning.md");
+    assert_marker(&lc, "engineer_planning.md");
+    assert_g1(&lc, "engineer_planning.md");
+    assert_g2_full(&lc, "engineer_planning.md");
+    assert_g3(&lc, "engineer_planning.md");
+}
+
+// --- Layer A: OODA reasoner prompts (lightweight marker + no-bridge) -------
+//
+// The Orient / Decide / Act(lifecycle) reasoners are compact meta-brains
+// (urgency float, action keyword, lifecycle variant). They carry a reference
+// to the guidelines so cognition/memory/parsing judgment inherits G1/G2/G3,
+// without over-pinning their narrow output contracts.
+
+const OODA_REASONERS: &[&str] = &["ooda_orient.md", "ooda_decide.md", "ooda_brain.md"];
+
+#[test]
+fn ooda_reasoners_reference_the_guidelines() {
+    for f in OODA_REASONERS {
+        let lc = prompt_lc(f);
+        assert_marker(&lc, f);
+    }
+}
+
+// --- Layer B: review gates (full G1+G2+G3 flag criteria) ------------------
+
+#[test]
+fn merge_readiness_judge_flags_all_three_guidelines() {
+    let lc = prompt_lc("merge_readiness_judge.md");
+    assert_marker(&lc, "merge_readiness_judge.md");
+    assert_g1(&lc, "merge_readiness_judge.md");
+    assert_g2_full(&lc, "merge_readiness_judge.md");
+    assert_g3(&lc, "merge_readiness_judge.md");
+}
+
+#[test]
+fn review_pipeline_flags_all_three_guidelines() {
+    let lc = prompt_lc("review_pipeline.md");
+    assert_marker(&lc, "review_pipeline.md");
+    assert_g1(&lc, "review_pipeline.md");
+    assert_g2_full(&lc, "review_pipeline.md");
+    assert_g3(&lc, "review_pipeline.md");
+}
+
+#[test]
+fn progress_assessment_reviewer_flags_live_self_measurement() {
+    // The progress-evidence gate's most relevant flag is G1: a cognition PR
+    // that reports only a corpus/proxy number with no live self-metric trended
+    // over time. It carries the marker so the G2/G3 context is reachable too.
+    let lc = prompt_lc("progress_assessment_reviewer.md");
+    assert_marker(&lc, "progress_assessment_reviewer.md");
+    assert_g1(&lc, "progress_assessment_reviewer.md");
+}
+
+// --- Layer C: goal-framing prompts (G1 + G2 success criteria) -------------
+
+const GOAL_FRAMING: &[&str] = &[
+    "goal_session_objective.md",
+    "goal_decomposition.md",
+    "goal_curator_system.md",
+];
+
+#[test]
+fn goal_framing_seeds_hybrid_measurement_and_upstream_routing() {
+    for f in GOAL_FRAMING {
+        let lc = prompt_lc(f);
+        assert_marker(&lc, f);
+        // G1: standing cognition/self-improvement goals require a hybrid
+        // benchmark + live self-measurement trended over time.
+        assert_contains_any(
+            &lc,
+            G1_LIVE,
+            f,
+            "G1: standing goals require a live self-measurement, not just a benchmark",
+        );
+        assert_contains_any(
+            &lc,
+            G1_TREND,
+            f,
+            "G1: the required self-metric is trended over time",
+        );
+        // G2: memory-arch work is routed upstream to amplihack-memory-lib.
+        assert_g2_framing(&lc, f);
+    }
+}
+
+// --- Mirror parity: edited reasoner/gate .md stays in sync with its .yaml --
+//
+// Every guideline-bearing prompt that is ALSO inlined into a recipe the daemon
+// runs must carry the marker in BOTH files, so a `.md` edit can't silently
+// leave the live recipe path unguided (policy drift).
+
+const MIRROR_PAIRS: &[(&str, &str)] = &[
+    ("ooda_orient.md", "ooda-orient.yaml"),
+    ("ooda_decide.md", "ooda-decide.yaml"),
+    ("ooda_brain.md", "ooda-engineer-lifecycle.yaml"),
+    ("merge_readiness_judge.md", "merge-readiness-judge.yaml"),
+    (
+        "progress_assessment_reviewer.md",
+        "progress-assessment.yaml",
+    ),
+    ("goal_decomposition.md", "goal-decomposition.yaml"),
+];
+
+#[test]
+fn recipe_mirrors_carry_the_guidelines_marker() {
+    let mut drifted = Vec::new();
+    for (md, yaml) in MIRROR_PAIRS {
+        let md_lc = prompt_lc(md);
+        let yaml_lc = recipe(yaml).to_lowercase();
+        let md_has = md_lc.contains(MARKER);
+        let yaml_has = yaml_lc.contains(MARKER);
+        if md_has != yaml_has {
+            drifted.push(format!(
+                "{md} (marker={md_has}) vs {yaml} (marker={yaml_has})"
+            ));
+        }
+        // Both must ultimately carry the marker once threaded.
+        assert!(
+            yaml_has,
+            "recipe mirror {yaml} must carry the {MARKER:?} guideline marker \
+             (parity with {md})"
+        );
+    }
+    assert!(
+        drifted.is_empty(),
+        "prompt/recipe mirror drift — the guideline marker must be present in \
+         BOTH the .md and its .yaml mirror: {drifted:?}"
+    );
+}
+
+// --- Terminology guard: one-Brain OODA phases are never renamed "Bridge" ---
+//
+// The edited OODA reasoner regions (and their recipe mirrors) keep one-Brain
+// terminology. The guard targets the specific antipattern — renaming a phase
+// or brain as a "Bridge" — via collocations, NOT a blanket ban on the
+// substring: `engineer_system.md` legitimately hosts the standing "never name
+// anything Bridge" rule, and `ooda_decide.md` references a pre-existing
+// `BridgeCallFailed` error type. Neither is a phase rename.
+
+const BRIDGE_RENAME_COLLOCATIONS: &[&str] = &[
+    "bridge phase",
+    "bridge brain",
+    "brain bridge",
+    "bridge reasoner",
+    "orient bridge",
+    "decide bridge",
+    "act bridge",
+    "ooda bridge",
+    "bridge pattern",
+];
+
+#[test]
+fn edited_ooda_reasoners_do_not_rename_phases_as_bridge() {
+    let mirrors = [
+        "ooda-orient.yaml",
+        "ooda-decide.yaml",
+        "ooda-engineer-lifecycle.yaml",
+    ];
+    for f in OODA_REASONERS {
+        let lc = prompt_lc(f);
+        for collocation in BRIDGE_RENAME_COLLOCATIONS {
+            assert_absent(
+                &lc,
+                collocation,
+                f,
+                "one-Brain OODA phases must not be renamed as a 'Bridge'",
+            );
+        }
+    }
+    for yaml in mirrors {
+        let lc = recipe(yaml).to_lowercase();
+        for collocation in BRIDGE_RENAME_COLLOCATIONS {
+            assert_absent(
+                &lc,
+                collocation,
+                yaml,
+                "one-Brain OODA recipe mirror must not rename a phase as a 'Bridge'",
+            );
+        }
+    }
+}
+
+// --- Layer D: durable doc (GREEN anchor) ----------------------------------
+//
+// CONTRIBUTING.md is the human-facing source of truth. These assertions are
+// already GREEN (the doc landed in the documentation step) and guard against a
+// future edit deleting the durable guidelines section.
+
+#[test]
+fn contributing_documents_all_three_guidelines() {
+    let lc = repo_file("CONTRIBUTING.md").to_lowercase();
+    assert_marker(&lc, "CONTRIBUTING.md");
+    assert_g1(&lc, "CONTRIBUTING.md");
+    assert_g2_full(&lc, "CONTRIBUTING.md");
+    assert_g3(&lc, "CONTRIBUTING.md");
+    // The durable section and its TOC entry must both be present.
+    assert_contains(
+        &lc,
+        "## engineering guidelines",
+        "CONTRIBUTING.md",
+        "a durable Engineering Guidelines section heading",
+    );
+    assert_contains(
+        &lc,
+        "#engineering-guidelines-g1g2g3",
+        "CONTRIBUTING.md",
+        "a table-of-contents anchor linking to the guidelines section",
+    );
+}


### PR DESCRIPTION
## Summary

Encodes **three durable engineering guidelines** into Simard's prompt assets,
recipe mirrors, review gates, goal-framing prompts, and `CONTRIBUTING.md`, so
both Simard's OODA reasoners / engineer sessions **and** human contributors
apply them. This is primarily a **prompts + docs** change — itself an
application of G3 (prefer prompts over code); the only code is a lightweight
presence test.

- **G1 — Prove gains on BOTH a fixed benchmark AND live self-measurement.**
  Cognition / self-improvement work must iterate toward proving its gains on a
  fixed **benchmark** *and* a **live self-measurement** (a production self-metric
  Simard emits about her own running behaviour, **trended over time**). A
  benchmark-corpus number or a coarse proxy is not sufficient on its own.
  (Context: PRs #2584 (+86% on a fixed corpus) and #2601 (`recall_precision_at_k`
  via a coarse substring proxy) proved benchmark/proxy gains but not yet a live,
  trended one.)
- **G2 — Memory-architecture work belongs upstream in `amplihack-memory-lib`.**
  Distillation, recall, ranking, storage, WAL, forgetting must land in
  `rysweet/amplihack-memory-lib`, then Simard **bumps** her pinned
  `amplihack-memory` dep. Do not fork memory logic into
  `src/memory_consolidation` / `src/cognitive_memory`. (Context: #2584 put
  distillation fact-yield logic in Simard's repo instead of the library.)
- **G3 — Prefer agentic steps over brittle parsing; prefer recipes/prompts over
  code.** Treat line/substring parsing of model/tool output as a brittle-parsing
  antipattern (e.g. #2573's parser in `src/recipe_output/extract.rs`); prefer a
  structured/JSON output contract + agent extraction, and prefer recipes/prompts
  over new code.

## Where encoded

| Layer | Assets |
|---|---|
| Engineer + OODA reasoner prompts | `engineer_system.md`, `engineer_planning.md`, `ooda_orient.md`, `ooda_decide.md`, `ooda_brain.md` (+ recipes `ooda-orient.yaml`, `ooda-decide.yaml`, `ooda-engineer-lifecycle.yaml`) |
| Review gates (soft flags) | `merge_readiness_judge.md` (+ `merge-readiness-judge.yaml`), `review_pipeline.md`, `progress_assessment_reviewer.md` (+ `progress-assessment.yaml`) |
| Goal framing | `goal_session_objective.md`, `goal_decomposition.md` (+ `goal-decomposition.yaml`), `goal_curator_system.md` |
| Durable doc | `CONTRIBUTING.md` → "Engineering Guidelines (G1/G2/G3)" section + TOC entry |
| Presence test | `tests/engineering_guidelines_prompts.rs` |

The standing `continuously-research-and-improve-your-own-cogn*` goal is seeded
at runtime into `~/.simard` state (not a committed asset), so G1/G2 are encoded
in the **goal-framing prompts** future instances inherit, not in a goal slug.

Every guideline-bearing reasoner/gate prompt that is inlined into a recipe the
daemon runs was edited in **both** the `.md` and its `.yaml` mirror, so the live
recipe path is not left unguided.

## QA-team evidence

The validation surface for a prompt-asset edit is the prompt text itself, pinned
by an in-repo presence test (same pattern as `tests/prompt_autonomy_contract.rs`
and `tests/recipe_brain_verdict_assets.rs`):

```
cargo test --test engineering_guidelines_prompts
# 10 passed; 0 failed
```

It asserts stable **keyword invariants** per guideline (e.g. `live
self-measurement` + `trended over time` for G1, `amplihack-memory-lib` +
anti-fork paths for G2, `brittle parsing` + `agentic step` for G3), asserts
`.md`/`.yaml` recipe-mirror parity, and guards the one-Brain OODA phases against
being renamed "Bridge". Keyword invariants (not full-sentence snapshots) keep
the test robust to rewording while catching a deleted guideline.

## Documentation

`CONTRIBUTING.md` gains a durable "Engineering Guidelines (G1/G2/G3)" section
(with TOC entry) as the canonical human-facing source of truth. It documents
each guideline, its motivating PR, "what done looks like", the soft-flag review
semantics, and the encode-layer map. `AGENTS.md` is intentionally excluded (it
is regenerated amplihack boilerplate).

## Quality-audit

- Edits are **additive** — no existing prompt behaviour, output contract, or
  `{{escalation_note}}` escalation seam was removed; pre-existing prompt-asset
  tests still pass (`prompt_autonomy_contract` 7/7, `recipe_brain_verdict_assets`
  3/3).
- Review gates add **advisory flags only** — they do not change the machine
  `verdict` enums.
- Terminology guard: one-Brain / "reasoner" language; no new "Bridge" naming.

## CI

Local gates mirroring required CI, all green:

- `cargo fmt --all -- --check` — passed (pre-commit)
- `cargo clippy --all-targets --all-features --locked -- -D warnings` — passed
  (pre-commit release + pre-push full)
- `cargo test --release --lib` race subset — passed (pre-push)
- rust-only gate — passed

No `git --no-verify`; no `gh pr merge --admin`. Required CI runs on this PR.

## Scope

18 files changed, +~436 lines: `CONTRIBUTING.md`, 10 `prompt_assets/simard/*.md`,
6 `prompt_assets/simard/recipes/*.yaml`, and one new test. No production Rust
logic, no daemon/`~/.simard` changes. Branch cut from latest `origin/main`.

## Activation note

`prompt_assets/simard/` hot-reload from `~/.simard/prompt_assets/`. The merge
alone does not change live daemon behaviour — **the operator syncs prompt
assets / redeploys after merge** to activate the updated prompts.

## Verdict

**Ready to merge** — all required checks green, guidelines encoded across
prompts + recipe mirrors + review gates + goal framing + durable doc, pinned by
a passing presence test.
