### PR TITLE
fix(status): daily budget never falsely shows "unset (no guard)" — single-source the ceiling (#6)

### DIFF
--- a/docs/howto/simard-status.md
+++ b/docs/howto/simard-status.md
@@ -73,7 +73,7 @@ LLM USAGE
   ledger today      $1.87    in 412,000  out 88,000
   ledger 7d         $11.42   in 2,740,000  out 610,000
   ledger all-time   $208.91  in 51,300,000  out 9,900,000
-  daily budget      $1.87 / $25.00  (OK — 7% used)
+  daily budget      $1.87 / $25.00
   reconciliation    ledger $1.87  vs  credits 940   ·  OK (within tolerance)
 
 MEMORY / BRAIN
@@ -152,7 +152,12 @@ memory, free disk on `/home` and `/tmp`, and the live engineer count. From
 
 The most recent Copilot per-turn tokens (in / cached / out) and AI-credits; the
 cost **ledger** for today / 7d / all-time (cost + in/out tokens); and the daily
-budget guard versus `SIMARD_DAILY_BUDGET_USD`. The **reconciliation** line shows
+budget guard as `$<spent> / $<ceiling>`. The ceiling is resolved through the
+canonical `overseer::config` resolver — the same value the Overseer's
+`BudgetGate` enforces — so it always shows the real ceiling (default `$500.00`)
+even when `SIMARD_DAILY_BUDGET_USD` is unset; it never prints "unset (no
+guard)". See the
+[daily-budget display guard](../reference/daily-budget-display-guard.md). The **reconciliation** line shows
 the **two books** — dollar ledger and Copilot AI-credits — side by side with a
 delta; it flags `under-count`/`over-count` if they diverge beyond tolerance.
 See the [two-books design](../concepts/unified-telemetry-and-status.md#two-books-of-cost-told-honestly).
@@ -260,7 +265,7 @@ unknown" are different facts, and `simard status` keeps them different.
 | Variable | Effect |
 |---|---|
 | `SIMARD_STATE_ROOT` | State root to read (`telemetry/metrics_snapshot.json`, cost ledger, memory). Defaults to `$HOME/.simard`. |
-| `SIMARD_DAILY_BUDGET_USD` | Sets the daily budget the LLM-usage section compares spend against. |
+| `SIMARD_DAILY_BUDGET_USD` | Sets the daily budget the LLM-usage section compares spend against. Resolved through `overseer::config` (default `500`, always guarded), so the displayed ceiling matches the enforced one even when unset. |
 | `SIMARD_SKIP_GYM` | Reflected in the GYM section. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Enables OTLP export of metrics **and** traces; unrelated to reading `simard status`, which is always local. Off by default. |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ Terminal sessions and repo-grounded engineer runs now bridge through one explici
 - [Meeting close lifecycle reference](./reference/meeting-close-lifecycle.md) - Bounded close, partial-handoff envelope, atomic writes (#1908).
 - [Handoff lifecycle API reference](./reference/handoff-lifecycle-api.md) - Write guard, batch processing, and reaping for meeting handoff files (#2268).
 - [State-root resolution reference](./reference/state-root-resolution.md) - The shared helper honoring `SIMARD_STATE_ROOT` across every Simard mode (#1906).
+- [Daily-budget display guard reference](./reference/daily-budget-display-guard.md) - Why `simard status`, the dashboard monitoring JSON, and the TUI all resolve the daily LLM budget through the single canonical `overseer::config` resolver, so the displayed ceiling always matches the Overseer `BudgetGate` and the false "unset (no guard)" line can no longer appear (#6).
 - [How to recover from a meeting close timeout](./howto/recover-from-meeting-close-timeout.md) - Playbook when `handoff_partial=true` fires.
 - [LightweightChatSession reference](./reference/lightweight-chat-session.md) - Direct-subprocess session used for Copilot-provider meeting turns (no PTY overhead).
 - [Dashboard Chat reference](./reference/dashboard-chat.md) - Durable, resumable dashboard chat sessions: the on-disk `chat_sessions/` store, the `GET /api/chat/sessions[/{id}]` REST API, and the `/ws/chat` streaming protocol with non-streaming fallback (issue #2577).

--- a/docs/reference/daily-budget-display-guard.md
+++ b/docs/reference/daily-budget-display-guard.md
@@ -1,0 +1,270 @@
+---
+title: Daily-budget display guard reference
+description: Why every operator surface that prints the daily LLM budget — `simard status`, the dashboard monitoring JSON, and the TUI — resolves the ceiling through the single canonical `overseer::config` resolver, so the displayed ceiling always matches the Overseer `BudgetGate` it enforces (default 500.0) and the old, false "unset (no guard)" line can no longer appear (issue #6).
+last_updated: 2026-07-06
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+related:
+  - ./status-snapshot-api.md
+  - ./telemetry-metrics.md
+  - ../howto/simard-status.md
+  - ../design/overseer.md
+  - ../dashboard.md
+---
+
+# Daily-budget display guard reference
+
+The daily LLM-spend budget is **always** guarded. When
+`SIMARD_DAILY_BUDGET_USD` is unset, empty, unparseable, or non-positive, Simard
+falls back to a hard-coded default ceiling of **`500.0` USD**. That ceiling is
+what the Overseer's `BudgetGate` enforces, and — as of issue #6 — it is also
+exactly what every operator surface **displays**.
+
+This page documents the display contract: one canonical resolver, one number,
+no display surface that can disagree with the `BudgetGate` the daemon runs
+under. (See [Scope and known boundary](#scope-and-known-boundary) for the one
+enforcement path — the OODA loop's own config — that is *not yet* routed through
+this resolver.)
+
+> **Modules:** resolver `src/overseer/config.rs`
+> (`resolve_daily_budget_usd` / `daily_budget_usd`); consumers
+> `src/status/provider.rs` (`assemble_llm`), `src/status/render.rs`
+> (`render_llm`), `src/operator_commands_dashboard/monitoring.rs`
+> (`get_budget`). Guard: `src/overseer/guardrails.rs` (`BudgetGate`,
+> single-sourced from the resolver). The OODA loop's own cycle enforcement
+> (`src/ooda_loop/cycle.rs`) reads a separate `OodaConfig.daily_budget_usd`
+> (`src/ooda_loop/types.rs`) — see
+> [Scope and known boundary](#scope-and-known-boundary).
+
+## The bug this closes
+
+Before issue #6, the **guard** and the **display** read the budget from two
+different places:
+
+- The **guard** (the Overseer's `BudgetGate`) resolved the budget through
+  `overseer::config`, which falls back to `500.0` when the env is absent — so a
+  ceiling was **always** enforced. (The OODA loop's own cycle enforcement also
+  defaults to `500.0` when the env is absent, so it was capping spend too.)
+- The **display** paths (`simard status`, the dashboard monitoring JSON) read
+  the **raw** `SIMARD_DAILY_BUDGET_USD` environment variable directly and
+  treated "absent" as "no budget":
+
+  ```text
+  daily budget      unset (no guard)
+  ```
+
+Because `simard status` and the dashboard run **outside** the daemon's systemd
+environment, they usually did **not** see `SIMARD_DAILY_BUDGET_USD`, so they
+printed `unset (no guard)` even though the daemon was enforcing the `500.0`
+ceiling the whole time. The line was **false** and actively misleading during
+operator review: it implied spend was uncapped when it was not.
+
+The fix routes every display path through the **same** canonical resolver the
+guard uses, so the displayed ceiling can never diverge from the enforced one.
+
+## Canonical resolver (single source of truth)
+
+All budget-aware code — guard *and* display — resolves the daily ceiling
+through one pair of functions in `src/overseer/config.rs`:
+
+```rust
+/// Env-injectable core. Falls back to DEFAULT_DAILY_BUDGET_USD (500.0) when the
+/// value is unset, empty, unparseable, or non-positive. This is the single
+/// source of truth the BudgetGate reads.
+pub fn resolve_daily_budget_usd(lookup: impl Fn(&str) -> Option<String>) -> f64;
+
+/// Production entry point: reads the real process environment.
+pub fn daily_budget_usd() -> f64;
+```
+
+`daily_budget_usd()` is `resolve_daily_budget_usd(|k| std::env::var(k).ok())`.
+Display code calls `daily_budget_usd()`; no display path calls
+`std::env::var("SIMARD_DAILY_BUDGET_USD")` or parses the raw env itself.
+
+### Resolution rules
+
+`resolve_daily_budget_usd` trims the looked-up value and applies these rules, in
+order:
+
+| Env value (`SIMARD_DAILY_BUDGET_USD`) | Resolved ceiling |
+|---|---|
+| unset | `500.0` (default) |
+| empty / whitespace-only | `500.0` (default) |
+| `"250"`, `"250.0"` | `250.0` |
+| `"25"` | `25.0` |
+| non-positive (`"0"`, `"-10"`) | `500.0` (default) |
+| non-finite (`NaN`, `inf`) | `500.0` (default) |
+| unparseable (`"abc"`) | `500.0` (default) |
+
+The resolver only accepts a **finite, strictly-positive** float; every other
+case falls back to the default. This validation is **stricter** than the old
+raw-env parse (which accepted `0`, negatives, `NaN`, and `inf`), so the
+displayed ceiling is now always a real, enforceable number.
+
+There is **no** explicit "disable the guard" sentinel: `0` and negatives do not
+turn the guard off, they fall back to `500.0`. The budget is always on.
+
+## `simard status` — LLM usage
+
+`assemble_llm` in `src/status/provider.rs` populates
+`LlmUsage.daily_budget_usd` from `overseer::config::daily_budget_usd()`. The
+field stays `Option<f64>` for wire compatibility, but the provider now **always**
+emits `Some(resolved)` — never `None` — because a ceiling always resolves.
+
+`render_llm` in `src/status/render.rs` renders the guard as
+`$<spent-today> / $<ceiling>`:
+
+```text
+LLM USAGE
+  copilot turn      in 4,120  cached 1,900  out 880   ·  AI-credits 12
+  ledger today      $1.87    in 412,000  out 88,000
+  ledger 7d         $11.42   in 2,740,000  out 610,000
+  ledger all-time   $208.91  in 51,300,000  out 9,900,000
+  daily budget      $1.87 / $500.00
+  reconciliation    ledger $1.87  vs  credits 940   ·  OK (within tolerance)
+```
+
+With `SIMARD_DAILY_BUDGET_USD` unset, the line now reads `$1.87 / $500.00`
+(the real, enforced ceiling) instead of the old `unset (no guard)`.
+
+The renderer's fallback label — previously the false `"unset (no guard)"` — is
+now the neutral **`n/a`**. In production it is unreachable (the provider always
+supplies `Some`); it is retained only for type completeness over the
+`Option<f64>` and can never claim the guard is off.
+
+## Dashboard monitoring — `get_budget`
+
+`get_budget` in `src/operator_commands_dashboard/monitoring.rs` is **file-first**:
+it reads `~/.simard/budget.json` and returns that JSON verbatim when it parses.
+Only when the file is missing or invalid does it fall back to defaults — and the
+**daily** default is now single-sourced through
+`overseer::config::daily_budget_usd()` rather than a duplicated `500.0` literal:
+
+```jsonc
+// Fallback body when ~/.simard/budget.json is absent or unparseable,
+// with SIMARD_DAILY_BUDGET_USD unset:
+{
+  "daily_budget_usd": 500.0,   // from overseer::config::daily_budget_usd()
+  "weekly_budget_usd": 2500.0  // unchanged; no canonical weekly resolver yet
+}
+```
+
+The weekly fallback (`2500.0`) and the file-first `budget.json` behaviour are
+**unchanged** — only the daily fallback branch is single-sourced. With
+`SIMARD_DAILY_BUDGET_USD=250`, the daily fallback reports `250.0`.
+
+## `--json` / snapshot schema
+
+`simard status --json` and `GET /api/status/snapshot` serialize the same
+`StatusSnapshot`. `llm.data.daily_budget_usd` is now always a number:
+
+```json
+{
+  "llm": {
+    "availability": "ok",
+    "freshness": "live",
+    "data": {
+      "ledger_today": { "cost_usd": 1.87, "tokens_in": 412000, "tokens_out": 88000 },
+      "daily_budget_usd": 500.0,
+      "reconciliation": { "ledger_usd": 1.87, "credits": 940, "delta_flag": "ok" }
+    }
+  }
+}
+```
+
+The field type is unchanged (`Option<f64>`, `#[serde(default)]`), so older
+consumers keep deserializing; the only observable change is that the value is a
+number (the resolved ceiling) instead of `null` when the env is absent.
+
+## Guarantees
+
+- **Display = the `BudgetGate` ceiling.** Every display surface resolves the
+  ceiling through the same `overseer::config` resolver the Overseer's
+  `BudgetGate` reads, so the printed number is always the ceiling the
+  `BudgetGate` enforces. For every normal configuration (unset, or any finite
+  positive value) this is also exactly the OODA loop's own enforced ceiling; the
+  one exception is documented in
+  [Scope and known boundary](#scope-and-known-boundary).
+- **Always guarded.** Unset/empty/invalid/non-positive → `500.0`. There is no
+  configuration that renders the guard as absent.
+- **No false "no guard".** The `unset (no guard)` line is retired; the retained
+  fallback label is a neutral `n/a` that never claims spend is uncapped.
+- **Single-sourced (display).** No display path reads or parses raw
+  `SIMARD_DAILY_BUDGET_USD`; for display *and* the `BudgetGate`, the `500.0`
+  default lives once, in `overseer::config` (`DEFAULT_DAILY_BUDGET_USD`). The
+  OODA loop still carries its own `500.0` fallback — see
+  [Scope and known boundary](#scope-and-known-boundary).
+
+## Scope and known boundary
+
+Issue #6 unifies every **display** path and the Overseer's `BudgetGate` onto the
+canonical resolver. One **enforcement** path is intentionally out of scope for
+this display fix and remains a tracked follow-up:
+
+- The OODA loop builds its own `OodaConfig.daily_budget_usd`
+  (`src/ooda_loop/types.rs`) with a local `env_f64("SIMARD_DAILY_BUDGET_USD",
+  500.0)` helper, and `src/ooda_loop/cycle.rs` enforces spend against that value.
+  `env_f64` does a plain `f64::parse`, so — unlike `resolve_daily_budget_usd` —
+  it does **not** reject non-positive or non-finite input.
+
+For every configuration an operator would actually set, the two agree:
+
+| `SIMARD_DAILY_BUDGET_USD` | Display / `BudgetGate` | OODA-loop `cycle.rs` | Agree? |
+|---|---|---|---|
+| unset / empty / unparseable | `500.0` | `500.0` | yes |
+| `"250"` (any finite `> 0`) | `250.0` | `250.0` | yes |
+| `"0"` / `"-10"` | `500.0` | `0.0` / `-10.0` | **no** |
+| `NaN` / `inf` | `500.0` | `NaN` / `inf` | **no** |
+
+The divergence only occurs for pathological values no operator sets
+deliberately, and even then it fails safe: a `0` or negative ceiling makes the
+OODA loop's `daily.total_cost_usd >= config.daily_budget_usd` check refuse to run
+almost immediately, so the loop is *more* conservative than the displayed
+`500.0`, never less. It is nonetheless a second source of truth. The follow-up
+is to route `OodaConfig` through `overseer::config::resolve_daily_budget_usd`,
+after which "single source of truth" holds literally for enforcement as well as
+display. Tracked as a follow-up to issue #6.
+
+## Configuration
+
+| Variable | Effect | Default |
+|---|---|---|
+| `SIMARD_DAILY_BUDGET_USD` | The daily LLM-spend ceiling. Single-sourced through `overseer::config::daily_budget_usd()`; the same value the Overseer's `BudgetGate` enforces and every operator surface displays. Non-positive / invalid values fall back to the default. | `500` (always guarded) |
+
+To display the enforced ceiling on an out-of-daemon `simard status`, either set
+`SIMARD_DAILY_BUDGET_USD` in the reading shell or rely on the `500.0`
+default — both now render as `$<spent> / $<ceiling>`.
+
+## Examples
+
+```bash
+# Unset → the enforced default ceiling is shown (no more "unset (no guard)"):
+$ unset SIMARD_DAILY_BUDGET_USD
+$ simard status | grep 'daily budget'
+  daily budget      $1.87 / $500.00
+
+# Explicit lower ceiling:
+$ SIMARD_DAILY_BUDGET_USD=250 simard status | grep 'daily budget'
+  daily budget      $1.87 / $250.00
+
+# Invalid / non-positive → falls back to the default, still guarded:
+$ SIMARD_DAILY_BUDGET_USD=0 simard status | grep 'daily budget'
+  daily budget      $1.87 / $500.00
+
+# Dashboard monitoring fallback (no ~/.simard/budget.json):
+$ curl -fsS -H "Authorization: ******" \
+    http://localhost:8080/api/budget | jq .daily_budget_usd
+500
+```
+
+## See also
+
+- [StatusSnapshot API reference](./status-snapshot-api.md) — the typed snapshot
+  and the `LlmUsage.daily_budget_usd` field.
+- [Telemetry metrics reference](./telemetry-metrics.md#configuration) — the
+  `SIMARD_DAILY_BUDGET_USD` configuration knob.
+- [How to read `simard status`](../howto/simard-status.md) — the operator
+  walkthrough with the rendered LLM-usage block.
+- [Overseer design](../design/overseer.md) — the `BudgetGate` whose canonical
+  ceiling this display now mirrors.

--- a/docs/reference/status-snapshot-api.md
+++ b/docs/reference/status-snapshot-api.md
@@ -13,6 +13,7 @@ related:
   - ./simard-tui.md
   - ../dashboard.md
   - ./operator-read-state-root-contract.md
+  - ./daily-budget-display-guard.md
 ---
 
 # StatusSnapshot API reference
@@ -58,7 +59,7 @@ rather than fabricating data:
 |---|---|---|
 | Daemon / uptime | `systemctl show simard.service` (`LoadState`, `ActiveState`, `MainPID`, `NRestarts`, `ExecMainStartTimestamp`) | ~~`journalctl \| grep`~~ |
 | Resource snapshot | `/proc/loadavg`, `/proc/meminfo`, `/proc/<daemon-pid>/status` (RSS), `statvfs` (disk), `pgrep` (live engineers) | — |
-| LLM usage | `cost_tracking` ledger (`costs/ledger.jsonl`) + `$SIMARD_DAILY_BUDGET_USD` | — |
+| LLM usage | `cost_tracking` ledger (`costs/ledger.jsonl`) + daily budget via `overseer::config::daily_budget_usd()` (single-sourced; always the enforced ceiling — see the [daily-budget display guard](./daily-budget-display-guard.md)) | ~~raw `$SIMARD_DAILY_BUDGET_USD`~~ |
 | Memory / brain | `metrics_snapshot.json` — the daemon-sampled `simard.memory.nodes` / `.edges` gauges | ~~LadybugDB open from the CLI~~ |
 | Gym | `$SIMARD_SKIP_GYM` | — |
 | Goal board | *deferred* — rendered `unavailable`; surfaced live in the daemon-hosted dashboard / TUI goal tabs | — |

--- a/docs/reference/telemetry-metrics.md
+++ b/docs/reference/telemetry-metrics.md
@@ -10,6 +10,7 @@ related:
   - ./status-snapshot-api.md
   - ../howto/simard-status.md
   - ./runtime-contracts.md
+  - ./daily-budget-display-guard.md
 ---
 
 # Telemetry metrics reference
@@ -245,7 +246,7 @@ traces and is **off by default**.
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Enables OTLP export for **both** traces and metrics. Unset = local/in-process only. | unset (export off) |
 | `SIMARD_LOG_JSON` | `1` switches the fmt log layer to JSON; unrelated to metrics but part of the same `init_tracing()`. | text |
 | `SIMARD_STATE_ROOT` | Overrides the state root (`$HOME/.simard`), which is where `telemetry/metrics_snapshot.json`, the cost ledger, and `self_metrics` live. | `$HOME/.simard` |
-| `SIMARD_DAILY_BUDGET_USD` | The daily budget guard the LLM-usage section compares spend against. | unset (no guard) |
+| `SIMARD_DAILY_BUDGET_USD` | The daily budget guard the LLM-usage section compares spend against. Single-sourced through `overseer::config::daily_budget_usd()`, so the displayed ceiling always matches the Overseer `BudgetGate` even when unset; see the [daily-budget display guard](./daily-budget-display-guard.md). | `500` (always guarded) |
 | `SIMARD_SKIP_GYM` | Respected by the gym section of the status snapshot. | unset |
 
 ## Relationship to the four legacy stores

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -191,6 +191,7 @@ nav:
     - CLI Reference: reference/simard-cli.md
     - Telemetry Metrics: reference/telemetry-metrics.md
     - StatusSnapshot API: reference/status-snapshot-api.md
+    - Daily-Budget Display Guard: reference/daily-budget-display-guard.md
     - Overseer Activity Feed: reference/overseer-activity-feed.md
     - simard-engineer-step CLI: reference/simard-engineer-step.md
     - simard-tui Dashboard: reference/simard-tui.md

--- a/src/operator_commands_dashboard/monitoring.rs
+++ b/src/operator_commands_dashboard/monitoring.rs
@@ -49,9 +49,12 @@ pub(crate) async fn get_budget() -> Json<Value> {
     let content = std::fs::read_to_string(&path).unwrap_or_default();
     match serde_json::from_str::<Value>(&content) {
         Ok(v) => Json(v),
+        // Single-source the daily ceiling through the canonical resolver
+        // (bug #6): the budget is always guarded, so the fallback must apply
+        // the same `DEFAULT_DAILY_BUDGET_USD` the Overseer's `BudgetGate`
+        // enforces instead of duplicating a `500.0` literal here.
         Err(_) => Json(json!({
-            "daily_budget_usd": std::env::var("SIMARD_DAILY_BUDGET_USD")
-                .ok().and_then(|v| v.parse::<f64>().ok()).unwrap_or(500.0),
+            "daily_budget_usd": crate::overseer::config::daily_budget_usd(),
             "weekly_budget_usd": std::env::var("SIMARD_WEEKLY_BUDGET_USD")
                 .ok().and_then(|v| v.parse::<f64>().ok()).unwrap_or(2500.0),
         })),
@@ -75,6 +78,7 @@ pub(crate) async fn set_budget(Json(body): Json<Value>) -> Json<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     // ---- budget_config_path -----------------------------------------------
 
@@ -129,5 +133,86 @@ mod tests {
         assert!(daily > 0.0, "daily budget should be > 0");
         assert!(weekly > 0.0, "weekly budget should be > 0");
         assert!(weekly > daily, "weekly should exceed daily");
+    }
+
+    // ---- get_budget daily budget resolution (issue #6) --------------------
+    //
+    // The dashboard monitoring JSON must report the *actual* daily guard. The
+    // budget is always guarded, so the env/default fallback must single-source
+    // through `crate::overseer::config::daily_budget_usd()` (which applies the
+    // canonical `DEFAULT_DAILY_BUDGET_USD` for unset/empty/unparseable/non-positive
+    // values) rather than parsing the raw env with a duplicated `500.0` literal.
+
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<std::ffi::OsString>,
+    }
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prev = std::env::var_os(key);
+            // SAFETY: these tests are `#[serial(budget_env)]`.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prev }
+        }
+        fn unset(key: &'static str) -> Self {
+            let prev = std::env::var_os(key);
+            // SAFETY: these tests are `#[serial(budget_env)]`.
+            unsafe { std::env::remove_var(key) };
+            Self { key, prev }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: serialized via `#[serial(budget_env)]`.
+            unsafe {
+                match self.prev.take() {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    /// Point `HOME` at a fresh temp dir (so `budget.json` is absent, forcing the
+    /// env/default fallback branch), set the daily-budget env to `value`, and
+    /// return the `daily_budget_usd` `get_budget` reports.
+    async fn daily_budget_with_env(value: Option<&str>) -> f64 {
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HOME", home.path().to_str().unwrap());
+        let _weekly = EnvGuard::unset("SIMARD_WEEKLY_BUDGET_USD");
+        let _daily = match value {
+            Some(v) => EnvGuard::set("SIMARD_DAILY_BUDGET_USD", v),
+            None => EnvGuard::unset("SIMARD_DAILY_BUDGET_USD"),
+        };
+        let val = get_budget().await.0;
+        val["daily_budget_usd"]
+            .as_f64()
+            .expect("daily_budget_usd f64")
+    }
+
+    #[tokio::test]
+    #[serial(budget_env)]
+    async fn get_budget_daily_defaults_to_guard_when_env_unset() {
+        assert_eq!(
+            daily_budget_with_env(None).await,
+            crate::overseer::config::DEFAULT_DAILY_BUDGET_USD,
+        );
+    }
+
+    #[tokio::test]
+    #[serial(budget_env)]
+    async fn get_budget_daily_reflects_explicit_env() {
+        assert_eq!(daily_budget_with_env(Some("250")).await, 250.0);
+    }
+
+    #[tokio::test]
+    #[serial(budget_env)]
+    async fn get_budget_daily_nonpositive_env_falls_back_to_guard() {
+        // `0` is not a real ceiling; the canonical resolver applies the default
+        // guard rather than reporting `0` (single-sourcing, bug #6).
+        assert_eq!(
+            daily_budget_with_env(Some("0")).await,
+            crate::overseer::config::DEFAULT_DAILY_BUDGET_USD,
+        );
     }
 }

--- a/src/status/provider.rs
+++ b/src/status/provider.rs
@@ -355,9 +355,13 @@ fn assemble_llm(opts: &AssembleOptions) -> SectionEnvelope<LlmUsage> {
         });
     }
 
-    let daily_budget = std::env::var("SIMARD_DAILY_BUDGET_USD")
-        .ok()
-        .and_then(|v| v.parse::<f64>().ok());
+    // Single-source the ceiling through the canonical resolver (bug #6): the
+    // daily budget is always guarded (default `DEFAULT_DAILY_BUDGET_USD`), so
+    // the display must reflect the *enforced* ceiling — the same value the
+    // Overseer's `BudgetGate` reads — rather than parsing the raw env and
+    // falsely reporting "unset (no guard)" when the reading process lacks the
+    // var. Always `Some(resolved)`.
+    let daily_budget = Some(crate::overseer::config::daily_budget_usd());
 
     let usage = LlmUsage {
         copilot_turn: last_turn,

--- a/src/status/render.rs
+++ b/src/status/render.rs
@@ -224,7 +224,7 @@ fn render_llm(out: &mut String, env: &SectionEnvelope<super::LlmUsage>) {
                 let spent = l.ledger_today.as_ref().map(|w| w.cost_usd).unwrap_or(0.0);
                 label(out, "daily budget", format!("${spent:.2} / ${b:.2}"));
             }
-            None => label(out, "daily budget", "unset (no guard)"),
+            None => label(out, "daily budget", "n/a"),
         }
         match &l.reconciliation {
             Some(r) => label(

--- a/tests/status_render_contract.rs
+++ b/tests/status_render_contract.rs
@@ -291,3 +291,62 @@ fn stale_section_is_marked_stale() {
         "a stale section must carry a stale marker:\n{out}"
     );
 }
+
+// ── daily budget label (issue #6) ────────────────────────────────────────────
+
+/// The rendered "daily budget" line, isolated so assertions don't false-match
+/// other sections.
+fn daily_budget_line(out: &str) -> String {
+    out.lines()
+        .find(|l| l.contains("daily budget"))
+        .unwrap_or_else(|| panic!("no 'daily budget' line rendered:\n{out}"))
+        .to_string()
+}
+
+#[test]
+fn daily_budget_some_renders_spent_over_ceiling() {
+    // populated(): ledger_today cost 1.87, daily_budget 25.0.
+    let out = render::to_terminal(&populated());
+    let line = daily_budget_line(&out);
+    assert!(
+        line.contains("$1.87 / $25.00"),
+        "daily budget must render as `$spent / $ceiling`: {line}"
+    );
+    assert!(
+        !line.contains("unset (no guard)"),
+        "a resolved ceiling must never render the false 'unset (no guard)': {line}"
+    );
+}
+
+#[test]
+fn daily_budget_none_renders_neutral_marker_not_false_no_guard() {
+    // The provider now always resolves a ceiling, so the None arm is effectively
+    // unreachable in production; if ever hit it must show a neutral marker, never
+    // the misleading "unset (no guard)" — the budget is always guarded (bug #6).
+    let mut snap = StatusSnapshot::empty();
+    snap.llm = SectionEnvelope::live(
+        LlmUsage {
+            copilot_turn: None,
+            ledger_today: Some(LedgerWindow {
+                cost_usd: 0.0,
+                tokens_in: 0,
+                tokens_out: 0,
+            }),
+            ledger_7d: None,
+            ledger_all_time: None,
+            daily_budget_usd: None,
+            reconciliation: None,
+        },
+        None,
+    );
+    let out = render::to_terminal(&snap);
+    let line = daily_budget_line(&out);
+    assert!(
+        !line.contains("unset (no guard)"),
+        "the None arm must not claim 'no guard' — the budget is always guarded: {line}"
+    );
+    assert!(
+        line.contains("n/a"),
+        "the None arm must render a neutral 'n/a' marker: {line}"
+    );
+}

--- a/tests/status_snapshot.rs
+++ b/tests/status_snapshot.rs
@@ -265,3 +265,77 @@ fn assemble_reads_cost_ledger_under_state_root() {
     assert_eq!(all.tokens_out, 400);
     assert_eq!(llm.daily_budget_usd, Some(25.0));
 }
+
+// ── daily budget display guard (issue #6) ────────────────────────────────────
+//
+// The status display must report the *actual* guard. The daily budget is always
+// guarded — `crate::overseer::config::resolve_daily_budget_usd` falls back to
+// `DEFAULT_DAILY_BUDGET_USD` when the env is unset/empty/unparseable/non-positive
+// — so the provider must never emit `None` (rendered "unset (no guard)") when a
+// default applies. These pin that the provider single-sources the ceiling
+// through the canonical resolver rather than reading the raw env directly.
+
+/// Write a minimal single-entry cost ledger so the `llm` section assembles as
+/// `live` (the provider returns `absent` when no ledger exists).
+fn write_cost_ledger(state_root: &std::path::Path) {
+    let ledger = state_root.join("costs").join("ledger.jsonl");
+    std::fs::create_dir_all(ledger.parent().unwrap()).unwrap();
+    let now = chrono::Utc::now().to_rfc3339();
+    let line = format!(
+        "{{\"timestamp\":\"{now}\",\"session_id\":\"s\",\"model\":\"gpt\",\"prompt_tokens_est\":1000,\"completion_tokens_est\":200,\"cost_usd_est\":1.5,\"context\":\"c\"}}"
+    );
+    std::fs::write(&ledger, format!("{line}\n")).unwrap();
+}
+
+#[test]
+#[serial(status_env)]
+fn assemble_daily_budget_defaults_to_guard_when_env_unset() {
+    // Bug #6: running outside the daemon's systemd env (var absent) previously
+    // reported no budget guard. The budget is always guarded, so an unset env
+    // must surface the canonical default ceiling — never `None`.
+    let _skip = EnvGuard::unset("SIMARD_SKIP_GYM");
+    let _budget = EnvGuard::unset("SIMARD_DAILY_BUDGET_USD");
+    let dir = tempfile::tempdir().expect("tempdir");
+    write_cost_ledger(dir.path());
+
+    let snap = status::assemble(&hermetic_opts(dir.path()));
+    let llm: &LlmUsage = snap.llm.data.as_ref().expect("llm present");
+    assert_eq!(
+        llm.daily_budget_usd,
+        Some(simard::overseer::config::DEFAULT_DAILY_BUDGET_USD),
+        "unset env must resolve to the canonical default guard, not None"
+    );
+}
+
+#[test]
+#[serial(status_env)]
+fn assemble_daily_budget_reflects_explicit_env() {
+    let _skip = EnvGuard::unset("SIMARD_SKIP_GYM");
+    let _budget = EnvGuard::set("SIMARD_DAILY_BUDGET_USD", "250");
+    let dir = tempfile::tempdir().expect("tempdir");
+    write_cost_ledger(dir.path());
+
+    let snap = status::assemble(&hermetic_opts(dir.path()));
+    let llm: &LlmUsage = snap.llm.data.as_ref().expect("llm present");
+    assert_eq!(llm.daily_budget_usd, Some(250.0));
+}
+
+#[test]
+#[serial(status_env)]
+fn assemble_daily_budget_nonpositive_env_falls_back_to_guard() {
+    // A non-positive value is not a real ceiling; the canonical resolver rejects
+    // it and applies the default guard. The display must mirror that reality
+    // rather than reporting a misleading `0`.
+    let _skip = EnvGuard::unset("SIMARD_SKIP_GYM");
+    let _budget = EnvGuard::set("SIMARD_DAILY_BUDGET_USD", "0");
+    let dir = tempfile::tempdir().expect("tempdir");
+    write_cost_ledger(dir.path());
+
+    let snap = status::assemble(&hermetic_opts(dir.path()));
+    let llm: &LlmUsage = snap.llm.data.as_ref().expect("llm present");
+    assert_eq!(
+        llm.daily_budget_usd,
+        Some(simard::overseer::config::DEFAULT_DAILY_BUDGET_USD),
+        "non-positive env must fall back to the canonical default guard"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the daily-budget **"unset (no guard)" display bug** (issue #6): `simard status` and the dashboard monitoring JSON run **outside** the daemon's systemd env, so they didn't see `SIMARD_DAILY_BUDGET_USD` and falsely printed `unset (no guard)` — even though the Overseer's `BudgetGate` and the OODA loop were enforcing the canonical `500.0` default ceiling the whole time. The line was misleading during operator review: it implied spend was uncapped when it was not.

## Root cause

The **guard** resolves the ceiling through the canonical single source of truth (`overseer::config::resolve_daily_budget_usd` / `daily_budget_usd`, default `DEFAULT_DAILY_BUDGET_USD = 500.0`), but the **display** paths read the raw env directly and treated "absent" as "no guard".

## Fix (surgical, single-sourced)

- **`src/status/provider.rs`** — `assemble_llm` resolves via `overseer::config::daily_budget_usd()` and always emits `Some(resolved)`. Field stays `Option<f64>` for wire compatibility.
- **`src/status/render.rs`** — the now-unreachable `None` arm no longer claims `unset (no guard)`; relabelled to a neutral `n/a` (the budget is always guarded).
- **`src/operator_commands_dashboard/monitoring.rs`** — `get_budget`'s daily fallback single-sources `overseer::config::daily_budget_usd()`, dropping the duplicate `500.0` literal. Weekly fallback (`2500.0`) and the file-first `~/.simard/budget.json` behaviour are unchanged.

There is no explicit "disable" sentinel: `0`/negatives/`NaN`/unparseable fall back to `500.0`. The budget is always on, so "no guard" can no longer render.

## Tests (hermetic, env-guarded, serial)

- Provider (`tests/status_snapshot.rs`): env unset → `Some(500.0)`; `250` → `Some(250.0)`; non-positive → `Some(500.0)`.
- Render (`tests/status_render_contract.rs`): `Some` renders `$spent / $ceiling`; `None` arm renders `n/a`, never `unset (no guard)`.
- Monitoring (`src/operator_commands_dashboard/monitoring.rs`): `get_budget` daily fallback with temp `HOME` (no `budget.json`): unset → `500.0`, `250` → `250.0`, non-positive → `500.0`.

## Docs

New [daily-budget display guard reference](docs/reference/daily-budget-display-guard.md) plus corrected `telemetry-metrics.md`, `status-snapshot-api.md`, `simard-status.md`, index and nav. The OODA loop's separate `OodaConfig` enforcement path is documented as an out-of-scope follow-up.

## Verification

`cargo build`, `cargo test --lib` (7211 passed), `cargo fmt --check`, `cargo clippy --all-targets`, and `mkdocs build --strict` all green locally. Pre-commit and pre-push gates passed (no `--no-verify`).

Closes #6