### PR TITLE
fix(engineer): stop pre-mutation guard tripping on .simard-engineer-claim (#2621)

### DIFF
--- a/src/engineer_loop/mod.rs
+++ b/src/engineer_loop/mod.rs
@@ -633,6 +633,25 @@ fn count_new_status_paths(before: &[String], after: &[String]) -> Vec<String> {
         .collect()
 }
 
+/// Drop the Simard-managed claim sentinel (`.simard-engineer-claim`, issue
+/// #2621) from a parsed `git status` path list.
+///
+/// Simard writes this private liveness sentinel into every engineer worktree;
+/// it is Simard infra, not a user change, so **every** `git status` consumer in
+/// the engineer loop must ignore it. Applied to both `inspect_workspace` (the
+/// pre-mutation-guard input) and `verify_agent_spawn_artifacts` (the
+/// post-session evidence report) so the sentinel can never surface as a
+/// spurious change in either — including the degraded path where the
+/// worktree-allocation `.git/info/exclude` append failed (see
+/// `engineer_worktree::exclude_engineer_claim`), which is exactly when raw
+/// `git status` still lists the sentinel.
+fn strip_claim_sentinel(paths: Vec<String>) -> Vec<String> {
+    paths
+        .into_iter()
+        .filter(|path| path != crate::engineer_worktree::ENGINEER_CLAIM_FILE)
+        .collect()
+}
+
 /// Synthesize a [`VerificationReport`] from observable side-effects after an
 /// agent session completes (issue #1670). Replaces the previous hardcoded
 /// `"agent-completed"` status with post-hoc verification that checks:
@@ -685,7 +704,13 @@ fn verify_agent_spawn_artifacts(
         &["git", "status", "--short", "--untracked-files=all"],
     )
     .ok()
-    .map(|out| parse_status_paths(&out.stdout))
+    // Filter the Simard-managed claim sentinel here too (issue #2621): the
+    // pre-spawn baseline (`inspection.changed_files`) is already filtered, so
+    // leaving the sentinel in `post_status` would make `count_new_status_paths`
+    // (= after \ before) report it as a spurious "new changed file" whenever
+    // the `.git/info/exclude` append failed — falsely flipping a no-op session
+    // to "verified". Both consumers must strip the sentinel identically.
+    .map(|out| strip_claim_sentinel(parse_status_paths(&out.stdout)))
     .unwrap_or_default();
 
     let new_files = count_new_status_paths(&inspection.changed_files, &post_status);
@@ -906,10 +931,9 @@ pub fn inspect_workspace(workspace_root: &Path, state_root: &Path) -> SimardResu
     // it — aborting every mutating engineer before the coding agent spawns.
     // Belt-and-suspenders with the `.git/info/exclude` append performed at
     // worktree-allocation time (see `engineer_worktree::exclude_engineer_claim`).
-    let changed_files: Vec<String> = parse_status_paths(&status_output.stdout)
-        .into_iter()
-        .filter(|path| path != crate::engineer_worktree::ENGINEER_CLAIM_FILE)
-        .collect();
+    // Shared with `verify_agent_spawn_artifacts` via `strip_claim_sentinel` so
+    // both `git status` consumers ignore the sentinel identically.
+    let changed_files = strip_claim_sentinel(parse_status_paths(&status_output.stdout));
     let worktree_dirty = !changed_files.is_empty();
     let active_goals = {
         use crate::goals::GoalStore as _;

--- a/src/engineer_loop/mod.rs
+++ b/src/engineer_loop/mod.rs
@@ -29,6 +29,8 @@ mod tests_types_inline;
 #[cfg(test)]
 mod tests_checkpoint;
 #[cfg(test)]
+mod tests_claim_sentinel;
+#[cfg(test)]
 mod tests_meeting_decisions;
 
 use std::fs;
@@ -896,7 +898,18 @@ pub fn inspect_workspace(workspace_root: &Path, state_root: &Path) -> SimardResu
         &repo_root,
         &["git", "status", "--short", "--untracked-files=all"],
     )?;
-    let changed_files = parse_status_paths(&status_output.stdout);
+    // Filter the Simard-managed claim sentinel out of the reported changes
+    // (issue #2621). Simard drops `.simard-engineer-claim` into every engineer
+    // worktree; it is private infra, not a user change, and must never count
+    // toward `worktree_dirty` or the engineer-loop pre-mutation guard would
+    // trip on the untracked sentinel in any target repo that doesn't gitignore
+    // it — aborting every mutating engineer before the coding agent spawns.
+    // Belt-and-suspenders with the `.git/info/exclude` append performed at
+    // worktree-allocation time (see `engineer_worktree::exclude_engineer_claim`).
+    let changed_files: Vec<String> = parse_status_paths(&status_output.stdout)
+        .into_iter()
+        .filter(|path| path != crate::engineer_worktree::ENGINEER_CLAIM_FILE)
+        .collect();
     let worktree_dirty = !changed_files.is_empty();
     let active_goals = {
         use crate::goals::GoalStore as _;

--- a/src/engineer_loop/tests_claim_sentinel.rs
+++ b/src/engineer_loop/tests_claim_sentinel.rs
@@ -9,7 +9,8 @@ use std::process::Command;
 use serial_test::serial;
 use tempfile::tempdir;
 
-use super::inspect_workspace;
+use super::{inspect_workspace, strip_claim_sentinel};
+use crate::engineer_worktree::ENGINEER_CLAIM_FILE;
 
 fn git(repo: &Path, args: &[&str]) {
     let out = Command::new("git")
@@ -100,5 +101,34 @@ fn inspect_workspace_still_flags_real_changes_alongside_claim() {
         inspection.changed_files,
         vec!["user_change.txt".to_string()],
         "only the real change must be reported; the sentinel must be filtered"
+    );
+}
+
+/// `strip_claim_sentinel` is the shared filter used by BOTH `git status`
+/// consumers (`inspect_workspace` and `verify_agent_spawn_artifacts`). It must
+/// remove exactly the root sentinel and preserve every other path in order.
+#[test]
+fn strip_claim_sentinel_removes_only_the_root_sentinel() {
+    let input = vec![
+        "src/main.rs".to_string(),
+        ENGINEER_CLAIM_FILE.to_string(),
+        "Cargo.toml".to_string(),
+    ];
+    assert_eq!(
+        strip_claim_sentinel(input),
+        vec!["src/main.rs".to_string(), "Cargo.toml".to_string()],
+        "only the claim sentinel is removed; all other paths are preserved in order"
+    );
+}
+
+/// The filter is an exact root-path match, so a genuine change in a
+/// subdirectory that merely shares the sentinel's basename is NOT swallowed.
+#[test]
+fn strip_claim_sentinel_keeps_subdir_same_basename() {
+    let nested = format!("subdir/{ENGINEER_CLAIM_FILE}");
+    assert_eq!(
+        strip_claim_sentinel(vec![nested.clone(), ENGINEER_CLAIM_FILE.to_string()]),
+        vec![nested],
+        "a same-basename file under a subdirectory is a real change and must be kept"
     );
 }

--- a/src/engineer_loop/tests_claim_sentinel.rs
+++ b/src/engineer_loop/tests_claim_sentinel.rs
@@ -1,0 +1,104 @@
+//! Regression tests for issue #2621: `inspect_workspace` must filter the
+//! Simard-managed `.simard-engineer-claim` sentinel out of `changed_files`
+//! and `worktree_dirty`, so the engineer-loop pre-mutation guard never trips
+//! on the untracked sentinel in a target repo that doesn't gitignore it.
+
+use std::path::Path;
+use std::process::Command;
+
+use serial_test::serial;
+use tempfile::tempdir;
+
+use super::inspect_workspace;
+
+fn git(repo: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "test@test.com")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "test@test.com")
+        .output()
+        .expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git {:?} failed in {}: {}",
+        args,
+        repo.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Initialise a git repo that, like an external governed repo, does NOT
+/// gitignore Simard's private `.simard-engineer-claim` sentinel.
+fn init_repo(dir: &Path) {
+    git(dir, &["init", "--initial-branch=main", "--quiet"]);
+    git(dir, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(dir.join("README.md"), "seed\n").unwrap();
+    git(dir, &["add", "README.md"]);
+    git(dir, &["commit", "-m", "seed", "--quiet"]);
+}
+
+#[test]
+#[serial(cognitive_memory)]
+fn inspect_workspace_treats_claim_only_worktree_as_clean() {
+    let dir = tempdir().unwrap();
+    init_repo(dir.path());
+    let state_root = dir.path().join("state");
+    std::fs::create_dir_all(&state_root).unwrap();
+
+    // The ONLY change is the untracked Simard sentinel — the exact repro from
+    // issue #2621 (`?? .simard-engineer-claim`).
+    std::fs::write(
+        dir.path()
+            .join(crate::engineer_worktree::ENGINEER_CLAIM_FILE),
+        format!("{}\n", std::process::id()),
+    )
+    .unwrap();
+
+    let inspection = inspect_workspace(dir.path(), &state_root).expect("inspect_workspace");
+
+    assert!(
+        !inspection.worktree_dirty,
+        "worktree containing only the claim sentinel must report clean; changed_files={:?}",
+        inspection.changed_files
+    );
+    assert!(
+        inspection.changed_files.is_empty(),
+        "claim sentinel must be filtered out of changed_files; got {:?}",
+        inspection.changed_files
+    );
+}
+
+#[test]
+#[serial(cognitive_memory)]
+fn inspect_workspace_still_flags_real_changes_alongside_claim() {
+    let dir = tempdir().unwrap();
+    init_repo(dir.path());
+    let state_root = dir.path().join("state");
+    std::fs::create_dir_all(&state_root).unwrap();
+
+    // A genuine user change plus the sentinel: the sentinel must be filtered
+    // but the real change must still mark the tree dirty. Guards against an
+    // over-broad filter that would swallow real changes.
+    std::fs::write(
+        dir.path()
+            .join(crate::engineer_worktree::ENGINEER_CLAIM_FILE),
+        format!("{}\n", std::process::id()),
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("user_change.txt"), "real edit\n").unwrap();
+
+    let inspection = inspect_workspace(dir.path(), &state_root).expect("inspect_workspace");
+
+    assert!(
+        inspection.worktree_dirty,
+        "a genuine change must still mark the worktree dirty"
+    );
+    assert_eq!(
+        inspection.changed_files,
+        vec!["user_change.txt".to_string()],
+        "only the real change must be reported; the sentinel must be filtered"
+    );
+}

--- a/src/engineer_loop/tests_claim_sentinel.rs
+++ b/src/engineer_loop/tests_claim_sentinel.rs
@@ -9,7 +9,8 @@ use std::process::Command;
 use serial_test::serial;
 use tempfile::tempdir;
 
-use super::{inspect_workspace, strip_claim_sentinel};
+use super::types::RepoInspection;
+use super::{inspect_workspace, strip_claim_sentinel, verify_agent_spawn_artifacts};
 use crate::engineer_worktree::ENGINEER_CLAIM_FILE;
 
 fn git(repo: &Path, args: &[&str]) {
@@ -130,5 +131,96 @@ fn strip_claim_sentinel_keeps_subdir_same_basename() {
         strip_claim_sentinel(vec![nested.clone(), ENGINEER_CLAIM_FILE.to_string()]),
         vec![nested],
         "a same-basename file under a subdirectory is a real change and must be kept"
+    );
+}
+
+/// Build a `RepoInspection` pointed at `repo` with an empty (already-filtered)
+/// `changed_files` baseline and `head == "HEAD"` so `HEAD..HEAD` yields zero new
+/// commits — isolating `verify_agent_spawn_artifacts` to its `git status` /
+/// sentinel-filter behavior.
+fn inspection_for(repo: &Path) -> RepoInspection {
+    RepoInspection {
+        workspace_root: repo.to_path_buf(),
+        repo_root: repo.to_path_buf(),
+        branch: "main".to_string(),
+        head: "HEAD".to_string(),
+        worktree_dirty: false,
+        changed_files: vec![],
+        active_goals: vec![],
+        carried_meeting_decisions: vec![],
+        architecture_gap_summary: String::new(),
+    }
+}
+
+/// Issue #2621 (second consumer): `verify_agent_spawn_artifacts` must also strip
+/// the sentinel. This exercises the DEGRADED path — the sentinel is present on
+/// disk with NO `.git/info/exclude` entry (i.e. the allocation-time append
+/// failed), so raw `git status` lists it. Without the filter, the sentinel is a
+/// "new changed file" (`post_status \ inspection.changed_files`) and a genuine
+/// no-op agent session is falsely reported as `"verified"`. A regression that
+/// deleted `strip_claim_sentinel(...)` from the post-status path would compile
+/// and pass every other test in the suite — this is the test that catches it.
+#[test]
+fn verify_agent_spawn_artifacts_ignores_claim_only_no_op_session() {
+    let dir = tempdir().unwrap();
+    init_repo(dir.path());
+
+    // ONLY the untracked Simard sentinel, no exclude entry (degraded path).
+    std::fs::write(
+        dir.path().join(ENGINEER_CLAIM_FILE),
+        format!("{}\n", std::process::id()),
+    )
+    .unwrap();
+
+    // Objective deliberately references no issue/PR number so the best-effort
+    // `gh` probe is skipped and the test stays hermetic.
+    let report =
+        verify_agent_spawn_artifacts(&inspection_for(dir.path()), "no-op engineer session");
+
+    assert_eq!(
+        report.status, "unverified",
+        "a session whose only side-effect is the claim sentinel must NOT be reported verified; summary={}",
+        report.summary
+    );
+    assert!(
+        !report.summary.contains(ENGINEER_CLAIM_FILE),
+        "the claim sentinel must never surface in the verification summary; got: {}",
+        report.summary
+    );
+}
+
+/// Control for the filter above: a GENUINE agent-created file alongside the
+/// sentinel must still flip the report to `"verified"` (and only the real file
+/// appears in the evidence). Guards against an over-broad filter that would
+/// swallow real work and hide a productive session.
+#[test]
+fn verify_agent_spawn_artifacts_still_verifies_real_change_alongside_claim() {
+    let dir = tempdir().unwrap();
+    init_repo(dir.path());
+
+    std::fs::write(
+        dir.path().join(ENGINEER_CLAIM_FILE),
+        format!("{}\n", std::process::id()),
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("agent_output.txt"), "real work\n").unwrap();
+
+    let report =
+        verify_agent_spawn_artifacts(&inspection_for(dir.path()), "no-op engineer session");
+
+    assert_eq!(
+        report.status, "verified",
+        "a genuine new file must still verify the session; summary={}",
+        report.summary
+    );
+    assert!(
+        report.summary.contains("agent_output.txt"),
+        "the real change must appear in the verification evidence; got: {}",
+        report.summary
+    );
+    assert!(
+        !report.summary.contains(ENGINEER_CLAIM_FILE),
+        "the claim sentinel must be filtered even when a real change is present; got: {}",
+        report.summary
     );
 }

--- a/src/engineer_worktree/mod.rs
+++ b/src/engineer_worktree/mod.rs
@@ -507,15 +507,25 @@ fn first_existing_ancestor(path: &Path) -> Option<std::path::PathBuf> {
     None
 }
 
-/// Append [`ENGINEER_CLAIM_FILE`] to `worktree_dir`'s git exclude file so the
-/// Simard-managed sentinel is never reported as an untracked change by
-/// `git status` in the target repo (issue #2621).
+/// Append an anchored exclude entry for [`ENGINEER_CLAIM_FILE`] to
+/// `worktree_dir`'s git exclude file so the Simard-managed sentinel is never
+/// reported as an untracked change by `git status` in the target repo (issue
+/// #2621).
 ///
 /// The real exclude path is resolved via `git rev-parse --git-path
 /// info/exclude`, run *inside the worktree* so git returns the correct path
 /// into the linked worktree's git dir (git keeps `info/exclude` in the shared
 /// common dir, which is exactly what we want: excluding the sentinel filename
 /// is harmless and repo-local — `.git/info/exclude` is never committed).
+///
+/// The written pattern is **root-anchored** (`/.simard-engineer-claim`): the
+/// sentinel is only ever placed at the worktree root, and an unanchored bare
+/// filename would (per gitignore semantics) also hide any `subdir/…` file that
+/// happens to share the basename — silently dropping a real agent-created file
+/// from both `inspect_workspace` and `verify_agent_spawn_artifacts`. Anchoring
+/// keeps the exclude semantics identical to the exact-root `strip_claim_sentinel`
+/// filter (verified: an anchored entry in the shared exclude, evaluated from a
+/// linked worktree, hides only the root sentinel).
 ///
 /// The parent directory and file are created if absent, and the append is
 /// idempotent (an exact-line match short-circuits) so repeated allocations
@@ -545,11 +555,17 @@ fn exclude_engineer_claim(worktree_dir: &Path) -> Result<(), String> {
         Err(e) => return Err(format!("read {}: {e}", exclude_path.display())),
     };
 
+    // Root-anchored pattern (leading `/`) so only `<worktree>/.simard-engineer-claim`
+    // is excluded, never a same-basename file nested in a subdirectory.
+    let anchored = format!("/{ENGINEER_CLAIM_FILE}");
+
     // Idempotent: skip if the sentinel is already excluded (exact-line match,
     // ignoring surrounding whitespace so a hand-edited exclude still matches).
+    // A legacy bare `.simard-engineer-claim` line also counts as present so we
+    // never stack a duplicate on a worktree written by an earlier build.
     if existing
         .lines()
-        .any(|line| line.trim() == ENGINEER_CLAIM_FILE)
+        .any(|line| line.trim() == anchored || line.trim() == ENGINEER_CLAIM_FILE)
     {
         return Ok(());
     }
@@ -558,7 +574,7 @@ fn exclude_engineer_claim(worktree_dir: &Path) -> Result<(), String> {
     if !updated.is_empty() && !updated.ends_with('\n') {
         updated.push('\n');
     }
-    updated.push_str(ENGINEER_CLAIM_FILE);
+    updated.push_str(&anchored);
     updated.push('\n');
 
     fs::write(&exclude_path, updated).map_err(|e| format!("write {}: {e}", exclude_path.display()))

--- a/src/engineer_worktree/mod.rs
+++ b/src/engineer_worktree/mod.rs
@@ -339,6 +339,28 @@ impl EngineerWorktree {
             });
         }
 
+        // 4b. Exclude the Simard-managed claim sentinel from `git status` in
+        //     the target repo via the worktree's git exclude file (issue
+        //     #2621). Belt-and-suspenders with the `inspect_workspace`
+        //     sentinel filter: Simard drops `.simard-engineer-claim` into
+        //     every engineer worktree but must NOT depend on each *target*
+        //     repo gitignoring Simard's private infra file. Without this, an
+        //     external governed repo that doesn't gitignore the sentinel makes
+        //     `inspect_workspace().worktree_dirty == true`, so the engineer-
+        //     loop pre-mutation guard aborts every mutating engineer before
+        //     the coding agent is ever spawned — an infinite dispatch loop.
+        //     Fail-loud-but-non-fatal: log at WARN and continue; the
+        //     `inspect_workspace` filter still hides the sentinel if this
+        //     fails.
+        if let Err(e) = exclude_engineer_claim(&dir) {
+            tracing::warn!(
+                target: "simard::engineer_worktree",
+                error = %e,
+                worktree = %dir.display(),
+                "failed to add engineer-claim sentinel to git exclude; inspect_workspace filter still hides it",
+            );
+        }
+
         // 5. Write the per-worktree liveness sentinel (issue #1213, refined
         //    in #1238). If the sweep ever runs against this worktree while
         //    git's registration is transiently missing, the live PID +
@@ -470,4 +492,61 @@ fn first_existing_ancestor(path: &Path) -> Option<std::path::PathBuf> {
         cur = p.parent();
     }
     None
+}
+
+/// Append [`ENGINEER_CLAIM_FILE`] to `worktree_dir`'s git exclude file so the
+/// Simard-managed sentinel is never reported as an untracked change by
+/// `git status` in the target repo (issue #2621).
+///
+/// The real exclude path is resolved via `git rev-parse --git-path
+/// info/exclude`, run *inside the worktree* so git returns the correct path
+/// into the linked worktree's git dir (git keeps `info/exclude` in the shared
+/// common dir, which is exactly what we want: excluding the sentinel filename
+/// is harmless and repo-local — `.git/info/exclude` is never committed).
+///
+/// The parent directory and file are created if absent, and the append is
+/// idempotent (an exact-line match short-circuits) so repeated allocations
+/// against the same parent repo never duplicate the entry.
+fn exclude_engineer_claim(worktree_dir: &Path) -> Result<(), String> {
+    let raw = git_capture(worktree_dir, &["rev-parse", "--git-path", "info/exclude"])?;
+    let rel = raw.trim();
+    if rel.is_empty() {
+        return Err("`git rev-parse --git-path info/exclude` returned empty output".to_string());
+    }
+    let candidate = Path::new(rel);
+    let exclude_path = if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        // git resolves the path relative to the worktree cwd it was invoked in.
+        worktree_dir.join(candidate)
+    };
+
+    if let Some(parent) = exclude_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("create exclude parent {}: {e}", parent.display()))?;
+    }
+
+    let existing = match fs::read_to_string(&exclude_path) {
+        Ok(contents) => contents,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(format!("read {}: {e}", exclude_path.display())),
+    };
+
+    // Idempotent: skip if the sentinel is already excluded (exact-line match,
+    // ignoring surrounding whitespace so a hand-edited exclude still matches).
+    if existing
+        .lines()
+        .any(|line| line.trim() == ENGINEER_CLAIM_FILE)
+    {
+        return Ok(());
+    }
+
+    let mut updated = existing;
+    if !updated.is_empty() && !updated.ends_with('\n') {
+        updated.push('\n');
+    }
+    updated.push_str(ENGINEER_CLAIM_FILE);
+    updated.push('\n');
+
+    fs::write(&exclude_path, updated).map_err(|e| format!("write {}: {e}", exclude_path.display()))
 }

--- a/src/engineer_worktree/mod.rs
+++ b/src/engineer_worktree/mod.rs
@@ -352,7 +352,20 @@ impl EngineerWorktree {
         //     Fail-loud-but-non-fatal: log at WARN and continue; the
         //     `inspect_workspace` filter still hides the sentinel if this
         //     fails.
-        if let Err(e) = exclude_engineer_claim(&dir) {
+        //
+        //     Serialized under `worktree_mutation_lock` (the same lock guarding
+        //     `git worktree add`): `git rev-parse --git-path info/exclude`
+        //     resolves to the *shared common* git dir for linked worktrees, so
+        //     concurrent allocations against the same parent repo would
+        //     otherwise race on a non-atomic read-modify-write of that shared
+        //     file and could clobber the repo's pre-existing exclude entries.
+        let exclude_result = {
+            let _guard = worktree_mutation_lock()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            exclude_engineer_claim(&dir)
+        };
+        if let Err(e) = exclude_result {
             tracing::warn!(
                 target: "simard::engineer_worktree",
                 error = %e,

--- a/src/engineer_worktree/tests_extra.rs
+++ b/src/engineer_worktree/tests_extra.rs
@@ -406,13 +406,47 @@ fn allocate_excludes_claim_sentinel_from_git_status() {
         }
     };
     let exclude_body = fs::read_to_string(&exclude_path).expect("exclude file present");
+    let anchored = format!("/{}", super::ENGINEER_CLAIM_FILE);
     let sentinel_lines = exclude_body
         .lines()
-        .filter(|l| l.trim() == super::ENGINEER_CLAIM_FILE)
+        .filter(|l| l.trim() == anchored)
         .count();
     assert_eq!(
         sentinel_lines, 1,
-        "exclude must contain the sentinel exactly once (idempotent append); got:\n{exclude_body}"
+        "exclude must contain the anchored sentinel exactly once (idempotent append); got:\n{exclude_body}"
+    );
+
+    wt.cleanup().expect("cleanup");
+}
+
+/// Issue #2621 (hardening): the exclude entry is root-anchored, so a genuine
+/// agent-created file that merely shares the sentinel's basename in a
+/// subdirectory is NOT silently hidden from `git status` (and therefore is
+/// still counted by `inspect_workspace` / `verify_agent_spawn_artifacts`).
+#[test]
+#[serial_test::serial]
+fn allocate_exclude_does_not_hide_subdir_same_basename() {
+    let parent_dir = tempdir().unwrap();
+    let state_dir = tempdir().unwrap();
+    let parent_repo = init_parent_repo(parent_dir.path());
+
+    let wt = EngineerWorktree::allocate(&parent_repo, state_dir.path(), "claim-subdir")
+        .expect("allocate");
+
+    // A real change nested under a subdir that happens to share the sentinel's
+    // basename. With an UNANCHORED exclude this would be swallowed; with the
+    // root-anchored pattern it must still surface as an untracked change.
+    let nested_dir = wt.path().join("subdir");
+    fs::create_dir_all(&nested_dir).unwrap();
+    fs::write(nested_dir.join(super::ENGINEER_CLAIM_FILE), "real\n").unwrap();
+
+    let status = git_output(
+        wt.path(),
+        &["status", "--porcelain", "--untracked-files=all"],
+    );
+    assert!(
+        status.contains("subdir/.simard-engineer-claim"),
+        "a same-basename file in a subdirectory must NOT be hidden by the anchored exclude; got:\n{status}"
     );
 
     wt.cleanup().expect("cleanup");
@@ -444,12 +478,10 @@ fn exclude_engineer_claim_is_idempotent_and_preserves_existing_entries() {
         body.contains("*.log"),
         "pre-existing user exclude entry must be preserved; got:\n{body}"
     );
-    let sentinel_lines = body
-        .lines()
-        .filter(|l| l.trim() == super::ENGINEER_CLAIM_FILE)
-        .count();
+    let anchored = format!("/{}", super::ENGINEER_CLAIM_FILE);
+    let sentinel_lines = body.lines().filter(|l| l.trim() == anchored).count();
     assert_eq!(
         sentinel_lines, 1,
-        "sentinel must be appended exactly once across repeated calls; got:\n{body}"
+        "anchored sentinel must be appended exactly once across repeated calls; got:\n{body}"
     );
 }

--- a/src/engineer_worktree/tests_extra.rs
+++ b/src/engineer_worktree/tests_extra.rs
@@ -351,3 +351,69 @@ fn sweep_removes_unregistered_dir_with_dead_engineer_claim() {
         report.removed_orphan_dirs
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #2621 — the Simard-managed claim sentinel must never surface as an
+// untracked change in the target repo, even when that repo does NOT gitignore
+// `.simard-engineer-claim`. `allocate` appends it to the worktree's
+// `.git/info/exclude`, so `git status` reports a clean tree and the engineer-
+// loop pre-mutation guard does not trip.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[serial_test::serial]
+fn allocate_excludes_claim_sentinel_from_git_status() {
+    let parent_dir = tempdir().unwrap();
+    let state_dir = tempdir().unwrap();
+    // NOTE: `init_parent_repo` deliberately does NOT gitignore the sentinel —
+    // this mirrors an external governed repo (e.g. agent-kgpacks-rs) that has
+    // no knowledge of Simard's private infra file.
+    let parent_repo = init_parent_repo(parent_dir.path());
+
+    let wt = EngineerWorktree::allocate(&parent_repo, state_dir.path(), "claim-exclude")
+        .expect("allocate");
+
+    // The sentinel MUST exist on disk (it's the liveness claim)...
+    let claim = wt.path().join(super::ENGINEER_CLAIM_FILE);
+    assert!(
+        claim.exists(),
+        "claim sentinel must be written to the worktree"
+    );
+
+    // ...but MUST NOT appear in `git status`, because allocate excluded it.
+    let status = git_output(
+        wt.path(),
+        &["status", "--porcelain", "--untracked-files=all"],
+    );
+    assert!(
+        !status.contains(super::ENGINEER_CLAIM_FILE),
+        "claim sentinel must be excluded from git status; got:\n{status}"
+    );
+    assert!(
+        status.trim().is_empty(),
+        "worktree containing only the claim sentinel must be clean; got:\n{status}"
+    );
+
+    // The exclude entry must be discoverable via git's own path resolution.
+    let exclude_rel = git_output(wt.path(), &["rev-parse", "--git-path", "info/exclude"]);
+    let exclude_rel = exclude_rel.trim();
+    let exclude_path = {
+        let p = Path::new(exclude_rel);
+        if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            wt.path().join(p)
+        }
+    };
+    let exclude_body = fs::read_to_string(&exclude_path).expect("exclude file present");
+    let sentinel_lines = exclude_body
+        .lines()
+        .filter(|l| l.trim() == super::ENGINEER_CLAIM_FILE)
+        .count();
+    assert_eq!(
+        sentinel_lines, 1,
+        "exclude must contain the sentinel exactly once (idempotent append); got:\n{exclude_body}"
+    );
+
+    wt.cleanup().expect("cleanup");
+}

--- a/src/engineer_worktree/tests_extra.rs
+++ b/src/engineer_worktree/tests_extra.rs
@@ -417,3 +417,39 @@ fn allocate_excludes_claim_sentinel_from_git_status() {
 
     wt.cleanup().expect("cleanup");
 }
+
+/// Issue #2621 (hardening): the exclude append must be idempotent AND must
+/// never clobber the parent repo's pre-existing `.git/info/exclude` entries,
+/// even across repeated allocations against the same repo. This is the
+/// single-threaded proof that the read-modify-write preserves content; the
+/// concurrent case is additionally serialized under `worktree_mutation_lock`
+/// at the `allocate` call site.
+#[test]
+#[serial_test::serial]
+fn exclude_engineer_claim_is_idempotent_and_preserves_existing_entries() {
+    let repo_dir = tempdir().unwrap();
+    let repo = init_parent_repo(repo_dir.path());
+
+    // Pre-seed a genuine user exclude pattern.
+    let exclude_path = repo.join(".git/info/exclude");
+    fs::create_dir_all(exclude_path.parent().unwrap()).unwrap();
+    fs::write(&exclude_path, "# user rules\n*.log\n").unwrap();
+
+    // Two appends mirror two allocations against the same parent repo.
+    super::exclude_engineer_claim(&repo).expect("first exclude append");
+    super::exclude_engineer_claim(&repo).expect("second exclude append (idempotent)");
+
+    let body = fs::read_to_string(&exclude_path).expect("exclude present");
+    assert!(
+        body.contains("*.log"),
+        "pre-existing user exclude entry must be preserved; got:\n{body}"
+    );
+    let sentinel_lines = body
+        .lines()
+        .filter(|l| l.trim() == super::ENGINEER_CLAIM_FILE)
+        .count();
+    assert_eq!(
+        sentinel_lines, 1,
+        "sentinel must be appended exactly once across repeated calls; got:\n{body}"
+    );
+}

--- a/tests/qa-scenarios/engineer-claim-sentinel-guard.yaml
+++ b/tests/qa-scenarios/engineer-claim-sentinel-guard.yaml
@@ -1,0 +1,29 @@
+name: engineer-claim-sentinel-guard
+app_type: cli
+description: |
+  Regression coverage for issue #2621: the Simard-managed
+  `.simard-engineer-claim` sentinel must never trip the engineer-loop
+  pre-mutation guard in a target repo that does not gitignore it.
+
+  Belt-and-suspenders fix, verified end to end:
+  - `engineer_worktree::allocate` appends the sentinel to the worktree's
+    `.git/info/exclude` so `git status` reports a clean tree (idempotent).
+  - `inspect_workspace` filters the sentinel out of `changed_files` and
+    `worktree_dirty`, while still flagging genuine changes.
+
+  Schema note: the pinned `@gadugi/agentic-test` CLI runner only gates on
+  `run`-step exit codes and reads command text from `params.command`, so the
+  three regression tests are run under a single `bash -lc` wrapper that exits
+  zero only when all three report a passing "test result: ok".
+metadata:
+  tags:
+    - cli
+agents:
+  - name: cli-agent
+    type: cli
+    command: bash
+steps:
+  - action: run
+    params:
+      command: "bash -lc 'set -euo pipefail; OUT=$(cargo test --lib -- engineer_worktree::tests_extra::allocate_excludes_claim_sentinel_from_git_status engineer_loop::tests_claim_sentinel::inspect_workspace_treats_claim_only_worktree_as_clean engineer_loop::tests_claim_sentinel::inspect_workspace_still_flags_real_changes_alongside_claim 2>&1); echo \"$OUT\"; echo \"$OUT\" | grep -q \"3 passed\"'"
+    timeout: 300000


### PR DESCRIPTION
## Summary

Fixes #2621. The engineer-loop **pre-mutation guard** (`if analyzed.is_mutating() && inspection.worktree_dirty`) aborted every *mutating* engineer whose target repo did **not** gitignore Simard's private `.simard-engineer-claim` sentinel. Simard drops that sentinel into every engineer worktree but relied on the *target* repo's `.gitignore` to hide it, so external governed repos (e.g. `agent-kgpacks-rs`) reported `worktree_dirty == true` on the untracked sentinel and the guard failed Intake **before the coding agent was ever spawned** — an infinite engineer-dispatch loop with zero progress (blocked agent-kgpacks-rs WS #12/#16/#17/#18/#19/#20/#21).

## Fix (repo-agnostic, belt-and-suspenders)

1. **Worktree creation** — `engineer_worktree::allocate` now calls `exclude_engineer_claim`, which appends a **root-anchored** `/.simard-engineer-claim` line to the new worktree's git exclude file (resolved via `git rev-parse --git-path info/exclude`). Idempotent (exact-line match short-circuits, also matches a legacy bare entry), creates the file/parent dir if absent, serialized under `worktree_mutation_lock` (the shared common `info/exclude` is a read-modify-write race across concurrent allocations), best-effort non-fatal with a WARN log.
2. **`inspect_workspace`** — filters `ENGINEER_CLAIM_FILE` out of both `changed_files` and the `worktree_dirty` determination via the shared `strip_claim_sentinel` helper, so a worktree whose only change is the sentinel is treated as clean while genuine changes still count. The same filter is applied to `verify_agent_spawn_artifacts` (the post-session evidence report), so the sentinel can't be reported as a spurious "new changed file" on the degraded path where the exclude append failed.

Root-anchoring keeps the exclude/filter semantics identical (exact root path only): a genuine agent-created `subdir/.simard-engineer-claim` is NOT hidden.

## Merge-ready evidence

### 1. qa-team scenarios (validated + run)
`tests/qa-scenarios/engineer-claim-sentinel-guard.yaml`:
- `gadugi-test validate -f tests/qa-scenarios/engineer-claim-sentinel-guard.yaml` → `✓ Scenario "engineer-claim-sentinel-guard" is valid` (Valid files: 1, Invalid: 0).
- `gadugi-test run -d tests/qa-scenarios -s engineer-claim-sentinel-guard` → `✓ Passed: 1  ✗ Failed: 0` (`All tests passed!`). The scenario runs the three core regression tests under a single `bash -lc` wrapper that exits zero only when `cargo test` reports `3 passed`.

**Regression tests (9 total; all pass):**
- `engineer_loop::tests_claim_sentinel::inspect_workspace_treats_claim_only_worktree_as_clean` — the **exact #2621 repro**: a worktree whose only change is `.simard-engineer-claim` reports `worktree_dirty == false` **and** empty `changed_files`. Since the pre-mutation guard reduces to `is_mutating() && worktree_dirty`, this proves the guard passes.
- `inspect_workspace_still_flags_real_changes_alongside_claim` — a genuine change alongside the sentinel still marks the tree dirty (no over-broad filter).
- `verify_agent_spawn_artifacts_ignores_claim_only_no_op_session` — degraded path (sentinel present, no exclude entry): a no-op session is `"unverified"`, not a false `"verified"`. **Verified to fail if the post-status filter is removed** (negative control: without the filter the test fails with `left: "verified"`).
- `verify_agent_spawn_artifacts_still_verifies_real_change_alongside_claim` — a real new file still verifies and only the real change appears in the evidence.
- `strip_claim_sentinel_removes_only_the_root_sentinel`, `strip_claim_sentinel_keeps_subdir_same_basename` — shared-filter unit coverage.
- `engineer_worktree::tests_extra::allocate_excludes_claim_sentinel_from_git_status` — a freshly allocated worktree (parent repo does **not** gitignore the sentinel) reports a clean `git status`; exclude entry present exactly once (idempotent).
- `allocate_exclude_does_not_hide_subdir_same_basename` — root-anchored exclude does not hide a same-basename file in a subdirectory.
- `exclude_engineer_claim_is_idempotent_and_preserves_existing_entries` — repeated appends don't duplicate and preserve pre-existing exclude entries.

Local suite: `engineer_loop::` **234 passed / 0 failed**, `engineer_worktree::` **42 passed / 0 failed**.

### 2. Docs / changed surfaces
No user-facing surface change (no CLI/API/output change). Internal-only, changed surfaces:
- `engineer_worktree::allocate` now writes a repo-local `.git/info/exclude` entry (uncommitted, never pushed).
- `inspect_workspace` and `verify_agent_spawn_artifacts` ignore Simard's private sentinel.
Justification: these are private Simard infrastructure behaviors with no external contract; the sentinel (`.simard-engineer-claim`) is Simard-internal. Note (non-blocking): the exclude entry also benignly widens the daemon sweep / GC "recoverable work" probes to no longer treat the ever-present sentinel as work in non-gitignoring repos; genuine uncommitted work is still detected (root anchor), so no data-loss hazard.

### 3. quality-audit (≥3 SEEK→VALIDATE→FIX cycles, ended clean)
- **Cycle 1 (SEEK, breadth) → VALIDATE (3 independent lenses):** mandatory zero-stub scan of production changes — **clean** (no `todo!`/`unimplemented!`/`bail!("TODO")`/`panic!`/stub `Ok(())`; `exclude_engineer_claim` uses `map_err`/`?` throughout; all `unwrap`/`expect` are test-only). `cargo fmt --all -- --check` clean; `cargo clippy --all-targets --all-features --locked -- -D warnings` clean. Guard-coverage analysis: the guard is exactly `is_mutating() && worktree_dirty`, fully covered by the repro test. Deadlock analysis: step-4 `git worktree add` lock is dropped at its block end before step-4b re-acquires it (`std::sync::Mutex` non-reentrant, no nesting). Validated by two independent `code-review` agents.
- **Cycle 2 (VALIDATE, depth):** an independent reviewer **empirically** verified the git behaviors rather than reasoning abstractly: `git rev-parse --git-path info/exclude` returns an absolute path into the shared common dir for linked worktrees and a cwd-relative path in normal repos (both handled by the `is_absolute()` branch + `join` fallback); a root-anchored entry in the *shared* exclude hides only each worktree-root sentinel (a `subdir/` same-basename file still shows `??`, main repo unaffected); idempotency handles missing file / no-trailing-newline / legacy bare line; `strip_claim_sentinel` is applied identically to both `git status` consumers so `count_new_status_paths` (after \ before) cannot reintroduce the sentinel. **Zero critical/high/medium correctness or security findings.**
- **Cycle 3 (FIX + re-VALIDATE):** the one actionable finding — `verify_agent_spawn_artifacts`'s sentinel filter had no *behavioral* test (a regression deleting it would compile and pass every other test) — was **fixed** by adding the two `verify_agent_spawn_artifacts_*` tests above, proven to catch the regression via a negative control (removed the filter → test failed with the exact false-`verified` behavior → restored). Final re-scan: stub scan clean, fmt clean, clippy `-D warnings` clean, `engineer_loop::` 234 passed.

**Final cycle clean:** zero critical/high; zero medium correctness/security findings. The single medium coverage finding was fixed within the audit.

### 4. CI
**CI is 100% green on the current PR head `aeaa7e62764c638ca0187be5e28050cbe17cc80e`** — all 16 required checks concluded `SUCCESS`, 0 failing, 0 pending. Confirmed green workflow runs:
- **`verify`** — SUCCESS: https://github.com/rysweet/Simard/actions/runs/28761097315 and https://github.com/rysweet/Simard/actions/runs/28761096366 (jobs: `pre-commit`, `cargo-audit`, `cargo-deny`, `cargo-vet`, `npm-audit`, `install-real`, `e2e-dashboard`).
- **`coverage`** — SUCCESS: https://github.com/rysweet/Simard/actions/runs/28761097304
- **GitGuardian Security Checks** — SUCCESS.

`gh pr checks 2623` rollup: 15 pass + 1 security pass, 0 fail/pending. `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`. Local pre-push gates (mirror CI `verify.yml`) were also all green on this head: `cargo fmt --all -- --check`, `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)`, `cargo clippy --all-targets --all-features --locked -- -D warnings`. Branch is rebased onto latest `origin/main`.

### 5. Verdict — **READY TO MERGE**
**This PR is ready to merge.** Rationale: all six merge-ready criteria have substantive, concrete evidence tied to the decision — (1) qa-team scenario `engineer-claim-sentinel-guard.yaml` validated (`✓ Scenario … is valid`) and run (`✓ Passed: 1 ✗ Failed: 0`), backed by 9 named regression tests all passing including the exact #2621 repro `inspect_workspace_treats_claim_only_worktree_as_clean`; (2) changed surfaces are enumerated with internal-only justification (no user-facing contract change — the sentinel is Simard-private infra); (3) three explicit SEEK→VALIDATE→FIX quality-audit cycles ending clean, with a negative-control proof that the `verify_agent_spawn_artifacts` filter test catches its own regression; (4) CI 100% green on head `aeaa7e62` with the run links above; (6) the diff is focused on exactly 5 files scoped to the fix with no unrelated edits. The change is a targeted, root-anchored filename filter over git's stable porcelain `git status --short` output plus a best-effort, non-fatal `.git/info/exclude` append — low blast radius, no cognition/memory-consolidation logic touched, no brittle model-output parsing. It resolves the P1 infinite engineer-dispatch loop blocking the agent-kgpacks-rs WS cascade. No blocking findings remain.

### 6. Diff focused
Scoped to the fix: `engineer_loop/mod.rs` (shared `strip_claim_sentinel` filter + both consumers + test-module registration), `engineer_loop/tests_claim_sentinel.rs`, `engineer_worktree/mod.rs` (`exclude_engineer_claim` helper + call site), `engineer_worktree/tests_extra.rs`, one qa-scenario. No unrelated edits.

Closes #2621

