### PR TITLE
feat(dashboard): per-page feedback widget that launches a dev-orchestrator workstream (#2629)

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -230,9 +230,37 @@ holding thousands of facts told operators that memory was empty when it was
 rich. The panel now hides empty legacy tiles so the displayed numbers always
 match Simard's actual remembered state.
 
+## Feedback widget: report a bug / request a feature (#2629)
+
+Every tab carries a **Report bug / Request feature** control in the shared
+header (top-right, next to **Glossary** and **Releases**). It lets an operator
+file a defect or a change request **from the page they are looking at**. On
+submit, the widget:
+
+1. captures the **current page context** — the active tab, the state/JSON that
+   page renders, a timestamp, and page identifiers;
+2. bundles it with the operator's report (`type` = bug \| feature, title,
+   description); and
+3. starts a **new `dev-orchestrator` workstream** — the same
+   `smart-orchestrator` → `default-workflow` recipe run engineers and the
+   Overseer use, launched through the shipped
+   [`RecipeLauncher`](reference/dashboard-feedback-widget.md#launcher-reuse)
+   plumbing (no ad-hoc shell-out).
+
+The modal then shows the workstream id and polls until the resulting **PR**
+appears, surfacing a link to it. Both endpoints (`POST /api/feedback` and
+`GET /api/feedback/status/{id}`) sit **behind the same access-code gate** as the
+rest of the dashboard, accept JSON only, sanitize and size-cap all inputs, and
+compose the workstream's `task_description` as plain data (never interpolated
+into a shell). See
+[Dashboard Feedback Widget](reference/dashboard-feedback-widget.md) for the full
+API reference and
+[How to report a bug or request a feature](howto/report-a-bug-or-request-a-feature.md)
+for the walkthrough.
+
 ## Read-only
 
-The dashboard does not let operators force shell commands or edit code through the browser. Goal promotion, status changes, and refresh are the only state-changing operations. All other panels are observational.
+The dashboard is observational: it does not let operators force shell commands or edit code through the browser. Goal promotion, status changes, refresh, and the [feedback widget](#feedback-widget-report-a-bug-request-a-feature-2629) (which starts a governed workstream, not a shell command) are the only state-changing operations. All other panels are observational. A feedback-launched workstream runs the standard `default-workflow` with CI required green and a human merge — it cannot merge or run arbitrary commands on its own.
 
 ## Tab identity contract
 
@@ -371,3 +399,5 @@ The `SIMARD_DASHBOARD_URL` environment variable is honored by `conftest.py` (def
 - [Run the OODA daemon](howto/run-ooda-daemon.md)
 - [Dashboard E2E tests](reference/dashboard-e2e-tests.md)
 - [Overview action-detail humanization](reference/dashboard-action-detail-humanization.md)
+- [Dashboard Feedback Widget](reference/dashboard-feedback-widget.md)
+- [How to report a bug or request a feature from the dashboard](howto/report-a-bug-or-request-a-feature.md)

--- a/docs/howto/report-a-bug-or-request-a-feature.md
+++ b/docs/howto/report-a-bug-or-request-a-feature.md
@@ -1,0 +1,125 @@
+---
+title: How to report a bug or request a feature from the dashboard
+description: Use the dashboard feedback widget to report a bug or request a feature directly from any tab. Simard captures the page context, starts a new dev-orchestrator workstream, and surfaces the resulting PR — all behind the existing dashboard access-code gate.
+last_updated: 2026-07-06
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../dashboard.md
+  - ../reference/dashboard-feedback-widget.md
+  - ../howto/spawn-engineers-from-ooda-daemon.md
+  - ../architecture/engineer-agent-orchestration.md
+---
+
+# How to report a bug or request a feature from the dashboard
+
+Every dashboard tab has a **Report bug / Request feature** control in the top
+header. Use it to file a defect or a change request **from the page you're
+looking at**. Simard snapshots the page's context, starts a new
+`dev-orchestrator` workstream (the same `default-workflow` engineers run), and
+shows you the pull request when it opens — without you leaving the dashboard.
+
+## Prerequisites
+
+- The dashboard is running and you are **logged in** (the widget and its
+  endpoints sit behind the existing access-code gate):
+
+  ```bash
+  simard dashboard serve --port=8080
+  ```
+
+  Open `http://localhost:8080/`, enter the login code
+  (printed on first start, also stored in `~/.simard/.dashkey`), and you'll land
+  on the dashboard with a session cookie set. See
+  [Dashboard](../dashboard.md) for details.
+
+## Steps
+
+### 1. Open the feedback form
+
+On any tab, click **💬 Feedback** in the top-right of the header (next to
+**Glossary** and **Releases**; its tooltip reads *Report bug / Request
+feature*). A modal opens.
+
+The control is in the shared header, so it looks and behaves identically on
+every tab — Overview, Goals, Traces, Logs, Processes, Memory, Costs, Chat,
+Workboard, Thinking, and the rest.
+
+### 2. Fill in the report
+
+| Field | What to enter |
+|-------|---------------|
+| **Type** | `Bug` for something broken, `Feature` for something you want added. |
+| **Title** | A short summary (≤ 200 characters). |
+| **Description** | What happened and what you expected — or what you want built (≤ 5000 characters). |
+
+You do **not** need to describe which page you're on or paste the data you're
+looking at — Simard captures that automatically in the next step.
+
+### 3. Submit
+
+Click **Start workstream**. The widget:
+
+1. Captures the **current page context** — the active tab, the key state/JSON
+   the page is rendering, a timestamp, and page identifiers (the page slug, the
+   URL path, the URL hash, and the document title).
+2. Sends `{report, context}` to `POST /api/feedback` (authenticated with your
+   session cookie).
+3. Starts a new workstream and shows you a **workstream id**.
+
+### 4. Watch for the PR
+
+The modal switches to a status line and polls automatically:
+
+- **Running** — "Workstream `recipe-…` started — waiting for a PR…"
+- **PR ready** — a link to the pull request (for example
+  `rysweet/Simard#2637`). Click through to review it.
+- **Failed** — a short message if the run couldn't produce a PR.
+
+That's it. The workstream runs the standard `default-workflow`: it branches off
+`main`, implements the change, and opens a PR with **CI required to be green**
+and a **human** to merge. Your report and the captured page context are written
+into the workstream's task description so the engineer starts with real context.
+
+## What gets captured (and what doesn't)
+
+**Captured:** the active tab slug, the visible/rendered state of that panel
+(size-bounded to 16 KiB), a timestamp, and page identifiers.
+
+**Not captured:** your login code or session cookie (the cookie is `HttpOnly`
+and unreadable to the widget). Even so, treat the description and any on-page
+data as content that may appear in a **public PR** — don't paste secrets.
+
+## Notes and limits
+
+- **Each accepted report starts a real, cost-bearing run.** A submission that
+  isn't a duplicate launches a full `dev-orchestrator` workstream — there is no
+  budget gate on this path, so submit deliberately rather than in bursts.
+- **One at a time per report.** Submitting the *same* report (same type, title,
+  and description) twice within ~30 seconds is de-duplicated — you'll get a
+  "duplicate" notice instead of a second workstream. This absorbs accidental
+  double-clicks.
+- **Busy signal.** If many *different* reports are launched at once and the
+  concurrency cap is saturated, you'll get a short "busy" notice — try again in
+  a moment.
+- **JSON only.** The endpoint accepts JSON from the in-page widget; it does not
+  accept HTML form posts (a CSRF-hardening measure).
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| Clicking the button does nothing / redirects to login | Your session expired. Log in again, then reopen the form. |
+| "duplicate" notice | You submitted the same report within ~30 s. Change the text or wait, then resubmit. |
+| "busy" notice | The launch concurrency cap is saturated. Retry shortly. |
+| "invalid" / "too long" | Type must be `bug`/`feature`; title ≤ 200 chars; description ≤ 5000 chars. |
+| Status stays "running" for a long time | The workstream is still working. Follow the link once the PR appears, or check the [Processes](../dashboard.md) tab for the live subprocess. |
+
+## See also
+
+- [Dashboard Feedback Widget](../reference/dashboard-feedback-widget.md) — full
+  API reference (endpoints, schemas, security model, tests).
+- [Dashboard](../dashboard.md) — the operator dashboard and its tabs.
+- [Engineer-Loop Agent Orchestration](../architecture/engineer-agent-orchestration.md)
+  — what a launched `dev-orchestrator` workstream does end-to-end.

--- a/docs/reference/dashboard-feedback-widget.md
+++ b/docs/reference/dashboard-feedback-widget.md
@@ -1,0 +1,437 @@
+---
+title: Dashboard Feedback Widget — report a bug / request a feature
+description: API reference for the dashboard feedback widget. Every dashboard tab carries a "Report bug / Request feature" control that captures the current page context and starts a new dev-orchestrator workstream through Simard's existing recipe-launch plumbing. Covers the widget, the authenticated REST endpoints, request/response schemas, context capture, task_description composition, the launcher reuse contract, validation, de-duplication, and the security model.
+last_updated: 2026-07-06
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+related:
+  - ../dashboard.md
+  - ../howto/report-a-bug-or-request-a-feature.md
+  - ./recipe-context-var-sanitization.md
+  - ./cross-repo-merge-authority.md
+  - ./concurrent-engineer-dispatch.md
+  - ./dashboard-chat.md
+  - ../architecture/engineer-agent-orchestration.md
+---
+
+# Dashboard Feedback Widget
+
+Every page of the [operator dashboard](../dashboard.md) carries a small
+**Report bug / Request feature** control. An operator who notices a defect or
+wants a change can file it **from the page they are looking at**, without
+switching tools or hand-writing a goal. On submit, the widget captures the
+current page context, bundles it with the operator's report, and starts a **new
+`dev-orchestrator` workstream** — the same `smart-orchestrator` →
+`default-workflow` recipe run that Simard's Overseer and manual operator
+workstreams use.
+
+The widget is **cross-cutting**: it lives in the shared dashboard `<header>`, so
+it is present on the whole tab set — Overview, Goals, Traces, Logs, Processes,
+Memory, Costs, Chat, Workboard, Thinking, and any others in the current
+catalogue — with identical placement. There is no per-tab wiring.
+
+!!! note "One launch path, reused — not re-implemented"
+    The endpoint does **not** shell out to `amplihack` on its own. It composes a
+    [`RecipeBrief`](#recipebrief) and calls the shipped
+    [`RecipeLauncher`](#launcher-reuse) (`SmartOrchestratorLauncher`,
+    `src/overseer/launch.rs`) — byte-for-byte the same `amplihack recipe run
+    amplifier-bundle/recipes/smart-orchestrator.yaml -c task_description=… -c
+    target_repo=…` invocation engineers and the Overseer already use. There is no
+    second notion of "launch a workstream" in the codebase.
+
+## At a glance
+
+| Property | Value |
+|----------|-------|
+| Widget location | Shared dashboard `<header>` — present on every tab |
+| Trigger | **Report bug / Request feature** button → modal form |
+| Submit endpoint | `POST /api/feedback` |
+| Status endpoint | `GET /api/feedback/status/{id}` |
+| Auth | Behind the existing dashboard access-code gate (`require_auth`); session cookie required |
+| Content type | `application/json` only (form-encoding is rejected) |
+| Recipe launched | `smart-orchestrator` → `default-workflow` |
+| Launcher | `crate::overseer::launch::SmartOrchestratorLauncher` (reused) |
+| Durable artifact | The resulting GitHub **PR** (feedback state itself is ephemeral) |
+
+## The widget
+
+The control renders in the top-right of the dashboard header, next to the
+existing **Glossary** / **Releases** actions:
+
+```
+🌲 Simard Dashboard        … ⟨/⟩ Source   📦 Releases   📖 Glossary   💬 Feedback   12:04
+```
+
+The button reads **💬 Feedback** and carries the tooltip / accessible label
+**Report bug / Request feature**. Clicking it opens a modal form with three
+inputs:
+
+| Field | Control | Meaning |
+|-------|---------|---------|
+| **Type** | select — `Bug` / `Feature` | Whether this is a defect report or a feature request. Maps to `report.type` = `bug` \| `feature`. |
+| **Title** | single-line text | Short summary. ≤ 200 characters. |
+| **Description** | multi-line text | What happened / what you want. ≤ 5000 characters. |
+
+On **Submit**, the client-side JS:
+
+1. Reads the **active tab** and the key state it renders (see
+   [Context capture](#context-capture)).
+2. `POST`s `{report, context}` as JSON to `/api/feedback` with
+   `credentials: "same-origin"` (so the session cookie is sent).
+3. Shows the returned **workstream id** and then **polls**
+   `/api/feedback/status/{id}` until a PR appears or the run ends
+   (see [UI feedback](#ui-feedback)).
+
+Server responses are rendered with DOM `textContent` wherever possible. The one
+`innerHTML` use — the "PR ready" line — first validates the server-supplied PR
+URL against `^https://github\.com/[^/]+/[^/]+/pull/\d+$` and HTML-escapes every
+interpolated part; a URL that fails the allow-list falls back to a plain-text
+line with no link.
+
+## Context capture
+
+When the operator submits, the widget snapshots **what they were looking at** so
+the workstream starts with real context instead of a bare sentence. The captured
+`context` object is:
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `page` | The active tab's stable slug (`data-tab` id, e.g. `overview`, `goals`, `memory`) | Read from the DOM / tab metadata; decoupled from the tab-switch handlers so it survives tab restructuring. |
+| `state` | The rendered content of the active panel (its visible text / the JSON it rendered) | Bounded — truncated to ≤ 16 KiB on a char boundary; control characters stripped. |
+| `timestamp` | Client clock at submit | ISO-8601 (RFC-3339). |
+| `identifiers` | Page identifiers visible at submit | An object carrying the active `page` slug, `url` (path), `hash`, and `doc_title`. Rendered into the task as compact JSON and truncated to ≤ 4 KiB. |
+
+The captured `state` is deliberately **minimal and page-scoped**: it is the
+section/JSON the page already renders to the operator. It must never include
+auth material (the login code, the session cookie is `HttpOnly` and unreadable),
+and the server enforces the size cap regardless of what the client sends.
+
+## Endpoints
+
+Both endpoints are registered **before** the `require_auth` layer in
+`src/operator_commands_dashboard/routes.rs`, so they inherit the existing
+dashboard access-code gate automatically. An unauthenticated request is
+redirected/refused exactly like every other `/api/*` route.
+
+### `POST /api/feedback`
+
+Start a workstream from a report + captured context.
+
+**Request** (`Content-Type: application/json`):
+
+```json
+{
+  "report": {
+    "type": "bug",
+    "title": "Costs tab shows $0 after midnight rollover",
+    "description": "After the daily ledger rolls over, the Costs tab renders $0.00 for every provider until the first new call lands. Expected: it should show the prior day's total until the new day has spend."
+  },
+  "context": {
+    "page": "costs",
+    "state": "{\"providers\":[{\"name\":\"anthropic\",\"model\":\"claude-opus\",\"usd\":0.0}]}",
+    "timestamp": "2026-07-06T02:41:10Z",
+    "identifiers": {
+      "url": "https://localhost:8080/#costs",
+      "session": null
+    }
+  }
+}
+```
+
+**Response — `202 Accepted`** (the run is spawned, not awaited):
+
+```json
+{
+  "ok": true,
+  "state": "started",
+  "workstream_id": "recipe-48213",
+  "poll": "/api/feedback/status/recipe-48213"
+}
+```
+
+The `workstream_id` is the [`WorkstreamHandle.id`](#workstreamhandle) returned by
+the launcher. `poll` is the ready-made status URL for the client.
+
+**Error responses** (all `application/json`, `{ "ok": false, "error": "…" }`):
+
+| Status | `error` | Cause |
+|--------|---------|-------|
+| `400 Bad Request` | `invalid report` | The body is missing the `report` object (this also covers a missing, non-JSON, form-encoded, malformed, or oversized body: the `Option<Json<Value>>` extractor coerces any such request to an empty object, which then fails this check). |
+| `400 Bad Request` | `invalid type` | `report.type` is missing or not exactly `bug` or `feature`. |
+| `400 Bad Request` | `title required` / `title too long` | Empty title, or title > 200 chars. |
+| `400 Bad Request` | `description required` / `description too long` | Empty description, or description > 5000 chars. |
+| `429 Too Many Requests` | `duplicate` | An identical report (same `type` + `title` + `description`) was submitted within the de-dup window (~30 s). See [De-duplication & throttle](#de-duplication-throttle). |
+| `429 Too Many Requests` | `busy` | The distinct-launch concurrency cap is saturated. |
+| `500 Internal Server Error` | `failed to start workstream` | The launcher failed to spawn. The internal detail is logged server-side via `tracing::warn!` only; the response body carries a generic message (never internal paths). |
+
+> **Malformed / non-JSON bodies never launch anything.** The submit handler
+> extracts the body as `Option<Json<Value>>`: a missing, malformed, non-JSON,
+> **form-encoded**, or oversized request deserialises to `None`, is coerced to an
+> empty object, and is rejected as `400 invalid report`. Rejecting form-encoding
+> this way is a CSRF-hardening measure — a cross-site `<form>` POST can never
+> compose the JSON shape required to start a workstream.
+
+### `GET /api/feedback/status/{id}`
+
+Poll a launched workstream by its `workstream_id`. Same auth gate.
+
+**Response — `200 OK`** while running:
+
+```json
+{ "ok": true, "state": "running", "workstream_id": "recipe-48213" }
+```
+
+**Response — `200 OK`** once a PR is produced:
+
+```json
+{
+  "ok": true,
+  "state": "pr",
+  "workstream_id": "recipe-48213",
+  "repo": "rysweet/Simard",
+  "pr": 2637,
+  "pr_url": "https://github.com/rysweet/Simard/pull/2637"
+}
+```
+
+**Response — `200 OK`** on failure:
+
+```json
+{ "ok": true, "state": "failed", "workstream_id": "recipe-48213", "reason": "recipe finished but produced no PR" }
+```
+
+**Response — `404 Not Found`** for an unknown or unreadable id:
+
+```json
+{ "ok": false, "error": "unknown workstream" }
+```
+
+!!! note "Poll failures return 404, never leak"
+    Every `RecipeLauncher::poll` failure — an unknown id (the real
+    `AmplihackRecipeRunner::probe` returns
+    `Capability { what: "recipe.probe", detail: "unknown workstream …" }`) or any
+    other probe error — maps to a single generic `404 { "error": "unknown
+    workstream" }`. The underlying detail is logged server-side via
+    `tracing::warn!` only, so no internal path or reason ever reaches the client.
+    A `200` is returned only when `poll` succeeds and yields a live
+    [`WorkstreamStatus`](#workstreamstatus).
+
+The three `state` values map directly from
+[`WorkstreamStatus`](#workstreamstatus) via the pure `status_json` mapper; the
+endpoint additionally echoes the polled `workstream_id`:
+
+| `WorkstreamStatus` | `state` | Extra fields |
+|--------------------|---------|--------------|
+| `Running` | `running` | — |
+| `ProducedPr { repo, pr }` | `pr` | `repo`, `pr`, `pr_url` |
+| `Failed { reason }` | `failed` | `reason` |
+
+## Launcher reuse
+
+The handler is a thin adapter over the **existing** Overseer launch plumbing.
+No new subprocess or shell-out code is introduced.
+
+- **Trait:** `crate::overseer::capabilities::RecipeLauncher`
+  ```rust
+  pub trait RecipeLauncher {
+      fn launch(&self, brief: &RecipeBrief) -> Result<WorkstreamHandle, OverseerError>;
+      fn poll(&self, handle: &WorkstreamHandle) -> Result<WorkstreamStatus, OverseerError>;
+  }
+  ```
+- **Production implementation:** `crate::overseer::launch::SmartOrchestratorLauncher`
+  (built with `SmartOrchestratorLauncher::from_env()`), which runs
+  `amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml` with
+  `AMPLIHACK_AGENT_BINARY` preserved (Copilot/Claude parity), captures output,
+  and extracts the resulting `github.com/<owner>/<repo>/pull/<n>` reference on
+  completion.
+
+The dashboard holds a single shared launcher (a `OnceLock<SmartOrchestratorLauncher>`)
+so the `POST` and status handlers observe the same stateful runner — the one that
+knows which subprocess each `workstream_id` maps to — across axum's worker threads.
+
+!!! note "One required upstream change"
+    Sharing the launcher across axum's multithreaded handlers requires it to be
+    `Send + Sync`. That is the **single** production edit needed in the reused
+    plumbing: add `Send + Sync` as a supertrait to the `RecipeRunner` trait
+    (`pub trait RecipeRunner: Send + Sync`, `src/overseer/launch.rs`), which the
+    `SmartOrchestratorLauncher`'s `Box<dyn RecipeRunner>` field then inherits.
+    Both the real runner (`AmplihackRecipeRunner`, whose only state is a
+    `Mutex<HashMap<..>>`) and every test `FakeRunner` already satisfy the bound,
+    so no other impl is affected.
+
+### `RecipeBrief`
+
+The handler composes one brief per submit:
+
+```rust
+RecipeBrief {
+    task_description: /* composed from report + context, see below */,
+    target_repo: /* Simard's own slug — the dashboard is a Simard surface */,
+    sequence_group: None,
+}
+```
+
+### `WorkstreamHandle`
+
+```rust
+pub struct WorkstreamHandle { pub id: String }
+```
+
+### `WorkstreamStatus`
+
+```rust
+pub enum WorkstreamStatus {
+    Running,
+    ProducedPr { repo: String, pr: u32 },
+    Failed { reason: String },
+}
+```
+
+## `task_description` composition
+
+The `task_description` is built by a **pure, unit-tested** function from the
+validated report and captured context. It is assembled as plain data and passed
+as a single `String` argument, so there is **no shell interpolation** anywhere on
+the path (see [Security](#security-model)). The template is deterministic:
+
+```
+[BUG] Costs tab shows $0 after midnight rollover
+
+After the daily ledger rolls over, the Costs tab renders $0.00 for every
+provider until the first new call lands. Expected: it should show the prior
+day's total until the new day has spend.
+
+--- Operator feedback (untrusted input; captured from the dashboard) ---
+Page/tab: costs
+Timestamp: 2026-07-06T02:41:10Z
+Identifiers: {"hash":"#costs","url":"/","doc_title":"Simard · Costs"}
+Page state:
+{"providers":[{"name":"anthropic","model":"claude-opus","usd":0.0}]}
+
+Filed from the Simard dashboard feedback widget (issue #2629). Please triage
+this operator report and, if actionable, address the bug or build the requested
+feature following the default development workflow.
+```
+
+Notes:
+
+- The first line is `[BUG]` or `[FEATURE]` followed by the title.
+- The description follows verbatim (already length-capped and control-char
+  stripped).
+- The context block is clearly delimited and **labelled as untrusted input** so
+  the downstream orchestrator treats operator text as data, not instructions.
+- `Identifiers` is the captured identifiers object rendered as compact JSON.
+- The rendered `state` is the ≤ 16 KiB truncated snapshot.
+- A closing instruction directs the orchestrator to triage the report under the
+  default development workflow.
+
+## Validation
+
+Server-side validation is authoritative (the client mirrors it only for UX):
+
+| Rule | Limit | On violation |
+|------|-------|--------------|
+| `report.type` | exactly `bug` or `feature` | `400 invalid type` |
+| `report.title` | non-empty, ≤ 200 chars (after trim) | `400 title required` / `title too long` |
+| `report.description` | non-empty, ≤ 5000 chars (after trim) | `400 description required` / `description too long` |
+| `context.state` | truncated to ≤ 16 KiB on a char boundary | silently truncated |
+| `context.identifiers` | serialized JSON truncated to ≤ 4 KiB | silently truncated |
+| all text | control characters stripped | silently sanitized |
+| request body | missing / non-JSON / form-encoded / oversized | `400 invalid report` (coerced to empty by the `Option<Json<Value>>` extractor) |
+
+## De-duplication & throttle
+
+To keep an accidental double-click — or an operator retrying — from spawning
+duplicate workstreams, the handler keeps ephemeral in-memory state (a
+`OnceLock<FeedbackDedup>` wrapping a `Mutex` over a recent-report map keyed on
+`hash(type | title | description)` plus a rolling list of accepted-launch
+instants):
+
+- A **duplicate** within ~30 s returns `429 { "error": "duplicate" }` and does
+  **not** launch.
+- A **distinct-launch concurrency cap** protects against a flood of *different*
+  reports (which de-dup alone would not stop); over the cap returns
+  `429 { "error": "busy" }`.
+
+!!! warning "This path bypasses the Overseer's budget & per-cycle gates"
+    When the Overseer launches a workstream it first passes `Overseer::gate`
+    (the per-cycle launch cap **and** the daily-budget gate). The dashboard
+    calls `SmartOrchestratorLauncher::launch()` **directly**, so *neither* of
+    those ceilings applies here — the launcher itself
+    (`AmplihackRecipeRunner`) spawns unconditionally. Each accepted submission
+    is a full, cost-bearing `smart-orchestrator` run. On this surface the **only**
+    cost-DoS controls are therefore the auth gate, the ~30 s de-dup window, and
+    the handler's own distinct-launch concurrency cap. Size that cap
+    conservatively, and treat it (not any Overseer ceiling) as the authoritative
+    throttle. The [Concurrent Engineer Dispatch](./concurrent-engineer-dispatch.md)
+    ceilings govern the Overseer loop, not this direct path.
+
+All feedback state is **ephemeral** — there is no database, no migration, no
+schema. The only durable output is the GitHub PR the workstream opens. (Note:
+the launcher's in-memory run table retains each launched child until process
+exit; a long-lived dashboard should evict terminal `ProducedPr`/`Failed`
+entries on poll to keep that map bounded.)
+
+## UI feedback
+
+After a successful `POST`, the modal switches to a status line and begins
+polling `poll`:
+
+- **Running:** "Workstream `recipe-48213` started — waiting for a PR…"
+- **PR ready:** the workstream id plus a **link to the PR**
+  (`rysweet/Simard#2637`), rendered only after the URL passes the
+  `github.com/…/pull/<n>` allow-list check.
+- **Failed:** a short, generic failure line (the internal reason is not
+  surfaced beyond `WorkstreamStatus::Failed.reason`).
+
+## Security model
+
+| Concern | Mitigation |
+|---------|-----------|
+| **AuthN/Z** | Both routes are registered before `.layer(require_auth)` → auto-gated, fail-closed. No new auth code; the client sends `credentials: "same-origin"`. |
+| **CSRF** | The endpoint accepts **only** `application/json` (form-encoding is rejected) and the session cookie is `SameSite=Strict`. |
+| **OS-command injection** | Impossible by construction: the launcher uses `Command::args(Vec<String>)` (no shell). The `task_description` is one argument. A regression test submits a `; rm -rf /` payload and asserts it appears only as inert text. |
+| **Prompt injection** | The captured context and operator text are delimited and labelled *untrusted* in the `task_description`. The downstream workstream retains all existing guardrails: no `git --no-verify`, no `gh pr merge --admin`, CI must be green, and a human merges. |
+| **Input DoS** | Title/description length caps, `state` truncation to 16 KiB, `identifiers` truncation to 4 KiB, and coercion of any missing/non-JSON/oversized body to `400` — plus the de-dup window and distinct-launch concurrency cap. |
+| **Client XSS** | All responses render via `textContent`/DOM APIs; the PR URL is validated against `^https://github\.com/[^/]+/[^/]+/pull/\d+$` before assignment. |
+| **Data protection** | Feedback is ephemeral (no DB). Logs use `tracing::warn!` with generic messages — never the full body, cookie, or login code. Captured `state` is page-scoped and size-bounded; keep it free of secrets. |
+
+!!! info "Known limitation — cookie lacks `Secure`"
+    The dashboard session cookie (`auth.rs`) is set `HttpOnly; SameSite=Strict`
+    but **not** `Secure`. That is acceptable for the default loopback deployment
+    and is unchanged by this feature. If the dashboard is ever served over TLS
+    to a non-loopback origin, add `Secure` to the cookie so it is not exposed on
+    a downgraded connection. This is a pre-existing, out-of-scope finding noted
+    here for completeness.
+
+## Testing
+
+The feature ships with **hermetic** tests (no subprocess, no network) that
+inject a fake `RecipeLauncher`:
+
+- **Launch contract** — `handle_feedback` with a fake launcher asserts the
+  composed `task_description` carries `[BUG]`/`[FEATURE]`, the title,
+  description, and the page context; asserts the correct `target_repo`; and
+  asserts no real `amplihack` process is spawned.
+- **`compose_task_description`** — pure unit test pins the template.
+- **Validation matrix** — bad `type`, empty/oversized title and description,
+  and body-limit behaviour.
+- **Injection safety** — a `; rm -rf /` payload is proven inert (argument, not
+  shell).
+- **De-dup** — a repeated identical report returns `429 duplicate`.
+- **Concurrency throttle** — over-cap distinct reports return `429 busy`.
+- **Status mapping** — `Running` / `ProducedPr` / `Failed` map to
+  `running` / `pr` / `failed`; unknown id → `404`; launcher error → generic
+  `500`.
+- **Widget presence** — the rendered dashboard HTML
+  (`index_html_string()`) contains the feedback button, the modal, and the
+  `POST /api/feedback` client JS, so the control is present on every tab.
+
+## See also
+
+- [Dashboard](../dashboard.md) — the operator dashboard overview and tabs.
+- [How to report a bug or request a feature from the dashboard](../howto/report-a-bug-or-request-a-feature.md) — task-oriented walkthrough.
+- [Recipe Context-Var Sanitization](./recipe-context-var-sanitization.md) — how `-c key=value` context vars are kept injection-safe.
+- [Concurrent Engineer Dispatch](./concurrent-engineer-dispatch.md) — the concurrency ceilings that govern the **Overseer** loop. These do **not** apply to this direct launch path; the handler's own cap is the throttle here (see [De-duplication & throttle](#de-duplication-throttle)).
+- [Engineer-Loop Agent Orchestration](../architecture/engineer-agent-orchestration.md) — what a launched `dev-orchestrator` workstream does end-to-end.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
     - Interpret Brain Confidence and Verify Completion: howto/interpret-brain-confidence-and-verify-completion.md
     - Configure Brain Introspection: howto/configure-brain-introspection.md
     - Start a Meeting: howto/start-a-meeting.md
+    - Report a Bug or Request a Feature: howto/report-a-bug-or-request-a-feature.md
     - Resume an Interrupted Meeting: howto/resume-an-interrupted-meeting.md
     - Recover from Meeting-Close Timeout: howto/recover-from-meeting-close-timeout.md
     - Use Meeting Templates: howto/use-meeting-templates.md
@@ -276,6 +277,7 @@ nav:
     - Signal Continuous Conversation: reference/signal-continuous-conversation.md
     - LightweightChatSession: reference/lightweight-chat-session.md
     - Dashboard Chat: reference/dashboard-chat.md
+    - Dashboard Feedback Widget: reference/dashboard-feedback-widget.md
     - Copilot Meeting Mode: reference/copilot-meeting-mode.md
     - Meeting Close Lifecycle: reference/meeting-close-lifecycle.md
     - Meeting Handoff Schema: reference/meeting-handoff-schema.md

--- a/src/operator_commands_dashboard/feedback.rs
+++ b/src/operator_commands_dashboard/feedback.rs
@@ -1,0 +1,478 @@
+//! Backend for the dashboard "Report bug / Request feature" widget (#2629).
+//!
+//! The widget on every dashboard tab POSTs `{report, context}` here. The
+//! handler validates + sanitizes the operator's report, composes a
+//! `task_description` from the report plus the captured page context, and
+//! launches a NEW dev-orchestrator workstream by REUSING the existing
+//! [`RecipeLauncher`] plumbing
+//! ([`SmartOrchestratorLauncher`](crate::overseer::launch::SmartOrchestratorLauncher),
+//! which runs `smart-orchestrator` → default-workflow exactly as engineers do).
+//! No ad-hoc shell-out: the brief flows through the launcher, whose real runner
+//! feeds `task_description` to `Command::args` (a `Vec<String>`), never a shell —
+//! so free-text is structurally inert as data.
+//!
+//! The pure core (`compose_task_description`, `handle_feedback`,
+//! `handle_feedback_status`, `status_json`) takes an injectable
+//! `&dyn RecipeLauncher` and returns `(StatusCode, Value)`, so the whole flow is
+//! unit-testable with an in-memory fake (see `tests_feedback`). The thin axum
+//! handlers wrap the `Value` in `Json` and share one stateful launcher/dedup so
+//! `poll` can find the run it spawned. Both routes register BEFORE the existing
+//! `require_auth` layer, inheriting the dashboard access-code gate.
+
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use axum::extract::Path;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::{Json, response::Response};
+use serde_json::{Value, json};
+
+use crate::overseer::capabilities::{
+    RecipeBrief, RecipeLauncher, WorkstreamHandle, WorkstreamStatus,
+};
+use crate::overseer::launch::SmartOrchestratorLauncher;
+use crate::stewardship::TargetRepo;
+
+// ─────────────────────────── limits & windows ──────────────────────────────
+
+/// Max characters accepted for a report title (rejected over cap).
+pub(crate) const MAX_TITLE_LEN: usize = 200;
+/// Max characters accepted for a report description (rejected over cap).
+pub(crate) const MAX_DESCRIPTION_LEN: usize = 5_000;
+/// Max characters of captured page state carried into the task (truncated, not
+/// rejected — a huge/hostile page must never blow up the task_description).
+pub(crate) const MAX_STATE_LEN: usize = 16_384;
+/// Max serialized characters of the captured `identifiers` object (truncated).
+pub(crate) const MAX_IDENTIFIERS_LEN: usize = 4_096;
+/// An identical report resubmitted inside this window is a duplicate.
+pub(crate) const DEDUP_WINDOW_SECS: u64 = 30;
+/// No more than this many distinct workstreams may launch per dedup window
+/// (subprocess cost-DoS guard).
+pub(crate) const MAX_FEEDBACK_LAUNCHES_PER_WINDOW: usize = 5;
+
+// ─────────────────────────── report / context ──────────────────────────────
+
+/// The kind of operator report the widget submits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FeedbackKind {
+    Bug,
+    Feature,
+}
+
+impl FeedbackKind {
+    /// The uppercase marker embedded in the composed task_description.
+    fn marker(self) -> &'static str {
+        match self {
+            FeedbackKind::Bug => "[BUG]",
+            FeedbackKind::Feature => "[FEATURE]",
+        }
+    }
+
+    /// Parse the wire value, accepting exactly `bug` | `feature`.
+    fn parse(raw: &str) -> Option<Self> {
+        match raw.trim() {
+            "bug" => Some(FeedbackKind::Bug),
+            "feature" => Some(FeedbackKind::Feature),
+            _ => None,
+        }
+    }
+}
+
+/// A validated, sanitized operator report.
+pub(crate) struct FeedbackReport {
+    pub(crate) kind: FeedbackKind,
+    pub(crate) title: String,
+    pub(crate) description: String,
+}
+
+/// The page context captured client-side when the report was filed.
+pub(crate) struct FeedbackContext {
+    pub(crate) page: String,
+    pub(crate) state: String,
+    pub(crate) timestamp: String,
+    pub(crate) identifiers: Value,
+}
+
+// ─────────────────────────── de-dupe / throttle ────────────────────────────
+
+#[derive(Default)]
+struct DedupState {
+    /// `report-hash → time accepted`, for the duplicate-window check.
+    recent: HashMap<u64, Instant>,
+    /// Timestamps of accepted launches, for the per-window launch cap.
+    launches: Vec<Instant>,
+}
+
+/// De-dupe + rate-limit state for the feedback endpoint. Interior-mutable so a
+/// shared `&FeedbackDedup` (held in a process-wide `OnceLock` in production) can
+/// record accepted launches without a `&mut`.
+pub(crate) struct FeedbackDedup {
+    inner: Mutex<DedupState>,
+}
+
+impl FeedbackDedup {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Mutex::new(DedupState::default()),
+        }
+    }
+}
+
+/// Verdict of the dedup/throttle gate, evaluated before a launch.
+enum Gate {
+    Ok,
+    Duplicate,
+    RateLimited,
+}
+
+impl FeedbackDedup {
+    /// Purge window-expired entries, then decide whether `hash` may launch at
+    /// `now`. Pure decision — recording happens only after a successful launch.
+    fn evaluate(&self, hash: u64, now: Instant) -> Gate {
+        let window = Duration::from_secs(DEDUP_WINDOW_SECS);
+        let mut st = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        st.recent
+            .retain(|_, &mut t| now.saturating_duration_since(t) < window);
+        st.launches
+            .retain(|&t| now.saturating_duration_since(t) < window);
+
+        if st.recent.contains_key(&hash) {
+            Gate::Duplicate
+        } else if st.launches.len() >= MAX_FEEDBACK_LAUNCHES_PER_WINDOW {
+            Gate::RateLimited
+        } else {
+            Gate::Ok
+        }
+    }
+
+    /// Record an accepted launch so later duplicates/floods are gated.
+    fn record(&self, hash: u64, now: Instant) {
+        let mut st = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        st.recent.insert(hash, now);
+        st.launches.push(now);
+    }
+}
+
+// ─────────────────────────── sanitization ──────────────────────────────────
+
+/// Strip ASCII control characters. `keep_newlines` retains `\n`/`\t` for
+/// multi-line free text (description, page state); titles strip everything.
+fn strip_control(s: &str, keep_newlines: bool) -> String {
+    s.chars()
+        .filter(|c| !c.is_control() || (keep_newlines && (*c == '\n' || *c == '\t')))
+        .collect()
+}
+
+/// Truncate to at most `max` Unicode chars, appending `…` when shortened.
+fn truncate_chars(s: &str, max: usize) -> String {
+    let mut chars = s.chars();
+    let head: String = chars.by_ref().take(max).collect();
+    if chars.next().is_some() {
+        format!("{head}…")
+    } else {
+        head
+    }
+}
+
+/// Stable hash of the report identity for de-dupe.
+fn report_hash(kind: FeedbackKind, title: &str, description: &str) -> u64 {
+    let mut h = DefaultHasher::new();
+    kind.marker().hash(&mut h);
+    title.hash(&mut h);
+    description.hash(&mut h);
+    h.finish()
+}
+
+// ─────────────────────────── parsing / validation ──────────────────────────
+
+/// Parse+validate+sanitize the request body into a `(report, context)` pair, or
+/// a human-safe rejection reason (→ 400). Never trusts sizes: the page state
+/// and identifiers are truncated rather than rejected.
+fn parse_body(body: &Value) -> Result<(FeedbackReport, FeedbackContext), &'static str> {
+    let report = body.get("report").ok_or("invalid report")?;
+    let context = body.get("context").cloned().unwrap_or_else(|| json!({}));
+
+    let kind_raw = report
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or("invalid type")?;
+    let kind = FeedbackKind::parse(kind_raw).ok_or("invalid type")?;
+
+    let title = strip_control(
+        report.get("title").and_then(Value::as_str).unwrap_or(""),
+        false,
+    );
+    let title = title.trim().to_string();
+    if title.is_empty() {
+        return Err("title required");
+    }
+    if title.chars().count() > MAX_TITLE_LEN {
+        return Err("title too long");
+    }
+
+    let description = strip_control(
+        report
+            .get("description")
+            .and_then(Value::as_str)
+            .unwrap_or(""),
+        true,
+    );
+    if description.trim().is_empty() {
+        return Err("description required");
+    }
+    if description.chars().count() > MAX_DESCRIPTION_LEN {
+        return Err("description too long");
+    }
+
+    let page = truncate_chars(
+        strip_control(
+            context.get("page").and_then(Value::as_str).unwrap_or(""),
+            false,
+        )
+        .trim(),
+        MAX_TITLE_LEN,
+    );
+    let state = truncate_chars(
+        &strip_control(
+            context.get("state").and_then(Value::as_str).unwrap_or(""),
+            true,
+        ),
+        MAX_STATE_LEN,
+    );
+    let timestamp = truncate_chars(
+        strip_control(
+            context
+                .get("timestamp")
+                .and_then(Value::as_str)
+                .unwrap_or(""),
+            false,
+        )
+        .trim(),
+        MAX_TITLE_LEN,
+    );
+    let identifiers = bound_identifiers(context.get("identifiers"));
+
+    Ok((
+        FeedbackReport {
+            kind,
+            title,
+            description,
+        },
+        FeedbackContext {
+            page,
+            state,
+            timestamp,
+            identifiers,
+        },
+    ))
+}
+
+/// Keep the captured `identifiers` object but bound its serialized size so a
+/// hostile payload can't bloat the task. Non-objects degrade to `{}`.
+fn bound_identifiers(v: Option<&Value>) -> Value {
+    match v {
+        Some(Value::Object(_)) => {
+            let serialized = v.map(|x| x.to_string()).unwrap_or_default();
+            if serialized.chars().count() <= MAX_IDENTIFIERS_LEN {
+                v.cloned().unwrap_or_else(|| json!({}))
+            } else {
+                json!({ "truncated": truncate_chars(&serialized, MAX_IDENTIFIERS_LEN) })
+            }
+        }
+        _ => json!({}),
+    }
+}
+
+// ─────────────────────────── task composition ──────────────────────────────
+
+/// Compose the workstream `task_description` from the report + captured page
+/// context. Pure and deterministic: identical inputs yield identical output.
+/// The result is carried as data through `Command::args`, never a shell.
+pub(crate) fn compose_task_description(
+    report: &FeedbackReport,
+    context: &FeedbackContext,
+) -> String {
+    let identifiers = if context.identifiers.is_null() {
+        "{}".to_string()
+    } else {
+        context.identifiers.to_string()
+    };
+    format!(
+        "{marker} {title}\n\
+         \n\
+         {description}\n\
+         \n\
+         --- Operator feedback (untrusted input; captured from the dashboard) ---\n\
+         Page/tab: {page}\n\
+         Timestamp: {timestamp}\n\
+         Identifiers: {identifiers}\n\
+         Page state:\n{state}\n\
+         \n\
+         Filed from the Simard dashboard feedback widget (issue #2629). Please \
+         triage this operator report and, if actionable, address the bug or \
+         build the requested feature following the default development workflow.",
+        marker = report.kind.marker(),
+        title = report.title,
+        description = report.description,
+        page = context.page,
+        timestamp = context.timestamp,
+        identifiers = identifiers,
+        state = context.state,
+    )
+}
+
+// ─────────────────────────── pure core handlers ────────────────────────────
+
+/// Handle a feedback submission against an injectable launcher + dedup state.
+///
+/// * 400 — invalid/oversize report (never launches).
+/// * 429 — duplicate within the dedup window, or per-window launch cap hit.
+/// * 500 — the launcher failed (detail is NOT leaked to the client).
+/// * 202 — launched; body carries `workstream_id` + a `poll` URL.
+pub(crate) fn handle_feedback(
+    launcher: &dyn RecipeLauncher,
+    dedup: &FeedbackDedup,
+    now: Instant,
+    body: Value,
+) -> (StatusCode, Value) {
+    let (report, context) = match parse_body(&body) {
+        Ok(pair) => pair,
+        Err(reason) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                json!({ "ok": false, "error": reason }),
+            );
+        }
+    };
+
+    let hash = report_hash(report.kind, &report.title, &report.description);
+    match dedup.evaluate(hash, now) {
+        Gate::Duplicate => {
+            return (
+                StatusCode::TOO_MANY_REQUESTS,
+                json!({ "ok": false, "error": "duplicate" }),
+            );
+        }
+        Gate::RateLimited => {
+            return (
+                StatusCode::TOO_MANY_REQUESTS,
+                json!({ "ok": false, "error": "busy" }),
+            );
+        }
+        Gate::Ok => {}
+    }
+
+    let brief = RecipeBrief {
+        task_description: compose_task_description(&report, &context),
+        target_repo: TargetRepo::Simard.slug().to_string(),
+        sequence_group: None,
+    };
+
+    match launcher.launch(&brief) {
+        Ok(handle) => {
+            dedup.record(hash, now);
+            let poll = format!("/api/feedback/status/{}", handle.id);
+            (
+                StatusCode::ACCEPTED,
+                json!({
+                    "ok": true,
+                    "state": "started",
+                    "workstream_id": handle.id,
+                    "poll": poll,
+                }),
+            )
+        }
+        Err(err) => {
+            tracing::warn!(target: "dashboard.feedback", error = %err, "feedback workstream launch failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                json!({ "ok": false, "error": "failed to start workstream" }),
+            )
+        }
+    }
+}
+
+/// Poll a launched feedback workstream by id. Unknown ids / probe failures map
+/// to 404 without leaking internal detail; a live status maps via
+/// [`status_json`].
+pub(crate) fn handle_feedback_status(
+    launcher: &dyn RecipeLauncher,
+    id: String,
+) -> (StatusCode, Value) {
+    let handle = WorkstreamHandle { id: id.clone() };
+    match launcher.poll(&handle) {
+        Ok(status) => {
+            let mut body = status_json(&status);
+            if let Some(obj) = body.as_object_mut() {
+                obj.insert("workstream_id".to_string(), json!(id));
+            }
+            (StatusCode::OK, body)
+        }
+        Err(err) => {
+            tracing::warn!(target: "dashboard.feedback", error = %err, "feedback workstream poll failed");
+            (
+                StatusCode::NOT_FOUND,
+                json!({ "ok": false, "error": "unknown workstream" }),
+            )
+        }
+    }
+}
+
+/// Map a [`WorkstreamStatus`] to a UI-facing JSON body. A produced PR surfaces a
+/// clickable `github.com/<repo>/pull/<n>` URL so the widget can link it.
+pub(crate) fn status_json(status: &WorkstreamStatus) -> Value {
+    match status {
+        WorkstreamStatus::Running => json!({ "ok": true, "state": "running" }),
+        WorkstreamStatus::ProducedPr { repo, pr } => json!({
+            "ok": true,
+            "state": "pr",
+            "repo": repo,
+            "pr": pr,
+            "pr_url": format!("https://github.com/{repo}/pull/{pr}"),
+        }),
+        WorkstreamStatus::Failed { reason } => json!({
+            "ok": true,
+            "state": "failed",
+            "reason": reason,
+        }),
+    }
+}
+
+// ─────────────────────────── production plumbing ───────────────────────────
+
+/// The process-wide launcher. A single stateful instance so a workstream
+/// spawned by `POST /api/feedback` can be found by `GET /api/feedback/status/…`.
+fn launcher() -> &'static dyn RecipeLauncher {
+    static LAUNCHER: OnceLock<SmartOrchestratorLauncher> = OnceLock::new();
+    LAUNCHER.get_or_init(SmartOrchestratorLauncher::from_env)
+}
+
+/// The process-wide dedup/throttle state.
+fn dedup() -> &'static FeedbackDedup {
+    static DEDUP: OnceLock<FeedbackDedup> = OnceLock::new();
+    DEDUP.get_or_init(FeedbackDedup::new)
+}
+
+/// `POST /api/feedback` — receive `{report, context}`, launch a workstream.
+/// Behind the dashboard `require_auth` layer (registered in `routes.rs`).
+pub(crate) async fn feedback_submit(body: Option<Json<Value>>) -> Response {
+    let Json(body) = body.unwrap_or_else(|| Json(json!({})));
+    let (status, value) = handle_feedback(launcher(), dedup(), Instant::now(), body);
+    (status, Json(value)).into_response()
+}
+
+/// `GET /api/feedback/status/{id}` — poll a launched workstream. Behind auth.
+pub(crate) async fn feedback_status(Path(id): Path<String>) -> Response {
+    let (status, value) = handle_feedback_status(launcher(), id);
+    (status, Json(value)).into_response()
+}

--- a/src/operator_commands_dashboard/index_html/feedback_widget.rs
+++ b/src/operator_commands_dashboard/index_html/feedback_widget.rs
@@ -1,0 +1,171 @@
+//! The "Report bug / Request feature" feedback widget markup (#2629).
+//!
+//! A SINGLE control anchored in the shared dashboard `<header>` (so it appears
+//! on every tab with consistent placement) plus the modal form, styles, and the
+//! client JS that captures the current page context and POSTs it to the
+//! auth-gated `/api/feedback` endpoint, then polls `/api/feedback/status/<id>`
+//! for the launched workstream's PR.
+//!
+//! Assembled into the page by [`super::index_html_string`]:
+//!
+//! * [`FEEDBACK_WIDGET_BUTTON`] replaces the `{{FEEDBACK_WIDGET_BUTTON}}` marker
+//!   inside the `<header>` (part_00).
+//! * [`FEEDBACK_WIDGET_BODY`] is injected just before `</body>`.
+//!
+//! Kept as flat string consts (no nested `{{`) so it survives the
+//! `index_html_string` template pass and a `grep` audit. All server/user data is
+//! HTML-escaped client-side before `innerHTML`; the fetch uses
+//! `credentials:'same-origin'` so the dashboard auth cookie is sent.
+
+/// The header button that opens the feedback modal. Reuses the existing
+/// `glossary-toggle` button styling for visual consistency across the header.
+pub(crate) const FEEDBACK_WIDGET_BUTTON: &str = r##"<button id="feedback-widget-button" class="glossary-toggle" onclick="openFeedbackModal()" title="Report bug / Request feature" style="border-color:#3fb950;color:#3fb950">💬 Feedback</button>"##;
+
+/// The feedback modal, its styles, and the capture/submit/poll client script.
+pub(crate) const FEEDBACK_WIDGET_BODY: &str = r##"<style>
+    #feedback-modal{display:none;position:fixed;inset:0;background:rgba(1,4,9,0.7);z-index:2000;align-items:flex-start;justify-content:center}
+    #feedback-modal .fb-card{background:var(--card);border:1px solid var(--border);border-radius:10px;padding:1.25rem;margin-top:8vh;width:min(560px,92vw);box-shadow:0 12px 32px rgba(0,0,0,0.45)}
+    #feedback-modal h2{color:var(--accent);font-size:1.05rem;margin:0 0 .25rem}
+    #feedback-modal .fb-sub{color:#8b949e;font-size:.8rem;margin:0 0 1rem;line-height:1.4}
+    #feedback-modal label{display:block;color:#c9d1d9;font-size:.8rem;font-weight:600;margin:.6rem 0 .25rem}
+    #feedback-modal select,#feedback-modal input,#feedback-modal textarea{width:100%;padding:.5rem;border:1px solid var(--border);border-radius:6px;background:#010409;color:var(--fg);font-size:.9rem;font-family:inherit}
+    #feedback-modal textarea{resize:vertical;min-height:96px}
+    #feedback-modal .fb-actions{display:flex;justify-content:flex-end;gap:.5rem;margin-top:1rem}
+    #feedback-modal .fb-btn{padding:.5rem 1.1rem;border:none;border-radius:6px;font-weight:600;cursor:pointer;font-size:.85rem}
+    #feedback-modal .fb-btn.primary{background:#3fb950;color:#0d1117}
+    #feedback-modal .fb-btn.secondary{background:transparent;color:#8b949e;border:1px solid var(--border)}
+    #feedback-modal .fb-btn:hover{opacity:.9}
+    #feedback-result{margin-top:.85rem;font-size:.82rem;color:#9bb1c4;line-height:1.5;word-break:break-word;min-height:1.2rem}
+    #feedback-result a{color:var(--accent)}
+  </style>
+  <div id="feedback-modal" role="dialog" aria-modal="true" aria-label="Report bug or request feature">
+    <div class="fb-card">
+      <h2>Report bug / Request feature</h2>
+      <p class="fb-sub">Send this straight to Simard. On submit we capture the current page and its visible data, then start a new dev-orchestrator workstream from your report.</p>
+      <form id="feedback-form">
+        <label for="feedback-type">Type</label>
+        <select id="feedback-type">
+          <option value="bug">Report bug</option>
+          <option value="feature">Request feature</option>
+        </select>
+        <label for="feedback-title">Title</label>
+        <input id="feedback-title" type="text" maxlength="200" placeholder="Short summary" required>
+        <label for="feedback-description">Description</label>
+        <textarea id="feedback-description" maxlength="5000" placeholder="What happened, or what would you like?" required></textarea>
+        <div class="fb-actions">
+          <button type="button" id="feedback-cancel" class="fb-btn secondary" onclick="closeFeedbackModal()">Cancel</button>
+          <button type="submit" id="feedback-submit" class="fb-btn primary">Start workstream</button>
+        </div>
+      </form>
+      <div id="feedback-result" aria-live="polite"></div>
+    </div>
+  </div>
+  <script>
+    function fbEsc(s){
+      return String(s==null?'':s)
+        .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+        .replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+    }
+    function openFeedbackModal(){
+      var m=document.getElementById('feedback-modal');
+      if(!m)return;
+      m.style.display='flex';
+      var r=document.getElementById('feedback-result');
+      if(r)r.textContent='';
+      var t=document.getElementById('feedback-title');
+      if(t)t.focus();
+    }
+    function closeFeedbackModal(){
+      var m=document.getElementById('feedback-modal');
+      if(m)m.style.display='none';
+    }
+    function fbActivePage(){
+      var el=document.querySelector('.tab-content.active');
+      if(el&&el.id){return el.id.replace('tab-','');}
+      return 'overview';
+    }
+    function fbCaptureState(){
+      var el=document.querySelector('.tab-content.active');
+      var txt=el?(el.innerText||el.textContent||''):'';
+      return txt.slice(0,16000);
+    }
+    function fbPollStatus(id,out){
+      if(!id||!out)return;
+      var url='/api/feedback/status/'+encodeURIComponent(id);
+      var tries=0;
+      var timer=setInterval(function(){
+        tries++;
+        fetch(url,{credentials:'same-origin'})
+          .then(function(r){return r.json();})
+          .then(function(j){
+            if(!j){return;}
+            if(j.state==='pr'){
+              clearInterval(timer);
+              var prUrl=String(j.pr_url||'');
+              if(/^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/.test(prUrl)){
+                out.innerHTML='Workstream <code>'+fbEsc(id)+'</code> opened a PR: <a href="'+fbEsc(prUrl)+'" target="_blank" rel="noopener">'+fbEsc(prUrl)+'</a>';
+              }else{
+                out.textContent='Workstream '+id+' opened a PR.';
+              }
+            }else if(j.state==='failed'){
+              clearInterval(timer);
+              out.textContent='Workstream '+id+' finished without a PR yet.';
+            }else{
+              out.textContent='Workstream '+id+' is running…';
+            }
+            if(tries>=60){clearInterval(timer);}
+          })
+          .catch(function(){});
+      },5000);
+    }
+    (function(){
+      var form=document.getElementById('feedback-form');
+      if(!form)return;
+      var modal=document.getElementById('feedback-modal');
+      if(modal){
+        modal.addEventListener('click',function(ev){if(ev.target===modal)closeFeedbackModal();});
+      }
+      document.addEventListener('keydown',function(ev){if(ev.key==='Escape')closeFeedbackModal();});
+      form.addEventListener('submit',function(ev){
+        ev.preventDefault();
+        var type=(document.getElementById('feedback-type')||{}).value||'bug';
+        var title=((document.getElementById('feedback-title')||{}).value||'').trim();
+        var description=((document.getElementById('feedback-description')||{}).value||'').trim();
+        var out=document.getElementById('feedback-result');
+        if(!title||!description){if(out)out.textContent='Please fill in both a title and a description.';return;}
+        var page=fbActivePage();
+        var ids={page:page,url:location.pathname,hash:location.hash,doc_title:document.title};
+        var report={type:type,title:title,description:description};
+        var context={page:page,state:fbCaptureState(),timestamp:new Date().toISOString(),identifiers:ids};
+        var btn=document.getElementById('feedback-submit');
+        if(btn)btn.disabled=true;
+        if(out)out.textContent='Starting workstream…';
+        fetch('/api/feedback',{
+          method:'POST',
+          credentials:'same-origin',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify({report:report,context:context})
+        })
+          .then(function(r){return r.json().then(function(j){return {status:r.status,body:j};});})
+          .then(function(res){
+            if(btn)btn.disabled=false;
+            var b=res.body||{};
+            if(res.status===202&&b.ok){
+              if(out)out.textContent='Workstream started ('+b.workstream_id+'). Watching for a PR…';
+              document.getElementById('feedback-title').value='';
+              document.getElementById('feedback-description').value='';
+              fbPollStatus(b.workstream_id,out);
+            }else if(res.status===429){
+              if(out)out.textContent='That report was just submitted, or too many are in flight. Please wait a moment.';
+            }else{
+              if(out)out.textContent='Could not start a workstream: '+(b.error||('HTTP '+res.status));
+            }
+          })
+          .catch(function(){
+            if(btn)btn.disabled=false;
+            if(out)out.textContent='Network error submitting feedback.';
+          });
+      });
+    })();
+  </script>
+"##;

--- a/src/operator_commands_dashboard/index_html/mod.rs
+++ b/src/operator_commands_dashboard/index_html/mod.rs
@@ -1,3 +1,4 @@
+mod feedback_widget;
 mod part_00;
 mod part_01;
 mod part_02;
@@ -30,6 +31,10 @@ use part_05::PART_05;
 ///   ledes are forbidden from containing (#2358).
 /// * `{{DEFAULT_TITLE}}` — the `<title>` for the initial render, matching
 ///   the default-active tab.
+/// * `{{FEEDBACK_WIDGET_BUTTON}}` — the shared "Report bug / Request feature"
+///   control, anchored in the `<header>` so it renders on every tab (#2629).
+///   The matching modal/styles/script ([`feedback_widget::FEEDBACK_WIDGET_BODY`])
+///   are injected just before `</body>`.
 ///
 /// All per-tab `<h1>` / `<p class="page-lede">` blocks are inlined
 /// directly in the parts so they survive a `grep` audit; the
@@ -41,7 +46,15 @@ pub(crate) fn index_html_string() -> String {
         .replace("{{TAB_NAV}}", &tab_meta::tab_nav_html())
         .replace("{{TAB_META_JS}}", &tab_meta::tab_meta_js())
         .replace("{{BANNED_JARGON_JS}}", &tab_meta::banned_jargon_js())
-        .replace("{{DEFAULT_TITLE}}", tab_meta::default_title());
+        .replace(
+            "{{FEEDBACK_WIDGET_BUTTON}}",
+            feedback_widget::FEEDBACK_WIDGET_BUTTON,
+        )
+        .replace("{{DEFAULT_TITLE}}", tab_meta::default_title())
+        .replace(
+            "</body>",
+            &format!("{}\n</body>", feedback_widget::FEEDBACK_WIDGET_BODY),
+        );
     debug_assert!(
         !rendered.contains("{{"),
         "unresolved template marker remains in dashboard HTML"

--- a/src/operator_commands_dashboard/index_html/part_00.rs
+++ b/src/operator_commands_dashboard/index_html/part_00.rs
@@ -124,6 +124,7 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
       <a href="https://github.com/rysweet/Simard" target="_blank" style="color:#8b949e;text-decoration:none;font-size:.85rem;padding:.2rem .4rem" title="Source on GitHub">⟨/⟩ Source</a>
       <a href="https://github.com/rysweet/Simard/releases/latest" target="_blank" style="color:#3fb950;text-decoration:none;font-size:.85rem;border:1px solid #3fb950;padding:.2rem .6rem;border-radius:4px">📦 Releases</a>
       <button class="glossary-toggle" onclick="toggleGlossary()" title="Show glossary of Simard terms">📖 Glossary</button>
+      {{FEEDBACK_WIDGET_BUTTON}}
       <span id="clock" style="color:#8b949e;font-size:.85rem"></span>
     </div>
   </header>

--- a/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
@@ -674,3 +674,87 @@ fn rendered_html_workboard_recent_actions_humanized_with_raw_tooltip() {
         "Workboard must not pre-escape before renderActionDetail() (double-escape)"
     );
 }
+
+// ─────────────────────────── Feedback widget (#2629) ────────────────────────
+//
+// The "Report bug / Request feature" widget must be a SINGLE control anchored
+// in the shared <header> so it appears on every dashboard tab with consistent
+// placement, and its client JS must POST the report + captured page context to
+// the auth-gated `/api/feedback` endpoint, rendering results safely.
+
+#[test]
+fn feedback_widget_button_lives_in_shared_header() {
+    let html = INDEX_HTML.as_str();
+    let header_start = html
+        .find("<header>")
+        .expect("dashboard must have a <header>");
+    let header_end = html
+        .find("</header>")
+        .expect("dashboard must close its <header>");
+    let button = html
+        .find("id=\"feedback-widget-button\"")
+        .expect("a #feedback-widget-button control must exist");
+
+    assert!(
+        header_start < button && button < header_end,
+        "the feedback button must live inside <header> so it renders on every tab"
+    );
+    assert_eq!(
+        html.matches("id=\"feedback-widget-button\"").count(),
+        1,
+        "there must be exactly ONE shared feedback widget, not one per tab"
+    );
+}
+
+#[test]
+fn feedback_widget_control_is_labeled_for_bug_and_feature() {
+    let html = INDEX_HTML.as_str();
+    assert!(
+        html.contains("Report bug") && html.contains("Request feature"),
+        "the widget must offer both 'Report bug' and 'Request feature'"
+    );
+}
+
+#[test]
+fn feedback_widget_modal_and_form_fields_present() {
+    let html = INDEX_HTML.as_str();
+    for hook in [
+        "id=\"feedback-modal\"",
+        "id=\"feedback-form\"",
+        "id=\"feedback-type\"",
+        "id=\"feedback-title\"",
+        "id=\"feedback-description\"",
+    ] {
+        assert!(html.contains(hook), "feedback widget markup missing {hook}");
+    }
+    // The type selector must offer exactly bug|feature.
+    assert!(
+        html.contains("value=\"bug\"") && html.contains("value=\"feature\""),
+        "feedback type selector must offer value=\"bug\" and value=\"feature\""
+    );
+}
+
+#[test]
+fn feedback_widget_posts_report_and_context_to_authed_endpoint() {
+    let html = INDEX_HTML.as_str();
+    assert!(
+        html.contains("/api/feedback"),
+        "widget JS must POST to /api/feedback"
+    );
+    assert!(
+        html.contains("/api/feedback/status/"),
+        "widget JS must poll /api/feedback/status/<id> for the workstream result"
+    );
+    // Cookie-based auth: the fetch must send the session cookie.
+    assert!(
+        html.contains("same-origin"),
+        "widget fetch must use credentials:'same-origin' so the auth cookie is sent"
+    );
+    // The captured page context fields must be gathered client-side.
+    for key in ["page", "state", "timestamp", "identifiers"] {
+        assert!(
+            html.contains(key),
+            "widget JS must capture the '{key}' context field"
+        );
+    }
+}

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -7,6 +7,7 @@ mod chat_store;
 mod current_work;
 mod cycle_source;
 mod distributed;
+mod feedback;
 mod goals;
 mod goals_status;
 mod hosts;
@@ -38,6 +39,8 @@ mod tests_attach;
 mod tests_chat_routes;
 #[cfg(test)]
 mod tests_chat_store;
+#[cfg(test)]
+mod tests_feedback;
 #[cfg(test)]
 mod tests_goal_records_migration;
 #[cfg(test)]

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -12,6 +12,7 @@ use super::chat::ws_chat_handler;
 use super::chat_store::{chat_session_by_id, chat_sessions};
 use super::current_work::current_work;
 use super::distributed::{distributed, vacate_vm};
+use super::feedback::{feedback_status, feedback_submit};
 use super::goals::{
     add_goal, demote_goal, goals, promote_backlog_item, remove_goal, seed_goals, update_goal_status,
 };
@@ -87,6 +88,8 @@ pub fn build_router() -> Router {
         .route("/api/journal/entry/{date}", get(journal_entry))
         .route("/api/journal/render/{date}", get(journal_render))
         .route("/api/status/snapshot", get(status_snapshot))
+        .route("/api/feedback", post(feedback_submit))
+        .route("/api/feedback/status/{id}", get(feedback_status))
         .route("/api/subagent-sessions", get(subagent_sessions))
         .route("/api/chat/sessions", get(chat_sessions))
         .route("/api/chat/sessions/{id}", get(chat_session_by_id))

--- a/src/operator_commands_dashboard/tests_feedback.rs
+++ b/src/operator_commands_dashboard/tests_feedback.rs
@@ -1,0 +1,545 @@
+//! TDD contract for the dashboard feedback endpoint (issue #2629).
+//!
+//! These tests are written BEFORE `super::feedback` exists. They fail to
+//! compile until Step 8 creates `src/operator_commands_dashboard/feedback.rs`
+//! with the API surface exercised below, then fail on assertions until the
+//! behaviour is implemented. They pin the behaviour of the "Report bug /
+//! Request feature" widget's backend without spawning a subprocess or touching
+//! the network — the `RecipeLauncher` seam (`crate::overseer::capabilities`) is
+//! replaced with an in-memory [`FakeLauncher`].
+//!
+//! Contract that `super::feedback` MUST provide (all `pub(crate)`):
+//!
+//! ```ignore
+//! use std::time::Instant;
+//! use axum::http::StatusCode;
+//! use serde_json::Value;
+//! use crate::overseer::capabilities::{RecipeLauncher, WorkstreamStatus};
+//!
+//! pub(crate) enum FeedbackKind { Bug, Feature }
+//! pub(crate) struct FeedbackReport { kind: FeedbackKind, title: String, description: String }
+//! pub(crate) struct FeedbackContext { page: String, state: String, timestamp: String, identifiers: Value }
+//! pub(crate) struct FeedbackDedup { /* OnceLock<Mutex<..>> in production */ }
+//! impl FeedbackDedup { fn new() -> Self }
+//!
+//! pub(crate) const MAX_TITLE_LEN: usize;
+//! pub(crate) const MAX_DESCRIPTION_LEN: usize;
+//! pub(crate) const MAX_STATE_LEN: usize;
+//! pub(crate) const DEDUP_WINDOW_SECS: u64;
+//! pub(crate) const MAX_FEEDBACK_LAUNCHES_PER_WINDOW: usize;
+//!
+//! pub(crate) fn compose_task_description(report: &FeedbackReport, context: &FeedbackContext) -> String;
+//! pub(crate) fn handle_feedback(launcher: &dyn RecipeLauncher, dedup: &FeedbackDedup, now: Instant, body: Value) -> (StatusCode, Value);
+//! pub(crate) fn handle_feedback_status(launcher: &dyn RecipeLauncher, id: String) -> (StatusCode, Value);
+//! pub(crate) fn status_json(status: &WorkstreamStatus) -> Value;
+//! ```
+//!
+//! The pure core returns `(StatusCode, serde_json::Value)`; the thin axum
+//! handlers wrap the `Value` in `Json` and register BOTH routes before the
+//! existing `require_auth` layer, so this endpoint inherits the dashboard
+//! access-code gate.
+
+#![cfg(test)]
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use axum::http::StatusCode;
+use serde_json::{Value, json};
+
+use crate::overseer::capabilities::{
+    OverseerError, RecipeBrief, RecipeLauncher, WorkstreamHandle, WorkstreamStatus,
+};
+use crate::stewardship::TargetRepo;
+
+use super::feedback::{
+    DEDUP_WINDOW_SECS, FeedbackContext, FeedbackDedup, FeedbackKind, FeedbackReport,
+    MAX_DESCRIPTION_LEN, MAX_FEEDBACK_LAUNCHES_PER_WINDOW, MAX_STATE_LEN, MAX_TITLE_LEN,
+    compose_task_description, handle_feedback, handle_feedback_status, status_json,
+};
+
+// ─────────────────────────── fake launcher seam ────────────────────────────
+
+/// In-memory [`RecipeLauncher`] that records every launched brief and returns
+/// canned results. It NEVER spawns a process or opens a socket, so every test
+/// below is hermetic: the injection-safety guarantee is structural (the real
+/// runner feeds `brief.task_description` to `Command::args`, never a shell).
+struct FakeLauncher {
+    launched: Mutex<Vec<RecipeBrief>>,
+    handle_id: String,
+    /// When `Some`, `launch` fails with this error (drives the 500 test).
+    fail_launch: Option<OverseerError>,
+    /// Result returned by `poll` (drives the status-route tests).
+    poll: Result<WorkstreamStatus, OverseerError>,
+}
+
+impl FakeLauncher {
+    fn accepting() -> Self {
+        Self {
+            launched: Mutex::new(Vec::new()),
+            handle_id: "ws-42".to_string(),
+            fail_launch: None,
+            poll: Ok(WorkstreamStatus::Running),
+        }
+    }
+
+    fn launched(&self) -> Vec<RecipeBrief> {
+        self.launched.lock().unwrap().clone()
+    }
+
+    fn launched_count(&self) -> usize {
+        self.launched.lock().unwrap().len()
+    }
+}
+
+impl RecipeLauncher for FakeLauncher {
+    fn launch(&self, brief: &RecipeBrief) -> Result<WorkstreamHandle, OverseerError> {
+        if let Some(e) = &self.fail_launch {
+            return Err(e.clone());
+        }
+        self.launched.lock().unwrap().push(brief.clone());
+        Ok(WorkstreamHandle {
+            id: self.handle_id.clone(),
+        })
+    }
+
+    fn poll(&self, _handle: &WorkstreamHandle) -> Result<WorkstreamStatus, OverseerError> {
+        self.poll.clone()
+    }
+}
+
+// ─────────────────────────── request builders ──────────────────────────────
+
+fn valid_body() -> Value {
+    body_with(
+        "bug",
+        "Costs panel shows stale total",
+        "The daily total did not refresh after midnight.",
+    )
+}
+
+fn body_with(kind: &str, title: &str, description: &str) -> Value {
+    json!({
+        "report": { "type": kind, "title": title, "description": description },
+        "context": {
+            "page": "costs",
+            "state": "{\"daily_total_usd\": 12.5}",
+            "timestamp": "2026-07-06T03:00:00Z",
+            "identifiers": { "hash": "#costs", "active_goal_id": "reduce-spend" }
+        }
+    })
+}
+
+fn str_field(v: &Value, key: &str) -> String {
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+// ─────────────────────────── happy path ────────────────────────────────────
+
+#[test]
+fn handle_feedback_launches_workstream_with_composed_task_description() {
+    let fake = FakeLauncher::accepting();
+    let dedup = FeedbackDedup::new();
+
+    let (status, resp) = handle_feedback(&fake, &dedup, Instant::now(), valid_body());
+
+    assert_eq!(
+        status,
+        StatusCode::ACCEPTED,
+        "a valid report must be accepted (202)"
+    );
+    assert_eq!(resp.get("ok").and_then(Value::as_bool), Some(true));
+    assert_eq!(
+        str_field(&resp, "workstream_id"),
+        "ws-42",
+        "the launched workstream id must be surfaced so the UI can poll it"
+    );
+    assert_eq!(str_field(&resp, "state"), "started");
+    assert!(
+        str_field(&resp, "poll").contains("ws-42"),
+        "response must include a poll URL carrying the workstream id, got {resp}"
+    );
+
+    let launched = fake.launched();
+    assert_eq!(launched.len(), 1, "exactly one workstream must be launched");
+    let brief = &launched[0];
+    assert_eq!(
+        brief.target_repo,
+        TargetRepo::Simard.slug(),
+        "feedback about the Simard dashboard must target Simard's own repo"
+    );
+    assert_eq!(
+        brief.sequence_group, None,
+        "an operator report is not part of a mechanical sweep sequence group"
+    );
+    // The task_description is composed from report + captured page context.
+    let td = &brief.task_description;
+    assert!(
+        td.contains("Costs panel shows stale total"),
+        "td missing title: {td}"
+    );
+    assert!(
+        td.contains("The daily total did not refresh after midnight."),
+        "td missing description: {td}"
+    );
+    assert!(td.contains("costs"), "td missing captured page id: {td}");
+    assert!(
+        td.contains("2026-07-06T03:00:00Z"),
+        "td missing captured timestamp: {td}"
+    );
+}
+
+// ─────────────────────────── compose_task_description ───────────────────────
+
+fn sample_report(kind: FeedbackKind) -> FeedbackReport {
+    FeedbackReport {
+        kind,
+        title: "Widget overlaps clock".to_string(),
+        description: "The feedback button covers the header clock on narrow screens.".to_string(),
+    }
+}
+
+fn sample_context() -> FeedbackContext {
+    FeedbackContext {
+        page: "overview".to_string(),
+        state: "{\"cycle\": 1680}".to_string(),
+        timestamp: "2026-07-06T03:09:41Z".to_string(),
+        identifiers: json!({ "hash": "#overview", "active_goal_id": "polish-ui" }),
+    }
+}
+
+#[test]
+fn compose_task_description_includes_report_and_context() {
+    let report = sample_report(FeedbackKind::Bug);
+    let context = sample_context();
+
+    let td = compose_task_description(&report, &context);
+
+    assert!(td.contains("Widget overlaps clock"), "missing title: {td}");
+    assert!(
+        td.contains("The feedback button covers the header clock on narrow screens."),
+        "missing description: {td}"
+    );
+    assert!(td.contains("overview"), "missing captured page: {td}");
+    assert!(
+        td.contains("2026-07-06T03:09:41Z"),
+        "missing timestamp: {td}"
+    );
+    assert!(
+        td.contains("{\"cycle\": 1680}") || td.contains("cycle"),
+        "missing captured page state: {td}"
+    );
+
+    // Deterministic: same inputs → identical task_description.
+    let again = compose_task_description(&sample_report(FeedbackKind::Bug), &sample_context());
+    assert_eq!(
+        td, again,
+        "compose_task_description must be pure/deterministic"
+    );
+}
+
+#[test]
+fn compose_task_description_distinguishes_bug_from_feature() {
+    let bug = compose_task_description(&sample_report(FeedbackKind::Bug), &sample_context());
+    let feature =
+        compose_task_description(&sample_report(FeedbackKind::Feature), &sample_context());
+
+    assert!(
+        bug.contains("[BUG]"),
+        "bug reports must carry a [BUG] marker, got: {bug}"
+    );
+    assert!(
+        feature.contains("[FEATURE]"),
+        "feature requests must carry a [FEATURE] marker, got: {feature}"
+    );
+    assert_ne!(
+        bug, feature,
+        "the report type must change the composed task"
+    );
+}
+
+// ─────────────────────────── validation matrix ─────────────────────────────
+
+/// Assert `body` is rejected with 400 and that NO workstream is launched.
+fn assert_rejected(body: Value, why: &str) -> Value {
+    let fake = FakeLauncher::accepting();
+    let dedup = FeedbackDedup::new();
+    let (status, resp) = handle_feedback(&fake, &dedup, Instant::now(), body);
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "{why}: expected 400, got {resp}"
+    );
+    assert_eq!(
+        resp.get("ok").and_then(Value::as_bool),
+        Some(false),
+        "{why}: rejection body must set ok=false"
+    );
+    assert_eq!(
+        fake.launched_count(),
+        0,
+        "{why}: a rejected report must NEVER launch a workstream"
+    );
+    resp
+}
+
+#[test]
+fn rejects_unknown_report_type() {
+    assert_rejected(
+        body_with("spam", "t", "d"),
+        "type must be exactly bug|feature",
+    );
+}
+
+#[test]
+fn rejects_missing_report_type() {
+    let mut body = valid_body();
+    body["report"]["type"] = Value::Null;
+    assert_rejected(body, "missing type");
+}
+
+#[test]
+fn rejects_empty_title() {
+    assert_rejected(body_with("bug", "   ", "a real description"), "empty title");
+}
+
+#[test]
+fn rejects_overlong_title() {
+    let long = "T".repeat(MAX_TITLE_LEN + 1);
+    assert_rejected(body_with("feature", &long, "desc"), "title over cap");
+}
+
+#[test]
+fn rejects_empty_description() {
+    assert_rejected(body_with("bug", "a title", "   "), "empty description");
+}
+
+#[test]
+fn rejects_overlong_description() {
+    let long = "D".repeat(MAX_DESCRIPTION_LEN + 1);
+    assert_rejected(body_with("bug", "a title", &long), "description over cap");
+}
+
+// ─────────────────────────── sanitization ──────────────────────────────────
+
+#[test]
+fn truncates_oversized_context_state_but_still_launches() {
+    // A malicious/huge page state must not blow up the task_description.
+    let huge_state = "x".repeat(MAX_STATE_LEN + 5_000);
+    let body = json!({
+        "report": { "type": "bug", "title": "Overview panel wedged", "description": "Panel not refreshing" },
+        "context": {
+            "page": "overview",
+            "state": huge_state,
+            "timestamp": "2026-07-06T03:00:00Z",
+            "identifiers": {}
+        }
+    });
+
+    let fake = FakeLauncher::accepting();
+    let dedup = FeedbackDedup::new();
+    let (status, _resp) = handle_feedback(&fake, &dedup, Instant::now(), body);
+
+    assert_eq!(
+        status,
+        StatusCode::ACCEPTED,
+        "oversized state is truncated, not rejected"
+    );
+    let launched = fake.launched();
+    assert_eq!(launched.len(), 1);
+    // Only the state contributes 'x' chars; it must be bounded by MAX_STATE_LEN.
+    let x_count = launched[0].task_description.matches('x').count();
+    assert!(
+        x_count <= MAX_STATE_LEN,
+        "captured state must be truncated to <= {MAX_STATE_LEN} chars, got {x_count}"
+    );
+}
+
+#[test]
+fn injection_payload_is_carried_as_inert_data() {
+    // A shell-injection attempt in free text must be carried verbatim as data.
+    // Structural guarantee: brief.task_description flows to Command::args (a
+    // Vec<String>), never `sh -c`, so this string can never be executed.
+    let payload = "; rm -rf / # $(reboot) `whoami`";
+    let body = body_with("bug", "malicious title", payload);
+
+    let fake = FakeLauncher::accepting();
+    let dedup = FeedbackDedup::new();
+    let (status, _resp) = handle_feedback(&fake, &dedup, Instant::now(), body);
+
+    assert_eq!(status, StatusCode::ACCEPTED);
+    let launched = fake.launched();
+    assert_eq!(launched.len(), 1);
+    assert!(
+        launched[0].task_description.contains(payload),
+        "the payload must be carried verbatim as data (proving it is not shell-interpreted)"
+    );
+}
+
+// ─────────────────────────── de-dupe + throttle ────────────────────────────
+
+#[test]
+fn duplicate_report_within_window_is_rate_limited() {
+    let fake = FakeLauncher::accepting();
+    let dedup = FeedbackDedup::new();
+    let t0 = Instant::now();
+
+    let (s1, _) = handle_feedback(&fake, &dedup, t0, valid_body());
+    assert_eq!(s1, StatusCode::ACCEPTED, "first submission is accepted");
+
+    let (s2, r2) = handle_feedback(&fake, &dedup, t0, valid_body());
+    assert_eq!(
+        s2,
+        StatusCode::TOO_MANY_REQUESTS,
+        "an identical resubmission inside the {DEDUP_WINDOW_SECS}s window is a duplicate"
+    );
+    assert_eq!(r2.get("ok").and_then(Value::as_bool), Some(false));
+    assert_eq!(str_field(&r2, "error"), "duplicate");
+
+    // After the window elapses, the same report is allowed again.
+    let (s3, _) = handle_feedback(
+        &fake,
+        &dedup,
+        t0 + Duration::from_secs(DEDUP_WINDOW_SECS + 1),
+        valid_body(),
+    );
+    assert_eq!(s3, StatusCode::ACCEPTED, "the dedup window must expire");
+
+    assert_eq!(
+        fake.launched_count(),
+        2,
+        "only the two non-duplicate submissions launch a workstream"
+    );
+}
+
+#[test]
+fn distinct_reports_are_throttled_after_launch_cap() {
+    // De-dup alone won't stop a flood of DISTINCT reports; a per-window launch
+    // cap protects against subprocess cost-DoS.
+    let fake = FakeLauncher::accepting();
+    let dedup = FeedbackDedup::new();
+    let t0 = Instant::now();
+
+    for i in 0..MAX_FEEDBACK_LAUNCHES_PER_WINDOW {
+        let (status, _) = handle_feedback(
+            &fake,
+            &dedup,
+            t0,
+            body_with("bug", &format!("distinct {i}"), "d"),
+        );
+        assert_eq!(
+            status,
+            StatusCode::ACCEPTED,
+            "submission {i} within cap must succeed"
+        );
+    }
+
+    let (status, resp) = handle_feedback(&fake, &dedup, t0, body_with("bug", "one too many", "d"));
+    assert_eq!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "the {}-th distinct launch in the window must be throttled",
+        MAX_FEEDBACK_LAUNCHES_PER_WINDOW + 1
+    );
+    assert_eq!(resp.get("ok").and_then(Value::as_bool), Some(false));
+    assert_eq!(
+        fake.launched_count(),
+        MAX_FEEDBACK_LAUNCHES_PER_WINDOW,
+        "no more than {MAX_FEEDBACK_LAUNCHES_PER_WINDOW} launches per window"
+    );
+}
+
+// ─────────────────────────── status route ──────────────────────────────────
+
+#[test]
+fn status_json_maps_running_pr_and_failed() {
+    let running = status_json(&WorkstreamStatus::Running);
+    assert_eq!(str_field(&running, "state"), "running");
+
+    let pr = status_json(&WorkstreamStatus::ProducedPr {
+        repo: "rysweet/Simard".to_string(),
+        pr: 2601,
+    });
+    assert_eq!(str_field(&pr, "state"), "pr");
+    assert_eq!(
+        str_field(&pr, "pr_url"),
+        "https://github.com/rysweet/Simard/pull/2601",
+        "a produced PR must surface a clickable github PR URL"
+    );
+
+    let failed = status_json(&WorkstreamStatus::Failed {
+        reason: "recipe finished but produced no PR".to_string(),
+    });
+    assert_eq!(str_field(&failed, "state"), "failed");
+}
+
+#[test]
+fn feedback_status_returns_pr_for_known_workstream() {
+    let mut fake = FakeLauncher::accepting();
+    fake.poll = Ok(WorkstreamStatus::ProducedPr {
+        repo: "rysweet/Simard".to_string(),
+        pr: 2601,
+    });
+
+    let (status, resp) = handle_feedback_status(&fake, "ws-42".to_string());
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(str_field(&resp, "state"), "pr");
+    assert_eq!(
+        str_field(&resp, "pr_url"),
+        "https://github.com/rysweet/Simard/pull/2601"
+    );
+}
+
+#[test]
+fn feedback_status_unknown_workstream_is_404_without_leaking_detail() {
+    let internal = "unknown workstream ws-x at /home/azureuser/.simard/secret";
+    let mut fake = FakeLauncher::accepting();
+    fake.poll = Err(OverseerError::Capability {
+        what: "recipe.probe",
+        detail: internal.to_string(),
+    });
+
+    let (status, resp) = handle_feedback_status(&fake, "ws-x".to_string());
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "polling an unknown workstream id must be 404"
+    );
+    assert_eq!(resp.get("ok").and_then(Value::as_bool), Some(false));
+    assert!(
+        !resp.to_string().contains("/home/azureuser/.simard/secret"),
+        "the status error must not leak internal paths/details: {resp}"
+    );
+}
+
+// ─────────────────────────── error handling ────────────────────────────────
+
+#[test]
+fn launcher_error_maps_to_generic_500_without_leaking_detail() {
+    let internal = "/home/azureuser/.simard/secret spawn amplihack: No such file";
+    let fake = FakeLauncher {
+        launched: Mutex::new(Vec::new()),
+        handle_id: "ws-42".to_string(),
+        fail_launch: Some(OverseerError::Capability {
+            what: "recipe.spawn",
+            detail: internal.to_string(),
+        }),
+        poll: Ok(WorkstreamStatus::Running),
+    };
+    let dedup = FeedbackDedup::new();
+
+    let (status, resp) = handle_feedback(&fake, &dedup, Instant::now(), valid_body());
+    assert_eq!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "a launcher failure must be a 500"
+    );
+    assert_eq!(resp.get("ok").and_then(Value::as_bool), Some(false));
+    assert!(
+        !resp.to_string().contains("/home/azureuser/.simard/secret"),
+        "the 500 body must not leak internal paths/details: {resp}"
+    );
+}

--- a/src/overseer/launch.rs
+++ b/src/overseer/launch.rs
@@ -79,7 +79,12 @@ pub fn extract_pr_ref(output: &str) -> Option<(String, u32)> {
 
 /// Spawns and probes a recipe workstream. Injectable so the launch→PR flow is
 /// testable with a fake; production uses [`AmplihackRecipeRunner`].
-pub trait RecipeRunner {
+///
+/// `Send + Sync` so a [`SmartOrchestratorLauncher`] can be held in a shared,
+/// process-wide handle across an async server's worker threads (e.g. the
+/// dashboard feedback endpoint's `OnceLock<SmartOrchestratorLauncher>`). Every
+/// implementation is already thread-safe (its state lives behind a `Mutex`).
+pub trait RecipeRunner: Send + Sync {
     fn spawn(&self, brief: &RecipeBrief) -> Result<WorkstreamHandle, OverseerError>;
     fn probe(&self, handle: &WorkstreamHandle) -> Result<WorkstreamStatus, OverseerError>;
 }


### PR DESCRIPTION
Closes #2629.

## What

Adds a **Report bug / Request feature** widget to **every** dashboard tab. It captures the current page's context and starts a **new `dev-orchestrator` workstream** from the operator's report + captured context, reusing Simard's existing recipe-launch plumbing.

## How it works

1. **Widget (every tab).** A single **💬 Feedback** control lives in the shared `<header>` (tooltip *Report bug / Request feature*), so it renders identically on every tab. Clicking opens a modal with `type` (bug|feature), `title`, `description`.
2. **Context capture.** On submit the client captures `{page, state, timestamp, identifiers}` — the active tab slug, the visible rendered state of that panel (bounded), an ISO-8601 timestamp, and page identifiers — and `POST`s `{report, context}` to `/api/feedback` with `credentials:'same-origin'`.
3. **Launch (reuse, not ad-hoc).** The handler composes a `task_description` from the report + context and launches through the **existing** `crate::overseer::launch::SmartOrchestratorLauncher` (`RecipeLauncher`), i.e. `smart-orchestrator` → `default-workflow`, exactly as engineers and the Overseer do. `target_repo = TargetRepo::Simard.slug()`, `sequence_group = None`.
4. **UI feedback.** The modal shows the `workstream_id` and polls `/api/feedback/status/{id}`, surfacing the resulting **PR** link when it appears.

## Security / safety

- **Auth:** both routes are registered **before** the existing `require_auth` layer → they inherit the dashboard access-code gate (no new auth code).
- **No shell injection:** `task_description` flows through `Command::args(Vec<String>)`, never a shell. A regression test submits a `; rm -rf /` payload and asserts it is carried as inert data.
- **Sanitize + cap:** `type` must be exactly `bug|feature`; title ≤ 200, description ≤ 5000; state truncated to 16 KiB, identifiers to 4 KiB; control chars stripped. Malformed / non-JSON / oversized bodies coerce to `400` (also rejects cross-site form posts).
- **De-dup / throttle:** identical report within ~30 s → `429 duplicate`; per-window distinct-launch cap → `429 busy`.
- **Prompt-injection aware:** captured context is delimited and labelled **untrusted** in the task; the launched workstream keeps all guardrails (no `--no-verify`, no `gh pr merge --admin`, CI green, human merge).
- **Client:** PR link is allow-listed (`^https://github.com/…/pull/\d+$`) and HTML-escaped.

## Reused plumbing — one upstream edit

`RecipeRunner` gains a `Send + Sync` supertrait (`src/overseer/launch.rs`) so the shared `OnceLock<SmartOrchestratorLauncher>` can be held across the async server's threads. Every existing runner already satisfies it; no behavior change.

## Tests (hermetic)

- Backend (`tests_feedback.rs`, fake `RecipeLauncher`, no subprocess/network): launch contract + composed `task_description`, `compose_task_description` purity + bug/feature markers, full validation matrix, oversized-state truncation, injection-inert, de-dup + throttle, status mapping (running/pr/failed), unknown-id → 404, launcher error → generic 500 (no detail leak).
- Widget markup (`tests_tab_meta.rs`): button in shared `<header>` (exactly one), bug/feature labels, modal/form ids, `/api/feedback` + status polling + `same-origin` + captured context keys.
- `overseer::` (187) and `operator_commands_dashboard::` (447) suites green; `mkdocs build --strict` passes.

## Docs

- `docs/reference/dashboard-feedback-widget.md` (API, schemas, launcher reuse, validation, de-dup, security).
- `docs/howto/report-a-bug-or-request-a-feature.md`.
- Wired into `mkdocs.yml` nav and `docs/dashboard.md`.

## Concurrency note

The widget is cross-cutting (single control in the shared header + body injected before `</body>`), so it applies to the final tab set regardless of the in-flight tab-consolidation PRs. Rebased onto latest `origin/main`.