### PR TITLE
fix(dashboard-chat): keep chat continuous across page reloads (#2581)

### DIFF
--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -33,7 +33,14 @@ pub(crate) const PART_04: &str = r#"            let fmt;
     fetchBudget();
 
     /* --- Chat --- */
-    let ws=null, currentSessionId=null, streamSpan=null, streamText='';
+    // Persist the active chat session id across page reloads so the
+    // conversation stays continuous (issue #2581). Without this the id lived
+    // only in memory, so any reload reset it to null and silently started a
+    // fresh, empty session — the agent "forgot" the whole conversation.
+    const CHAT_SESSION_KEY='simardChatSession';
+    function loadStoredChatSession(){ try{ return localStorage.getItem(CHAT_SESSION_KEY)||null; }catch(e){ return null; } }
+    function storeChatSession(id){ try{ if(id) localStorage.setItem(CHAT_SESSION_KEY,id); else localStorage.removeItem(CHAT_SESSION_KEY); }catch(e){} }
+    let ws=null, currentSessionId=loadStoredChatSession(), streamSpan=null, streamText='';
 
     async function loadChatSessions(){
       const box=document.getElementById('chat-sessions');
@@ -64,6 +71,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
           item.addEventListener('click',()=>openSession(s.id));
           box.appendChild(item);
         });
+        maybeResumeChat();
       }catch(e){
         box.textContent='';
         const err=document.createElement('div');
@@ -73,8 +81,27 @@ pub(crate) const PART_04: &str = r#"            let fmt;
       }
     }
 
+    // After a page reload, transparently reconnect to the last conversation
+    // (persisted in localStorage) so the chat stays continuous instead of
+    // starting a fresh, empty session (issue #2581). Only connects when there
+    // is no live socket, and only for a session that still exists on disk
+    // (verified against the freshly-rendered session list).
+    function maybeResumeChat(){
+      if(ws && (ws.readyState===WebSocket.OPEN || ws.readyState===WebSocket.CONNECTING)) return;
+      if(!currentSessionId) return;
+      let found=false;
+      document.querySelectorAll('.chat-session-item').forEach(el=>{
+        const match=el.dataset.id===currentSessionId;
+        el.classList.toggle('active', match);
+        if(match) found=true;
+      });
+      if(!found){ storeChatSession(null); currentSessionId=null; return; }
+      initChat(currentSessionId);
+    }
+
     async function openSession(id){
       currentSessionId=id;
+      storeChatSession(id);
       document.querySelectorAll('.chat-session-item').forEach(el=>{
         el.classList.toggle('active', el.dataset.id===id);
       });
@@ -88,6 +115,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
 
     function newChat(){
       currentSessionId=null;
+      storeChatSession(null);
       document.querySelectorAll('.chat-session-item.active').forEach(el=>el.classList.remove('active'));
       clearMessages();
       initChat(null);
@@ -119,7 +147,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
       try{ m=JSON.parse(ev.data); }
       catch(ex){ removeTypingIndicator();setChatBusy(false);appendMsg('system',ev.data); return; }
       // Handshake: bind the session id + streaming capability.
-      if(m && m.type==='ready'){ if(m.session_id) currentSessionId=m.session_id; return; }
+      if(m && m.type==='ready'){ if(m.session_id){ currentSessionId=m.session_id; storeChatSession(currentSessionId); } return; }
       // Resume: replay persisted history into the panel.
       if(m && m.type==='restore'){
         clearMessages();


### PR DESCRIPTION
## Problem

The operator reported: *"made the conversation continuous… it worked for a while, then it stopped working."*

## Root cause (verified live against the running dashboard on :8080)

The chat **backend** continuity is fully functional — `/ws/chat` persists every turn to `~/.simard/chat_sessions/`, restores prior history on `?session_id=`, and the agent recalls it. I verified this end-to-end on the live server: persisted a session, reconnected with its id, and the agent correctly recalled a secret word from before the reconnect.

The bug is entirely in the **frontend**. `currentSessionId` lived only in an in-memory JS variable (`part_04.rs`), initialized to `null` and never saved. Consequences:

- While the tab stays open, the conversation is continuous (the variable survives the in-page "Reconnect").
- **Any full page reload / reopen** resets `currentSessionId` to `null`, so the next connection mints a brand-new empty session and the agent "forgets" everything. The prior chat is orphaned in the sidebar list.

Present in the deployed build **and** current `main` (the frontend file is byte-identical between them).

## Fix (frontend only — `part_04.rs`)

- Persist `currentSessionId` to `localStorage` whenever it becomes a real id (the `ready` handshake and when a sidebar session is opened).
- Initialize `currentSessionId` from `localStorage` on page load.
- Clear the stored id on **New chat**.
- On opening the Chat tab, transparently reconnect to the stored session (`maybeResumeChat`) when no socket is live and the session still exists in the freshly-rendered list — so a reload resumes the same conversation instead of showing *Disconnected* / starting blank.

No backend changes.

## Validation

- Embedded JS syntax validated with `node --check` (placeholders neutralized).
- `cargo check --lib` passes.
- Pre-commit + pre-push gates (`cargo fmt`, `cargo clippy --all-targets --all-features --locked -D warnings`, race-subset tests) all pass.

## Manual test plan

1. Open the dashboard Chat tab, start a conversation, tell the agent something.
2. Reload the page (F5).
3. Open the Chat tab → the previous conversation auto-resumes and the agent still remembers the earlier context.
4. "New chat" starts a fresh session and does not resurrect the old one after reload.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>