### PR TITLE
fix(signal): pin idle-liveness turn-lifecycle parity (no wall-clock cap)

### DIFF
--- a/src/signal_conversation/channel.rs
+++ b/src/signal_conversation/channel.rs
@@ -657,6 +657,28 @@ fn load_meeting_system_prompt() -> String {
     std::fs::read_to_string(&path).unwrap_or_default()
 }
 
+/// The [`crate::identity::OperatingMode`] the Signal channel opens its agent
+/// session in.
+///
+/// This MUST remain [`crate::identity::OperatingMode::Meeting`]. Meeting mode is
+/// the seam that routes the session through
+/// [`crate::meeting_backend::agent_proxy::PersistentAgentProxy`], whose turn
+/// lifecycle reaps the agent child **only on idle-liveness** — no output for a
+/// generous window, with every streamed chunk resetting the clock — and
+/// **never on a wall-clock elapsed-time cap**. That is precisely what gives the
+/// Signal channel turn-lifecycle parity with the meeting REPL and dashboard
+/// chat: a long-but-productive turn is never killed.
+///
+/// Changing this to any non-Meeting mode would drop Signal onto the per-turn
+/// adapter path and silently reintroduce the wall-clock turn timeout that
+/// issue #2607 forbids, breaking the cross-transport parity issue #2604
+/// requires. The `signal_opens_agent_in_meeting_mode_for_idle_liveness_parity`
+/// regression test pins this decision. (Idle-liveness: #2581; hours-scale
+/// default: PR #2608.)
+pub(crate) const fn signal_agent_mode() -> crate::identity::OperatingMode {
+    crate::identity::OperatingMode::Meeting
+}
+
 /// Open a Meeting-mode agent session for the Signal channel, mirroring the CLI
 /// and dashboard backends so all three channels get identical behavior.
 fn open_signal_agent_session() -> Option<Box<dyn crate::base_types::BaseTypeSession>> {
@@ -667,14 +689,11 @@ fn open_signal_agent_session() -> Option<Box<dyn crate::base_types::BaseTypeSess
             return None;
         }
     };
-    match crate::session_builder::SessionBuilder::new(
-        crate::identity::OperatingMode::Meeting,
-        provider,
-    )
-    .node_id("signal-channel")
-    .address("signal-channel://local")
-    .adapter_tag("signal")
-    .open()
+    match crate::session_builder::SessionBuilder::new(signal_agent_mode(), provider)
+        .node_id("signal-channel")
+        .address("signal-channel://local")
+        .adapter_tag("signal")
+        .open()
     {
         Ok(s) => Some(s),
         Err(e) => {

--- a/src/signal_conversation/tests.rs
+++ b/src/signal_conversation/tests.rs
@@ -360,3 +360,33 @@ own_device_id = 4
         );
     }
 }
+
+// ── Turn-lifecycle parity: Signal inherits idle-liveness (no wall-clock cap) ──
+
+/// Regression guard for issues #2604 and #2607.
+///
+/// The Signal channel must open its agent session in
+/// [`crate::identity::OperatingMode::Meeting`] so every turn runs through the
+/// [`crate::meeting_backend::agent_proxy::PersistentAgentProxy`] idle-liveness
+/// lifecycle — reap the child only after a generous window of *no output*
+/// (every streamed chunk resets the clock), never on elapsed wall-clock time.
+/// That is the cross-transport parity #2604 requires and the "no wall-clock
+/// turn timeout" #2607 mandates; the hours-scale idle default that governs it
+/// is PR #2608.
+///
+/// If [`super::channel::signal_agent_mode`] is ever flipped to a non-Meeting
+/// mode, Signal falls back onto the per-turn adapter and the wall-clock turn
+/// timeout that kills long-but-productive turns returns silently. This test
+/// fails loudly in that case and points back to the parity requirement.
+#[test]
+fn signal_opens_agent_in_meeting_mode_for_idle_liveness_parity() {
+    use crate::identity::OperatingMode;
+
+    assert_eq!(
+        super::channel::signal_agent_mode(),
+        OperatingMode::Meeting,
+        "Signal must open its agent in Meeting mode so turns inherit \
+         PersistentAgentProxy idle-liveness (no wall-clock per-turn cap); \
+         see issues #2604 and #2607",
+    );
+}


### PR DESCRIPTION
## What

Locks the **Signal** channel to the idle-liveness turn lifecycle (no wall-clock per-turn timeout), completing the cross-transport parity tracked by #2604 / #2607 and finishing the work PR #2608 started for the meeting surface.

## Why

The idle-liveness / no-wall-clock-timeout turn-lifecycle fix had to span **dashboard, meeting, AND signal** (#2604). Meeting got the hours-scale idle default in #2608; dashboard and signal route through the same `MeetingBackend` → `PersistentAgentProxy` path.

On `main`, Signal **already** inherits idle-liveness: `open_signal_agent_session()` builds its `SessionBuilder` in `OperatingMode::Meeting`, and Meeting mode is the seam that routes turns through `PersistentAgentProxy` — which reaps the agent child only on *idle-liveness* (no output for a generous window; every streamed chunk resets the clock) and **never** on a wall-clock elapsed-time cap. `SIMARD_MEETING_IDLE_LIVENESS_SECS` (default 3600s, per #2608) governs it, `0` = unbounded.

The gap #2604/#2607 leaves open is that **nothing locked that wiring**. A future refactor of the signal agent session onto a non-Meeting mode would silently drop it back onto the per-turn adapter and reintroduce the wall-clock turn timeout #2607 forbids — with no test to catch the regression.

## Scope

- `src/signal_conversation/channel.rs` — extract the mode decision into a documented `signal_agent_mode()` returning `OperatingMode::Meeting`, with rationale citing #2604/#2607; call it from `open_signal_agent_session`.
- `src/signal_conversation/tests.rs` — hermetic regression test `signal_opens_agent_in_meeting_mode_for_idle_liveness_parity` pinning the mode. If someone flips signal off Meeting mode, this fails loudly and points back to the parity requirement.

No behavioral change: signal turn handling already runs through the idle-liveness proxy today. This makes the guarantee explicit and regression-proof — the missing "Signal parity + test" acceptance criterion of #2604/#2607.

## Tests

- `cargo test --release --lib signal_conversation::` — **89 passed** (incl. the new test)
- `cargo clippy --release --no-deps -- -D warnings` — clean
- `cargo clippy --all-targets --all-features --locked -- -D warnings` (pre-push) — clean
- `cargo fmt --all -- --check` — clean

Refs #2607, #2604. Follow-up to #2608, #2581, #2612.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>