### PR TITLE
fix(tests): restore green verify — add whispers/whispers_suppressed to overseer_activity report() helper

### DIFF
--- a/tests/overseer_activity.rs
+++ b/tests/overseer_activity.rs
@@ -65,6 +65,8 @@ fn report(
         deploys: 0,
         escalations: 0,
         held,
+        whispers: 0,
+        whispers_suppressed: 0,
         errors: 0,
         panicked: false,
         duration_ms: 42,

--- a/tests/qa-scenarios/overseer-activity-report-fields.yaml
+++ b/tests/qa-scenarios/overseer-activity-report-fields.yaml
@@ -1,0 +1,74 @@
+name: overseer-activity-report-fields
+app_type: cli
+description: |
+  Regression coverage for issue #2615 — the `verify` workflow was red on `main`
+  for every commit after the Whisperer feature (#2605/#2611) because the
+  `report()` test helper in `tests/overseer_activity.rs` constructed
+  `OverseerTickReport { … }` with an exhaustive struct literal that was missing
+  the two new fields (`whispers`, `whispers_suppressed`), producing:
+
+      error[E0063]: missing fields `whispers` and `whispers_suppressed`
+                    in initializer of `OverseerTickReport`
+
+  A compile break in one test target fails `cargo test`, taking down the whole
+  `verify` workflow. This scenario pins the fix end to end (the CLI runner
+  rejects any non-zero exit, so every `run` step below is also an assertion):
+  1. The `OverseerTickReport` struct still declares both fields.
+  2. The `report()` helper initializes both fields (the exact regression site).
+  3. The previously-broken `overseer_activity` test target compiles and passes.
+  4. The build no longer emits the E0063 "missing fields" error.
+agents:
+  - name: shell
+    type: cli
+    command: bash
+steps:
+  # 1. The struct definition declares the two Whisperer tally fields.
+  - action: run
+    params:
+      command: "grep -Eq 'pub whispers: usize' src/overseer/wiring.rs && grep -Eq 'pub whispers_suppressed: usize' src/overseer/wiring.rs"
+    timeout: 15000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # 2. The report() test helper initializes BOTH fields (the exact fix site).
+  - action: run
+    params:
+      command: "grep -Eq '^[[:space:]]*whispers: 0,' tests/overseer_activity.rs && grep -Eq '^[[:space:]]*whispers_suppressed: 0,' tests/overseer_activity.rs"
+    timeout: 15000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # 3. The previously-broken test target compiles and passes cleanly.
+  #    Exit 0 only happens once the E0063 initializer gap is closed.
+  - action: run
+    params:
+      command: "cargo test --test overseer_activity > /tmp/qa-overseer-activity.log 2>&1"
+    timeout: 1200000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # 4. The build did NOT hit the #2615 E0063 missing-fields error.
+  - action: run
+    params:
+      command: "bash -c '! grep -qiE \"missing fields .?whispers.? and .?whispers_suppressed.?\" /tmp/qa-overseer-activity.log'"
+    timeout: 15000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # 5. The full overseer_activity contract suite reports an all-green result.
+  - action: run
+    params:
+      command: "grep -Eq 'test result: ok\\. [0-9]+ passed; 0 failed' /tmp/qa-overseer-activity.log"
+    timeout: 15000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000


### PR DESCRIPTION
## Summary

Restores a green `verify` workflow on `main`. Since the Whisperer feature landed (dbcab56d, #2611), `verify` has been **red on every commit** because the `report()` test helper in `tests/overseer_activity.rs` constructs `OverseerTickReport { … }` with an exhaustive struct literal missing the two new fields:

```
error[E0063]: missing fields `whispers` and `whispers_suppressed` in initializer of `OverseerTickReport`
  --> tests/overseer_activity.rs:60:5
```

A compile break in one test target fails the `pre-commit` job's `cargo test`, taking down the whole `verify` workflow. This was the **only** failing default-branch workflow across governed repos.

Fixes #2615.

## Root cause

The Whisperer feature (#2605) added two `usize` fields to `OverseerTickReport` in `src/overseer/wiring.rs` (`whispers`, `whispers_suppressed`). Sibling call-sites in `src/` (`overseer/activity.rs`, `bin/simard_tui/tabs/overseer.rs`, `operator_commands_dashboard/overseer.rs`) already use `..OverseerTickReport::default()` and were unaffected. Only the exhaustive literal in the test helper needed updating.

CI history isolates the regression precisely: run 28748816508 (7613b694, #2610) was **green**; the very next run 28749496183 (dbcab56d, #2611) went **red** and stayed red through 3d6158e8.

## Fix

`tests/overseer_activity.rs` — add the two missing tallies (default 0), matching struct field order (after `held`, before `errors`):

```diff
         deploys: 0,
         escalations: 0,
         held,
+        whispers: 0,
+        whispers_suppressed: 0,
         errors: 0,
         panicked: false,
         duration_ms: 42,
```

## Evidence

### Criterion 6 — Diff focused, no unrelated edits
```
 tests/overseer_activity.rs                          |  2 +
 tests/qa-scenarios/overseer-activity-report-fields.yaml | 74 +++++++++++
 2 files changed, 76 insertions(+)
```
Test-only change: the 2-line helper fix plus one regression scenario. No production code touched. Zero-stub scan across changed files: clean (no `todo!`/`unimplemented!`/`TODO`/`FIXME`/`panic!` introduced).

### Criterion 1 — qa scenarios written, validated, run
Added `tests/qa-scenarios/overseer-activity-report-fields.yaml` (mirrors the existing `precommit-clippy-lbug-link.yaml` CI-health pattern). It pins the #2615 regression: struct declares both fields, helper initializes both, `cargo test --test overseer_activity` passes, no E0063 emitted, all-green result line.
- `gadugi-test validate -f … --strict` → **✓ Scenario is valid (1 valid, 0 invalid)**.
- `gadugi-test run -d tests/qa-scenarios -s overseer-activity-report-fields` → **✓ Passed: 1, Failed: 0** (all 5 steps exit 0; cargo target compiled+passed in-scenario).
- Direct Rust coverage: the restored `tests/overseer_activity.rs` contract suite (tests-first spec for this exact surface) → **19 passed; 0 failed**.

### Criterion 3 — quality-audit (≥3 cycles, clean final)
Applied the quality-audit core loop scoped to the diff (the full 7-phase issue/worktree flow is for whole-codebase audits, not a single focused test-only PR):
- **Cycle 1 (correctness/scope):** field names/types/order correct vs struct; `0` default consistent with sibling zero-initialized fields and the derived `Default`. Zero findings.
- **Cycle 2 (qa scenario + grep logic):** scenario validates + runs green; `whispers: 0,` grep does not false-match `whispers_suppressed: 0,` (verified empirically). Zero findings.
- **Cycle 3 (security/philosophy/regression + independent code-review agent):** no security surface; minimal/proportionate; test-only scope. An independent `code-review` agent verdict: **"correct and low-risk; no significant issues found"** across all four checkpoints. Zero findings.
- Final cycle clean: **zero critical/high; zero medium correctness/security**.

### Criterion 4 — CI 100% green
- Local: previously-broken target now green (`cargo test --test overseer_activity` → 19/0); full suite → **7147+ passed**. The only local reds are **environmental, not caused by this change**:
  - 4 concurrency tests fail only because this shell sets `SIMARD_SCALING=auto` + `SIMARD_MAX_CONCURRENT_ACTIONS=5` (injects an AIMD scaler that overrides `max_concurrent_actions`). Re-run with those unset → **all pass** (22/15/13/1).
  - 2 e2e tests fail only because this env uses a custom `CARGO_TARGET_DIR`, so `<manifest>/target/debug/simard` is absent. With the binary at the expected path → **3 passed, 2 ignored, 0 failed**.
  - `decide.rs` is unchanged since the last green `verify`, confirming these reds are pre-existing environmental noise, not a regression.
- Pre-commit hooks (rust-only gate, `cargo fmt --check`, `cargo clippy --release`) and pre-push hooks (race-subset lib tests, `cargo clippy --all-targets --all-features --locked -D warnings`) **all pass**. No `--no-verify` used anywhere.
- Authoritative confirmation: the `verify` run on this PR (see checks).

### Criterion 2 — Docs
No user-facing surface changed (test-only). `docs/reference/simard-whisperer-api.md` already documents `whispers`/`whispers_suppressed`; no doc update required. Changed surfaces: `tests/overseer_activity.rs` (internal test helper), `tests/qa-scenarios/…` (internal qa harness) — internal-only, justification recorded here.

## Merge-ready checklist
- [x] Criterion 1: qa scenario written, validated (`gadugi-test validate`), run (`gadugi-test run`)
- [x] Criterion 2: docs — internal-only test surfaces, justification above
- [x] Criterion 3: quality-audit ≥3 cycles, clean final (zero critical/high; zero medium correctness/security)
- [ ] Criterion 4: CI 100% green (verify on this PR — pending)
- [x] Criterion 6: diff focused, no unrelated edits