### PR TITLE
feat(signal): wire Signal conversations into OODA context + graph memory (#2527 follow-up)

### DIFF
--- a/docs/reference/signal-continuous-conversation.md
+++ b/docs/reference/signal-continuous-conversation.md
@@ -1,7 +1,7 @@
 ---
 title: Signal continuous conversation — per-operator durable sessions
 description: Reference for the continuous, multi-turn Signal conversation. One long-lived meeting session per operator identity (keyed by Signal number) is reused across successive inbound messages, appended turn-by-turn, persisted to a durable session store that survives daemon restarts, and controlled by the operator with /new (reset), the existing /help, and the existing /close. Reuses the dashboard-chat session-file envelope and crash-durable persistence pipeline (adding a new per-operator index); preserves the allowlist, identity binding, high-risk gating, and Note-to-Self loop prevention.
-last_updated: 2026-07-05
+last_updated: 2026-07-06
 review_schedule: as-needed
 owner: simard
 doc_type: reference
@@ -42,9 +42,22 @@ The operator controls the conversation lifecycle over Signal: `/new` (alias
 > continuous conversation replaces that single global backend with a
 > **per-operator registry** backed by a **durable session store**.
 
-> **Naming.** This feature adds no `bridge`/`Bridge` symbol. Continuity is
-> expressed in one-Brain / reasoner terms: one meeting **session** per operator,
-> driven by the shared meeting backend.
+> **Also new (issue #2527).** Each per-operator backend is now wired into the
+> **same OODA-loop context and graph cognitive memory as the CLI meeting**. On
+> first touch the operator's system prompt is enriched with live OODA state
+> (recent meetings, decisions, active goals, operator identity, known projects)
+> via the shared `build_enriched_meeting_system_prompt`, and the backend carries
+> its **own** cognitive-memory store, so a `/close` **consolidates** the
+> conversation back into graph memory (episodes, summary facts) — not just the
+> flat handoff bundle. Recall is reached only through `operator_commands_meeting`;
+> the channel never calls `build_live_meeting_context` directly.
+
+> **Naming.** These features add no `bridge`/`Bridge` symbol of their own. The
+> #2527 OODA wiring does call the pre-existing external helper
+> `memory_ipc::launch_writer_bridge`, but binds the returned cognitive-memory
+> handle locally as `memory`. Continuity is expressed in one-Brain / reasoner
+> terms: one meeting **session** per operator, driven by the shared meeting
+> backend.
 
 This reference documents the concepts, the on-disk store, the lifecycle
 commands, the public API, the tracing contract, configuration, and worked
@@ -64,6 +77,8 @@ examples. For channel setup, guardrails, and the wire protocol, see the
 | **Operator index** | The single `operators.json` file mapping each operator identity to its **active** `session_id`. This is how an E.164 (which is not a valid filename) points at a session file. |
 | **Rehydration / resume** | On the first message after a restart, the operator's persisted history is replayed into a fresh `MeetingBackend` (via `restore`) so the agent regains full prior context — not just the transcript. |
 | **Registry** | The in-process `HashMap<operator, MeetingBackend>` the run loop keeps so back-to-back messages reuse the same live backend without touching disk on every turn. |
+| **OODA context** | The live OODA-loop state — recent meetings, decisions, active goals, operator identity, known projects, research topics, improvements — injected into each operator's system prompt on first touch via the shared `build_enriched_meeting_system_prompt` (issue #2527). Makes Simard start a Signal chat already knowing her own state, identical to the CLI meeting. |
+| **Cognitive-memory store** | The per-operator graph-memory handle (`memory_ipc::launch_writer_bridge`, bound as `memory`) each backend carries. It supplies the OODA recall **in** and, on `/close`, consolidates the conversation back **into** graph memory (episodes, summary facts) — bidirectional, not read-only. |
 
 Every Signal turn is routed through the **same** `MeetingBackend`
 (`OperatingMode::Meeting`) used by the CLI meeting REPL and the dashboard chat —
@@ -222,7 +237,7 @@ and `/close` are recognized by the run-loop pre-check on the accepted inbound te
 |-------------------------------------|------|--------|
 | `/new` (alias `/reset`) | **new** | Start a **fresh** conversation for this operator: mint a new `session_id`, point `operators.json` at it, and drop the operator's in-memory backend. The prior session file is left on disk (history is detached, not deleted). The next message begins a brand-new session. Handled entirely in the run loop. |
 | `/help` | pre-existing word | The pre-check intercepts `/help` and replies with a **Signal-specific banner** that also advertises `/new`. Because the interception happens in the run loop, this deliberately **supersedes** the generic meeting `/help` banner **on the Signal channel** — a conscious, documented replacement, not a silent shadow. Never persisted as a turn; never resets. |
-| `/close` | pre-existing word | The pre-check closes the operator's live backend via `MeetingBackend::close` — writing the handoff bundle and carrying decisions onto the goal board exactly as on every channel — replies with the closing summary, and rotates the operator onto a fresh `session_id` so the **next** message begins a new conversation. |
+| `/close` | pre-existing word | The pre-check closes the operator's live backend via `MeetingBackend::close` — writing the handoff bundle, **consolidating the conversation into graph cognitive memory** (episodes, summary facts), and carrying decisions onto the goal board exactly as on every channel — replies with the closing summary, and rotates the operator onto a fresh `session_id` so the **next** message begins a new conversation. |
 
 So the run-loop pre-check owns exactly three words — `/new` (`/reset`), `/help`, and
 `/close`; everything else (the lightweight commands and ordinary turns) continues

--- a/docs/reference/signal-conversation.md
+++ b/docs/reference/signal-conversation.md
@@ -1,7 +1,7 @@
 ---
 title: Signal channel reference
 description: Reference for SignalConversation — the optional, feature-gated ConversationChannel that connects Simard to a locally-run signal-cli JSON-RPC daemon, with a sender allowlist, operator-identity binding, high-risk gating, Note-to-Self (sync-sent) command handling with loop prevention, inbound commands, and outbound notifications.
-last_updated: 2026-07-04
+last_updated: 2026-07-06
 review_schedule: as-needed
 owner: simard
 doc_type: reference
@@ -33,7 +33,10 @@ installation and linking.
 
 > **Naming.** `SignalConversation` is a first-class conversation channel. It does
 > **not** implement, extend, or route through the pre-existing cognitive-memory
-> `BridgeTransport`. No symbol added by this feature contains `bridge`/`Bridge`.
+> `BridgeTransport`. No symbol this feature *defines* contains `bridge`/`Bridge`:
+> the per-operator OODA/graph-memory wiring (issue #2527) does call the external
+> helper `memory_ipc::launch_writer_bridge`, but binds the returned cognitive-
+> memory handle locally as `memory`.
 
 ## Feature gate
 
@@ -374,6 +377,15 @@ conversation** — the session is keyed by operator identity, persisted across d
 restarts, and controlled with `/new` (reset), `/help`, and `/close`. See
 [Signal continuous conversation](./signal-continuous-conversation.md).
 
+Every Signal conversation also starts with the **same live OODA-loop context as
+the CLI meeting** — recent meetings, decisions, active goals, operator identity,
+and known projects are recalled into the system prompt (via the shared
+`build_enriched_meeting_system_prompt`) — and each per-operator backend carries its
+own graph cognitive-memory store, so `/close` **consolidates** the conversation
+back into graph memory (episodes, summary facts), not just the handoff bundle
+(issue #2527). See
+[Signal continuous conversation](./signal-continuous-conversation.md).
+
 ## Notifications out
 
 `SignalConversation::notify` (`src/signal_conversation/channel.rs`) sends a message
@@ -417,8 +429,9 @@ OODA / merge authority / gate ─▶ SignalConversation::notify ─▶ transport
 **Meeting turn / carryover:** identical to every channel — a `Conversation` inbound
 flows through `run_conversation` + `MeetingBackend`, with `/close` writing the
 handoff under `default_handoff_dir()` (`$SIMARD_HANDOFF_DIR`, else
-`<state_root>/meeting_handoffs`, default `~/.simard/meeting_handoffs`) and
-`check_meeting_handoffs` carrying decisions onto the goal board. See
+`<state_root>/meeting_handoffs`, default `~/.simard/meeting_handoffs`),
+**consolidating the conversation into graph cognitive memory** (episodes, summary
+facts), and `check_meeting_handoffs` carrying decisions onto the goal board. See
 [Conversation channels](../architecture/conversation-channel.md).
 
 ## Testing

--- a/src/meeting_backend/closing.rs
+++ b/src/meeting_backend/closing.rs
@@ -518,9 +518,14 @@ impl MeetingBackend {
             }
         }
 
-        // ── Memory consolidation ── (no-op in current production; bridge
-        // is always `None`. Kept for forward compatibility; bounded with
-        // the agent-close budget if a future caller wires a bridge in.)
+        // ── Memory consolidation ── Runs whenever the backend was opened
+        // with a cognitive-memory store (`Some`). The Signal conversation
+        // channel wires a per-operator store in (issue #2527), so a Signal
+        // `/close` consolidates the meeting back into graph cognitive memory
+        // (episodes, summary facts) — not just the flat handoff bundle.
+        // Callers that pass `None` — the CLI meeting REPL and the dashboard
+        // chat, which recall live context into the prompt but do not write
+        // back here — skip it. Bounded with the agent-close budget.
         if let Some(ref bridge) = self.bridge {
             persist::store_enriched_cognitive_memory(
                 &**bridge,

--- a/src/operator_commands_meeting/meeting_session.rs
+++ b/src/operator_commands_meeting/meeting_session.rs
@@ -1,6 +1,7 @@
 use std::io::{self, BufReader};
 
 use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::error::SimardResult;
 use crate::greeting_banner::print_greeting_banner;
 use crate::identity::OperatingMode;
 use crate::meeting_repl::run_meeting_repl;
@@ -13,6 +14,24 @@ use super::live_context::build_live_meeting_context;
 fn load_meeting_system_prompt() -> String {
     let path = prompt_root().join("simard/meeting_system.md");
     std::fs::read_to_string(&path).unwrap_or_default()
+}
+
+/// Build the full meeting system prompt: the base `meeting_system.md` identity
+/// prompt plus the live OODA-loop state recalled from the graph cognitive
+/// memory (past meetings, decisions, active goals, operator identity, known
+/// projects, research topics, improvements).
+///
+/// This is the single source of truth for "what context a Simard conversation
+/// starts with". Every operator↔Simard channel — the CLI meeting REPL and the
+/// Signal conversation channel — builds its system prompt through this helper
+/// so all channels get identical OODA-loop context and the same graph-memory
+/// wiring. Bridge errors propagate per PHILOSOPHY.md (no silent degradation).
+pub(crate) fn build_enriched_meeting_system_prompt(
+    bridge: &dyn CognitiveMemoryOps,
+) -> SimardResult<String> {
+    let base_prompt = load_meeting_system_prompt();
+    let live_context = build_live_meeting_context(bridge)?;
+    Ok(format!("{base_prompt}\n\n{live_context}"))
 }
 
 /// Launch a cognitive memory backend suitable for meeting mode.
@@ -64,9 +83,7 @@ pub fn run_meeting_repl_command(topic: &str) -> Result<(), Box<dyn std::error::E
     print_greeting_banner(Some(&*bridge));
 
     let agent_session = open_meeting_agent_session();
-    let base_prompt = load_meeting_system_prompt();
-    let live_context = build_live_meeting_context(&*bridge)?;
-    let meeting_system_prompt = format!("{base_prompt}\n\n{live_context}");
+    let meeting_system_prompt = build_enriched_meeting_system_prompt(&*bridge)?;
 
     if agent_session.is_some() {
         tracing::info!("Meeting agent ready");

--- a/src/operator_commands_meeting/mod.rs
+++ b/src/operator_commands_meeting/mod.rs
@@ -15,5 +15,6 @@ pub use goal_curation::{run_goal_curation_probe, run_goal_curation_read_probe};
 pub use improvement_curation::{
     run_improvement_curation_probe, run_improvement_curation_read_probe,
 };
+pub(crate) use meeting_session::build_enriched_meeting_system_prompt;
 pub use meeting_session::run_meeting_repl_command;
 pub use probes::{run_meeting_probe, run_meeting_read_probe};

--- a/src/operator_commands_meeting/test_support.rs
+++ b/src/operator_commands_meeting/test_support.rs
@@ -47,6 +47,22 @@ pub fn bridge_with_meeting_facts() -> CognitiveMemoryBridge {
     CognitiveMemoryBridge::new(Box::new(transport))
 }
 
+/// Create a bridge whose `search_facts` (and every other method) fails.
+///
+/// Used to pin the "no silent degradation" contract (PHILOSOPHY.md): recall
+/// failures must propagate out of `build_live_meeting_context` and
+/// `build_enriched_meeting_system_prompt`, never be swallowed into a partial or
+/// empty prompt.
+pub fn erroring_bridge() -> CognitiveMemoryBridge {
+    let transport = InMemoryBridgeTransport::new("test-error", |method, _params| {
+        Err(crate::bridge::BridgeErrorPayload {
+            code: crate::bridge::BRIDGE_ERROR_INTERNAL,
+            message: format!("simulated recall failure on {method}"),
+        })
+    });
+    CognitiveMemoryBridge::new(Box::new(transport))
+}
+
 /// Create a bridge that returns facts for a specific query prefix.
 pub fn bridge_with_specific_facts(
     prefix: &'static str,

--- a/src/operator_commands_meeting/tests_live_context.rs
+++ b/src/operator_commands_meeting/tests_live_context.rs
@@ -397,3 +397,88 @@ fn all_types_contains_error_handling() {
     let ctx = build_live_meeting_context(&bridge).unwrap();
     assert!(ctx.contains("Add better error handling"));
 }
+
+// ── build_enriched_meeting_system_prompt ────────────────────────────
+//
+// The enriched prompt is the single source of truth for "what context a
+// Simard conversation starts with", shared by every operator↔Simard channel
+// (CLI meeting REPL + Signal). These tests pin that it is exactly the base
+// `meeting_system.md` identity prompt followed by the live OODA-loop context
+// recalled from graph cognitive memory — and that recall failures propagate
+// (PHILOSOPHY.md: no silent degradation).
+
+use super::build_enriched_meeting_system_prompt;
+
+#[test]
+fn enriched_prompt_appends_live_context_after_base() {
+    let bridge = bridge_with_meeting_facts();
+    let enriched = build_enriched_meeting_system_prompt(&bridge).unwrap();
+    let live = build_live_meeting_context(&bridge).unwrap();
+
+    // The enriched prompt is `{base}\n\n{live}` — regardless of whether the base
+    // asset is present in the test env, the live context is the suffix, joined
+    // by exactly one blank line. This pins the DRY join used by both channels.
+    assert!(
+        enriched.ends_with(&format!("\n\n{live}")),
+        "enriched prompt must end with the live OODA context, blank-line separated"
+    );
+    assert!(
+        enriched.contains("## Live State (from cognitive memory)"),
+        "enriched prompt must carry the recalled live-state section"
+    );
+}
+
+#[test]
+fn enriched_prompt_carries_recalled_facts() {
+    let bridge = bridge_with_meeting_facts();
+    let enriched = build_enriched_meeting_system_prompt(&bridge).unwrap();
+    // A fact recalled from graph memory reaches the system prompt verbatim, so
+    // a Signal/CLI session starts already knowing Simard's own OODA state.
+    assert!(
+        enriched.contains("Discussed deployment timeline"),
+        "recalled meeting fact must appear in the enriched prompt"
+    );
+}
+
+#[test]
+fn enriched_prompt_includes_all_fact_types() {
+    let bridge = bridge_with_all_fact_types();
+    let enriched = build_enriched_meeting_system_prompt(&bridge).unwrap();
+    for expected in [
+        "Previous Meeting Summaries",
+        "Past Decisions",
+        "Active Goals",
+        "Operator Context",
+        "Known Projects",
+        "Research Topics",
+        "Improvement Backlog",
+    ] {
+        assert!(
+            enriched.contains(expected),
+            "enriched prompt missing OODA section: {expected}"
+        );
+    }
+}
+
+#[test]
+fn enriched_prompt_propagates_bridge_errors() {
+    // No silent degradation: if recall fails, the enriched prompt is NOT built
+    // from a partial/bare base — the error propagates so the caller fails loud.
+    let bridge = erroring_bridge();
+    let result = build_enriched_meeting_system_prompt(&bridge);
+    assert!(
+        result.is_err(),
+        "recall failure must propagate out of build_enriched_meeting_system_prompt"
+    );
+}
+
+#[test]
+fn live_context_propagates_bridge_errors() {
+    // Companion contract for the underlying recall builder.
+    let bridge = erroring_bridge();
+    let result = build_live_meeting_context(&bridge);
+    assert!(
+        result.is_err(),
+        "recall failure must propagate out of build_live_meeting_context"
+    );
+}

--- a/src/operator_commands_meeting/tests_live_context.rs
+++ b/src/operator_commands_meeting/tests_live_context.rs
@@ -409,8 +409,19 @@ fn all_types_contains_error_handling() {
 
 use super::build_enriched_meeting_system_prompt;
 
+#[serial_test::serial(cognitive_memory)]
 #[test]
 fn enriched_prompt_appends_live_context_after_base() {
+    // `build_live_meeting_context` resolves the operator name from the
+    // process-global `SIMARD_OPERATOR_NAME` env var. This test builds the live
+    // context twice (once inside the enriched prompt, once directly) and
+    // compares them as a suffix, so it must serialize with — and hold the lock
+    // against — the other env-mutating tests and pin the var to a deterministic
+    // state. Otherwise a concurrent mutation landing between the two builds
+    // would make the two contexts differ and the suffix check flake.
+    let _lock = ENV_MUTEX.lock().unwrap();
+    unsafe { std::env::remove_var("SIMARD_OPERATOR_NAME") };
+
     let bridge = bridge_with_meeting_facts();
     let enriched = build_enriched_meeting_system_prompt(&bridge).unwrap();
     let live = build_live_meeting_context(&bridge).unwrap();

--- a/src/signal_conversation/channel.rs
+++ b/src/signal_conversation/channel.rs
@@ -7,6 +7,13 @@
 //! **same** meeting engine and handoff/goal-carryover chain as the CLI and
 //! dashboard channels.
 //!
+//! Each operator's conversation is also wired into the **same OODA-loop context
+//! and graph cognitive memory as the CLI meeting** (issue #2527): its system
+//! prompt starts with live OODA state (recent meetings, decisions, active goals,
+//! operator identity, known projects) and each per-operator backend carries its
+//! own cognitive-memory store, so a `/close` consolidates the conversation back
+//! into graph memory (episodes, summary facts) — not just the flat handoff bundle.
+//!
 //! The three remote-command guardrails from the task live here and are enforced
 //! before anything reaches the shared driver:
 //! - **(a) sender allowlist** — [`Allowlist::authorize`] is applied in
@@ -24,9 +31,12 @@
 //!
 //! # Naming
 //!
-//! Nothing here is named `bridge`/`Bridge`. `SignalConversation` is a first-class
-//! conversation channel and does not implement the cognitive-memory
-//! `BridgeTransport`.
+//! No symbol *defined here* is named `bridge`/`Bridge`. `SignalConversation` is a
+//! first-class conversation channel and does not implement the cognitive-memory
+//! `BridgeTransport`. The per-operator OODA/graph-memory wiring (issue #2527) does
+//! call the pre-existing external helper `memory_ipc::launch_writer_bridge` to
+//! obtain a cognitive-memory handle, but that handle is bound locally as `memory`
+//! — never `bridge` — so the guardrail holds for every symbol this module names.
 
 use std::collections::VecDeque;
 use std::time::Instant;

--- a/src/signal_conversation/channel.rs
+++ b/src/signal_conversation/channel.rs
@@ -364,34 +364,65 @@ pub async fn run(config: SignalConfig) -> SimardResult<()> {
         });
     }
 
-    let system_prompt = load_meeting_system_prompt();
     let state_root = crate::state_root::simard_state_root();
 
     // Per-operator backend factory: each operator gets an independent meeting
-    // backend (its own agent session + its own history), so two operators never
-    // share context. `run_continuous` calls this once per operator on first
-    // touch and replays that operator's persisted history into the fresh
-    // backend. A post-startup agent-open failure (unexpected after the provider
-    // check above) degrades to a backend that reports the outage per turn rather
-    // than crashing the daemon that serves every operator.
-    let mut make_backend = |_operator: &str| -> crate::meeting_backend::MeetingBackend {
-        let agent: Box<dyn crate::base_types::BaseTypeSession> = match open_signal_agent_session() {
-            Some(a) => a,
-            None => {
-                eprintln!(
-                    "[simard][ERROR] signal: agent session open failed after startup validation; \
-                     replies will report the outage until it recovers"
-                );
-                Box::new(UnavailableAgent::new())
-            }
+    // backend (its own agent session, its own history, AND its own cognitive-
+    // memory store), so two operators never share context. `run_continuous`
+    // calls this once per operator on first touch and replays that operator's
+    // persisted history into the fresh backend.
+    //
+    // This is where the Signal channel is wired into the same OODA-loop context
+    // and graph cognitive-memory model as the CLI meeting (issue #2527 follow-up,
+    // adapted to the per-operator run_continuous structure of #2575/#2577):
+    //
+    //   1. Recall — a live cognitive-memory store is opened on the daemon's
+    //      state root (`launch_writer_bridge`, which shares the running daemon's
+    //      store over IPC when one is up). The system prompt is enriched with the
+    //      live OODA state (goals, decisions, operator identity, projects, …) via
+    //      the shared `build_enriched_meeting_system_prompt`, so Simard starts a
+    //      Signal chat already knowing her own state — no manual context loading.
+    //   2. Write-back — that same store is moved into the `MeetingBackend`, so on
+    //      `/close` the Signal conversation is consolidated back into graph memory
+    //      (episodes, summary facts, goal carryover) exactly like the CLI meeting
+    //      (see `meeting_backend::closing`).
+    //
+    // Each per-operator backend gets its OWN store instance because the store is
+    // moved into the backend. Memory/recall failures propagate (PHILOSOPHY.md:
+    // no silent degradation); a post-startup agent-open failure (unexpected after
+    // the provider check above) still degrades to a backend that reports the
+    // outage per turn rather than crashing the daemon that serves every operator.
+    let mut make_backend =
+        |_operator: &str| -> SimardResult<crate::meeting_backend::MeetingBackend> {
+            let agent: Box<dyn crate::base_types::BaseTypeSession> = match open_signal_agent_session(
+            ) {
+                Some(a) => a,
+                None => {
+                    eprintln!(
+                        "[simard][ERROR] signal: agent session open failed after startup validation; \
+                             replies will report the outage until it recovers"
+                    );
+                    Box::new(UnavailableAgent::new())
+                }
+            };
+
+            // Open this operator's own cognitive-memory store on the daemon's
+            // state root (recall + write-back). Named `memory`, never `bridge`,
+            // per the signal_conversation naming guardrail.
+            let memory = crate::memory_ipc::launch_writer_bridge(&state_root)?.into_box();
+
+            // Recall: enrich the prompt with live OODA context (borrows the
+            // store), then move the store into the backend for write-back.
+            let system_prompt =
+                crate::operator_commands_meeting::build_enriched_meeting_system_prompt(&*memory)?;
+
+            Ok(crate::meeting_backend::MeetingBackend::new_session(
+                "signal",
+                agent,
+                Some(memory),
+                system_prompt,
+            ))
         };
-        crate::meeting_backend::MeetingBackend::new_session(
-            "signal",
-            agent,
-            None,
-            system_prompt.clone(),
-        )
-    };
 
     run_continuous(&mut channel, &state_root, &mut make_backend).await
 }
@@ -468,8 +499,10 @@ fn redact_operator(operator: &str) -> String {
 ///      onto a fresh session id (previous history retained on disk); `/help`
 ///      shows the lifecycle banner; `/close` ends the current conversation.
 ///
-/// `make_backend(operator)` mints a fresh backend for a given operator key; the
-/// real `run` supplies the meeting agent + system prompt, tests inject a fake.
+/// `make_backend(operator)` mints a fresh backend for a given operator key —
+/// the real `run` supplies the meeting agent, the enriched OODA-context system
+/// prompt, and the operator's own cognitive-memory store (and so may fail if
+/// recall/memory setup fails); tests inject a fake.
 /// Loop-prevention (device gate + echo suppression) stays entirely inside
 /// [`SignalConversation::recv`], so Simard's own outbound is never re-consumed
 /// as a new turn.
@@ -481,7 +514,7 @@ pub async fn run_continuous<T, H, F>(
 where
     T: SignalTransport + Send,
     H: SignalCommandHandler,
-    F: FnMut(&str) -> crate::meeting_backend::MeetingBackend,
+    F: FnMut(&str) -> SimardResult<crate::meeting_backend::MeetingBackend>,
 {
     use std::collections::HashMap;
 
@@ -586,7 +619,7 @@ where
                     fresh
                 }
             };
-            let mut backend = make_backend(&operator);
+            let mut backend = make_backend(&operator)?;
             let resumed = match session_store::load_session_at(state_root, &sid)? {
                 Some(sess) => {
                     let n = sess.history.len();
@@ -649,12 +682,6 @@ where
         channel.send(out).await?;
     }
     Ok(())
-}
-
-/// Load the shared meeting system prompt (same asset the CLI/dashboard use).
-fn load_meeting_system_prompt() -> String {
-    let path = crate::operator_commands::prompt_root().join("simard/meeting_system.md");
-    std::fs::read_to_string(&path).unwrap_or_default()
 }
 
 /// Open a Meeting-mode agent session for the Signal channel, mirroring the CLI

--- a/src/signal_conversation/tests_continuity.rs
+++ b/src/signal_conversation/tests_continuity.rs
@@ -217,7 +217,7 @@ fn same_operator_two_messages_share_one_continuous_session() {
     set_hermetic_env(tmp.path());
 
     let captured: Captured = Arc::new(Mutex::new(Vec::new()));
-    let mut make_backend = |_op: &str| recording_backend(REPLY, &captured);
+    let mut make_backend = |_op: &str| Ok(recording_backend(REPLY, &captured));
 
     let mut ch = channel(
         vec![
@@ -278,7 +278,7 @@ fn distinct_operators_get_isolated_sessions() {
     set_hermetic_env(tmp.path());
 
     let captured: Captured = Arc::new(Mutex::new(Vec::new()));
-    let mut make_backend = |_op: &str| recording_backend(REPLY, &captured);
+    let mut make_backend = |_op: &str| Ok(recording_backend(REPLY, &captured));
 
     let mut ch = channel(
         vec![
@@ -330,7 +330,7 @@ fn new_command_starts_a_fresh_session_and_retains_the_old_one() {
     set_hermetic_env(tmp.path());
 
     let captured: Captured = Arc::new(Mutex::new(Vec::new()));
-    let mut make_backend = |_op: &str| recording_backend(REPLY, &captured);
+    let mut make_backend = |_op: &str| Ok(recording_backend(REPLY, &captured));
 
     let mut ch = channel(
         vec![
@@ -403,7 +403,7 @@ fn reset_is_an_alias_for_new() {
     set_hermetic_env(tmp.path());
 
     let captured: Captured = Arc::new(Mutex::new(Vec::new()));
-    let mut make_backend = |_op: &str| recording_backend(REPLY, &captured);
+    let mut make_backend = |_op: &str| Ok(recording_backend(REPLY, &captured));
 
     let mut ch = channel(
         vec![
@@ -448,7 +448,7 @@ fn conversation_resumes_after_a_simulated_restart() {
     // daemon "stops". Its in-memory backends are dropped at the end of the run.
     let captured1: Captured = Arc::new(Mutex::new(Vec::new()));
     {
-        let mut make_backend = |_op: &str| recording_backend(REPLY, &captured1);
+        let mut make_backend = |_op: &str| Ok(recording_backend(REPLY, &captured1));
         let mut ch = channel(
             vec![receive_line(OPERATOR, "the code word is BANANA")],
             &[OPERATOR],
@@ -465,7 +465,7 @@ fn conversation_resumes_after_a_simulated_restart() {
     // state root. The next message must resume the existing conversation.
     let captured2: Captured = Arc::new(Mutex::new(Vec::new()));
     {
-        let mut make_backend = |_op: &str| recording_backend(REPLY, &captured2);
+        let mut make_backend = |_op: &str| Ok(recording_backend(REPLY, &captured2));
         let mut ch = channel(
             vec![receive_line(OPERATOR, "what is the code word")],
             &[OPERATOR],
@@ -515,7 +515,7 @@ fn synced_echo_of_simards_reply_is_not_reconsumed_as_a_turn() {
     set_hermetic_env(tmp.path());
 
     let captured: Captured = Arc::new(Mutex::new(Vec::new()));
-    let mut make_backend = |_op: &str| recording_backend(REPLY, &captured);
+    let mut make_backend = |_op: &str| Ok(recording_backend(REPLY, &captured));
 
     let mut ch = channel(
         vec![
@@ -560,7 +560,7 @@ fn reply_synced_from_linked_device_is_ignored() {
     set_hermetic_env(tmp.path());
 
     let captured: Captured = Arc::new(Mutex::new(Vec::new()));
-    let mut make_backend = |_op: &str| recording_backend(REPLY, &captured);
+    let mut make_backend = |_op: &str| Ok(recording_backend(REPLY, &captured));
 
     let mut ch = channel(
         vec![
@@ -597,7 +597,7 @@ fn help_does_not_persist_a_turn_or_reset_the_session() {
     set_hermetic_env(tmp.path());
 
     let captured: Captured = Arc::new(Mutex::new(Vec::new()));
-    let mut make_backend = |_op: &str| recording_backend(REPLY, &captured);
+    let mut make_backend = |_op: &str| Ok(recording_backend(REPLY, &captured));
 
     let mut ch = channel(
         vec![

--- a/src/signal_conversation/tests_continuity.rs
+++ b/src/signal_conversation/tests_continuity.rs
@@ -636,3 +636,52 @@ fn help_does_not_persist_a_turn_or_reset_the_session() {
         "only the two real messages reach the reasoner; /help does not"
     );
 }
+
+// ── 7. No silent degradation: a make_backend failure propagates ──────────────
+
+/// The real `run` builds each per-operator backend inside `make_backend` by
+/// opening that operator's own cognitive-memory store (recall) and building the
+/// enriched OODA-context system prompt (issue #2527 follow-up, wired onto the
+/// per-operator `run_continuous`/`make_backend` structure of #2575/#2577). Both
+/// of those steps can fail, which is why `make_backend` returns
+/// `SimardResult<MeetingBackend>`.
+///
+/// This pins that a `make_backend` failure on a real turn PROPAGATES out of
+/// `run_continuous` rather than being swallowed into a bare/empty reply or a
+/// half-persisted conversation (PHILOSOPHY.md: no silent degradation).
+#[test]
+#[serial(cognitive_memory)]
+fn make_backend_failure_propagates_for_a_real_turn() {
+    let tmp = tempfile::tempdir().unwrap();
+    set_hermetic_env(tmp.path());
+
+    // Simulate recall/memory wiring failing while minting the per-operator
+    // backend (e.g. the cognitive-memory store or the enriched prompt fails).
+    let mut make_backend = |_op: &str| -> SimardResult<MeetingBackend> {
+        Err(crate::error::SimardError::BridgeError(
+            "simulated recall/memory failure while wiring the Signal backend".to_string(),
+        ))
+    };
+
+    let mut ch = channel(
+        vec![receive_line(OPERATOR, "hello simard")],
+        &[OPERATOR],
+        ACCOUNT,
+        None,
+    );
+
+    let result = block_on(run_continuous(&mut ch, tmp.path(), &mut make_backend));
+    assert!(
+        result.is_err(),
+        "a make_backend failure on a real turn must propagate out of run_continuous"
+    );
+
+    // Nothing was silently persisted as a completed conversation: no session
+    // content file exists (the turn never reached the backend).
+    assert!(
+        session_store::list_sessions_at(tmp.path())
+            .unwrap()
+            .is_empty(),
+        "a failed backend build must not persist a conversation turn"
+    );
+}


### PR DESCRIPTION
## The gap

Follow-up to the closed issue #2527, which introduced the shared `ConversationChannel`/`MeetingBackend` abstraction. Chatting with Simard over **Signal** did *not* start with the same OODA-loop context as the CLI meeting, and was *not* wired into the graph-based cognitive-memory model.

On `main`, `src/signal_conversation/channel.rs` `run()` built per-operator backends inside the `make_backend` closure via:

```rust
MeetingBackend::new_session("signal", agent, None, load_meeting_system_prompt())
```

— a **bare** system prompt and a **`None`** cognitive-memory bridge. So over Signal Simard had:

- **no OODA-loop context** at session start (no goals/decisions/operator-identity/projects recall), and
- **no memory write-back** on `/close` — `meeting_backend::closing` consolidation is a no-op while the bridge is `None`.

The CLI reference (`operator_commands_meeting::meeting_session::run_meeting_repl_command`) already does the right thing: launches a real bridge, builds live context, enriches the prompt, and passes the bridge into the backend.

## The fix (DRY — mirrors the CLI)

1. **Shared helper** — add `pub(crate) build_enriched_meeting_system_prompt(bridge)` in `meeting_session.rs` = base `meeting_system.md` prompt + `build_live_meeting_context(bridge)`, propagating bridge errors (PHILOSOPHY.md: no silent degradation). It is now the single source of truth for "what context a Simard conversation starts with".
2. **Re-export** it from `operator_commands_meeting::mod`.
3. **Refactor the CLI** `run_meeting_repl_command` to use the shared helper (behavior-preserving).
4. **Wire the Signal channel** — in `channel.rs` `run()`, each per-operator backend built in `make_backend` now:
   - **(recall)** opens its **own** cognitive-memory store via `memory_ipc::launch_writer_bridge` on `state_root::simard_state_root()` (shares the running daemon's store over IPC when one is up),
   - builds the **enriched** system prompt via the shared helper, and
   - **(write-back)** passes `Some(memory)` into `MeetingBackend::new_session`, so `/close` consolidates episodes / summary facts / goal carryover into graph memory.

   The `make_backend` closure now returns `SimardResult<MeetingBackend>` (and `run_continuous`'s generic bound is widened to match) so recall/memory failures propagate rather than degrade silently. The **fail-fast provider check** and the **`UnavailableAgent` graceful-degradation** path are preserved. The binding is named `memory` (never `bridge`) per the `signal_conversation` naming guardrail, and the now-unused private `load_meeting_system_prompt` is removed.

## Adapted to current `main`

Re-implemented against `main`'s **per-operator** `run_continuous`/`make_backend` structure introduced by the Note-to-Self sync-sent loop guard (#2575) and continuous per-operator conversations (#2577) — **not** the old single-backend `run()`. Each per-operator backend gets its **own** store instance because the store is moved into the backend.

Everything stays behind the default-off `signal` cargo feature.

## Verification

- `cargo build --features signal` ✅
- `cargo test --features signal signal_conversation` ✅ (88 passed)
- `cargo test operator_commands_meeting::` ✅ (66 passed)
- `cargo clippy --features signal -- -D warnings` ✅
- default `cargo clippy -- -D warnings` ✅
- pre-push `cargo clippy --all-targets --all-features --locked -- -D warnings` ✅

Refs #2527, #2575, #2577.