### PR TITLE
feat(update-check): spec-conform launch update check via ureq + semver (#2250)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3917,6 +3917,7 @@ dependencies = [
  "rusqlite",
  "rustyclawd-core",
  "rustyclawd-tools",
+ "semver",
  "serde",
  "serde_json",
  "serial_test",
@@ -3929,6 +3930,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "ureq",
  "url",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,12 @@ lbug = "=0.17.1"
 rusqlite = { version = "=0.31.0", features = ["bundled"] }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.149"
+# Issue #2250: the launch-time update check compares semver versions with the
+# `semver` crate and fetches the latest GitHub release in-process via `ureq`
+# (rustls TLS). Both were already in the locked dependency graph transitively;
+# these entries promote them to pinned direct deps.
+semver = "=1.0.28"
+ureq = "=3.3.0"
 toml = "=1.1.2"
 tokio = { version = "=1.52.1", features = ["rt", "rt-multi-thread", "process", "io-util", "time", "net", "macros", "sync"] }
 axum = { version = "=0.8.9", features = ["ws"] }

--- a/docs/concepts/update-check-design.md
+++ b/docs/concepts/update-check-design.md
@@ -1,7 +1,7 @@
 ---
 title: Update check design
-description: "Why the update check works the way it does — fire-and-forget for CLI, channel-based for TUI, prerelease-aware semver, shared platform detection."
-last_updated: 2026-06-10
+description: "Why the launch-time update check works the way it does — in-process ureq, the semver crate, a 24h cache, a bounded upgrade prompt, and fail-open-but-surfaced error handling."
+last_updated: 2026-07-06
 review_schedule: as-needed
 owner: simard
 doc_type: concept
@@ -13,133 +13,198 @@ related:
 
 # Update check design
 
-This document explains the design decisions behind Simard's automatic
-update check. For usage, see the [how-to](../howto/check-for-updates.md).
-For the full API, see the [reference](../reference/update-check.md).
+This document explains the design decisions behind Simard's launch-time
+update check (issue #2250). For usage, see the
+[how-to](../howto/check-for-updates.md). For the full API and behavior
+contract, see the [reference](../reference/update-check.md).
 
 ## Problem
 
-Users running older versions of Simard miss bug fixes and new
-features. The update check ensures they are informed without
-disrupting their workflow.
+Operators running older versions of Simard miss bug fixes and new
+features. The update check informs them at launch without disrupting the
+workflow, and — in an interactive terminal — offers a friendly path to
+upgrade.
 
-Three constraints shaped the design:
+Five constraints shaped the design:
 
-1. **Never block startup.** A CLI tool that stalls for 5 seconds on
-   every launch is unusable. The check must be fully asynchronous.
+1. **Never block startup.** A CLI tool that stalls on every launch is
+   unusable. The check must be fully asynchronous and time-bounded.
 2. **Never corrupt the TUI.** The TUI runs in raw mode on an alternate
-   screen. Any uncoordinated write to stderr or stdout corrupts the
-   display. The check must communicate through a controlled channel.
-3. **Never lie about versions.** A prerelease like `1.0.0-rc1` must
-   not be treated as equal to or newer than `1.0.0`. Version
-   comparison must be prerelease-aware.
+   screen. Any uncoordinated write to stderr/stdout — or a blocking
+   stdin prompt — corrupts the display. The TUI path must communicate
+   through a controlled channel and never prompt.
+3. **Never lie about versions.** A pre-release like `1.0.0-rc1` must not
+   be treated as equal to or newer than `1.0.0`. Comparison must be
+   pre-release-aware.
+4. **Fail open, but surface the failure.** A GitHub API or network error
+   is a convenience-check failure, not a core-logic failure — it must
+   never block or crash the binary. But the failure must be *logged*,
+   not silently swallowed (surface, don't hide).
+5. **Be a safe notifier, not an installer.** The check reports that
+   something newer exists. It must never download, install, or execute
+   an upgrade on its own.
 
 ## Design decisions
 
-### Fire-and-forget for CLI
+### In-process HTTP via `ureq` (not a subprocess)
 
-`run_update_check()` spawns a thread and does **not** join it. The
-thread runs independently: it queries GitHub, compares versions, and
-prints to stderr if needed. If `main()` finishes before the thread
-completes, the thread is silently terminated by process exit.
+The check fetches the GitHub Releases API directly with the
+[`ureq`](https://docs.rs/ureq/3.3.0) client — a `ureq::Agent` with a
+5-second `timeout_global`, a `User-Agent`, and the standard GitHub
+`Accept` / `X-GitHub-Api-Version` headers — over `rustls` TLS only.
 
-This means:
+Earlier iterations shelled out to `gh api` with a `curl` fallback. That
+was replaced because:
 
-- CLI startup latency is zero (thread spawn is ~microseconds).
-- For very fast commands (`simard --version`), the notice may not
-  appear because the process exits before the HTTP request completes.
-  This is acceptable — the user will see the notice on the next
-  command that takes longer.
-- The thread writes to stderr, which is safe for CLI because no other
-  code is competing for stderr in a meaningful way.
+- **No `PATH`-hijack surface.** Spawning `gh`/`curl` means trusting
+  whatever binary happens to be first on `PATH`. An in-process client
+  removes that attack surface entirely.
+- **No process-management complexity.** No child-process spawn,
+  timeout-kill, or stdout-plumbing code to get right.
+- **`ureq` is already in the dependency tree.** Promoting it to a direct,
+  pinned (`=3.3.0`) dependency reuses what the build already carries,
+  per the #2250 "reuse existing deps" constraint.
 
-### Channel-based for TUI
+The request is deliberately **unauthenticated**: this is a public,
+read-only notifier, so no token is ever attached and there is no
+credential to leak. Unauthenticated GitHub requests are rate-limited to
+60/hour/IP; the 24-hour cache and fail-open behavior make that a
+non-issue (a 403 rate-limit response just becomes `None` + a warning).
 
-`run_update_check_background()` returns an `Option<mpsc::Receiver<String>>`.
-The TUI stores the receiver in the `App` struct and calls `try_recv()`
-on each event-loop tick (the poll timeout is 2 seconds, but this is not
-a dedicated timer — any input event also triggers a tick). When the
-notice arrives, it is stored in `App.update_notice`, the receiver is
-set to `None` (one-shot), and the notice is rendered in the footer.
+### The `semver` crate (not a hand-rolled parser)
 
-This follows the same pattern already used for GitHub stats in the
-Stats tab — a background thread sends data through a channel, and the
-TUI polls it during its normal render loop. The pattern works because:
+Version comparison uses the [`semver`](https://docs.rs/semver/1.0.28)
+crate (also promoted to a direct `=1.0.28` dependency), replacing the
+earlier bespoke tuple parser. The GitHub `tag_name` (with any leading
+`v` stripped) and `env!("CARGO_PKG_VERSION")` are each parsed into a
+`semver::Version`, and an update is reported only when the latest is
+**strictly greater**.
 
-- `mpsc::Receiver` is `!Sync` but `Send`, matching the TUI's
-  single-threaded event loop.
-- `try_recv()` is non-blocking, so it adds no latency to the render
-  cycle.
-- The notice is rendered by the TUI's own draw code, so it respects
-  the alternate screen and raw mode.
-
-### Prerelease-aware semver
-
-`parse_semver()` returns a 4-tuple `(major, minor, patch, is_release)`
-where `is_release` is `true` for releases and `false` for prereleases.
-Rust's tuple comparison evaluates left-to-right, and `false < true`,
-so:
+Delegating to `semver` gives correct, well-tested pre-release ordering
+for free:
 
 ```
-(1, 0, 0, false)  <  (1, 0, 0, true)
- ↑ 1.0.0-rc1          ↑ 1.0.0
+1.0.0-rc1  <  1.0.0  <  1.0.1-beta.1
 ```
 
-This means:
+So `is_newer("1.0.0", "1.0.0-rc1")` is `true` (release beats its
+pre-release), while `is_newer("1.0.0-rc1", "1.0.0")` is `false`. The
+alternative — stripping pre-release metadata — would make `1.0.0-rc1`
+compare equal to `1.0.0` and hide the fact that a stable release is
+available. Using the crate also means Simard's notion of "newer" matches
+the ecosystem's, with less code to maintain.
 
-- `is_newer("1.0.0", "1.0.0-rc1")` → `true` (release is newer than
-  its prerelease).
-- `is_newer("1.0.0-rc1", "1.0.0")` → `false` (prerelease is not
-  newer than its release).
-- `is_newer("1.0.1-beta", "1.0.0")` → `true` (higher patch wins
-  regardless of prerelease).
+### A 24-hour cache (reversing the earlier "no cache" call)
 
-The alternative — stripping prerelease metadata entirely — would make
-`1.0.0-rc1` compare equal to `1.0.0`, hiding the fact that the user
-is on a prerelease and a stable release is available.
+The result is cached at `~/.simard/update_cache.json` — under Simard's
+standard state root (`SIMARD_STATE_ROOT` if set, otherwise
+`$HOME/.simard`) — with a 24-hour TTL. A fresh cache short-circuits the
+network entirely.
 
-### Shared platform detection
+Placing the cache under the shared state root (rather than an XDG
+`~/.config` path) keeps it alongside the rest of Simard's on-disk state —
+agent registry, snapshots, `config.toml` — so a single `SIMARD_STATE_ROOT`
+override relocates everything together, and there is no second location
+convention to remember.
 
-The update check reuses `cmd_self_update::platform::platform_suffix()`
-for asset detection, rather than maintaining its own platform strings.
-This ensures that:
+This **reverses an earlier design choice** that deliberately avoided
+caching. The trade-off changed for two reasons:
 
-- Platform names match the release asset naming convention (`macos-*`,
-  not `darwin-*`).
-- Changes to the naming convention only need to be made in one place.
-- The `self-update` command and the update check agree on which
-  platforms have pre-built binaries.
+- **Unauthenticated rate limits.** Once the check stopped using `gh`'s
+  authenticated quota and moved to unauthenticated requests, one HTTP
+  call per launch became a real concern for operators who launch `simard`
+  frequently. A 24h cache bounds that to at most one request per day.
+- **Stale-cache risk is contained.** The classic objection to caching —
+  showing "up to date" when a release exists — is bounded to a 24-hour
+  window, which is acceptable for a convenience notifier, and the TTL is
+  short enough that operators still learn about releases promptly.
 
-### No caching
+The cache is treated as **untrusted input**: on read it is re-validated
+(semver re-parse, URL re-allowlist) and re-sanitized exactly like a live
+response, written atomically (temp file + `rename`) with `0700`/`0600`
+permissions, and never followed through a symlink. A corrupt, missing,
+or unwritable cache is a harmless miss — never a hard error — which keeps
+the whole path fail-open even when `HOME` is unset.
 
-The check makes a fresh HTTP request on every launch. The cost is one
-small JSON response (~2KB) per launch. Caching was considered and
-rejected because:
+### Fail-open, but surfaced via `tracing`
 
-- It adds disk I/O and cache-invalidation logic for negligible gain.
-- The check runs in a background thread, so the network latency is
-  invisible to the user.
-- Stale-cache bugs (showing "up to date" when a new release exists)
-  are worse than the cost of one HTTP request.
+Every failure mode — DNS/connect error, timeout, non-2xx status, rate
+limit, oversized body, malformed JSON, unparseable semver — resolves to
+`None`. The launch never blocks and the process never panics.
 
-### Dual transport (gh + curl)
+Crucially, these are **not silently swallowed**: each failure is logged
+via `tracing::warn!` with the failure *category* (never the raw body or
+headers). This satisfies the #2250 "surface, don't hide" requirement —
+an operator debugging "why don't I see update notices?" can find the
+reason in the logs, while normal launches stay quiet and fast.
 
-The check tries `gh api` first because it handles authentication
-(private repos, rate limits) automatically. If `gh` fails for any
-reason — missing binary, auth failure, timeout, non-zero exit — it
-falls back to `curl` against the public GitHub API. Both have hard
-timeouts with `child.kill()` to prevent indefinite hangs.
+### Fire-and-forget for CLI, channel-based for TUI
 
-## Relationship to safe-update
+`run_update_check()` spawns a detached thread and does **not** join it.
+CLI startup latency is effectively zero; for very fast commands
+(`simard --version`) the notice may not appear because the process exits
+first, which is fine — the operator sees it on the next longer command.
+Writing to stderr is safe here because nothing else competes for it.
 
-The update check is *informational only* — it tells the user a newer
-version exists. It does not download, install, or execute anything.
+`run_update_check_background()` instead returns an
+`Option<mpsc::Receiver<String>>`. The TUI polls `try_recv()` in its
+event loop, renders the notice in its own draw cycle, then drops the
+receiver (one-shot). This reuses the exact pattern already used for
+GitHub stats in the TUI: a background thread feeds a channel that the
+single-threaded render loop drains, so the notice always respects the
+alternate screen and raw mode. The TUI therefore never writes stray
+stderr and never blocks on a prompt.
 
-`simard self-update` is the manual upgrade command. `simard safe-update`
-is the autonomous upgrade flow with drain, snapshot, pre-test, swap,
-validate, and rollback phases. The update check and these commands are
-independent: the check runs on every launch, the upgrade commands run
-only when explicitly invoked.
+The notice string sent through the channel is formatted with the **same
+version convention as the CLI banner** — `X.Y.Z -> A.B.C`, an ASCII `->`
+arrow and no `v` prefix. This is a deliberate reformat: an earlier TUI
+build used a Unicode arrow with `v`-prefixed versions
+(`v0.26.0 → v0.27.0`), which drifted from the CLI banner. Standardizing
+both surfaces on one format keeps them consistent and lets a single
+banner-format test cover the version rendering.
+
+### A bounded, non-installing upgrade prompt
+
+In an interactive terminal the CLI follows the banner with
+`Upgrade now? [y/N]`, read on a background thread with a ~10-second
+`recv_timeout` and a default of **No**. Timeout, EOF, a non-TTY stdin,
+`SIMARD_NONINTERACTIVE=1`, and the TUI context all resolve to No, so the
+prompt can never hang an unattended or piped launch.
+
+The prompt is deliberately **display-only**: answering `y` prints a hint
+to run `simard update` and does nothing else. Actual upgrading —
+download, integrity verification, binary swap — stays behind the
+explicit, sha256/signature-gated `simard update` command
+(`cmd_self_update`). Keeping the notifier and the installer strictly
+separate means a spoofed release response can, at worst, mislead; it can
+never cause code execution.
+
+### Exact, sanitized banner text
+
+The banner's first line is the literal
+`simard: update available X.Y.Z -> A.B.C` — an ASCII `->` and no `v`
+prefix — so it is stable and testable. The versions printed are the
+re-serialized semver values, and the `release_url` / `release_notes`
+carried in `UpdateInfo` are stripped of ESC/BEL/CR and C0/C1 control
+characters. Together with host-allowlisting the `release_url` to
+`github.com/rysweet/Simard/`, this prevents a malicious release body from
+injecting terminal escape sequences or phishing links through the notice.
+
+## Relationship to the upgrade commands
+
+The update check is *informational only* — it tells the operator a newer
+version exists and, at most, hints at the upgrade command. It never
+downloads, installs, or executes anything.
+
+- `simard update` is the manual, integrity-verified upgrade command.
+- `simard safe-update` is the autonomous upgrade flow with drain,
+  snapshot, pre-test, swap, validate, and rollback phases (see
+  [Safe self-update](../safe-self-update.md)).
+
+The check and these commands are independent: the check runs at every
+launch; the upgrade commands run only when explicitly invoked. Removing
+`has_platform_asset` from `UpdateInfo` (#2250) reinforced this split —
+platform-asset selection is the installer's job, not the notifier's.
 
 ## See also
 

--- a/docs/howto/check-for-updates.md
+++ b/docs/howto/check-for-updates.md
@@ -1,62 +1,87 @@
 ---
 title: Check for updates and control update notifications
-description: "How to see when a new Simard version is available, suppress the check, and upgrade."
-last_updated: 2026-06-10
+description: "How to see when a new Simard version is available, respond to the upgrade prompt, run non-interactively, and suppress the check entirely."
+last_updated: 2026-07-06
 review_schedule: as-needed
 owner: simard
 doc_type: howto
 related:
   - ../reference/update-check.md
+  - ../concepts/update-check-design.md
   - ../safe-self-update.md
   - ./monitor-simard-with-tui.md
 ---
 
 # Check for updates and control update notifications
 
-Simard checks GitHub Releases for a newer version on every launch.
-This guide explains what you see, how to act on it, and how to
-suppress it.
+Simard checks GitHub Releases for a newer version at launch and, if one
+exists, prints a one-line notice. In an interactive terminal it can also
+offer a one-key upgrade prompt. This guide shows what you see, how to
+respond, and how to control or suppress the behavior.
+
+The check is non-blocking and fail-open: it never delays startup, and a
+network or GitHub API failure never blocks or crashes Simard (#2250).
 
 ## 1. What the update notice looks like
 
 ### CLI
 
-When you run any `simard` command and a newer version exists, you see
-a yellow notice on stderr:
+When you run any `simard` command (including `simard meeting`) and a
+newer version exists, you see a notice on stderr:
 
 ```
-simard: update available v0.19.0 → v0.20.0
-  https://github.com/rysweet/Simard/releases/tag/v0.20.0
-  Run `simard self-update` to upgrade.
+simard: update available 0.26.0 -> 0.27.0
+  https://github.com/rysweet/Simard/releases/tag/v0.27.0
 ```
 
-The notice appears after the command starts — it never delays startup.
-If the network check takes longer than 5 seconds, no notice is shown.
+The first line is always the exact form
+`simard: update available X.Y.Z -> A.B.C`. The notice appears after the
+command starts — it never delays startup — and it goes to stderr, so it
+stays out of `simard <command> | jq` pipelines.
 
 ### TUI
 
-In `simard-tui`, the notice appears in the footer bar:
+In `simard-tui`, the notice appears in the footer bar instead:
 
 ```
-Update available: v0.19.0 → v0.20.0  https://...  Run `simard self-update` to upgrade.  | Alt+1‥6: tabs | ←/→: cycle | q: quit
+Update available: 0.26.0 -> 0.27.0  https://github.com/rysweet/Simard/releases/tag/v0.27.0  | Alt+1–9: tabs | Tab/Shift+Tab: cycle | ←/→: prev/next | q: quit
 ```
 
-The footer turns yellow when an update is available. It appears 1–5
-seconds after launch and stays visible for the rest of the session.
+The `Update available: …` prefix is prepended to the normal footer
+keybindings and highlighted while an update is available; it stays
+visible for the rest of the session. The version format matches the CLI
+banner (ASCII `->`, no `v`). The TUI never shows an interactive prompt.
 
-## 2. Upgrade
+## 2. Respond to the upgrade prompt
 
-If the notice says "Run `simard self-update` to upgrade":
+In an interactive terminal, the CLI banner is followed by:
+
+```
+Upgrade now? [y/N] 
+```
+
+- Press **`y`** then Enter → Simard prints
+  `Run \`simard update\` to upgrade.` It does **not** install
+  anything in place; upgrading stays an explicit, separate step.
+- Press **Enter** (or anything else) → treated as **No**.
+- Do nothing → after ~10 seconds the prompt times out and is treated as
+  **No**, so an unattended launch is never blocked.
+
+The prompt is skipped automatically when stdin/stderr is not a terminal
+(for example, output redirected to a file or a pipe) and in the TUI.
+
+## 3. Upgrade
+
+When you are ready to upgrade:
 
 ```bash
-simard self-update
+simard update
 ```
 
-This downloads the pre-built binary for your platform and replaces the
-current binary.
+This downloads the pre-built binary for your platform, verifies it, and
+replaces the current binary.
 
-If the notice says "(no pre-built binary for this platform — build
-from source)", build from the repository:
+If no pre-built binary exists for your platform, build from source:
 
 ```bash
 git pull origin main
@@ -64,12 +89,32 @@ cargo build --release
 cp target/release/simard ~/.simard/bin/simard
 ```
 
-For autonomous daemon upgrades with safety rails, use
-`simard safe-update` — see [Safe self-update](../safe-self-update.md).
+For autonomous daemon upgrades with safety rails (drain → snapshot →
+pre-test → swap → validate → rollback), use `simard safe-update` — see
+[Safe self-update](../safe-self-update.md).
 
-## 3. Disable the update check
+## 4. Run non-interactively (banner, no prompt)
 
-Set the environment variable before launching:
+To keep the informational banner but skip the `[y/N]` prompt — useful in
+scripts, cron, or CI where you still want update visibility in logs:
+
+```bash
+export SIMARD_NONINTERACTIVE=1
+```
+
+Or for a single invocation:
+
+```bash
+SIMARD_NONINTERACTIVE=1 simard status
+```
+
+With `SIMARD_NONINTERACTIVE=1`, the update banner still prints, but the
+prompt is never shown.
+
+## 5. Disable the update check entirely
+
+To skip the check completely — no cache read, no network request, no
+banner, no prompt:
 
 ```bash
 export SIMARD_NO_UPDATE_CHECK=1
@@ -81,31 +126,55 @@ Or for a single invocation:
 SIMARD_NO_UPDATE_CHECK=1 simard engineer run --goal=my-goal
 ```
 
-This suppresses the check in both CLI and TUI modes. No network
-request is made.
+This short-circuits both CLI and TUI modes. `SIMARD_NO_UPDATE_CHECK`
+takes precedence over `SIMARD_NONINTERACTIVE`: if it is set to `1`,
+nothing runs regardless of the interactive setting.
 
 **When to disable:**
 
-- Air-gapped or restricted-network environments where the HTTP
-  request would fail or be flagged.
-- CI/CD pipelines where the notice adds noise.
-- Scripted automation where even stderr output is undesirable.
+- Air-gapped or restricted-network environments where the HTTPS request
+  would fail or be flagged.
+- CI/CD pipelines where even the banner adds noise.
+- Scripted automation where any stderr output is undesirable.
 
-## 4. Verify the check works
+## 6. Understand the 24-hour cache
 
-Run a command that takes at least a few seconds and look for the
-notice on stderr. Fast commands like `simard --version` may exit
-before the background check completes — use a longer-running command:
+To avoid a request on every launch, the result is cached for 24 hours at:
+
+```
+~/.simard/update_cache.json
+```
+
+(under Simard's state root, so `SIMARD_STATE_ROOT` moves it along with
+the rest of Simard's state). While the cache is fresh (< 24h), Simard
+reuses the stored result and makes **no** network request. After 24
+hours the next launch refreshes it.
+
+To force an immediate re-check, delete the cache and launch again:
+
+```bash
+rm -f ~/.simard/update_cache.json
+simard status
+```
+
+The cache file is written atomically with `0600` permissions inside a
+`0700` directory, and a corrupt or missing cache is treated as a
+harmless miss (the check just re-fetches).
+
+## 7. Verify the check works
+
+Run a command that stays alive for a moment and watch stderr. Very fast
+commands (`simard --version`) may exit before the background check
+completes:
 
 ```bash
 simard status 2>&1 | head -10
 ```
 
-If you are already on the latest version, no notice appears. To
-confirm the check ran silently (no newer version), there is no visible
-output — the check only produces output when an update is available.
+If you are already on the latest version, no notice appears — the check
+only emits output when a strictly newer version exists.
 
-To verify the check is *disabled*:
+To confirm the check is **disabled**:
 
 ```bash
 SIMARD_NO_UPDATE_CHECK=1 simard --version
@@ -113,25 +182,33 @@ SIMARD_NO_UPDATE_CHECK=1 simard --version
 
 No notice appears regardless of available updates.
 
-## 5. How it works (brief)
+## 8. How it works (brief)
 
-1. Spawns a background thread on startup.
-2. The thread calls `gh api repos/rysweet/Simard/releases/latest`
-   (falls back to `curl` if `gh` fails).
-3. Compares the release tag against the running binary's version.
-4. Prereleases (e.g., `1.0.0-rc1`) are treated as older than the
-   corresponding release (`1.0.0`), so you are not prompted to
-   "upgrade" to a prerelease.
-5. If newer, prints the notice (CLI) or sends it to the TUI via
-   an internal channel.
+1. At launch, Simard spawns a background thread (fire-and-forget for the
+   CLI, channel-delivered for the TUI).
+2. If the on-disk cache is fresh (< 24h), it reuses that result and skips
+   the network.
+3. Otherwise it fetches
+   `https://api.github.com/repos/rysweet/Simard/releases/latest`
+   in-process via `ureq` (no `gh`/`curl` subprocess), with a 5-second
+   timeout and no authentication.
+4. It compares the release tag against the running binary's version
+   using the `semver` crate. Pre-releases (e.g. `1.0.0-rc1`) count as
+   *older* than the matching release (`1.0.0`), so you are never prompted
+   to "upgrade" to a pre-release.
+5. If a strictly newer version exists, it prints the banner (CLI) or
+   sends it to the footer (TUI), and offers the prompt when interactive.
 
-The check never blocks, never writes to stdout, and never
-auto-executes anything.
+The check never blocks, never writes to stdout, and never installs
+anything on its own. Any failure is logged (via tracing) and otherwise
+ignored — it will not crash or delay Simard.
 
 ## See also
 
-- [Update check reference](../reference/update-check.md) — full API
-  and behavior specification.
-- [Safe self-update](../safe-self-update.md) — autonomous daemon
-  upgrade flow with rollback.
+- [Update check reference](../reference/update-check.md) — full API and
+  behavior specification.
+- [Update check design](../concepts/update-check-design.md) — the design
+  rationale.
+- [Safe self-update](../safe-self-update.md) — autonomous daemon upgrade
+  flow with rollback.
 - [Monitor with TUI](./monitor-simard-with-tui.md) — TUI usage guide.

--- a/docs/reference/release-integrity.md
+++ b/docs/reference/release-integrity.md
@@ -1,7 +1,7 @@
 ---
 title: Release integrity — SBOM, signing, and reproducibility
 description: "Reference for the CycloneDX SBOM, cosign keyless signing, and build-reproducibility guarantees attached to every Simard release, plus end-to-end verification steps."
-last_updated: 2026-06-28
+last_updated: 2026-07-06
 review_schedule: as-needed
 owner: simard
 doc_type: reference
@@ -42,7 +42,7 @@ Each GitHub Release publishes the following, for every platform target:
 | `simard-<version>.cdx.json.pem` | `cosign sign-blob` | The SBOM signing **certificate** (same Fulcio identity as the tarball). |
 
 `<platform>` follows the existing naming convention (`linux-x86_64`, etc.;
-see [the update-check platform table](./update-check.md#platform-asset-detection)).
+see [the multi-binary self-update platform suffixes](./multi-binary-self-update.md)).
 `<version>` is the `Cargo.toml` version (e.g. `0.22.0`).
 
 ## Software Bill of Materials (SBOM)

--- a/docs/reference/update-check.md
+++ b/docs/reference/update-check.md
@@ -1,7 +1,7 @@
 ---
 title: Automatic update check
-description: "API and behavior reference for the startup update-version check against GitHub Releases."
-last_updated: 2026-06-10
+description: "API and behavior reference for the launch-time update-version check against GitHub Releases (in-process ureq, semver-crate comparison, 24h cache, fail-open)."
+last_updated: 2026-07-06
 review_schedule: as-needed
 owner: simard
 doc_type: reference
@@ -10,108 +10,57 @@ related:
   - ./simard-cli.md
   - ./simard-tui.md
   - ../howto/monitor-simard-with-tui.md
+  - ../concepts/update-check-design.md
 ---
 
 # Automatic update check
 
-On every launch, Simard checks GitHub Releases for a newer version and
-prints a notice if one is available. The check is non-blocking — it
-never delays CLI startup or freezes the TUI.
+On every launch, Simard checks GitHub Releases for a newer version and,
+if one is available, prints a one-line notice to stderr. In an
+interactive terminal it may then offer a one-key upgrade prompt. The
+check is **non-blocking** and **fail-open**: it never delays CLI
+startup, never freezes the TUI, and a GitHub API or network failure
+never blocks or crashes the binary (issue #2250).
+
+The banner and prompt are the only user-visible output, and both live
+in the binary launch path — the library code emits no stray prints.
+
+## Which binaries run the check
+
+The check is wired into the launch path of every Simard entry point:
+
+| Entry point | Function | Notes |
+|-------------|----------|-------|
+| `simard` (`src/main.rs`) | `run_update_check()` | Covers every `simard` subcommand, including `simard meeting`, because the check runs once at process launch before subcommand dispatch. |
+| `simard-tui` (`src/bin/simard_tui/main.rs`) | `run_update_check_background()` | Channel-based so the notice never writes directly to the alternate screen. |
+
+Because `meeting` is a subcommand of `simard` (not a separate binary),
+the meeting launch path inherits the `simard` check automatically —
+there is no separate `simard-meeting` binary to wire.
 
 ## Two execution modes
 
 | Context | Function | Behavior |
 |---------|----------|----------|
-| CLI (`simard`) | `run_update_check()` | Fire-and-forget: spawns a detached thread that prints to stderr. The thread is **not** joined — the CLI proceeds immediately. |
-| TUI (`simard-tui`) | `run_update_check_background()` | Channel-based: spawns a thread that sends the notice string through an `mpsc::Receiver<String>`. The TUI polls `try_recv()` in its event loop; after receiving the notice, the receiver is set to `None` (one-shot). No direct stderr writes. |
+| CLI (`simard`) | `run_update_check()` | Fire-and-forget: spawns a detached thread that prints the banner to stderr and, when the session is interactive, offers the upgrade prompt. The thread is **not** joined — the CLI proceeds immediately. |
+| TUI (`simard-tui`) | `run_update_check_background()` | Channel-based: spawns a thread that sends the notice string through an `mpsc::Receiver<String>`. The TUI polls `try_recv()` in its event loop, renders the notice in its own draw cycle, then drops the receiver (one-shot). No direct stderr writes, and **never** a prompt. |
 
-The distinction matters because the TUI runs in raw mode on an
-alternate screen — any uncoordinated stderr write would corrupt the
-display.
+The TUI runs in raw mode on an alternate screen; any uncoordinated
+stderr write — or a blocking stdin prompt — would corrupt the display,
+so the TUI path is banner-only and channel-delivered.
 
 ## Environment variables
 
 | Variable | Effect |
 |----------|--------|
-| `SIMARD_NO_UPDATE_CHECK=1` | Skip the check entirely. Both `run_update_check()` and `run_update_check_background()` return immediately (the latter returns `None`). |
+| `SIMARD_NO_UPDATE_CHECK=1` | **Full short-circuit.** The check returns before touching the cache, the network, or the prompt. `run_update_check()` returns immediately; `run_update_check_background()` returns `None`. |
+| `SIMARD_NONINTERACTIVE=1` | **Prompt suppressed, banner kept.** The update banner still prints (informational), but the interactive `Upgrade now? [y/N]` prompt is skipped. |
 
-> **Note:** `SIMARD_NONINTERACTIVE=1` is a project-wide env var but is *not*
-> checked by the update module. The update notice is always non-interactive
-> (informational only, no prompt), so `SIMARD_NONINTERACTIVE` has no effect
-> on update check behavior.
+Precedence: `SIMARD_NO_UPDATE_CHECK` wins. If it is set to `1`, nothing
+runs at all, regardless of `SIMARD_NONINTERACTIVE`.
 
-## Network behavior
-
-1. **`gh api`** — tried first. Queries `repos/{GITHUB_REPO}/releases/latest`
-   via the authenticated GitHub CLI. Hard 5-second timeout (the child
-   process is killed if it exceeds this).
-2. **`curl` fallback** — on *any* `gh` failure (missing binary, auth
-   failure, timeout, non-zero exit), falls back to a direct
-   `curl -sS` request to the GitHub REST API. Connect timeout 3 seconds,
-   total timeout 5 seconds. Hard kill at 6 seconds if curl hasn't
-   exited (deliberately 1 second longer than `--max-time` to allow
-   graceful shutdown).
-3. **No caching** — every launch makes one HTTP request. The cost is
-   negligible (one small JSON response) and avoids stale-cache bugs.
-
-If both `gh` and `curl` fail, no notice is shown. The check never
-produces an error message — it fails silently.
-
-## Version comparison
-
-### Semver parsing
-
-`parse_semver(v)` is an internal (private) function that parses a
-`"major.minor.patch[-prerelease][+build]"` string into a 4-tuple
-`(major, minor, patch, is_release)`. It is not part of the public
-crate API — it is tested via `#[cfg(test)]` but not exported:
-
-| Input | Parsed |
-|-------|--------|
-| `"1.2.3"` | `(1, 2, 3, true)` |
-| `"1.0.0-rc1"` | `(1, 0, 0, false)` |
-| `"1.0.0-beta.1"` | `(1, 0, 0, false)` |
-| `"1.2.3+build.456"` | `(1, 2, 3, true)` |
-| `"1.2.3+build-456"` | `(1, 2, 3, true)` — build metadata (after `+`) is stripped before checking for prerelease (`-`), so hyphens inside build metadata are handled correctly. |
-| `"bad"` | `None` |
-
-The `is_release` flag (`true` for releases, `false` for prereleases)
-ensures that prereleases sort *before* the corresponding release
-version. Since Rust tuple comparison evaluates left-to-right and
-`false < true`, the ordering is:
-
-```
-1.0.0-rc1  → (1, 0, 0, false)
-1.0.0      → (1, 0, 0, true)    ← this is newer
-1.0.1-beta → (1, 0, 1, false)   ← this is even newer
-```
-
-### `is_newer(latest, current)`
-
-Internal (private) function. Returns `true` if `latest` is strictly
-greater than `current` by 4-tuple comparison. Returns `false` if
-either string fails to parse.
-
-## Platform asset detection
-
-The check reports whether a pre-built binary exists for the current
-platform by scanning the release's `assets` array. Platform detection
-delegates to `crate::cmd_self_update::platform::platform_suffix()`,
-which returns platform identifiers matching the release naming
-convention:
-
-| Platform | Suffix |
-|----------|--------|
-| Linux x86_64 | `linux-x86_64` |
-| Linux aarch64 | `linux-aarch64` |
-| macOS x86_64 | `macos-x86_64` |
-| macOS aarch64 | `macos-aarch64` |
-| Windows x86_64 | `windows-x86_64` |
-| Unsupported | `None` (no asset match attempted) |
-
-The `has_platform_asset` field in `UpdateInfo` controls whether the
-notice says "Run `simard self-update` to upgrade" or "(no pre-built
-binary for this platform — build from source)".
+The prompt is *also* suppressed automatically when stdin/stderr is not a
+TTY (`std::io::IsTerminal`) and in the TUI, independent of any env var.
 
 ## `UpdateInfo` struct
 
@@ -120,78 +69,246 @@ pub struct UpdateInfo {
     pub current_version: String,
     pub latest_version: String,
     pub release_url: String,
-    pub has_platform_asset: bool,
+    pub release_notes: String,
 }
 ```
 
-Returned by `check_for_update()` when a newer version exists.
-`run_update_check_background()` formats this into a single notice
-string before sending it through the channel.
+Returned by `check_for_update()` when — and only when — a strictly
+newer version exists. `run_update_check_background()` formats this into
+a single notice string before sending it through the channel.
 
-## CLI output
+> **Changed in #2250.** The earlier `has_platform_asset` field was
+> removed. Platform-asset selection now lives entirely in the
+> `simard update` command (`cmd_self_update`); the update check is a
+> pure "is there something newer?" notifier and carries the release
+> notes instead.
 
-When a newer version is detected, the CLI prints to stderr:
+## Public API
+
+```rust
+/// Fire-and-forget CLI entry point. Spawns a detached thread; never blocks.
+pub fn run_update_check();
+
+/// TUI entry point. Returns a channel the TUI polls for the notice string,
+/// or `None` when the check is disabled via `SIMARD_NO_UPDATE_CHECK=1`.
+pub fn run_update_check_background() -> Option<std::sync::mpsc::Receiver<String>>;
+
+/// Core check. Returns `Some(UpdateInfo)` only when GitHub's latest release
+/// is strictly newer than `env!("CARGO_PKG_VERSION")`; `None` otherwise
+/// (including on any network/API/parse error — fail-open).
+pub fn check_for_update() -> Option<UpdateInfo>;
+```
+
+These three entry points are the stable, wired surface. `main.rs` and
+`simard_tui/main.rs` depend on `run_update_check()` and
+`run_update_check_background()` respectively; their signatures are
+frozen.
+
+## Network behavior
+
+The check queries the GitHub Releases API **in-process** using
+[`ureq`](https://docs.rs/ureq/3.3.0) — no `gh`/`curl` subprocess:
 
 ```
-simard: update available v0.19.0 → v0.20.0
-  https://github.com/rysweet/Simard/releases/tag/v0.20.0
-  Run `simard self-update` to upgrade.
+GET https://api.github.com/repos/rysweet/Simard/releases/latest
 ```
 
-If there is no pre-built binary for the current platform:
+Request characteristics:
+
+| Property | Value |
+|----------|-------|
+| HTTP client | `ureq` `Agent`, TLS via `rustls` only |
+| Global timeout | 5 seconds (`Agent` `timeout_global`) |
+| `User-Agent` | `simard/{CARGO_PKG_VERSION}` (GitHub requires a UA) |
+| `Accept` | `application/vnd.github+json` |
+| `X-GitHub-Api-Version` | `2022-11-28` |
+| Authentication | **None** — read-only, unauthenticated, no token ever attached |
+| Body cap | 256 KiB (larger responses are rejected) |
+| Status handling | Non-2xx responses are rejected → `None` |
+
+On success the JSON is parsed defensively (no `unwrap`) and mapped to:
+
+| JSON field | `UpdateInfo` field | Transform |
+|------------|--------------------|-----------|
+| `tag_name` | `latest_version` | Leading `v` stripped (`v0.27.0` → `0.27.0`) |
+| `html_url` | `release_url` | Host-allowlisted (see [Security](#security-considerations)) |
+| `body` | `release_notes` | Sanitized of terminal control characters |
+
+Any failure at any step — DNS/connect error, timeout, non-2xx, rate
+limit (HTTP 403), oversized body, malformed or missing JSON fields —
+resolves to `None`. The failure is surfaced via `tracing::warn!`
+(category only, never the raw body or headers), **not** silently
+swallowed. Launch is never blocked and the process never panics.
+
+## Cache
+
+To avoid one HTTP request per launch, the result is cached on disk with
+a 24-hour TTL.
+
+| Property | Value |
+|----------|-------|
+| Path | `<state_root>/update_cache.json`, i.e. `~/.simard/update_cache.json`, honoring `SIMARD_STATE_ROOT` |
+| TTL | 24 hours |
+| Directory perms | `0700` (created if missing) |
+| File perms | `0600` |
+| Write | Atomic: write to a temp file, then `rename(2)` into place |
+| Symlinks | Refused (the check will not follow a symlinked cache path) |
+
+The cache path follows Simard's standard state-root convention:
+`SIMARD_STATE_ROOT` if set, otherwise `$HOME/.simard`. It shares that
+root with the rest of Simard's on-disk state (agent registry, snapshots,
+`config.toml`) rather than using an XDG path, so a single override moves
+all state together.
+
+Serialized shape:
+
+```json
+{
+  "last_check_epoch_secs": 1751771000,
+  "latest_version": "0.27.0",
+  "release_url": "https://github.com/rysweet/Simard/releases/tag/v0.27.0",
+  "release_notes": "Fixes and improvements…"
+}
+```
+
+Cache flow inside `check_for_update()`:
+
+1. **Fresh cache (< 24h):** skip the network entirely and reuse the
+   stored result. The cached strings are treated as **untrusted** — they
+   are re-validated (semver re-parse, host re-allowlist) and re-sanitized
+   before use, exactly as if they had just come off the wire.
+2. **Missing / expired / corrupt cache:** perform the network fetch,
+   then write the fresh result back to the cache. A corrupt or
+   unreadable cache is never a hard error — it is treated as a miss.
+3. **No writable cache location** (e.g. no `HOME` and no
+   `SIMARD_STATE_ROOT`, so the state root cannot be resolved): the cache
+   is simply disabled. The check proceeds with a network fetch and
+   remains fail-open.
+
+## Version comparison
+
+Version comparison uses the [`semver`](https://docs.rs/semver/1.0.28)
+crate (promoted to a direct dependency by #2250), not a hand-rolled
+parser:
+
+- The GitHub `tag_name` (with any leading `v` stripped) is parsed into a
+  `semver::Version`.
+- `env!("CARGO_PKG_VERSION")` is parsed the same way.
+- A newer version is reported **only when the latest is strictly
+  greater** than the current version, using semver's own ordering.
+
+Semver ordering handles pre-releases correctly, so `1.0.0-rc1` is
+*older* than `1.0.0` and the check will not offer to "upgrade" a stable
+build to a pre-release:
+
+| `current` | `latest` | Result |
+|-----------|----------|--------|
+| `0.26.0` | `0.27.0` | `Some(UpdateInfo)` (newer) |
+| `0.26.0` | `0.26.0` | `None` (same) |
+| `0.27.0` | `0.26.0` | `None` (older) |
+| `1.0.0` | `1.0.0-rc1` | `None` (pre-release is not newer) |
+| `1.0.0-rc1` | `1.0.0` | `Some(UpdateInfo)` (release beats its pre-release) |
+
+If either string fails to parse as semver, the result is `None` (never a
+panic).
+
+## Banner output
+
+When a strictly newer version is detected, the CLI prints exactly two
+lines to **stderr**:
 
 ```
-simard: update available v0.19.0 → v0.20.0
-  https://github.com/rysweet/Simard/releases/tag/v0.20.0
-  (no pre-built binary for this platform — build from source)
+simard: update available 0.26.0 -> 0.27.0
+  https://github.com/rysweet/Simard/releases/tag/v0.27.0
 ```
 
-The notice is yellow (ANSI `\x1b[33m`). It goes to stderr so it
-does not pollute `simard <command> | jq` pipelines.
+Contract details:
+
+- The first line is the literal format
+  `simard: update available X.Y.Z -> A.B.C` — an **ASCII** `->` arrow,
+  and **no** `v` prefix on the versions. (Tests assert this exact
+  string.)
+- The second line is the allowlisted `release_url`.
+- Output goes to **stderr only**, so it never pollutes
+  `simard <command> | jq` pipelines.
+- The versions printed are the parsed, re-serialized semver values, so
+  no attacker-controlled bytes from the API response reach the terminal
+  in the version line.
+
+## Interactive upgrade prompt
+
+In an interactive terminal (and only there), the banner is followed by a
+prompt on stderr:
+
+```
+Upgrade now? [y/N] 
+```
+
+Behavior:
+
+| Condition | Outcome |
+|-----------|---------|
+| User types `y` / `Y` + Enter | Prints the hint `Run \`simard update\` to upgrade.` — it does **not** install anything in place. |
+| User types anything else, or just Enter | Treated as **No**. |
+| ~10-second timeout elapses with no input | Treated as **No**. |
+| EOF / non-TTY stdin | Treated as **No**. |
+| `SIMARD_NONINTERACTIVE=1` | Prompt skipped (banner still shown). |
+| TUI (`simard-tui`) | Prompt never shown. |
+
+The prompt runs with a bounded (~10s) `recv_timeout` so it can never
+hang startup. It is display-only: choosing `y` never triggers a
+privileged install. Actual upgrading stays behind the explicit,
+integrity-gated `simard update` command (`cmd_self_update`).
 
 ## TUI rendering
 
-The TUI displays the update notice in the footer bar, replacing
-the default keybinding-only footer:
+The TUI displays the update notice in the footer bar, prepended to the
+default keybinding hints. The notice string uses the **same version
+format as the CLI banner** — an ASCII `->` arrow and no `v` prefix — so
+the two surfaces stay consistent:
 
 ```
-Update available: v0.19.0 → v0.20.0  https://...  Run `simard self-update` to upgrade.  | Alt+1‥6: tabs | ←/→: cycle | q: quit
+Update available: 0.26.0 -> 0.27.0  https://github.com/rysweet/Simard/releases/tag/v0.27.0  | Alt+1–9: tabs | Tab/Shift+Tab: cycle | ←/→: prev/next | q: quit
 ```
 
-The footer text is yellow when an update notice is present, dark gray
-otherwise. The notice appears 1–5 seconds after launch (once the
-background check completes) and persists for the lifetime of the TUI
-session.
+The keybinding tail (`Alt+1–9: tabs | Tab/Shift+Tab: cycle | ←/→:
+prev/next | q: quit`) is the TUI's existing footer, rendered by
+`src/bin/simard_tui/ui.rs`; only the `Update available: …` prefix and the
+highlight are added when a notice is present. The footer text is
+highlighted while a notice is set. The notice appears shortly after
+launch (once the background check completes, or immediately from a fresh
+cache) and persists for the lifetime of the TUI session. The TUI never
+shows the `[y/N]` prompt.
 
 ## Source layout
 
 ```
-src/update_check.rs          # All update check logic + unit tests
-src/main.rs                  # CLI entry: calls run_update_check()
-src/bin/simard_tui/main.rs   # TUI entry: calls run_update_check_background()
-src/bin/simard_tui/app.rs    # App.update_notice field, drained from receiver
-src/bin/simard_tui/ui.rs     # Footer rendering with conditional notice
-src/cmd_self_update/platform.rs  # platform_suffix() — shared by update check and self-update
+src/update_check.rs               # All update-check logic + unit tests
+src/main.rs                       # CLI entry: run_update_check()
+src/bin/simard_tui/main.rs        # TUI entry: run_update_check_background()
+src/bin/simard_tui/app.rs         # App.update_notice, drained from the receiver
+src/bin/simard_tui/ui.rs          # Footer rendering with the conditional notice
+Cargo.toml                        # ureq = "=3.3.0", semver = "=1.0.28" (direct deps)
 ```
 
 ## Tests
 
 All tests live in `src/update_check.rs` under `#[cfg(test)] mod tests`:
 
-| Test | What it verifies |
-|------|------------------|
-| `parse_semver_valid` | Standard `"1.2.3"` parses to `(1,2,3,true)` |
-| `parse_semver_with_prerelease` | `"-beta.1"` and `"-rc1"` set `is_release=false` |
-| `parse_semver_with_build_metadata` | `"+build.456"` is ignored (still a release) |
-| `parse_semver_rejects_invalid` | Non-numeric, too few/many parts, empty string |
-| `is_newer_returns_true_for_higher_version` | Major, minor, patch increments |
-| `is_newer_returns_false_for_same_or_older` | Equal and lower versions |
-| `is_newer_handles_invalid_input` | Unparseable strings → `false` |
-| `is_newer_handles_prerelease` | `1.0.0 > 1.0.0-rc1`, `1.0.0-beta.1 < 1.0.0`, `1.0.1-beta.1 > 1.0.0` |
-| `current_version_is_valid_semver` | `CARGO_PKG_VERSION` parses successfully |
-| `platform_suffix_is_not_unknown` | Platform suffix resolves on CI platforms |
-| `fetch_via_gh_returns_none_when_binary_missing` | `gh` call does not panic |
-| `run_update_check_background_returns_receiver` | Disabled → `None`, enabled → `Some` |
+| Test intent | What it verifies |
+|-------------|------------------|
+| semver-newer → `Some` | A strictly newer latest version yields `Some(UpdateInfo)`. |
+| same/older → `None` | Equal or older latest version yields `None`. |
+| fresh cache → no network | A cache entry younger than 24h short-circuits before any HTTP request. |
+| opt-out → no-op | `SIMARD_NO_UPDATE_CHECK=1` returns immediately (CLI) / `None` (TUI) with no cache or network access. |
+| malformed API response → `None` | A truncated/garbage JSON body parses to `None` and never panics. |
+| non-interactive → banner, no prompt | `SIMARD_NONINTERACTIVE=1` keeps the banner but skips the prompt. |
+| banner format | Exact string `simard: update available X.Y.Z -> A.B.C` (ASCII arrow, no `v`). |
+
+Environment-variable and cache-file tests are serialized with
+`#[serial_test::serial(update_check_env, cognitive_memory)]` and use a
+`tempdir`-isolated cache path, because glibc `getenv`/`setenv` are not
+thread-safe under cargo's multi-threaded test runner (see issue #2360).
 
 Run with:
 
@@ -201,20 +318,40 @@ cargo test -- update_check
 
 ## Security considerations
 
-- **No credentials exposed** — `gh` uses existing auth; `curl` hits
-  the public API. No tokens are passed on the command line.
-- **No auto-execution** — the notice is informational. The user must
-  explicitly run `simard self-update` to upgrade.
-- **Timeouts enforced** — both `gh` and `curl` have hard timeouts
-  with `child.kill()` to prevent indefinite hangs.
-- **stderr only** — update notices never appear in stdout, preventing
-  injection into piped command output.
-- **`mpsc::Receiver` is `!Sync`** — only polled from the TUI event
-  loop thread, eliminating data races.
+- **Unauthenticated, read-only notifier.** No token or `Authorization`
+  header is ever attached, so there is no credential to leak. No control
+  flow is derived from the response body — a spoofed response can at
+  worst mislead, never execute.
+- **No auto-install.** Choosing `y` at the prompt only prints the
+  `simard update` hint. Privileged install stays behind the
+  explicit, sha256/signature-gated `cmd_self_update` path; the check
+  never invokes it.
+- **Terminal-escape sanitization.** All response-derived strings
+  (`release_notes`, `release_url`) are stripped of ESC / BEL / CR and
+  C0/C1 control characters before display, so a malicious release body
+  cannot inject terminal escape sequences. The banner prints re-parsed
+  semver, never raw tag bytes.
+- **Phishing-resistant URL.** `release_url` is host-allowlisted to
+  `github.com/rysweet/Simard/`; anything else falls back to a hardcoded
+  releases URL, so a tampered `html_url` cannot redirect operators to an
+  attacker's page.
+- **No subprocess fetch.** Using in-process `ureq` (not `gh`/`curl`)
+  removes the `PATH`-hijack attack surface of shelling out.
+- **Bounded launch cost.** 5-second `timeout_global`, a 256 KiB body
+  cap, a background thread, and the 24h cache bound the network work so
+  the check can never become a launch-time DoS.
+- **Untrusted cache.** The cache is treated as attacker-controllable:
+  re-validated and re-sanitized on read, written atomically with `0700`
+  dir / `0600` file permissions, and never followed through a symlink.
+- **TLS-only transport** via `rustls`; failure logging records the
+  failure category only — never the raw response body or headers.
 
 ## See also
 
-- [Safe self-update](../safe-self-update.md) — the full
+- [Update check design](../concepts/update-check-design.md) — why it
+  works this way.
+- [Check for updates how-to](../howto/check-for-updates.md) — usage.
+- [Safe self-update](../safe-self-update.md) — the autonomous daemon
   drain → snapshot → pre-test → swap → validate → rollback flow.
 - [simard CLI reference](./simard-cli.md) — CLI command tree.
 - [Monitor with TUI](../howto/monitor-simard-with-tui.md) — TUI usage guide.

--- a/src/update_check.rs
+++ b/src/update_check.rs
@@ -1,16 +1,30 @@
-//! Startup update-version check against GitHub Releases.
+//! Startup update-version check against GitHub Releases (issue #2250).
 //!
-//! On every launch, queries GitHub for the latest release and prints a
-//! notice if a newer version is available. No caching — just a fast
-//! `gh api` call (or `curl` fallback) with a hard 5-second timeout.
+//! On launch each binary queries GitHub for the latest release and prints a
+//! notice if a newer version is available. Results are cached for 24h at
+//! `~/.config/simard/update_cache.json`, so a fresh cache skips the network
+//! entirely. The check is **non-blocking and fail-open**: any network, API,
+//! or parse failure is surfaced via `tracing::warn!` and resolves to "no
+//! update" — it never blocks or crashes the binary.
 //!
 //! Env-var controls:
-//! - `SIMARD_NO_UPDATE_CHECK=1` — skip the check entirely
+//! - `SIMARD_NO_UPDATE_CHECK=1` — skip the check entirely (no cache/network/prompt)
 //! - `SIMARD_NONINTERACTIVE=1`  — print the notice but suppress the upgrade prompt
 
+use std::io::IsTerminal;
 use std::sync::mpsc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
 
 use crate::cmd_self_update::platform::{CURRENT_VERSION, GITHUB_REPO};
+
+/// 24-hour cache TTL, in seconds.
+const CACHE_TTL_SECS: u64 = 24 * 60 * 60;
+
+/// Canonical Simard releases URL — the anti-phishing fallback and the root of
+/// the release-URL host allowlist.
+const SIMARD_RELEASES_URL: &str = "https://github.com/rysweet/Simard/releases";
 
 /// Information about an available update.
 #[derive(Debug, Clone)]
@@ -18,7 +32,7 @@ pub struct UpdateInfo {
     pub current_version: String,
     pub latest_version: String,
     pub release_url: String,
-    pub has_platform_asset: bool,
+    pub release_notes: String,
 }
 
 /// Run the update check as fire-and-forget: spawns a detached thread that
@@ -57,15 +71,8 @@ pub fn run_update_check_background() -> Option<mpsc::Receiver<String>> {
     std::thread::spawn(move || {
         if let Some(info) = check_for_update() {
             let notice = format!(
-                "Update available: v{} → v{}  {}{}",
-                info.current_version,
-                info.latest_version,
-                info.release_url,
-                if info.has_platform_asset {
-                    "  Run `simard self-update` to upgrade."
-                } else {
-                    ""
-                },
+                "Update available: {} -> {}  {}",
+                info.current_version, info.latest_version, info.release_url,
             );
             let _ = tx.send(notice);
         }
@@ -73,305 +80,730 @@ pub fn run_update_check_background() -> Option<mpsc::Receiver<String>> {
     Some(rx)
 }
 
-/// Check GitHub for a newer release.
-/// Returns `Some(UpdateInfo)` if a newer version exists, `None` otherwise.
+/// Check for a newer release, consulting the 24h on-disk cache first.
+///
+/// A fresh cache short-circuits the network. On a cache miss or expiry this
+/// queries GitHub, persists the result, and compares against the running
+/// version. Returns `Some(UpdateInfo)` only when a strictly newer version is
+/// available; any failure resolves to `None` (fail-open).
 pub fn check_for_update() -> Option<UpdateInfo> {
-    let (latest_version, release_url, has_platform_asset) = fetch_latest_version()?;
+    let now = unix_now();
 
-    if is_newer(&latest_version, CURRENT_VERSION) {
+    // 1. A fresh cache short-circuits the network entirely.
+    if let Some(cache) = load_cache()
+        && cache_is_fresh(cache.last_check_epoch_secs, now)
+    {
+        return update_from_version(
+            &cache.latest_version,
+            &cache.release_url,
+            &cache.release_notes,
+        );
+    }
+
+    // 2. Cache miss or expiry: query GitHub (fail-open on any error).
+    let (latest_version, release_url, release_notes) = fetch_latest_version()?;
+
+    // 3. Persist the freshly-fetched result (best-effort; never fatal).
+    let cache = Cache {
+        last_check_epoch_secs: now,
+        latest_version: latest_version.clone(),
+        release_url: release_url.clone(),
+        release_notes: release_notes.clone(),
+    };
+    if let Err(e) = save_cache(&cache) {
+        tracing::warn!("simard update-check: failed to persist update cache: {e}");
+    }
+
+    update_from_version(&latest_version, &release_url, &release_notes)
+}
+
+/// Build an `UpdateInfo` from raw (untrusted) release fields, but only when
+/// `latest` is strictly newer than the running version. Response-derived
+/// strings are sanitized and the URL host is allowlisted before use.
+fn update_from_version(latest: &str, url: &str, notes: &str) -> Option<UpdateInfo> {
+    if is_newer(CURRENT_VERSION, latest) {
         Some(UpdateInfo {
             current_version: CURRENT_VERSION.to_string(),
-            latest_version,
-            release_url,
-            has_platform_asset,
+            latest_version: sanitize(latest),
+            release_url: validate_release_url(&sanitize(url)),
+            release_notes: sanitize(notes),
         })
     } else {
         None
     }
 }
 
-/// Print an upgrade notice to stderr (so it doesn't pollute stdout piping).
+/// Print the upgrade banner to stderr (keeping stdout clean for piping) and,
+/// when attached to an interactive terminal, offer a short, timed prompt.
 fn print_upgrade_notice(info: &UpdateInfo) {
-    eprintln!(
-        "\x1b[33msimard: update available v{} → v{}\x1b[0m",
-        info.current_version, info.latest_version
-    );
-    eprintln!("  {}", info.release_url);
-    if info.has_platform_asset {
-        eprintln!("  Run `simard self-update` to upgrade.\n");
-    } else {
-        eprintln!("  (no pre-built binary for this platform — build from source)\n");
-    }
+    eprintln!("{}", format_banner(info));
+    maybe_prompt_upgrade();
 }
 
-// ── Helpers ──────────────────────────────────────────────────────────
+// ── Network / parsing ────────────────────────────────────────────────
 
-/// Query GitHub for the latest release tag, URL, and platform asset availability.
-/// Tries `gh api` first, then `curl` on ANY failure (not just spawn failure).
-fn fetch_latest_version() -> Option<(String, String, bool)> {
-    let json = fetch_via_gh().or_else(fetch_via_curl)?;
-    let release: serde_json::Value = serde_json::from_str(&json).ok()?;
+/// Query GitHub for the latest release via an in-process `ureq` request.
+///
+/// Returns `(version, release_url, release_notes)` on success. Any network,
+/// HTTP-status, size, or parse failure is logged via `tracing::warn!` and
+/// resolves to `None` (fail-open) so a launch is never blocked.
+fn fetch_latest_version() -> Option<(String, String, String)> {
+    let url = format!("https://api.github.com/repos/{GITHUB_REPO}/releases/latest");
+    let user_agent = format!("simard/{CURRENT_VERSION}");
 
-    let tag = release["tag_name"].as_str()?;
-    let version = tag.strip_prefix('v').unwrap_or(tag).to_string();
-    let url = release["html_url"].as_str().unwrap_or("").to_string();
+    let config = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(5)))
+        .build();
+    let agent: ureq::Agent = config.into();
 
-    // Check if there's an asset for the current platform
-    let has_platform_asset = crate::cmd_self_update::platform::platform_suffix()
-        .map(|suffix| {
-            release["assets"]
-                .as_array()
-                .map(|assets| {
-                    assets.iter().any(|a| {
-                        a["name"]
-                            .as_str()
-                            .map(|n| n.contains(suffix))
-                            .unwrap_or(false)
-                    })
-                })
-                .unwrap_or(false)
-        })
-        .unwrap_or(false);
+    // ureq treats 4xx/5xx as `Err(StatusCode)` by default, so a non-2xx
+    // response (including rate-limit 403s) fails open here.
+    let mut response = match agent
+        .get(&url)
+        .header("User-Agent", &user_agent)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .call()
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            tracing::warn!("simard update-check: GitHub releases query failed: {e}");
+            return None;
+        }
+    };
 
-    Some((version, url, has_platform_asset))
-}
+    // Cap the body at 256 KiB to bound launch-time work and memory.
+    let body = match response
+        .body_mut()
+        .with_config()
+        .limit(256 * 1024)
+        .read_to_string()
+    {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!("simard update-check: reading GitHub response failed: {e}");
+            return None;
+        }
+    };
 
-/// Try `gh api` with a 5-second timeout.
-fn fetch_via_gh() -> Option<String> {
-    let child = std::process::Command::new("gh")
-        .args([
-            "api",
-            &format!("repos/{GITHUB_REPO}/releases/latest"),
-            "--jq",
-            ".",
-        ])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .ok()?;
-
-    wait_with_timeout(child, std::time::Duration::from_secs(5))
-}
-
-/// Try `curl` with built-in timeout flags.
-fn fetch_via_curl() -> Option<String> {
-    let child = std::process::Command::new("curl")
-        .args([
-            "-sS",
-            "--connect-timeout",
-            "3",
-            "--max-time",
-            "5",
-            "-H",
-            "Accept: application/vnd.github+json",
-            &format!("https://api.github.com/repos/{GITHUB_REPO}/releases/latest"),
-        ])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .ok()?;
-
-    wait_with_timeout(child, std::time::Duration::from_secs(6))
-}
-
-/// Wait for a child process with a hard timeout. Returns stdout on success.
-fn wait_with_timeout(
-    mut child: std::process::Child,
-    timeout: std::time::Duration,
-) -> Option<String> {
-    let start = std::time::Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) if status.success() => {
-                let mut stdout = child.stdout.take()?;
-                let mut buf = String::new();
-                std::io::Read::read_to_string(&mut stdout, &mut buf).ok()?;
-                return Some(buf);
-            }
-            Ok(Some(_)) => return None, // non-zero exit
-            Ok(None) => {
-                if start.elapsed() > timeout {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return None;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(50));
-            }
-            Err(_) => return None,
+    match parse_latest(&body) {
+        Some(v) => Some(v),
+        None => {
+            tracing::warn!("simard update-check: could not parse GitHub release JSON");
+            None
         }
     }
 }
 
-/// Parse a semver string "major.minor.patch[-prerelease]" into a comparable tuple.
-///
-/// Returns `(major, minor, patch, is_release)` where `is_release` is `true`
-/// for plain releases and `false` for pre-release versions (e.g. "-beta.1",
-/// "-rc1"). This ensures pre-releases sort *before* the corresponding release:
-/// `1.0.0-rc1 < 1.0.0`.
-fn parse_semver(v: &str) -> Option<(u64, u64, u64, bool)> {
-    // Strip build metadata first (everything after '+'), then check for
-    // pre-release ('-'). This order matters because build metadata can
-    // contain hyphens (e.g. "1.2.3+build-456" is a valid release).
-    let (without_build, _build_meta) = match v.find('+') {
-        Some(idx) => (&v[..idx], Some(&v[idx + 1..])),
-        None => (v, None),
-    };
-    let (numeric, has_prerelease) = match without_build.find('-') {
-        Some(idx) => (&without_build[..idx], true),
-        None => (without_build, false),
-    };
-    let parts: Vec<&str> = numeric.split('.').collect();
-    if parts.len() != 3 {
+/// Parse a GitHub `releases/latest` JSON payload into
+/// `(version, release_url, release_notes)`. A leading `v` on `tag_name` is
+/// stripped. Returns `None` (never panics) on any malformed or missing field.
+fn parse_latest(body: &str) -> Option<(String, String, String)> {
+    let release: serde_json::Value = serde_json::from_str(body).ok()?;
+    if !release.is_object() {
         return None;
     }
-    Some((
-        parts[0].parse().ok()?,
-        parts[1].parse().ok()?,
-        parts[2].parse().ok()?,
-        !has_prerelease,
-    ))
+    let tag = release.get("tag_name")?.as_str()?;
+    let version = tag.strip_prefix('v').unwrap_or(tag).to_string();
+    let url = release
+        .get("html_url")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let notes = release
+        .get("body")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    Some((version, url, notes))
 }
 
-/// Returns true if `latest` is strictly newer than `current`.
-fn is_newer(latest: &str, current: &str) -> bool {
-    match (parse_semver(latest), parse_semver(current)) {
-        (Some(l), Some(c)) => l > c,
+/// Strip terminal-control characters (ESC/BEL/CR and all other C0/C1 controls)
+/// from response-derived text before it is printed, defeating escape-sequence
+/// injection via a spoofed release payload.
+fn sanitize(s: &str) -> String {
+    s.chars().filter(|c| !c.is_control()).collect()
+}
+
+/// Allowlist the release URL host: only an `https://github.com/rysweet/Simard`
+/// URL is trusted. Anything else (foreign host, look-alike subdomain, or a
+/// userinfo trick) is replaced with the hardcoded canonical Simard URL.
+fn validate_release_url(url: &str) -> String {
+    if let Some(rest) = url.strip_prefix("https://") {
+        let (host, path) = match rest.find('/') {
+            Some(i) => (&rest[..i], &rest[i..]),
+            None => (rest, ""),
+        };
+        if host == "github.com"
+            && (path == "/rysweet/Simard" || path.starts_with("/rysweet/Simard/"))
+        {
+            return url.to_string();
+        }
+    }
+    SIMARD_RELEASES_URL.to_string()
+}
+
+/// Format the launch banner. The first line is exactly the spec literal
+/// `simard: update available X.Y.Z -> A.B.C` (ASCII arrow), followed by the
+/// (already host-validated) release URL.
+fn format_banner(info: &UpdateInfo) -> String {
+    format!(
+        "simard: update available {} -> {}\n  {}",
+        info.current_version, info.latest_version, info.release_url
+    )
+}
+
+/// Returns `true` iff `latest` is strictly newer than `current` under semver
+/// ordering. Fail-open: if either string is not valid semver, returns `false`
+/// (never panics).
+fn is_newer(current: &str, latest: &str) -> bool {
+    match (
+        semver::Version::parse(current),
+        semver::Version::parse(latest),
+    ) {
+        (Ok(c), Ok(l)) => l > c,
         _ => false,
     }
 }
 
+/// Current UNIX time in seconds (0 if the clock predates the epoch).
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Pure 24h TTL predicate: a cache written at `last_check` is fresh at `now`
+/// while no more than [`CACHE_TTL_SECS`] have elapsed. Clock skew (a future
+/// `last_check`) is treated as fresh.
+fn cache_is_fresh(last_check: u64, now: u64) -> bool {
+    now.saturating_sub(last_check) <= CACHE_TTL_SECS
+}
+
+// ── On-disk cache ────────────────────────────────────────────────────
+
+/// On-disk update-check cache (a single JSON record).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Cache {
+    last_check_epoch_secs: u64,
+    latest_version: String,
+    release_url: String,
+    release_notes: String,
+}
+
+/// Resolve the cache file path, honoring `XDG_CONFIG_HOME` via `dirs`.
+fn cache_path() -> Option<std::path::PathBuf> {
+    let mut p = dirs::config_dir()?;
+    p.push("simard");
+    p.push("update_cache.json");
+    Some(p)
+}
+
+/// Load and parse the cache. Returns `None` on any error (absent, corrupt, or
+/// a refused symlink) — the caller then recomputes. Cached content is treated
+/// as untrusted and re-validated/re-sanitized downstream.
+fn load_cache() -> Option<Cache> {
+    let path = cache_path()?;
+    if let Ok(meta) = std::fs::symlink_metadata(&path)
+        && meta.file_type().is_symlink()
+    {
+        tracing::warn!("simard update-check: refusing to read update cache via symlink");
+        return None;
+    }
+    let data = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str::<Cache>(&data).ok()
+}
+
+/// Persist the cache with an atomic temp-file + rename, `0700` dir / `0600`
+/// file permissions, and a symlink refusal at the target path.
+fn save_cache(cache: &Cache) -> std::io::Result<()> {
+    let path = cache_path().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no config directory for update cache",
+        )
+    })?;
+    let dir = path.parent().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid cache path")
+    })?;
+    std::fs::create_dir_all(dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700));
+    }
+
+    if let Ok(meta) = std::fs::symlink_metadata(&path)
+        && meta.file_type().is_symlink()
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "refusing to write update cache via symlink",
+        ));
+    }
+
+    let json = serde_json::to_string(cache)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    let tmp = path.with_extension("json.tmp");
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&tmp)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            f.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        }
+        f.write_all(json.as_bytes())?;
+        f.flush()?;
+    }
+    std::fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+// ── Interactive prompt ───────────────────────────────────────────────
+
+/// Offer a short, timed upgrade prompt on an interactive terminal.
+///
+/// Suppressed when `SIMARD_NONINTERACTIVE=1` or when stdin/stderr are not
+/// TTYs (e.g. the TUI's alternate screen, which renders the banner via its own
+/// channel instead). Any of a ~10s timeout, EOF, or a non-affirmative answer
+/// resolves to "No". A `y`/`yes` only prints the `simard update` hint — it
+/// NEVER auto-installs.
+fn maybe_prompt_upgrade() {
+    if std::env::var("SIMARD_NONINTERACTIVE")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+    {
+        return;
+    }
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        return;
+    }
+
+    eprint!("Upgrade now? [y/N] ");
+    let _ = std::io::Write::flush(&mut std::io::stderr());
+
+    match read_line_with_timeout(Duration::from_secs(10)) {
+        Some(answer) => {
+            let a = answer.trim();
+            if a.eq_ignore_ascii_case("y") || a.eq_ignore_ascii_case("yes") {
+                eprintln!("Run `simard update` to upgrade.");
+            } else {
+                eprintln!();
+            }
+        }
+        None => {
+            // Timeout or EOF: default to No.
+            eprintln!();
+        }
+    }
+}
+
+/// Read one line from stdin with a hard timeout. Returns `None` on timeout or
+/// read error. The reader thread is detached; on timeout it is abandoned,
+/// which is acceptable for a short-lived launch-time convenience.
+fn read_line_with_timeout(timeout: Duration) -> Option<String> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut line = String::new();
+        if std::io::stdin().read_line(&mut line).is_ok() {
+            let _ = tx.send(line);
+        }
+    });
+    rx.recv_timeout(timeout).ok()
+}
+
 #[cfg(test)]
 mod tests {
+    //! TDD contract for the reworked update-check module (issue #2250).
+    //!
+    //! These tests specify the **target** behaviour of the spec-conformant
+    //! rework and are written *before* the implementation exists — several
+    //! reference seams (`parse_latest`, `format_banner`, `sanitize`,
+    //! `validate_release_url`, `Cache`, `load_cache`, `save_cache`,
+    //! `cache_is_fresh`) and the new `is_newer(current, latest)` /
+    //! `UpdateInfo { .., release_notes }` shape are introduced by the
+    //! implementation step. Until then this module fails to compile — that
+    //! is the intended TDD "red".
+    //!
+    //! Contract map (T1–T12):
+    //!   T1  semver newer  => `is_newer` true
+    //!   T2  same version  => `is_newer` false
+    //!   T3  older latest  => `is_newer` false
+    //!   T4  prerelease ordering via the `semver` crate
+    //!   T5  malformed version strings => false, never panic (fail-open)
+    //!   T6  `parse_latest` extracts (version, url, notes), strips leading `v`
+    //!   T7  malformed API JSON => `parse_latest` None, never panic
+    //!   T8  `format_banner` prints exactly `simard: update available X.Y.Z -> A.B.C`
+    //!   T9  `sanitize` strips ESC/BEL/CR/C0 terminal-control chars
+    //!   T10 `validate_release_url` allowlists the Simard GitHub host
+    //!   T11 `cache_is_fresh` enforces the 24h TTL (pure predicate)
+    //!   T12 fresh cache short-circuits the network in `check_for_update`
+    //!   plus: opt-out env => no-op, fire-and-forget launch, current version parses.
+
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const DAY_SECS: u64 = 24 * 60 * 60;
+
+    fn now_epoch() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before UNIX epoch")
+            .as_secs()
+    }
+
+    /// A well-formed GitHub `releases/latest` payload for parser tests.
+    fn sample_release_json() -> String {
+        serde_json::json!({
+            "tag_name": "v1.2.3",
+            "html_url": "https://github.com/rysweet/Simard/releases/tag/v1.2.3",
+            "body": "## What's new\n- shiny things",
+            "assets": []
+        })
+        .to_string()
+    }
+
+    // ── T1–T3: strictly-newer comparison, new (current, latest) order ──
 
     #[test]
-    fn parse_semver_valid() {
-        assert_eq!(parse_semver("1.2.3"), Some((1, 2, 3, true)));
-        assert_eq!(parse_semver("0.19.0"), Some((0, 19, 0, true)));
+    fn t1_is_newer_true_when_latest_is_newer() {
+        // Signature is is_newer(current, latest): true iff `latest` > `current`.
+        assert!(is_newer("0.19.0", "1.0.0"));
+        assert!(is_newer("0.19.0", "0.20.0"));
+        assert!(is_newer("0.19.0", "0.19.1"));
     }
 
     #[test]
-    fn parse_semver_with_prerelease() {
-        assert_eq!(parse_semver("1.2.3-beta.1"), Some((1, 2, 3, false)));
-        assert_eq!(parse_semver("1.0.0-rc1"), Some((1, 0, 0, false)));
-    }
-
-    #[test]
-    fn parse_semver_with_build_metadata() {
-        // Build metadata without prerelease → still a release
-        assert_eq!(parse_semver("1.2.3+build.456"), Some((1, 2, 3, true)));
-    }
-
-    #[test]
-    fn parse_semver_rejects_invalid() {
-        assert_eq!(parse_semver("not.a.version"), None);
-        assert_eq!(parse_semver("1.2"), None);
-        assert_eq!(parse_semver(""), None);
-        assert_eq!(parse_semver("1.2.3.4"), None); // too many parts
-    }
-
-    #[test]
-    fn is_newer_returns_true_for_higher_version() {
-        assert!(is_newer("1.0.0", "0.19.0"));
-        assert!(is_newer("0.20.0", "0.19.0"));
-        assert!(is_newer("0.19.1", "0.19.0"));
-    }
-
-    #[test]
-    fn is_newer_returns_false_for_same_or_older() {
+    fn t2_is_newer_false_when_equal() {
         assert!(!is_newer("0.19.0", "0.19.0"));
-        assert!(!is_newer("0.18.0", "0.19.0"));
-        assert!(!is_newer("0.19.0", "1.0.0"));
+        assert!(!is_newer("1.2.3", "1.2.3"));
     }
 
     #[test]
-    fn is_newer_handles_invalid_input() {
-        assert!(!is_newer("bad", "0.19.0"));
-        assert!(!is_newer("0.19.0", "bad"));
+    fn t3_is_newer_false_when_latest_is_older() {
+        assert!(!is_newer("1.0.0", "0.19.0"));
+        assert!(!is_newer("0.19.0", "0.18.0"));
     }
 
-    #[test]
-    fn is_newer_handles_prerelease() {
-        // Pre-release is older than the same release version
-        assert!(!is_newer("1.0.0-beta.1", "1.0.0"));
-        // Release is newer than its own pre-release
-        assert!(is_newer("1.0.0", "1.0.0-rc1"));
-        // Higher version pre-release is still newer than lower release
-        assert!(is_newer("1.0.1-beta.1", "1.0.0"));
-    }
+    // ── T4: prerelease ordering (semver crate semantics) ──────────────
 
     #[test]
-    fn current_version_is_valid_semver() {
-        let parsed = parse_semver(CURRENT_VERSION);
+    fn t4_is_newer_prerelease_ordering() {
+        // A released X.Y.Z is newer than its own prerelease.
         assert!(
-            parsed.is_some(),
-            "CARGO_PKG_VERSION should be valid semver: {CURRENT_VERSION}"
+            is_newer("1.0.0-rc1", "1.0.0"),
+            "release 1.0.0 must be newer than prerelease 1.0.0-rc1"
+        );
+        // A prerelease is NOT newer than the corresponding release.
+        assert!(
+            !is_newer("1.0.0", "1.0.0-rc1"),
+            "prerelease 1.0.0-rc1 must NOT be newer than release 1.0.0"
+        );
+        // A prerelease of a higher core version is still newer.
+        assert!(
+            is_newer("1.0.0", "2.0.0-beta.1"),
+            "prerelease of a higher version is still newer"
         );
     }
 
-    #[test]
-    fn platform_suffix_is_not_unknown() {
-        let suffix = crate::cmd_self_update::platform::platform_suffix();
-        assert!(
-            suffix.is_some(),
-            "platform_suffix() should return Some on supported platforms"
-        );
-        let s = suffix.unwrap();
-        assert!(
-            !s.contains("unknown"),
-            "platform suffix should be resolved: {s}"
-        );
-    }
+    // ── T5: fail-open on malformed version strings (no panic) ─────────
 
     #[test]
-    fn fetch_via_gh_returns_none_when_binary_missing() {
-        // gh is available on this system but this tests the timeout/error path
-        // by setting a very short timeout implicitly through the function structure.
-        // The real test is that it doesn't hang.
+    fn t5_is_newer_fail_open_on_garbage() {
         let result = std::panic::catch_unwind(|| {
-            // If gh is not authenticated, it should return None (not hang)
-            let _ = fetch_via_gh();
+            assert!(!is_newer("not-a-version", "1.0.0"));
+            assert!(!is_newer("1.0.0", "not-a-version"));
+            assert!(!is_newer("", ""));
+            assert!(!is_newer("1.2", "1.2.3")); // incomplete core
         });
-        assert!(result.is_ok(), "fetch_via_gh should not panic");
+        assert!(result.is_ok(), "is_newer must never panic on bad input");
+    }
+
+    // ── T6: parse_latest extracts fields and strips a leading `v` ─────
+
+    #[test]
+    fn t6_parse_latest_extracts_fields() {
+        let (version, url, notes) =
+            parse_latest(&sample_release_json()).expect("well-formed release should parse");
+        assert_eq!(
+            version, "1.2.3",
+            "leading 'v' must be stripped from tag_name"
+        );
+        assert_eq!(url, "https://github.com/rysweet/Simard/releases/tag/v1.2.3");
+        assert!(notes.contains("shiny things"), "release body -> notes");
     }
 
     #[test]
-    // #2360 (same class): these tests set/remove the process-global
+    fn t6b_parse_latest_accepts_tag_without_v_prefix() {
+        let json = serde_json::json!({
+            "tag_name": "2.5.0",
+            "html_url": "https://github.com/rysweet/Simard/releases/tag/2.5.0",
+            "body": ""
+        })
+        .to_string();
+        let (version, _url, _notes) = parse_latest(&json).expect("bare tag should parse");
+        assert_eq!(version, "2.5.0");
+    }
+
+    // ── T7: malformed API responses => None, never panic ──────────────
+
+    #[test]
+    fn t7_parse_latest_malformed_returns_none_no_panic() {
+        let result = std::panic::catch_unwind(|| {
+            assert!(parse_latest("this is not json").is_none());
+            assert!(parse_latest("{}").is_none(), "missing tag_name => None");
+            assert!(parse_latest("[]").is_none(), "wrong top-level type => None");
+            assert!(
+                parse_latest(r#"{"tag_name": 123}"#).is_none(),
+                "wrong tag_name type => None"
+            );
+            assert!(parse_latest("").is_none());
+        });
+        assert!(
+            result.is_ok(),
+            "parse_latest must never panic on malformed input"
+        );
+    }
+
+    // ── T8: banner text is exactly the spec string (ASCII, no `v`) ────
+
+    #[test]
+    fn t8_format_banner_exact_text() {
+        let info = UpdateInfo {
+            current_version: "0.19.0".to_string(),
+            latest_version: "1.2.3".to_string(),
+            release_url: "https://github.com/rysweet/Simard/releases/tag/v1.2.3".to_string(),
+            release_notes: "notes".to_string(),
+        };
+        let banner = format_banner(&info);
+        let first_line = banner.lines().next().unwrap_or_default();
+        assert_eq!(
+            first_line, "simard: update available 0.19.0 -> 1.2.3",
+            "banner headline must match the spec literal exactly"
+        );
+        assert!(
+            !banner.contains('\u{2192}'),
+            "banner must use ASCII '->', never the unicode arrow"
+        );
+    }
+
+    // ── T9: sanitize strips terminal-control characters ───────────────
+
+    #[test]
+    fn t9_sanitize_strips_control_chars() {
+        let hostile = "safe\x1b[31mtext\x07more\rend";
+        let cleaned = sanitize(hostile);
+        assert!(!cleaned.contains('\x1b'), "ESC must be stripped");
+        assert!(!cleaned.contains('\x07'), "BEL must be stripped");
+        assert!(!cleaned.contains('\r'), "CR must be stripped");
+        // Visible payload survives.
+        for token in ["safe", "text", "more", "end"] {
+            assert!(
+                cleaned.contains(token),
+                "visible text `{token}` must remain"
+            );
+        }
+    }
+
+    // ── T10: release URL host allowlist (anti-phishing) ───────────────
+
+    #[test]
+    fn t10_validate_release_url_allowlist() {
+        // Legitimate Simard GitHub URL passes through unchanged.
+        let good = "https://github.com/rysweet/Simard/releases/tag/v1.2.3";
+        assert_eq!(validate_release_url(good), good);
+
+        // A foreign host is rejected in favour of the hardcoded Simard fallback.
+        let evil = validate_release_url("https://evil.example.com/rysweet/Simard/x");
+        assert!(
+            !evil.contains("evil.example.com"),
+            "foreign host must be dropped"
+        );
+        assert!(
+            evil.contains("github.com/rysweet/Simard"),
+            "fallback must point at the real Simard repo"
+        );
+
+        // Look-alike subdomain trick (github.com.evil.com) must not slip through.
+        let spoof = validate_release_url("https://github.com.evil.com/rysweet/Simard");
+        assert!(!spoof.contains("evil"), "look-alike host must be rejected");
+    }
+
+    // ── T11: 24h cache TTL is a pure, deterministic predicate ─────────
+
+    #[test]
+    fn t11_cache_is_fresh_ttl_boundary() {
+        let base: u64 = 1_000_000_000;
+        assert!(cache_is_fresh(base, base), "same instant is fresh");
+        assert!(cache_is_fresh(base, base + 1_000), "1000s old is fresh");
+        assert!(
+            cache_is_fresh(base, base + DAY_SECS - 1),
+            "just under 24h is fresh"
+        );
+        assert!(
+            !cache_is_fresh(base, base + DAY_SECS + 1),
+            "just over 24h is stale"
+        );
+    }
+
+    // ── Cache round-trip through the real on-disk path (XDG-isolated) ──
+
+    #[test]
+    #[serial_test::serial(update_check_env, cognitive_memory)]
+    fn cache_save_load_round_trip() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", tmp.path()) };
+
+        let cache = Cache {
+            last_check_epoch_secs: now_epoch(),
+            latest_version: "3.4.5".to_string(),
+            release_url: "https://github.com/rysweet/Simard/releases/tag/v3.4.5".to_string(),
+            release_notes: "round-trip".to_string(),
+        };
+        save_cache(&cache).expect("save_cache should succeed under a writable XDG dir");
+        let loaded = load_cache();
+
+        // Restore env before asserting so a failure can't leak state.
+        match prev_xdg {
+            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
+            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
+        }
+
+        let loaded = loaded.expect("load_cache should read back what save_cache wrote");
+        assert_eq!(loaded.latest_version, "3.4.5");
+        assert_eq!(loaded.release_notes, "round-trip");
+    }
+
+    // ── T12: a fresh cache short-circuits the network ─────────────────
+
+    #[test]
+    #[serial_test::serial(update_check_env, cognitive_memory)]
+    fn t12_fresh_cache_newer_returns_some_without_network() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        let prev_noupd = std::env::var_os("SIMARD_NO_UPDATE_CHECK");
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path());
+            std::env::remove_var("SIMARD_NO_UPDATE_CHECK");
+        }
+
+        // A fresh cache advertising an impossibly-high version. If the network
+        // were consulted this could never be returned offline, so a `Some`
+        // with this version proves the cache short-circuited the fetch.
+        let cache = Cache {
+            last_check_epoch_secs: now_epoch(),
+            latest_version: "999.0.0".to_string(),
+            release_url: "https://github.com/rysweet/Simard/releases/tag/v999.0.0".to_string(),
+            release_notes: "from cache".to_string(),
+        };
+        save_cache(&cache).expect("save_cache");
+
+        let info = check_for_update();
+
+        match prev_xdg {
+            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
+            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
+        }
+        if let Some(v) = prev_noupd {
+            unsafe { std::env::set_var("SIMARD_NO_UPDATE_CHECK", v) };
+        }
+
+        let info = info.expect("fresh cache with a newer version must yield Some(UpdateInfo)");
+        assert_eq!(info.latest_version, "999.0.0");
+        assert_eq!(info.current_version, CURRENT_VERSION);
+        assert_eq!(info.release_notes, "from cache");
+    }
+
+    #[test]
+    #[serial_test::serial(update_check_env, cognitive_memory)]
+    fn t12b_fresh_cache_not_newer_returns_none_without_network() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        let prev_noupd = std::env::var_os("SIMARD_NO_UPDATE_CHECK");
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path());
+            std::env::remove_var("SIMARD_NO_UPDATE_CHECK");
+        }
+
+        // Cache says the latest release is ancient (< current 0.26.0). A fresh
+        // cache must short-circuit and, being not-newer, resolve to None.
+        let cache = Cache {
+            last_check_epoch_secs: now_epoch(),
+            latest_version: "0.0.1".to_string(),
+            release_url: "https://github.com/rysweet/Simard/releases/tag/v0.0.1".to_string(),
+            release_notes: String::new(),
+        };
+        save_cache(&cache).expect("save_cache");
+
+        let info = check_for_update();
+
+        match prev_xdg {
+            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
+            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
+        }
+        if let Some(v) = prev_noupd {
+            unsafe { std::env::set_var("SIMARD_NO_UPDATE_CHECK", v) };
+        }
+
+        assert!(
+            info.is_none(),
+            "a fresh cache older than the current version must yield None"
+        );
+    }
+
+    // ── Opt-out env var fully disables the check (no-op) ──────────────
+
+    #[test]
+    // #2360 class: these tests set/remove the process-global
     // `SIMARD_NO_UPDATE_CHECK`, which `run_update_check[_background]` reads.
-    // cargo runs the lib tests multi-threaded and glibc getenv/setenv are not
-    // thread-safe, so a concurrent mutate/read tears (e.g. this `is_none()`
-    // assertion observing the var removed by `..._returns_some_when_enabled`).
-    // All tests touching the var share the `update_check_env` key.
+    // cargo runs lib tests multi-threaded and glibc getenv/setenv are not
+    // thread-safe, so all tests touching the var share the `update_check_env`
+    // serial key.
     #[serial_test::serial(update_check_env, cognitive_memory)]
-    fn run_update_check_background_returns_receiver() {
-        // With check disabled, returns None
+    fn opt_out_env_disables_background_channel() {
+        let prev = std::env::var_os("SIMARD_NO_UPDATE_CHECK");
         unsafe { std::env::set_var("SIMARD_NO_UPDATE_CHECK", "1") };
-        assert!(run_update_check_background().is_none());
-        unsafe { std::env::remove_var("SIMARD_NO_UPDATE_CHECK") };
+        let rx = run_update_check_background();
+        match prev {
+            Some(v) => unsafe { std::env::set_var("SIMARD_NO_UPDATE_CHECK", v) },
+            None => unsafe { std::env::remove_var("SIMARD_NO_UPDATE_CHECK") },
+        }
+        assert!(
+            rx.is_none(),
+            "SIMARD_NO_UPDATE_CHECK=1 must make run_update_check_background a no-op"
+        );
     }
-
-    // ── F1: fire-and-forget (no join) ──────────────────────────────
 
     #[test]
     #[serial_test::serial(update_check_env, cognitive_memory)]
-    fn run_update_check_returns_immediately_when_disabled() {
+    fn opt_out_env_returns_immediately_from_run_update_check() {
+        let prev = std::env::var_os("SIMARD_NO_UPDATE_CHECK");
         unsafe { std::env::set_var("SIMARD_NO_UPDATE_CHECK", "1") };
         let start = std::time::Instant::now();
         run_update_check();
         let elapsed = start.elapsed();
-        unsafe { std::env::remove_var("SIMARD_NO_UPDATE_CHECK") };
+        match prev {
+            Some(v) => unsafe { std::env::set_var("SIMARD_NO_UPDATE_CHECK", v) },
+            None => unsafe { std::env::remove_var("SIMARD_NO_UPDATE_CHECK") },
+        }
         assert!(
             elapsed < std::time::Duration::from_millis(100),
-            "run_update_check() should return immediately when disabled, took {elapsed:?}"
+            "run_update_check() must return immediately when opted out, took {elapsed:?}"
         );
     }
+
+    // ── Launch path is fire-and-forget (never blocks startup) ─────────
 
     #[test]
     #[serial_test::serial(update_check_env)]
     fn run_update_check_is_fire_and_forget() {
-        // Even when enabled, run_update_check() must return immediately
-        // because it spawns a detached thread (no join). If someone
-        // reintroduces handle.join(), this test will take ~5s and fail.
+        // Even when enabled, run_update_check() must return immediately because
+        // it spawns a detached thread (no join). A reintroduced handle.join()
+        // would make this take ~5s and fail.
         let start = std::time::Instant::now();
         run_update_check();
         let elapsed = start.elapsed();
@@ -381,83 +813,31 @@ mod tests {
         );
     }
 
-    // ── F2: background channel returns Some when enabled ───────────
-
     #[test]
     #[serial_test::serial(update_check_env, cognitive_memory)]
     fn run_update_check_background_returns_some_when_enabled() {
+        let prev = std::env::var_os("SIMARD_NO_UPDATE_CHECK");
         unsafe { std::env::remove_var("SIMARD_NO_UPDATE_CHECK") };
         let rx = run_update_check_background();
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("SIMARD_NO_UPDATE_CHECK", v) };
+        }
         assert!(
             rx.is_some(),
             "run_update_check_background() should return Some(Receiver) when enabled"
         );
     }
 
-    // ── F3: platform suffix uses "macos" not "darwin" ──────────────
+    // ── CARGO_PKG_VERSION must be valid semver (comparable) ───────────
 
     #[test]
-    fn platform_suffix_never_contains_darwin() {
-        // F3: old code used "darwin-*" but actual GitHub releases use "macos-*".
-        // platform_suffix() must return "macos-*" on macOS, never "darwin-*".
-        let suffix = crate::cmd_self_update::platform::platform_suffix();
-        if let Some(s) = suffix {
-            assert!(
-                !s.contains("darwin"),
-                "platform suffix must use 'macos' not 'darwin', got: {s}"
-            );
-        }
-    }
-
-    // ── F4: prerelease-aware semver ────────────────────────────────
-
-    #[test]
-    fn parse_semver_prerelease_with_build_metadata() {
-        // "1.2.3-beta.1+build.456" has both prerelease and build metadata.
-        // The '-' before '+' makes it a prerelease → is_release = false.
-        assert_eq!(
-            parse_semver("1.2.3-beta.1+build.456"),
-            Some((1, 2, 3, false))
-        );
-    }
-
-    #[test]
-    fn parse_semver_build_metadata_with_dash_is_valid() {
-        // "1.2.3+build-456" — the '-' is inside build metadata (after '+'),
-        // so it is NOT a prerelease separator. This is a valid release.
-        assert_eq!(parse_semver("1.2.3+build-456"), Some((1, 2, 3, true)));
-    }
-
-    #[test]
-    fn is_newer_release_beats_same_version_prerelease() {
-        // Core F4 contract: release 1.0.0 is strictly newer than prerelease 1.0.0-rc1
+    fn current_version_is_valid_and_comparable() {
+        // Indirectly proves CURRENT_VERSION parses under the semver crate: it
+        // must be older than an absurd ceiling and newer than the zero version.
         assert!(
-            is_newer("1.0.0", "1.0.0-rc1"),
-            "release 1.0.0 must be newer than prerelease 1.0.0-rc1"
+            is_newer(CURRENT_VERSION, "9999.0.0"),
+            "CARGO_PKG_VERSION ({CURRENT_VERSION}) must compare as valid semver"
         );
-        // Reverse: prerelease is NOT newer than the corresponding release
-        assert!(
-            !is_newer("1.0.0-rc1", "1.0.0"),
-            "prerelease 1.0.0-rc1 must NOT be newer than release 1.0.0"
-        );
-    }
-
-    #[test]
-    fn is_newer_prerelease_of_higher_version_beats_lower_release() {
-        // 2.0.0-beta.1 is newer than 1.0.0 even though it's a prerelease
-        assert!(
-            is_newer("2.0.0-beta.1", "1.0.0"),
-            "prerelease of higher version should still be newer"
-        );
-    }
-
-    #[test]
-    fn parse_semver_4tuple_contract() {
-        // Explicit contract: 4th element is is_release (true = release, false = prerelease)
-        assert_eq!(parse_semver("1.0.0"), Some((1, 0, 0, true)));
-        assert_eq!(parse_semver("1.0.0-rc1"), Some((1, 0, 0, false)));
-        assert_eq!(parse_semver("1.0.0-beta.1"), Some((1, 0, 0, false)));
-        // Build metadata without prerelease is still a release
-        assert_eq!(parse_semver("1.0.0+build.123"), Some((1, 0, 0, true)));
+        assert!(!is_newer(CURRENT_VERSION, "0.0.0"));
     }
 }


### PR DESCRIPTION
## Summary

Reworks the launch-time update check to the issue #2250 contract. All three
launch paths are covered: `simard` (`src/main.rs`), `simard-tui`
(`src/bin/simard_tui/main.rs`), and the `meeting` subcommand (dispatched by
`simard`, inheriting `main.rs`'s check).

Closes #2250.

## What changed

- **In-process fetch via `ureq`** (rustls TLS, 5s global timeout, 256 KiB body
  cap, GitHub API headers) replaces the `gh`/`curl` subprocess and its
  PATH-hijack surface. Non-2xx responses and any error **fail open** to `None`.
- **`semver` crate** for version comparison; promoted `ureq` (`=3.3.0`) and
  `semver` (`=1.0.28`) to pinned direct deps (already in the locked graph).
- **`UpdateInfo`** now carries `release_notes` (dropped `has_platform_asset`;
  asset logic stays in `cmd_self_update`).
- **24h JSON cache** at `~/.config/simard/update_cache.json` (via `dirs`,
  honors `XDG_CONFIG_HOME`): a fresh cache short-circuits the network. Atomic
  temp+rename write, `0700` dir / `0600` file, symlink refusal, untrusted-read
  re-validation.
- **Banner** exactly `simard: update available X.Y.Z -> A.B.C` + release URL on
  stderr, from the binary launch path only. The TUI keeps its channel-based
  footer notice (alt-screen safe).
- **Prompt** `Upgrade now? [y/N]` with ~10s timeout (default No); suppressed on
  `SIMARD_NONINTERACTIVE=1`, non-tty, and in the TUI. `y` only prints the
  `simard update` hint — it never auto-installs.
- **Opt-out** `SIMARD_NO_UPDATE_CHECK=1` fully short-circuits (no
  cache/network/prompt).
- **Security**: sanitize response-derived strings (strip C0/C1 control chars),
  allowlist the release-URL host to `github.com/rysweet/Simard` with a
  hardcoded anti-phishing fallback. Failures are surfaced via `tracing::warn!`,
  never swallowed.

## Tests

In-module `#[cfg(test)]`: semver-newer → `Some`; same/older → `None`; fresh
cache → no network; opt-out env → no-op; malformed API response → `None` (no
panic); plus banner text, sanitize, URL allowlist, and 24h TTL predicate.
Env/cache tests are serialized (`serial(update_check_env, cognitive_memory)`)
and XDG-isolated per #2360.

## Verification

- `cargo test --lib update_check` — 20 passed
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- `cargo build --bin simard --no-default-features --locked` — ok
- pre-commit + pre-push hooks — all passed