### PR TITLE
feat(overseer): observe goal-board health — self-heal false-parks + escalate genuine blocks

### DIFF
--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -1265,7 +1265,8 @@ pub fn run_ooda_daemon(
                             &format!(
                                 "[simard] overseer tick: problems={} issues_filed={} \
                                  recipes_launched={} prs_merged={} deploys={} escalations={} \
-                                 held={} errors={} panicked={} ({}ms)",
+                                 held={} goals_unblocked={} goals_escalated={} errors={} \
+                                 panicked={} ({}ms)",
                                 report.problems,
                                 report.issues_filed,
                                 report.recipes_launched,
@@ -1273,6 +1274,8 @@ pub fn run_ooda_daemon(
                                 report.deploys,
                                 report.escalations,
                                 report.held,
+                                report.goals_unblocked,
+                                report.goals_escalated,
                                 report.errors,
                                 report.panicked,
                                 report.duration_ms,

--- a/src/overseer/activity.rs
+++ b/src/overseer/activity.rs
@@ -55,6 +55,10 @@ pub struct OverseerTotals {
     pub prs_merged: u64,
     pub deploys: u64,
     pub escalations: u64,
+    /// False-parked perpetual goals self-healed (auto-unblocked + reactivated).
+    pub goals_unblocked: u64,
+    /// Genuinely-blocked "needs human review" goals escalated to the operator.
+    pub goals_escalated: u64,
     pub held: u64,
     pub errors: u64,
 }
@@ -216,6 +220,8 @@ impl OverseerActivity {
             t.prs_merged += rep.prs_merged as u64;
             t.deploys += rep.deploys as u64;
             t.escalations += rep.escalations as u64;
+            t.goals_unblocked += rep.goals_unblocked as u64;
+            t.goals_escalated += rep.goals_escalated as u64;
             t.held += rep.held as u64;
             t.errors += rep.errors as u64;
         }
@@ -223,11 +229,18 @@ impl OverseerActivity {
     }
 
     /// Count of *actions taken* over the retained window (issues filed, fix
-    /// workstreams launched, PRs merged, deploys, escalations). `held` is
-    /// deliberately excluded: holding is observing-and-waiting, not an action.
+    /// workstreams launched, PRs merged, deploys, escalations, goal-board
+    /// self-heals + escalations). `held` is deliberately excluded: holding is
+    /// observing-and-waiting, not an action.
     pub fn interventions(&self) -> u64 {
         let t = &self.totals;
-        t.issues_filed + t.recipes_launched + t.prs_merged + t.deploys + t.escalations
+        t.issues_filed
+            + t.recipes_launched
+            + t.prs_merged
+            + t.deploys
+            + t.escalations
+            + t.goals_unblocked
+            + t.goals_escalated
     }
 
     /// The honest one-line status summary rendered on every surface.
@@ -397,6 +410,20 @@ pub fn humanize_tick(r: &OverseerTickReport) -> String {
     }
     if r.escalations > 0 {
         did.push(format!("escalated {} to the operator", r.escalations));
+    }
+    if r.goals_unblocked > 0 {
+        did.push(format!(
+            "self-healed {} blocked goal{}",
+            r.goals_unblocked,
+            plural(r.goals_unblocked)
+        ));
+    }
+    if r.goals_escalated > 0 {
+        did.push(format!(
+            "escalated {} blocked goal{} for human review",
+            r.goals_escalated,
+            plural(r.goals_escalated)
+        ));
     }
 
     let saw = format!("saw {} problem{}", r.problems, plural(r.problems));

--- a/src/overseer/capabilities.rs
+++ b/src/overseer/capabilities.rs
@@ -86,6 +86,12 @@ pub struct ObservedState {
     pub ready_prs: Vec<PrRef>,
     /// CI-failure clusters observed across recent runs.
     pub ci_failures: Vec<CiFailure>,
+    /// Blocked goals observed on Simard's goal board this Observe pass — the
+    /// goal-board *health* signal. Populated by the sensor from the durable
+    /// board markers (`BLOCKED`, the `🔒 [OODA-SAFEGUARD] … needs human review`
+    /// no-progress marker, and the brain-failure marker). Empty when the board
+    /// is clean or unreadable (degrade-to-empty, never a panic).
+    pub blocked_goals: Vec<BlockedGoal>,
     /// Consecutive OODA cycles the active goal has produced no action / no
     /// progress. Mirrors the OODA no-progress tracker; drives the loop-whisper.
     /// `None` when unknown (e.g. no active goal).
@@ -110,6 +116,33 @@ pub struct PrRef {
 pub struct CiFailure {
     pub repo: String,
     pub failing: u32,
+}
+
+/// One blocked goal observed on Simard's goal board — the unit of goal-board
+/// *health* the Overseer observes and (in the acting loop) acts on.
+///
+/// Derived from a `GoalProgress::Blocked(reason)` on the live board by the
+/// sensor's pure projection (`sensor::blocked_goals_from_board`). It reuses the
+/// EXISTING standing/perpetual detection (`ActiveGoal::is_perpetual`, #2589/#2609)
+/// and the EXISTING safeguard-marker predicates
+/// (`goal_curation::no_progress_breaker::is_no_progress_marker`,
+/// `ooda_actions::advance_goal::is_brain_failure_marker`) — it never invents a
+/// second notion of either.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlockedGoal {
+    /// The blocked goal's id on the active board.
+    pub id: String,
+    /// The verbatim `GoalProgress::Blocked` reason string (carries the marker).
+    pub reason: String,
+    /// True when the goal is standing/perpetual (`ActiveGoal::is_perpetual`).
+    pub perpetual: bool,
+    /// True when the block carries a "needs human review" safeguard marker
+    /// (the no-progress OODA-SAFEGUARD marker or the brain-failure marker) —
+    /// the signal that a human must be reached.
+    pub needs_review: bool,
+    /// Consecutive no-action / no-progress cycles parsed from the safeguard
+    /// marker, or `0` when the block is not a counted safeguard marker.
+    pub consecutive_no_action: u32,
 }
 
 // ─────────────────────────── Capability briefs ─────────────────────────────
@@ -304,6 +337,29 @@ pub trait IssueFiler {
 pub trait GoalCurator {
     fn propose(&self, goal: &GoalBrief) -> Result<(), OverseerError>;
     fn in_flight(&self) -> Result<Vec<InFlightItem>, OverseerError>;
+
+    /// Read the goal-board *health* — the goals currently `Blocked` — so the
+    /// Observe pass can surface them into [`ObservedState::blocked_goals`].
+    ///
+    /// **Reuse:** `crate::goal_curation::load_goal_board` projected by
+    /// `crate::overseer::sensor::blocked_goals_from_board`. Read-only; a board
+    /// read failure degrades to an empty list, never a panic. The default
+    /// returns an empty list for fakes that do not model a board.
+    fn blocked_goals(&self) -> Result<Vec<BlockedGoal>, OverseerError> {
+        Ok(Vec::new())
+    }
+
+    /// Auto-unblock + reactivate a false-parked goal — the exact operation
+    /// `simard goal unblock` performs: restore a `Blocked` goal to `NotStarted`
+    /// so the next OODA cycle re-enters the spawn path.
+    ///
+    /// **Reuse:** the `simard goal unblock` board mutation
+    /// (`src/operator_cli/goal.rs`) via `load_goal_board` → set status
+    /// `NotStarted` → `save_goal_board`. The default is a no-op for fakes that
+    /// do not model a board (real adapters override it).
+    fn unblock(&self, _goal_id: &str) -> Result<(), OverseerError> {
+        Ok(())
+    }
 }
 
 /// Run a quality-audit loop (crusty-old-engineer-gated).

--- a/src/overseer/config.rs
+++ b/src/overseer/config.rs
@@ -35,6 +35,12 @@ pub const OVERSEER_INTERVAL_ENV: &str = "SIMARD_OVERSEER_INTERVAL_SECS";
 /// whisperer off regardless of this flag.
 pub const SIMARD_OVERSEER_WHISPER_ENV: &str = "SIMARD_OVERSEER_WHISPER";
 
+/// Opt-out flag for **goal-board health handling** (the self-heal + escalate
+/// paths). ON by default whenever the acting Overseer runs; an explicit falsey
+/// value (`0`/`false`/`no`/`off`) disables it. Goal-board health only makes
+/// sense while the Overseer runs, so a disabled Overseer forces it off.
+pub const SIMARD_OVERSEER_GOAL_HEALTH_ENV: &str = "SIMARD_OVERSEER_GOAL_HEALTH";
+
 /// GitHub login the acting Overseer authors its own workstreams under. Sourced
 /// here so the daemon and the merge/recursion path agree on ONE stable, DISTINCT
 /// identity (never the human operator's login). Defaults to
@@ -115,6 +121,29 @@ pub fn whisper_enabled_from(lookup: impl Fn(&str) -> Option<String>) -> bool {
 /// Production entry point: read the real process environment.
 pub fn whisper_enabled() -> bool {
     whisper_enabled_from(|k| std::env::var(k).ok())
+}
+
+/// Resolve whether **goal-board health handling** (self-heal false-parked
+/// perpetual goals + escalate genuine "needs human review" blocks) is enabled,
+/// with **default ON** opt-out semantics consistent with the acting Overseer.
+/// Enabled UNLESS [`SIMARD_OVERSEER_GOAL_HEALTH_ENV`] is an explicit falsey
+/// value — AND only while the acting Overseer itself is enabled (an
+/// explicitly-disabled Overseer forces goal-board health off).
+pub fn goal_health_enabled_from(lookup: impl Fn(&str) -> Option<String>) -> bool {
+    // No Overseer ⇒ no goal-board health handling.
+    if !overseer_acting_enabled_from(&lookup) {
+        return false;
+    }
+    // Opt-out: enabled unless an explicit falsey value is set.
+    !matches!(
+        lookup(SIMARD_OVERSEER_GOAL_HEALTH_ENV).as_deref().map(str::trim),
+        Some(v) if is_falsey(v)
+    )
+}
+
+/// Production entry point: read the real process environment.
+pub fn goal_health_enabled() -> bool {
+    goal_health_enabled_from(|k| std::env::var(k).ok())
 }
 
 /// Resolve the Overseer's DISTINCT author login. Falls back to

--- a/src/overseer/guardrails.rs
+++ b/src/overseer/guardrails.rs
@@ -46,6 +46,13 @@ pub fn classify(iv: &Intervention) -> RiskClass {
         // is advisory context only. Routine; its own dedup/identity gates
         // ([`WhisperGate`] / [`RecursionGuard`]) apply in the act path.
         Intervention::Whisper { .. } => RiskClass::Routine,
+        // Goal-board self-heal and escalation are routine stewardship: unblocking
+        // a false-parked perpetual goal restores the shipped `simard goal unblock`
+        // state, and escalation is a notification. Both are deduped and
+        // identity-gated (fail-closed) in the act path, and spend no LLM budget.
+        Intervention::UnblockGoal { .. } | Intervention::EscalateBlockedGoal { .. } => {
+            RiskClass::Routine
+        }
         _ => RiskClass::Routine,
     }
 }

--- a/src/overseer/intervention.rs
+++ b/src/overseer/intervention.rs
@@ -46,6 +46,18 @@ pub enum Intervention {
         note: String,
         urgency: WhisperUrgency,
     },
+    /// SELF-HEAL a false-parked standing/perpetual goal: auto-unblock + reactivate
+    /// it — the exact operation `simard goal unblock` performs — so a perpetual
+    /// goal wrongly hard-blocked by the no-progress safeguard re-enters the OODA
+    /// spawn path. Deduped so it never fights itself; optionally followed by an
+    /// advisory whisper steering Simard to carve a bounded shippable sub-goal.
+    /// Capability: `GoalCurator::unblock` (+ optional `whisper_ops::WhisperSink`).
+    UnblockGoal { goal_id: String, reason: String },
+    /// ESCALATE a genuinely-blocked goal carrying a "needs human review" marker to
+    /// the operator (email + Signal) with the goal id + reason, so the marker
+    /// actually reaches a human — closing the silent-failure gap.
+    /// Capability: `notify::OperatorNotifier`.
+    EscalateBlockedGoal { goal_id: String, reason: String },
 }
 
 impl Intervention {
@@ -62,6 +74,8 @@ impl Intervention {
             Self::RunAudit { .. } => "run_audit",
             Self::Escalate { .. } => "escalate",
             Self::Whisper { .. } => "whisper",
+            Self::UnblockGoal { .. } => "unblock_goal",
+            Self::EscalateBlockedGoal { .. } => "escalate_blocked_goal",
         }
     }
 }

--- a/src/overseer/mod.rs
+++ b/src/overseer/mod.rs
@@ -66,6 +66,8 @@ pub mod whisper_ops;
 pub mod wiring;
 
 #[cfg(test)]
+mod tests_goal_health;
+#[cfg(test)]
 mod tests_m1;
 #[cfg(test)]
 mod tests_m2;
@@ -73,11 +75,12 @@ mod tests_m2;
 mod tests_whisper;
 
 pub use capabilities::{
-    Auditor, Deployer, GoalCurator, IssueFiler, MeetingHost, ObservedState, OrchestratorRunBrief,
-    OverseerError, PrOps, RecipeBrief, RecipeLauncher, StatusReader,
+    Auditor, BlockedGoal, Deployer, GoalCurator, IssueFiler, MeetingHost, ObservedState,
+    OrchestratorRunBrief, OverseerError, PrOps, RecipeBrief, RecipeLauncher, StatusReader,
 };
 pub use config::{
-    daily_budget_usd, overseer_acting_enabled, overseer_author_login, overseer_enabled,
+    daily_budget_usd, goal_health_enabled, overseer_acting_enabled, overseer_author_login,
+    overseer_enabled,
 };
 pub use guardrails::{
     AutonomyGate, BudgetGate, ConflictSequencer, RecursionGuard, RiskClass, Subject,
@@ -87,7 +90,7 @@ pub use intervention::{Intervention, PlannedIntervention};
 pub use observer::{StewardshipIssueFiler, decide_read_only, is_m1_permitted};
 pub use sensor::{
     ObserverReport, OverseerSensorThread, SnapshotSource, SnapshotStatusReader,
-    in_flight_from_board, observed_from_snapshot, run_observer_cycle,
+    blocked_goals_from_board, in_flight_from_board, observed_from_snapshot, run_observer_cycle,
 };
 pub use signal::{Priority, Problem, ProblemKind, Signal, signals_from};
 pub use whisper_ops::{
@@ -100,7 +103,10 @@ pub use wiring::{
     run_overseer_tick_isolated,
 };
 
-use crate::goal_curation::no_progress_breaker::NO_PROGRESS_BREAKER_THRESHOLD;
+use crate::goal_curation::no_progress_breaker::{
+    NO_PROGRESS_BREAKER_THRESHOLD, is_no_progress_marker,
+};
+use crate::overseer::notify::{OperatorNotification, OperatorNotifier};
 use capabilities::{DeployReport, GoalBrief, InFlightItem, IssueOutcome, WorkstreamHandle};
 use std::path::PathBuf;
 
@@ -137,6 +143,16 @@ pub struct Overseer {
     /// Whether the whisperer is enabled (config opt-out). When off, whispers are
     /// held (never delivered) even if the observed condition holds.
     whisper_enabled: bool,
+    /// The operator-notification seam (email + Signal) the ESCALATE-blocked-goal
+    /// path fires through so a "needs human review" marker reaches a human.
+    /// `None` until wired; escalation requires it.
+    notifier: Option<Box<dyn OperatorNotifier>>,
+    /// Dedup + rate-limit gate for goal-board self-heal / escalation actions, so
+    /// the same blocked goal is not re-unblocked or re-escalated every tick.
+    blocked_goal_gate: WhisperGate,
+    /// Whether goal-board health handling (self-heal + escalate) is enabled
+    /// (config opt-out). When off, both actions are held (never taken).
+    goal_health_enabled: bool,
 }
 
 /// The result of one meta-OODA turn. Side-effect free: it reports what was
@@ -172,6 +188,21 @@ pub enum ActOutcome {
     WhisperSuppressed {
         reason: &'static str,
     },
+    /// A false-parked standing/perpetual goal was auto-unblocked + reactivated
+    /// (the `simard goal unblock` operation) by the self-heal path.
+    GoalUnblocked {
+        goal_id: String,
+    },
+    /// A genuinely-blocked "needs human review" goal was escalated to the
+    /// operator on both channels (email + Signal).
+    GoalEscalated {
+        goal_id: String,
+    },
+    /// A goal-board self-heal / escalation was suppressed by the dedup gate
+    /// (duplicate within the window, or the per-hour cap was reached).
+    GoalHealthSuppressed {
+        reason: &'static str,
+    },
 }
 
 impl Overseer {
@@ -188,12 +219,32 @@ impl Overseer {
             // 15-minute dedup window; at most 5 whispers per rolling hour.
             whisper_gate: WhisperGate::new(900, 5),
             whisper_enabled: false,
+            notifier: None,
+            // 15-minute dedup window so a persistent blocked goal is self-healed
+            // / escalated once per window (never in a per-tick loop); a generous
+            // per-hour cap covers many distinct goals without flooding.
+            blocked_goal_gate: WhisperGate::new(900, 20),
+            goal_health_enabled: false,
         }
     }
 
     /// Wire the Simard Whisperer's delivery seam (advisory steering notes).
     pub fn with_whisper_sink(mut self, sink: Box<dyn WhisperSink>) -> Self {
         self.whisper_sink = Some(sink);
+        self
+    }
+
+    /// Wire the operator-notification seam (email + Signal) used by the
+    /// ESCALATE-blocked-goal path. `None` until wired; escalation requires it.
+    pub fn with_operator_notifier(mut self, notifier: Box<dyn OperatorNotifier>) -> Self {
+        self.notifier = Some(notifier);
+        self
+    }
+
+    /// Enable/disable goal-board health handling (self-heal + escalate). Off by
+    /// default; the daemon sets this from [`config::goal_health_enabled`].
+    pub fn with_goal_health_enabled(mut self, enabled: bool) -> Self {
+        self.goal_health_enabled = enabled;
         self
     }
 
@@ -229,7 +280,11 @@ impl Overseer {
     /// execute side effects; returns the plan for M2+ Act to run.
     pub fn run_cycle(&mut self) -> Result<CycleReport, OverseerError> {
         // Observe.
-        let observed = self.caps.status.snapshot()?;
+        let mut observed = self.caps.status.snapshot()?;
+        // Enrich with goal-board health: the goals currently BLOCKED on Simard's
+        // board (false-parks + genuine "needs human review" blocks). Read-only;
+        // a board-read failure degrades to "no blocked goals", never aborts.
+        observed.blocked_goals = self.caps.goals.blocked_goals().unwrap_or_default();
         let signals = signals_from(&observed);
 
         // Orient (dedup against Simard's in-flight work; failure to read the
@@ -269,6 +324,20 @@ impl Overseer {
                 intervention: iv.clone(),
                 admitted: false,
                 note: "held: whisper disabled (SIMARD_OVERSEER_WHISPER)".to_string(),
+            };
+        }
+
+        // Goal-board health opt-out: when disabled, hold the self-heal /
+        // escalation (no action taken) even though a blocked goal was observed.
+        if matches!(
+            iv,
+            Intervention::UnblockGoal { .. } | Intervention::EscalateBlockedGoal { .. }
+        ) && !self.goal_health_enabled
+        {
+            return PlannedIntervention {
+                intervention: iv.clone(),
+                admitted: false,
+                note: "held: goal-board health disabled (SIMARD_OVERSEER_GOAL_HEALTH)".to_string(),
             };
         }
 
@@ -357,6 +426,10 @@ impl Overseer {
             }
             Intervention::Escalate { .. } => Ok(ActOutcome::Escalated),
             Intervention::Whisper { note, urgency } => self.act_whisper(note, *urgency),
+            Intervention::UnblockGoal { goal_id, reason } => self.act_unblock_goal(goal_id, reason),
+            Intervention::EscalateBlockedGoal { goal_id, reason } => {
+                self.act_escalate_blocked_goal(goal_id, reason)
+            }
         }
     }
 
@@ -445,6 +518,158 @@ impl Overseer {
                 })
             }
         }
+    }
+
+    /// SELF-HEAL a false-parked standing/perpetual goal: auto-unblock +
+    /// reactivate it (the exact `simard goal unblock` operation), deduped so it
+    /// never re-fires in a tight loop, then OPTIONALLY whisper Simard to carve a
+    /// bounded shippable sub-goal. Fails CLOSED without a DISTINCT steward
+    /// identity (anti-recursion — the Overseer must never self-heal a goal
+    /// without a configured distinct identity, which also prevents a self-heal
+    /// loop). The whisper is best-effort: a whisper failure never fails the
+    /// unblock.
+    fn act_unblock_goal(
+        &mut self,
+        goal_id: &str,
+        reason: &str,
+    ) -> Result<ActOutcome, OverseerError> {
+        if !self.recursion.is_configured() {
+            return Err(OverseerError::Recursion {
+                subject: format!("unblock goal (unconfigured steward identity): {goal_id}"),
+            });
+        }
+        let signature = format!("unblock:{goal_id}");
+        let now = now_secs();
+        match self.blocked_goal_gate.peek(&signature, now) {
+            WhisperDecision::Deliver => {
+                self.caps.goals.unblock(goal_id)?;
+                // Consume the dedup slot only after a successful unblock.
+                self.blocked_goal_gate.commit(&signature, now);
+                tracing::info!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    reason,
+                    action = "unblock",
+                    "overseer self-healed a false-parked perpetual goal: auto-unblocked + reactivated"
+                );
+                // Optional advisory whisper: steer Simard to carve a bounded,
+                // shippable sub-goal instead of re-attempting the whole standing
+                // goal at once. Best-effort and reuses the whisper gate/identity.
+                self.try_whisper_carve_subgoal(goal_id);
+                Ok(ActOutcome::GoalUnblocked {
+                    goal_id: goal_id.to_string(),
+                })
+            }
+            WhisperDecision::SuppressDuplicate => {
+                tracing::debug!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    action = "unblock",
+                    reason = "duplicate",
+                    "overseer suppressed a duplicate self-heal within the dedup window"
+                );
+                Ok(ActOutcome::GoalHealthSuppressed {
+                    reason: "duplicate",
+                })
+            }
+            WhisperDecision::SuppressCapReached => {
+                tracing::debug!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    action = "unblock",
+                    reason = "cap_reached",
+                    "overseer suppressed a self-heal: per-hour cap reached"
+                );
+                Ok(ActOutcome::GoalHealthSuppressed {
+                    reason: "cap_reached",
+                })
+            }
+        }
+    }
+
+    /// ESCALATE a genuinely-blocked "needs human review" goal to the operator on
+    /// BOTH channels (email + Signal) with the goal id + reason, so the marker
+    /// actually reaches a human. Deduped so it never re-fires in a loop; fails
+    /// CLOSED without a DISTINCT steward identity (anti-recursion).
+    fn act_escalate_blocked_goal(
+        &mut self,
+        goal_id: &str,
+        reason: &str,
+    ) -> Result<ActOutcome, OverseerError> {
+        if !self.recursion.is_configured() {
+            return Err(OverseerError::Recursion {
+                subject: format!(
+                    "escalate blocked goal (unconfigured steward identity): {goal_id}"
+                ),
+            });
+        }
+        let signature = format!("escalate:{goal_id}");
+        let now = now_secs();
+        match self.blocked_goal_gate.peek(&signature, now) {
+            WhisperDecision::Deliver => {
+                let notifier = self.notifier.as_ref().ok_or(OverseerError::Capability {
+                    what: "notify.operator",
+                    detail: "no operator notifier configured".to_string(),
+                })?;
+                let notification = OperatorNotification::goal_blocked(goal_id, reason);
+                let report = notifier.notify(&notification);
+                // Consume the dedup slot only after a dispatch attempt (the
+                // notifier itself never drops — it queues/logs on failure).
+                self.blocked_goal_gate.commit(&signature, now);
+                tracing::info!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    reason,
+                    action = "escalate",
+                    dispatched = report.dispatched(),
+                    all_sent = report.all_sent(),
+                    "overseer escalated a genuinely-blocked needs-human-review goal to the operator"
+                );
+                Ok(ActOutcome::GoalEscalated {
+                    goal_id: goal_id.to_string(),
+                })
+            }
+            WhisperDecision::SuppressDuplicate => {
+                tracing::debug!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    action = "escalate",
+                    reason = "duplicate",
+                    "overseer suppressed a duplicate escalation within the dedup window"
+                );
+                Ok(ActOutcome::GoalHealthSuppressed {
+                    reason: "duplicate",
+                })
+            }
+            WhisperDecision::SuppressCapReached => {
+                tracing::debug!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    action = "escalate",
+                    reason = "cap_reached",
+                    "overseer suppressed an escalation: per-hour cap reached"
+                );
+                Ok(ActOutcome::GoalHealthSuppressed {
+                    reason: "cap_reached",
+                })
+            }
+        }
+    }
+
+    /// Best-effort advisory whisper steering Simard to carve ONE bounded,
+    /// shippable sub-goal from a just-unblocked standing goal. Silently skipped
+    /// when the whisperer is disabled/unwired; a delivery error or suppression is
+    /// ignored (the self-heal already succeeded).
+    fn try_whisper_carve_subgoal(&mut self, goal_id: &str) {
+        if !self.whisper_enabled || self.whisper_sink.is_none() {
+            return;
+        }
+        let note = format!(
+            "Overseer steering note for goal {goal_id}: this standing goal was auto-unblocked \
+             after a no-progress false-park. Carve ONE bounded, shippable sub-goal from it and \
+             ship that next, rather than re-attempting the whole standing goal at once."
+        );
+        let _ = self.act_whisper(&note, WhisperUrgency::Normal);
     }
 }
 
@@ -584,6 +809,28 @@ fn classify_signal(s: &Signal) -> (ProblemKind, Priority, String, String) {
             format!("drift:{goal_id}"),
             format!("goal {goal_id} drifting from intent: {detail}"),
         ),
+        Signal::GoalBlocked {
+            goal_id,
+            needs_review,
+            consecutive_no_action,
+            ..
+        } => (
+            ProblemKind::GoalHygiene,
+            if *needs_review {
+                Priority::High
+            } else {
+                Priority::Normal
+            },
+            format!("goal:blocked:{goal_id}"),
+            format!(
+                "goal {goal_id} blocked{} ({consecutive_no_action} no-action cycle(s))",
+                if *needs_review {
+                    " — needs human review"
+                } else {
+                    ""
+                }
+            ),
+        ),
     }
 }
 
@@ -637,14 +884,35 @@ pub fn decide(problem: &Problem) -> Intervention {
         ProblemKind::ResourcePressure => Intervention::Escalate {
             reason: problem.summary.clone(),
         },
-        ProblemKind::GoalHygiene => Intervention::TransferGoal {
-            goal: GoalBrief {
-                title: problem.summary.clone(),
-                rationale: "stale / re-litigated goal — transfer to Simard for closure".to_string(),
-                priority: 3,
-                target_repo: "rysweet/Simard".to_string(),
-            },
-        },
+        ProblemKind::GoalHygiene => {
+            // Goal-board health takes precedence when the evidence is a blocked
+            // goal: self-heal a false-parked perpetual goal, or escalate a
+            // genuine "needs human review" block. A stale/re-litigated goal
+            // (no `GoalBlocked` evidence) still transfers to Simard for closure.
+            if let Some((goal_id, reason, perpetual, needs_review)) =
+                problem.evidence.iter().find_map(|s| match s {
+                    Signal::GoalBlocked {
+                        goal_id,
+                        reason,
+                        perpetual,
+                        needs_review,
+                        ..
+                    } => Some((goal_id.clone(), reason.clone(), *perpetual, *needs_review)),
+                    _ => None,
+                })
+            {
+                return decide_blocked_goal(goal_id, reason, perpetual, needs_review);
+            }
+            Intervention::TransferGoal {
+                goal: GoalBrief {
+                    title: problem.summary.clone(),
+                    rationale: "stale / re-litigated goal — transfer to Simard for closure"
+                        .to_string(),
+                    priority: 3,
+                    target_repo: "rysweet/Simard".to_string(),
+                },
+            }
+        }
         // A looping goal is steered with a LIGHTWEIGHT whisper by default. Only
         // once the loop reaches Simard's no-progress breaker threshold (the
         // whisper was insufficient) does the Overseer escalate to a full meeting
@@ -684,6 +952,36 @@ pub fn decide(problem: &Problem) -> Intervention {
             urgency: WhisperUrgency::Normal,
         },
     }
+}
+
+/// Route a blocked goal to the right stewardship action (defense-in-depth for
+/// #2609):
+///
+/// - a PERPETUAL/standing goal false-parked by the **no-progress** safeguard is
+///   SELF-HEALED — auto-unblocked + reactivated (never escalated: it is a false
+///   park, not a genuine block);
+/// - ANY OTHER goal carrying a "needs human review" marker (a normal no-progress
+///   block, or any brain-failure block) is ESCALATED to the operator so the
+///   marker reaches a human;
+/// - a plain operator-set / dependency block is surfaced in the periodic Report
+///   and left untouched (respect the deliberate block).
+///
+/// Reuses the EXISTING no-progress marker predicate ([`is_no_progress_marker`])
+/// and the perpetual flag derived from #2589/#2609 — it invents no new notion of
+/// either.
+fn decide_blocked_goal(
+    goal_id: String,
+    reason: String,
+    perpetual: bool,
+    needs_review: bool,
+) -> Intervention {
+    if perpetual && is_no_progress_marker(&reason) {
+        return Intervention::UnblockGoal { goal_id, reason };
+    }
+    if needs_review {
+        return Intervention::EscalateBlockedGoal { goal_id, reason };
+    }
+    Intervention::Report
 }
 
 #[cfg(test)]

--- a/src/overseer/notify.rs
+++ b/src/overseer/notify.rs
@@ -141,6 +141,24 @@ impl OperatorNotification {
             autonomous: true,
         }
     }
+
+    /// Build a blocked-goal escalation: a goal carrying a "needs human review"
+    /// safeguard marker that a human must resolve. Sent on BOTH channels (email
+    /// and Signal) with the goal id and reason so the marker actually reaches a
+    /// person — closing the silent-failure gap where a "needs human review"
+    /// marker reached no human.
+    pub fn goal_blocked(goal_id: &str, reason: &str) -> Self {
+        Self {
+            kind: "goal-blocked",
+            headline: format!("goal {goal_id} needs human review"),
+            problem: format!(
+                "Goal `{goal_id}` is blocked and needs human review.\n  Reason: {reason}"
+            ),
+            link: None,
+            repo: "rysweet/Simard".to_string(),
+            autonomous: true,
+        }
+    }
 }
 
 fn short_commit(commit: &str) -> &str {
@@ -204,6 +222,21 @@ pub trait NotifyChannel: Send + Sync {
 /// Constructed with an email channel and a Signal channel so both fire.
 pub struct DualChannelNotifier {
     channels: Vec<Box<dyn NotifyChannel>>,
+}
+
+/// Object-safe seam the acting Overseer notifies the operator through. Lets the
+/// Overseer hold the mandatory [`DualChannelNotifier`] (email + Signal) in
+/// production while tests inject a fake that records the notification — reusing
+/// the ONE "notify on both channels, never drop" guarantee rather than adding a
+/// second notification path.
+pub trait OperatorNotifier: Send + Sync {
+    fn notify(&self, notification: &OperatorNotification) -> NotifyReport;
+}
+
+impl OperatorNotifier for DualChannelNotifier {
+    fn notify(&self, notification: &OperatorNotification) -> NotifyReport {
+        DualChannelNotifier::notify(self, notification)
+    }
 }
 
 impl DualChannelNotifier {

--- a/src/overseer/observer.rs
+++ b/src/overseer/observer.rs
@@ -233,6 +233,7 @@ fn signal_kind_label(s: &Signal) -> &'static str {
         Signal::Anomaly { .. } => "Anomaly",
         Signal::LoopDetected { .. } => "LoopDetected",
         Signal::DriftCorrection { .. } => "DriftCorrection",
+        Signal::GoalBlocked { .. } => "GoalBlocked",
     }
 }
 

--- a/src/overseer/sensor.rs
+++ b/src/overseer/sensor.rs
@@ -27,12 +27,18 @@ use crate::cognitive_threads::{
     CognitiveThread, Priority, SchedulePolicy, ThreadContext, ThreadHealth, ThreadKind,
     ThreadOutcome,
 };
-use crate::goal_curation::{GoalBoard, load_goal_board};
+use crate::goal_curation::no_progress_breaker::{
+    NO_PROGRESS_BLOCKED_PREFIX, is_no_progress_marker,
+};
+use crate::goal_curation::{ActiveGoal, GoalBoard, GoalProgress, load_goal_board};
+use crate::ooda_actions::advance_goal::spawn::{
+    BRAIN_FAILURE_BLOCKED_PREFIX, is_brain_failure_marker,
+};
 use crate::status::{AssembleOptions, StatusSnapshot, assemble};
 use crate::stewardship::RealGhClient;
 
 use crate::overseer::capabilities::{
-    InFlightItem, IssueFiler, IssueOutcome, ObservedState, OverseerError, StatusReader,
+    BlockedGoal, InFlightItem, IssueFiler, IssueOutcome, ObservedState, OverseerError, StatusReader,
 };
 use crate::overseer::config;
 use crate::overseer::intervention::Intervention;
@@ -121,6 +127,11 @@ pub fn observed_from_snapshot(snap: &StatusSnapshot) -> ObservedState {
         anomalies: telemetry.map(|t| t.anomalies.clone()).unwrap_or_default(),
         ready_prs: Vec::new(),
         ci_failures: Vec::new(),
+        // Goal-board health (blocked goals) is projected from the live board by
+        // the acting Overseer's Observe pass via the goal curator, not from the
+        // read-only status snapshot; left empty here so this projection stays
+        // additive and side-effect free.
+        blocked_goals: Vec::new(),
         // Loop/drift are surfaced from the OODA no-progress tracker, which the
         // read-only status snapshot does not yet expose. Left `None` here so the
         // adapter stays additive; a follow-up enriches this from the goal board's
@@ -160,6 +171,49 @@ pub fn in_flight_from_board(board: &GoalBoard) -> Vec<InFlightItem> {
         });
     }
     items
+}
+
+/// Project the goal board's *health* onto the Overseer's [`BlockedGoal`]s: one
+/// per active goal in a [`GoalProgress::Blocked`] state. Read-only and pure.
+///
+/// Reuses the EXISTING notions rather than inventing new ones:
+/// - `perpetual` ← [`ActiveGoal::is_perpetual`] (the standing/perpetual marker
+///   from #2589/#2609);
+/// - `needs_review` ← the two EXISTING "needs human review" safeguard-marker
+///   predicates ([`is_no_progress_marker`] and [`is_brain_failure_marker`]);
+/// - `consecutive_no_action` ← parsed from the safeguard marker's `{prefix}{n}`
+///   shape (`0` for a non-safeguard block, e.g. an operator-set one).
+///
+/// [`GoalProgress::Blocked`]: crate::goal_curation::GoalProgress::Blocked
+pub fn blocked_goals_from_board(board: &GoalBoard) -> Vec<BlockedGoal> {
+    board.active.iter().filter_map(blocked_goal_of).collect()
+}
+
+/// Project one active goal onto a [`BlockedGoal`] when it is `Blocked`.
+fn blocked_goal_of(goal: &ActiveGoal) -> Option<BlockedGoal> {
+    let GoalProgress::Blocked(reason) = &goal.status else {
+        return None;
+    };
+    let needs_review = is_no_progress_marker(reason) || is_brain_failure_marker(reason);
+    Some(BlockedGoal {
+        id: goal.id.clone(),
+        reason: reason.clone(),
+        perpetual: goal.is_perpetual(),
+        needs_review,
+        consecutive_no_action: safeguard_marker_count(reason).unwrap_or(0),
+    })
+}
+
+/// Parse the leading no-action/no-progress count from a safeguard-marker reason.
+/// Both markers share the `{prefix}{count}{suffix}` shape, so stripping whichever
+/// prefix matches and reading the leading digits yields the count. Returns `None`
+/// for a non-safeguard block.
+fn safeguard_marker_count(reason: &str) -> Option<u32> {
+    let rest = reason
+        .strip_prefix(NO_PROGRESS_BLOCKED_PREFIX)
+        .or_else(|| reason.strip_prefix(BRAIN_FAILURE_BLOCKED_PREFIX))?;
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse::<u32>().ok()
 }
 
 // ─────────────────────────── Read-only cycle ───────────────────────────────

--- a/src/overseer/signal.rs
+++ b/src/overseer/signal.rs
@@ -43,6 +43,19 @@ pub enum Signal {
     /// Active work appears to be drifting from a goal's stated intent. From
     /// `ObservedState.{drift_detail, active_goal_id}`.
     DriftCorrection { goal_id: String, detail: String },
+    /// A goal is `Blocked` on Simard's goal board — the goal-board *health*
+    /// signal. From `ObservedState.blocked_goals`. `perpetual` reuses the
+    /// standing/perpetual detection (#2589/#2609); `needs_review` is true when
+    /// the block carries a "needs human review" safeguard marker. Routed to
+    /// [`ProblemKind::GoalHygiene`]: a false-parked perpetual goal is
+    /// self-healed, a genuine "needs human review" block is escalated.
+    GoalBlocked {
+        goal_id: String,
+        reason: String,
+        perpetual: bool,
+        needs_review: bool,
+        consecutive_no_action: u32,
+    },
 }
 
 /// Coarse relative importance. `Ord` sorts ascending so `Critical` comes first,
@@ -176,6 +189,17 @@ pub fn signals_from(state: &ObservedState) -> Vec<Signal> {
         out.push(Signal::DriftCorrection {
             goal_id: goal_id.clone(),
             detail: detail.clone(),
+        });
+    }
+
+    // Goal-board health: one signal per blocked goal observed on the board.
+    for bg in &state.blocked_goals {
+        out.push(Signal::GoalBlocked {
+            goal_id: bg.id.clone(),
+            reason: bg.reason.clone(),
+            perpetual: bg.perpetual,
+            needs_review: bg.needs_review,
+            consecutive_no_action: bg.consecutive_no_action,
         });
     }
 

--- a/src/overseer/tests_goal_health.rs
+++ b/src/overseer/tests_goal_health.rs
@@ -1,0 +1,695 @@
+//! Tests for the Overseer's **goal-board health** OBSERVE→ACT surface — the
+//! defense-in-depth complement to #2609 (which exempts perpetual goals from the
+//! no-progress hard-block). These pin the contract that:
+//!
+//! - the sensor projection surfaces `Blocked` goals into
+//!   [`ObservedState::blocked_goals`] from the REAL board markers, reusing the
+//!   EXISTING perpetual detection (#2589/#2609) and the safeguard-marker
+//!   predicates — never a second notion;
+//! - a `Signal::GoalBlocked` maps to a [`ProblemKind::GoalHygiene`] problem;
+//! - a PERPETUAL goal false-parked by the no-progress safeguard is
+//!   auto-unblocked + reactivated EXACTLY ONCE (dedup prevents a loop) and is
+//!   NOT escalated;
+//! - ANY goal carrying a "needs human review" marker fires `NotifyOperator` on
+//!   BOTH channels (email + Signal) with the goal id + reason;
+//! - the recursion guard / distinct identity fails CLOSED (no self-heal /
+//!   self-whisper without a configured DISTINCT identity);
+//! - the enable flag holds both actions when off;
+//! - a single blocked-goal handling failure is isolated (the tick survives).
+//!
+//! Everything is exercised with injected fakes (goal store, notifier, clock via
+//! the dedup gate, identity) — no network, no `~/.simard`.
+
+use std::sync::{Arc, Mutex};
+
+use crate::goal_curation::no_progress_breaker::no_progress_blocked_reason;
+use crate::goal_curation::{ActiveGoal, GoalBoard, GoalProgress};
+use crate::ooda_actions::advance_goal::spawn::{
+    BRAIN_FAILURE_BLOCKED_PREFIX, BRAIN_FAILURE_BLOCKED_SUFFIX,
+};
+
+use crate::overseer::capabilities::{
+    AuditReport, AuditScope, Auditor, BlockedGoal, DeployReport, Deployer, GoalBrief, GoalCurator,
+    InFlightItem, IssueOutcome, MeetingHost, ObservedState, OrchestratorRunBrief, OverseerError,
+    PrOps, RecipeBrief, RecipeLauncher, StatusReader, VerifyReport, WorkstreamHandle,
+    WorkstreamStatus,
+};
+use crate::overseer::config::{SIMARD_OVERSEER_GOAL_HEALTH_ENV, goal_health_enabled_from};
+use crate::overseer::guardrails::{AutonomyGate, RiskClass, classify};
+use crate::overseer::intervention::Intervention;
+use crate::overseer::notify::{
+    ChannelDelivery, DualChannelNotifier, NotifyChannel, OperatorNotification,
+};
+use crate::overseer::sensor::blocked_goals_from_board;
+use crate::overseer::signal::{Problem, ProblemKind, Signal, signals_from};
+use crate::overseer::wiring::{overseer_identity, overseer_tick, run_overseer_tick_isolated};
+use crate::overseer::{Capabilities, Overseer, decide, orient};
+
+// ─────────────────────────── marker helpers ────────────────────────────────
+
+/// The brain-failure safeguard `Blocked` reason for `n` cycles (mirrors the
+/// deterministic marker `dispatch_spawn_engineer` writes).
+fn brain_failure_reason(n: u32) -> String {
+    format!("{BRAIN_FAILURE_BLOCKED_PREFIX}{n}{BRAIN_FAILURE_BLOCKED_SUFFIX}")
+}
+
+// ─────────────────────────── capability fakes ──────────────────────────────
+
+struct FakeStatus(ObservedState);
+impl StatusReader for FakeStatus {
+    fn snapshot(&self) -> Result<ObservedState, OverseerError> {
+        Ok(self.0.clone())
+    }
+}
+
+struct FakeRecipes;
+impl RecipeLauncher for FakeRecipes {
+    fn launch(&self, _b: &RecipeBrief) -> Result<WorkstreamHandle, OverseerError> {
+        Ok(WorkstreamHandle {
+            id: "ws-1".to_string(),
+        })
+    }
+    fn poll(&self, _h: &WorkstreamHandle) -> Result<WorkstreamStatus, OverseerError> {
+        Ok(WorkstreamStatus::Running)
+    }
+}
+
+struct FakePrs;
+impl PrOps for FakePrs {
+    fn verify(&self, _r: &str, _p: u32) -> Result<VerifyReport, OverseerError> {
+        Ok(VerifyReport {
+            ready: false,
+            checks: vec![],
+        })
+    }
+    fn merge(&self, _r: &str, _p: u32) -> Result<(), OverseerError> {
+        Ok(())
+    }
+    fn resolve_conflict(&self, _r: &str, _p: u32) -> Result<(), OverseerError> {
+        Ok(())
+    }
+}
+
+struct FakeDeployer;
+impl Deployer for FakeDeployer {
+    fn deploy(&self, commit: &str) -> Result<DeployReport, OverseerError> {
+        Ok(DeployReport {
+            deployed_commit: commit.to_string(),
+            gates_passed: true,
+        })
+    }
+    fn deployed_commit(&self) -> Result<String, OverseerError> {
+        Ok("deadbeef".to_string())
+    }
+}
+
+struct FakeIssues;
+impl crate::overseer::capabilities::IssueFiler for FakeIssues {
+    fn file(&self, _run: &OrchestratorRunBrief) -> Result<IssueOutcome, OverseerError> {
+        Ok(IssueOutcome::FiledNew {
+            url: "https://example/issues/1".to_string(),
+        })
+    }
+}
+
+struct FakeMeetings;
+impl MeetingHost for FakeMeetings {
+    fn transfer_goal(&self, _g: &GoalBrief) -> Result<(), OverseerError> {
+        Ok(())
+    }
+}
+
+struct FakeAuditor;
+impl Auditor for FakeAuditor {
+    fn run_audit(&self, scope: &AuditScope) -> Result<AuditReport, OverseerError> {
+        Ok(AuditReport {
+            scope: scope.clone(),
+            passed: true,
+            findings: vec![],
+        })
+    }
+}
+
+/// A goal-store fake: serves a fixed set of blocked goals and records every
+/// `unblock` call so the self-heal path is observable without a real board.
+/// `fail_unblock` makes `unblock` return an error so failure isolation can be
+/// proven.
+struct FakeGoalStore {
+    blocked: Vec<BlockedGoal>,
+    unblocked: Arc<Mutex<Vec<String>>>,
+    fail_unblock: bool,
+}
+impl FakeGoalStore {
+    fn new(blocked: Vec<BlockedGoal>) -> (Self, Arc<Mutex<Vec<String>>>) {
+        let unblocked = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                blocked,
+                unblocked: unblocked.clone(),
+                fail_unblock: false,
+            },
+            unblocked,
+        )
+    }
+    fn failing(blocked: Vec<BlockedGoal>) -> Self {
+        Self {
+            blocked,
+            unblocked: Arc::new(Mutex::new(Vec::new())),
+            fail_unblock: true,
+        }
+    }
+}
+impl GoalCurator for FakeGoalStore {
+    fn propose(&self, _g: &GoalBrief) -> Result<(), OverseerError> {
+        Ok(())
+    }
+    fn in_flight(&self) -> Result<Vec<InFlightItem>, OverseerError> {
+        Ok(vec![])
+    }
+    fn blocked_goals(&self) -> Result<Vec<BlockedGoal>, OverseerError> {
+        Ok(self.blocked.clone())
+    }
+    fn unblock(&self, goal_id: &str) -> Result<(), OverseerError> {
+        if self.fail_unblock {
+            return Err(OverseerError::Capability {
+                what: "goal_board.unblock",
+                detail: "board write failed".to_string(),
+            });
+        }
+        self.unblocked.lock().unwrap().push(goal_id.to_string());
+        Ok(())
+    }
+}
+
+/// A notify channel that records every notification and always reports `Sent`.
+struct RecordingChannel {
+    name: String,
+    seen: Arc<Mutex<Vec<OperatorNotification>>>,
+}
+impl RecordingChannel {
+    fn new(name: &str) -> (Self, Arc<Mutex<Vec<OperatorNotification>>>) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                name: name.to_string(),
+                seen: seen.clone(),
+            },
+            seen,
+        )
+    }
+}
+impl NotifyChannel for RecordingChannel {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn deliver(&self, n: &OperatorNotification) -> ChannelDelivery {
+        self.seen.lock().unwrap().push(n.clone());
+        ChannelDelivery::Sent
+    }
+}
+
+/// Build the Overseer's capabilities around a goal store; everything else is a
+/// canned fake (the status reader yields an otherwise-clean snapshot so the only
+/// signals are the goal-board ones).
+fn caps_with_goals(goals: Box<dyn GoalCurator>) -> Capabilities {
+    Capabilities {
+        status: Box::new(FakeStatus(ObservedState::default())),
+        recipes: Box::new(FakeRecipes),
+        prs: Box::new(FakePrs),
+        deployer: Box::new(FakeDeployer),
+        meetings: Box::new(FakeMeetings),
+        issues: Box::new(FakeIssues),
+        goals,
+        auditor: Box::new(FakeAuditor),
+    }
+}
+
+/// A `DualChannelNotifier` (the SAME mandatory notifier the merge path uses)
+/// wired with two recording channels so a test can prove BOTH email + Signal
+/// fired. Returns the notifier plus the two capture logs.
+type NotifierAndLogs = (
+    DualChannelNotifier,
+    Arc<Mutex<Vec<OperatorNotification>>>,
+    Arc<Mutex<Vec<OperatorNotification>>>,
+);
+fn dual_recording_notifier() -> NotifierAndLogs {
+    let (email, email_log) = RecordingChannel::new("email");
+    let (signal, signal_log) = RecordingChannel::new("signal");
+    let notifier = DualChannelNotifier::new(vec![Box::new(email), Box::new(signal)]);
+    (notifier, email_log, signal_log)
+}
+
+// ─────────────────── 1. Sensor: project the board → ObservedState ───────────
+
+#[test]
+fn blocked_goals_projection_surfaces_perpetual_and_needs_review_goals() {
+    let mut board = GoalBoard::new();
+    // A standing/perpetual research goal, false-parked by the no-progress
+    // safeguard (perpetual + needs_review, count parsed from the marker).
+    let mut research = ActiveGoal::new(
+        "research",
+        "Continuously research the frontier. Standing goal.",
+        1,
+    );
+    research.status = GoalProgress::Blocked(no_progress_blocked_reason(4));
+    // A NORMAL feature goal, genuinely blocked by the brain-failure safeguard
+    // (needs_review, not perpetual).
+    let mut feature = ActiveGoal::new("feature-x", "Ship feature X", 2);
+    feature.status = GoalProgress::Blocked(brain_failure_reason(3));
+    // A NORMAL goal blocked by an operator-set reason (no safeguard marker):
+    // surfaced, but neither perpetual nor needs_review.
+    let mut opsblock = ActiveGoal::new("ops", "Wait on infra", 3);
+    opsblock.status = GoalProgress::Blocked("waiting on the operator".to_string());
+    // A healthy in-progress goal: never surfaced.
+    let mut healthy = ActiveGoal::new("healthy", "Make progress", 4);
+    healthy.status = GoalProgress::InProgress { percent: 40 };
+    board.active = vec![research, feature, opsblock, healthy];
+
+    let blocked = blocked_goals_from_board(&board);
+    assert_eq!(
+        blocked.len(),
+        3,
+        "only the three Blocked goals are surfaced"
+    );
+
+    let research = blocked.iter().find(|b| b.id == "research").unwrap();
+    assert!(
+        research.perpetual,
+        "standing goal is perpetual (#2589/#2609)"
+    );
+    assert!(
+        research.needs_review,
+        "no-progress marker needs human review"
+    );
+    assert_eq!(
+        research.consecutive_no_action, 4,
+        "count parsed from marker"
+    );
+
+    let feature = blocked.iter().find(|b| b.id == "feature-x").unwrap();
+    assert!(!feature.perpetual);
+    assert!(
+        feature.needs_review,
+        "brain-failure marker needs human review"
+    );
+    assert_eq!(feature.consecutive_no_action, 3);
+
+    let ops = blocked.iter().find(|b| b.id == "ops").unwrap();
+    assert!(!ops.perpetual);
+    assert!(
+        !ops.needs_review,
+        "an operator-set block is not a review marker"
+    );
+    assert_eq!(ops.consecutive_no_action, 0);
+}
+
+#[test]
+fn run_cycle_populates_observed_blocked_goals_and_emits_signals() {
+    let blocked = vec![
+        BlockedGoal {
+            id: "research".to_string(),
+            reason: no_progress_blocked_reason(4),
+            perpetual: true,
+            needs_review: true,
+            consecutive_no_action: 4,
+        },
+        BlockedGoal {
+            id: "feature-x".to_string(),
+            reason: brain_failure_reason(3),
+            perpetual: false,
+            needs_review: true,
+            consecutive_no_action: 3,
+        },
+    ];
+    let (store, _log) = FakeGoalStore::new(blocked);
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_identity(overseer_identity())
+        .with_goal_health_enabled(true);
+
+    let cycle = ov.run_cycle().expect("cycle");
+    assert_eq!(
+        cycle.observed.blocked_goals.len(),
+        2,
+        "the Observe pass surfaces the board's blocked goals into ObservedState"
+    );
+    let goal_blocked: Vec<_> = cycle
+        .signals
+        .iter()
+        .filter(|s| matches!(s, Signal::GoalBlocked { .. }))
+        .collect();
+    assert_eq!(
+        goal_blocked.len(),
+        2,
+        "one GoalBlocked signal per blocked goal"
+    );
+}
+
+// ─────────────────── 2. Signal → GoalHygiene problem ────────────────────────
+
+#[test]
+fn goal_blocked_signal_maps_to_a_goal_hygiene_problem() {
+    let observed = ObservedState {
+        blocked_goals: vec![BlockedGoal {
+            id: "research".to_string(),
+            reason: no_progress_blocked_reason(4),
+            perpetual: true,
+            needs_review: true,
+            consecutive_no_action: 4,
+        }],
+        ..ObservedState::default()
+    };
+    let signals = signals_from(&observed);
+    assert!(
+        signals
+            .iter()
+            .any(|s| matches!(s, Signal::GoalBlocked { .. })),
+        "a blocked goal produces a GoalBlocked signal"
+    );
+    let problems = orient(&signals, &[]);
+    let problem = problems
+        .iter()
+        .find(|p| p.kind == ProblemKind::GoalHygiene)
+        .expect("GoalBlocked classifies to GoalHygiene");
+    assert_eq!(problem.dedup_key, "goal:blocked:research");
+}
+
+// ─────────────────── 3. Self-heal: unblock once, never escalate ─────────────
+
+#[test]
+fn perpetual_no_progress_goal_is_unblocked_once_and_not_escalated() {
+    let blocked = vec![BlockedGoal {
+        id: "research".to_string(),
+        reason: no_progress_blocked_reason(4),
+        perpetual: true,
+        needs_review: true,
+        consecutive_no_action: 4,
+    }];
+    let (store, unblocked) = FakeGoalStore::new(blocked);
+    let (notifier, email_log, signal_log) = dual_recording_notifier();
+
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_identity(overseer_identity())
+        .with_goal_health_enabled(true)
+        .with_operator_notifier(Box::new(notifier));
+
+    let first = overseer_tick(&mut ov);
+    assert_eq!(first.goals_unblocked, 1, "the false-park is self-healed");
+    assert_eq!(first.goals_escalated, 0, "a false-park is NOT escalated");
+    assert_eq!(first.errors, 0);
+    assert!(!first.panicked);
+
+    // The SAME blocked goal is still served next tick (the fake store does not
+    // reflect the unblock). Dedup must prevent a re-unblock loop.
+    let second = overseer_tick(&mut ov);
+    assert_eq!(
+        second.goals_unblocked, 0,
+        "dedup prevents a re-unblock loop"
+    );
+    assert_eq!(
+        second.goals_health_suppressed, 1,
+        "the duplicate is counted"
+    );
+
+    assert_eq!(
+        &*unblocked.lock().unwrap(),
+        &vec!["research".to_string()],
+        "the goal store's unblock was called EXACTLY ONCE across two ticks"
+    );
+    assert!(
+        email_log.lock().unwrap().is_empty() && signal_log.lock().unwrap().is_empty(),
+        "a self-healed false-park never notifies the operator"
+    );
+}
+
+// ─────────────────── 4. Escalate: NotifyOperator on both channels ───────────
+
+#[test]
+fn needs_review_goal_escalates_to_operator_on_both_channels() {
+    let reason = brain_failure_reason(3);
+    let blocked = vec![BlockedGoal {
+        id: "feature-x".to_string(),
+        reason: reason.clone(),
+        perpetual: false,
+        needs_review: true,
+        consecutive_no_action: 3,
+    }];
+    let (store, unblocked) = FakeGoalStore::new(blocked);
+    let (notifier, email_log, signal_log) = dual_recording_notifier();
+
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_identity(overseer_identity())
+        .with_goal_health_enabled(true)
+        .with_operator_notifier(Box::new(notifier));
+
+    let report = overseer_tick(&mut ov);
+    assert_eq!(report.goals_escalated, 1, "the genuine block is escalated");
+    assert_eq!(
+        report.goals_unblocked, 0,
+        "a normal goal is not self-healed"
+    );
+    assert!(
+        unblocked.lock().unwrap().is_empty(),
+        "escalation never unblocks the goal"
+    );
+
+    for (chan, log) in [("email", &email_log), ("signal", &signal_log)] {
+        let seen = log.lock().unwrap();
+        assert_eq!(seen.len(), 1, "the {chan} channel received the escalation");
+        let n = &seen[0];
+        assert!(
+            n.headline.contains("feature-x"),
+            "the {chan} notification names the goal id: {n:?}"
+        );
+        assert!(
+            n.problem.contains(&reason) || n.problem.contains("needs human review"),
+            "the {chan} notification carries the block reason: {n:?}"
+        );
+    }
+}
+
+// ─────────────────── 5. Anti-recursion: fail closed on no identity ──────────
+
+#[test]
+fn self_heal_and_escalate_fail_closed_without_a_distinct_identity() {
+    // No `.with_identity(...)` ⇒ the default RecursionGuard is unconfigured, so
+    // both goal-health actions must be REFUSED (fail closed) — the Overseer can
+    // never self-heal / escalate (nor self-whisper) without a DISTINCT identity.
+    let (store, unblocked) = FakeGoalStore::new(vec![]);
+    let (notifier, email_log, signal_log) = dual_recording_notifier();
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_goal_health_enabled(true)
+        .with_operator_notifier(Box::new(notifier));
+
+    let unblock = ov.act(&Intervention::UnblockGoal {
+        goal_id: "research".to_string(),
+        reason: no_progress_blocked_reason(4),
+    });
+    assert!(
+        matches!(unblock, Err(OverseerError::Recursion { .. })),
+        "unconfigured identity refuses the self-heal (fail closed): {unblock:?}"
+    );
+
+    let escalate = ov.act(&Intervention::EscalateBlockedGoal {
+        goal_id: "feature-x".to_string(),
+        reason: brain_failure_reason(3),
+    });
+    assert!(
+        matches!(escalate, Err(OverseerError::Recursion { .. })),
+        "unconfigured identity refuses the escalation (fail closed): {escalate:?}"
+    );
+
+    assert!(
+        unblocked.lock().unwrap().is_empty(),
+        "no unblock reached the store"
+    );
+    assert!(
+        email_log.lock().unwrap().is_empty() && signal_log.lock().unwrap().is_empty(),
+        "no notification reached the operator"
+    );
+}
+
+// ─────────────────── 6. Enable flag: disabled ⇒ no action ───────────────────
+
+#[test]
+fn disabled_goal_health_holds_both_actions() {
+    let blocked = vec![
+        BlockedGoal {
+            id: "research".to_string(),
+            reason: no_progress_blocked_reason(4),
+            perpetual: true,
+            needs_review: true,
+            consecutive_no_action: 4,
+        },
+        BlockedGoal {
+            id: "feature-x".to_string(),
+            reason: brain_failure_reason(3),
+            perpetual: false,
+            needs_review: true,
+            consecutive_no_action: 3,
+        },
+    ];
+    let (store, unblocked) = FakeGoalStore::new(blocked);
+    let (notifier, email_log, signal_log) = dual_recording_notifier();
+
+    // Identity configured, notifier wired — only the enable flag is OFF.
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_identity(overseer_identity())
+        .with_goal_health_enabled(false)
+        .with_operator_notifier(Box::new(notifier));
+
+    let report = overseer_tick(&mut ov);
+    assert_eq!(report.goals_unblocked, 0);
+    assert_eq!(report.goals_escalated, 0);
+    assert!(
+        report.held >= 2,
+        "both goal-health interventions are held: {report:?}"
+    );
+    assert!(
+        unblocked.lock().unwrap().is_empty(),
+        "disabled ⇒ no unblock is performed"
+    );
+    assert!(
+        email_log.lock().unwrap().is_empty() && signal_log.lock().unwrap().is_empty(),
+        "disabled ⇒ no escalation is dispatched"
+    );
+}
+
+#[test]
+fn goal_health_enable_flag_is_opt_out_and_off_when_overseer_off() {
+    use crate::overseer::config::OVERSEER_ENABLED_ENV;
+    let env = |pairs: &[(&str, &str)]| {
+        let owned: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        move |k: &str| owned.iter().find(|(ek, _)| ek == k).map(|(_, v)| v.clone())
+    };
+    // Default (unset): ON, because the acting Overseer is opt-out ON.
+    assert!(goal_health_enabled_from(env(&[])));
+    // Explicit falsey on the goal-health flag: OFF.
+    assert!(!goal_health_enabled_from(env(&[(
+        SIMARD_OVERSEER_GOAL_HEALTH_ENV,
+        "off"
+    )])));
+    // A disabled Overseer forces goal-health OFF regardless of the flag.
+    assert!(!goal_health_enabled_from(env(&[
+        (OVERSEER_ENABLED_ENV, "false"),
+        (SIMARD_OVERSEER_GOAL_HEALTH_ENV, "on"),
+    ])));
+}
+
+// ─────────────────── 7. Failure isolation: the tick survives ────────────────
+
+#[test]
+fn a_failing_unblock_is_isolated_and_the_tick_survives() {
+    let blocked = vec![BlockedGoal {
+        id: "research".to_string(),
+        reason: no_progress_blocked_reason(4),
+        perpetual: true,
+        needs_review: true,
+        consecutive_no_action: 4,
+    }];
+    // The goal store errors on unblock — a capability failure, not a panic.
+    let store = FakeGoalStore::failing(blocked);
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_identity(overseer_identity())
+        .with_goal_health_enabled(true);
+
+    let report = run_overseer_tick_isolated(&mut ov);
+    assert_eq!(
+        report.goals_unblocked, 0,
+        "the failed self-heal took no effect"
+    );
+    assert_eq!(report.errors, 1, "the failure is counted, isolated");
+    assert!(!report.panicked, "a capability error never panics the tick");
+    assert!(report.duration_ms < 60_000);
+}
+
+// ─────────────────── decide/classify unit routing ──────────────────────────
+
+#[test]
+fn decide_routes_a_blocked_goal_by_shape() {
+    // Perpetual + no-progress marker ⇒ self-heal (unblock), never escalate.
+    let self_heal = decide(&Problem {
+        kind: ProblemKind::GoalHygiene,
+        priority: crate::overseer::signal::Priority::High,
+        dedup_key: "goal:blocked:research".to_string(),
+        summary: "blocked".to_string(),
+        evidence: vec![Signal::GoalBlocked {
+            goal_id: "research".to_string(),
+            reason: no_progress_blocked_reason(4),
+            perpetual: true,
+            needs_review: true,
+            consecutive_no_action: 4,
+        }],
+    });
+    assert!(matches!(self_heal, Intervention::UnblockGoal { .. }));
+
+    // Normal + needs_review ⇒ escalate.
+    let escalate = decide(&Problem {
+        kind: ProblemKind::GoalHygiene,
+        priority: crate::overseer::signal::Priority::High,
+        dedup_key: "goal:blocked:feature-x".to_string(),
+        summary: "blocked".to_string(),
+        evidence: vec![Signal::GoalBlocked {
+            goal_id: "feature-x".to_string(),
+            reason: brain_failure_reason(3),
+            perpetual: false,
+            needs_review: true,
+            consecutive_no_action: 3,
+        }],
+    });
+    assert!(matches!(escalate, Intervention::EscalateBlockedGoal { .. }));
+
+    // A plain operator-set block (no marker) ⇒ Report only, no autonomous action.
+    let report = decide(&Problem {
+        kind: ProblemKind::GoalHygiene,
+        priority: crate::overseer::signal::Priority::Normal,
+        dedup_key: "goal:blocked:ops".to_string(),
+        summary: "blocked".to_string(),
+        evidence: vec![Signal::GoalBlocked {
+            goal_id: "ops".to_string(),
+            reason: "waiting on the operator".to_string(),
+            perpetual: false,
+            needs_review: false,
+            consecutive_no_action: 0,
+        }],
+    });
+    assert!(matches!(report, Intervention::Report));
+}
+
+#[test]
+fn goal_health_interventions_are_routine_and_admitted_by_default_gate() {
+    for iv in [
+        Intervention::UnblockGoal {
+            goal_id: "g".to_string(),
+            reason: "r".to_string(),
+        },
+        Intervention::EscalateBlockedGoal {
+            goal_id: "g".to_string(),
+            reason: "r".to_string(),
+        },
+    ] {
+        assert_eq!(classify(&iv), RiskClass::Routine);
+        assert!(
+            AutonomyGate::default().admit(&iv).is_ok(),
+            "routine goal-health actions are admitted; their own dedup/identity gates apply in act"
+        );
+    }
+    assert_eq!(
+        Intervention::UnblockGoal {
+            goal_id: "g".to_string(),
+            reason: "r".to_string()
+        }
+        .label(),
+        "unblock_goal"
+    );
+    assert_eq!(
+        Intervention::EscalateBlockedGoal {
+            goal_id: "g".to_string(),
+            reason: "r".to_string()
+        }
+        .label(),
+        "escalate_blocked_goal"
+    );
+}

--- a/src/overseer/wiring.rs
+++ b/src/overseer/wiring.rs
@@ -32,23 +32,28 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 
 use crate::cognitive_memory::CognitiveMemoryOps;
-use crate::goal_curation::{BacklogItem, GoalBoard};
+use crate::goal_curation::{BacklogItem, GoalBoard, GoalProgress};
 use crate::goal_curation::{
     DEFAULT_STEWARD_SCORE, add_backlog_item, load_goal_board, save_goal_board,
 };
 
 use crate::overseer::audit::SelfQualityAuditor;
 use crate::overseer::capabilities::{
-    DeployReport, Deployer, GoalBrief, GoalCurator, InFlightItem, OverseerError,
+    BlockedGoal, DeployReport, Deployer, GoalBrief, GoalCurator, InFlightItem, OverseerError,
 };
-use crate::overseer::config::{overseer_author_login, overseer_interval_secs, whisper_enabled};
+use crate::overseer::config::{
+    goal_health_enabled, overseer_author_login, overseer_interval_secs, whisper_enabled,
+};
 use crate::overseer::deploy::GuardedDeployer;
 use crate::overseer::guardrails::RecursionGuard;
 use crate::overseer::launch::SmartOrchestratorLauncher;
 use crate::overseer::meeting_ops::MeetingGoalTransfer;
 use crate::overseer::merge_ops::MergePrOps;
+use crate::overseer::notify::DualChannelNotifier;
 use crate::overseer::observer::StewardshipIssueFiler;
-use crate::overseer::sensor::{SnapshotStatusReader, in_flight_from_board};
+use crate::overseer::sensor::{
+    SnapshotStatusReader, blocked_goals_from_board, in_flight_from_board,
+};
 use crate::overseer::{ActOutcome, Capabilities, Overseer};
 
 // ─────────────────────────── cadence scheduler ─────────────────────────────
@@ -123,6 +128,15 @@ pub struct OverseerTickReport {
     pub whispers: usize,
     /// Whispers suppressed by the dedup window / per-hour cap this tick.
     pub whispers_suppressed: usize,
+    /// False-parked standing/perpetual goals auto-unblocked + reactivated this
+    /// tick (the self-heal path).
+    pub goals_unblocked: usize,
+    /// Genuinely-blocked "needs human review" goals escalated to the operator
+    /// (email + Signal) this tick.
+    pub goals_escalated: usize,
+    /// Goal-board self-heal / escalation actions suppressed by the dedup gate
+    /// this tick.
+    pub goals_health_suppressed: usize,
     /// Capability errors encountered while acting (isolated, never fatal).
     pub errors: usize,
     /// Set when the tick itself panicked and was isolated by
@@ -189,6 +203,9 @@ pub fn overseer_tick(overseer: &mut Overseer) -> OverseerTickReport {
         held = report.held,
         whispers = report.whispers,
         whispers_suppressed = report.whispers_suppressed,
+        goals_unblocked = report.goals_unblocked,
+        goals_escalated = report.goals_escalated,
+        goals_health_suppressed = report.goals_health_suppressed,
         errors = report.errors,
         duration_ms = report.duration_ms,
         "overseer tick complete"
@@ -229,6 +246,9 @@ fn tally_outcome(report: &mut OverseerTickReport, outcome: &ActOutcome) {
         ActOutcome::Escalated => report.escalations += 1,
         ActOutcome::Whispered { .. } => report.whispers += 1,
         ActOutcome::WhisperSuppressed { .. } => report.whispers_suppressed += 1,
+        ActOutcome::GoalUnblocked { .. } => report.goals_unblocked += 1,
+        ActOutcome::GoalEscalated { .. } => report.goals_escalated += 1,
+        ActOutcome::GoalHealthSuppressed { .. } => report.goals_health_suppressed += 1,
         ActOutcome::ConflictResolved
         | ActOutcome::GoalTransferred
         | ActOutcome::Reported
@@ -305,6 +325,31 @@ impl GoalCurator for BoardGoalCurator {
 
     fn in_flight(&self) -> Result<Vec<InFlightItem>, OverseerError> {
         Ok(in_flight_from_board(&self.load()?))
+    }
+
+    fn blocked_goals(&self) -> Result<Vec<BlockedGoal>, OverseerError> {
+        Ok(blocked_goals_from_board(&self.load()?))
+    }
+
+    fn unblock(&self, goal_id: &str) -> Result<(), OverseerError> {
+        // The exact `simard goal unblock` mutation: restore the blocked goal to
+        // `NotStarted` so the next OODA cycle re-enters the spawn path. Reuses
+        // the shipped `load_goal_board` / `save_goal_board` under the flock
+        // write-lock (`save_goal_board` acquires `BoardWriteLock`).
+        let mut board = self.load()?;
+        let goal = board
+            .active
+            .iter_mut()
+            .find(|g| g.id == goal_id)
+            .ok_or_else(|| OverseerError::Capability {
+                what: "goal_board.unblock",
+                detail: format!("goal '{goal_id}' not found on the active board"),
+            })?;
+        goal.status = GoalProgress::NotStarted;
+        save_goal_board(&board, self.mem.as_ref()).map_err(|e| OverseerError::Capability {
+            what: "goal_board.save",
+            detail: e.to_string(),
+        })
     }
 }
 
@@ -403,6 +448,12 @@ pub fn build_overseer(
                 crate::meeting_facilitator::default_handoff_dir(),
             ),
         ))
+        // Goal-board health: self-heal false-parked perpetual goals and escalate
+        // genuine "needs human review" blocks to the operator on BOTH channels
+        // (email + Signal) via the SAME mandatory notifier the merge path uses.
+        // Enabled by default (opt-out via SIMARD_OVERSEER_GOAL_HEALTH).
+        .with_goal_health_enabled(goal_health_enabled())
+        .with_operator_notifier(Box::new(DualChannelNotifier::from_env()))
 }
 
 /// Resolve the acting Overseer's tick cadence (seconds), clamped to the config

--- a/tests/overseer_activity.rs
+++ b/tests/overseer_activity.rs
@@ -62,12 +62,9 @@ fn report(
         issues_filed,
         recipes_launched,
         prs_merged,
-        deploys: 0,
-        escalations: 0,
         held,
-        errors: 0,
-        panicked: false,
         duration_ms: 42,
+        ..OverseerTickReport::default()
     }
 }
 


### PR DESCRIPTION
## Why

Defense-in-depth complement to #2609 (which exempts perpetual goals from the no-progress hard-block). **Found in production:** the OODA no-progress safeguard hard-blocked the standing research goal (`🔒 [OODA-SAFEGUARD] … needs human review`) and **nothing surfaced it** — the Overseer's `ObservedState` had no goal-board field, so it was blind, and the "needs human review" marker reached no human.

This teaches the acting Overseer to **observe** goal-board health and **act** on blocked/parked goals.

## What

**OBSERVE**
- `BlockedGoal { id, reason, perpetual, needs_review, consecutive_no_action }` + `ObservedState.blocked_goals` (`capabilities.rs`).
- Pure `sensor::blocked_goals_from_board` projection that **reuses** the existing perpetual detection (`ActiveGoal::is_perpetual`, #2589/#2609) and the existing safeguard-marker predicates (`is_no_progress_marker`, `is_brain_failure_marker`) — no second notion invented. The acting Overseer's Observe pass populates `blocked_goals` via a new read-only `GoalCurator::blocked_goals()`.

**SIGNAL → PROBLEM**
- `Signal::GoalBlocked{…}` maps to the existing `ProblemKind::GoalHygiene`.

**ACT** (under the existing overseer guardrails: dedup, distinct-identity fail-closed, enable flag)
- **SELF-HEAL false-parks** — a PERPETUAL/standing goal blocked by the no-progress safeguard is auto-unblocked + reactivated (the exact `simard goal unblock` operation via `GoalCurator::unblock`), deduped so it never fights itself; optionally emits a Whisper (reusing the #2611 Whisperer) steering Simard to carve a bounded shippable sub-goal.
- **ESCALATE genuine blocks** — ANY goal carrying a "needs human review" marker fires `NotifyOperator` (email + Signal via the mandatory `DualChannelNotifier`, behind the reused `OperatorNotifier` seam) with the goal id + reason, so the marker actually reaches a human. Closes the silent-failure gap.

**VISIBILITY**
- New actions are surfaced through the **existing #2610 operator-activity feed** — `OverseerTickReport.{goals_unblocked, goals_escalated, goals_health_suppressed}`, `OverseerTotals`, and `humanize_tick` (reused, not duplicated).

**CONFIG**
- `SIMARD_OVERSEER_GOAL_HEALTH` opt-out flag (default **ON** when the acting Overseer runs), gated in `gate()` like the whisperer.

## Routing (mutually exclusive per goal)
- `perpetual && no-progress marker` → **self-heal** (unblock + reactivate, optional whisper), **never escalated** (a false park is not a genuine block).
- otherwise `needs_review` (normal no-progress, or any brain-failure) → **escalate** to the operator.
- plain operator-set/dependency block → **Report only** (respect the deliberate block).

## Tests
Injected fakes for goal-store / notify / whisper / clock (dedup gate) / identity; **no network**:
- sensor surfaces a blocked perpetual goal **and** a blocked normal "needs human review" goal into `ObservedState`;
- `GoalBlocked` signal → `GoalHygiene` problem;
- a blocked PERPETUAL goal is auto-unblocked + reactivated **exactly once** (dedup prevents a loop) and is **NOT** escalated;
- a "needs human review" goal fires `NotifyOperator` on **both** channels (email + Signal) with the goal id + reason;
- recursion-guard / distinct-identity **fails closed** (no self-heal / self-whisper without a configured DISTINCT identity);
- the enable flag holds both actions when off;
- a failing unblock is **isolated** (the tick survives).

## Constraints honored
- All Rust, additive; reuses #2589/#2609 perpetual detection, #2611 Whisperer, #2610 operator-activity surface, and the existing guardrails / `NotifyOperator` — nothing duplicated.
- One-Brain / Overseer-steward terminology; no "Bridge" naming; structured `tracing` only (no `println!`/`eprintln!` beyond `[simard] …`).
- Branched off latest `origin/main` (includes #2609 + #2610 + #2611).
- Green pre-commit (fmt + release clippy) and full pre-push clippy (`--all-targets --all-features --locked -D warnings`); **no** `--no-verify`, **no** `gh pr merge --admin`.
- Does **not** touch the live daemon or `~/.simard`.

## Operator note
The daemon runs a compiled-in copy of the acting Overseer, so **the operator redeploys (rebuilds + hands over the binary) after this merges** for the new observe/act paths to take effect in the running daemon.