### PR TITLE
feat(overseer): reliable+safe operator notifications on Signal & email (#2631)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3898,6 +3898,7 @@ dependencies = [
  "amplihack-memory",
  "assert_cmd",
  "axum 0.8.9",
+ "base64",
  "chrono",
  "crc32fast",
  "crossterm",
@@ -3915,6 +3916,8 @@ dependencies = [
  "ratatui",
  "regex",
  "rusqlite",
+ "rustls",
+ "rustls-native-certs",
  "rustyclawd-core",
  "rustyclawd-tools",
  "semver",
@@ -3933,6 +3936,7 @@ dependencies = [
  "ureq",
  "url",
  "uuid",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,18 @@ crossterm = "=0.28.1"
 headless_chrome = { version = "=1.0.21", optional = true, default-features = false }
 regex = { version = "=1.12.3", optional = true }
 url = { version = "=2.5.8", optional = true }
+# Issue #2631: the Overseer's authenticated STARTTLS + AUTH LOGIN email relay
+# (`StartTlsSmtpSender` in src/overseer/notify.rs) reaching e.g. office365. All
+# three are already in the locked dependency graph transitively; this promotes
+# them to direct deps at exact pins matching Cargo.lock. `rustls` enables the
+# `ring` crypto provider explicitly so the relay never relies on an ambiguous
+# process-default provider, and `--no-default-features` still builds. `base64`
+# encodes the AUTH LOGIN payload (inside TLS only). No secret is ever hardcoded —
+# SMTP credentials come solely from the environment.
+base64 = "=0.22.1"
+rustls = { version = "=0.23.38", features = ["ring"] }
+rustls-native-certs = "=0.8.3"
+webpki-roots = "=1.0.7"
 
 [target.'cfg(unix)'.dependencies]
 libc = "=0.2.185"

--- a/docs/design/overseer.md
+++ b/docs/design/overseer.md
@@ -15,6 +15,8 @@ doc_type: design
 status: draft
 related:
   - ../concepts/operational-autonomy-model.md
+  - ../reference/overseer-operator-notifications.md
+  - ../howto/configure-overseer-email-notifications.md
   - ../concepts/simard-whisperer.md
   - ../reference/simard-whisperer-api.md
   - ../howto/configure-the-simard-whisperer.md
@@ -515,3 +517,7 @@ built, these must be resolved — they are hard gates, not advice.
 - [Self-Deploy API](../reference/self-deploy-api.md) and
   [Cross-repo merge authority](../reference/cross-repo-merge-authority.md) — the
   guarded deploy and merge actions.
+- [Overseer operator-notification reliability](../reference/overseer-operator-notifications.md)
+  and [Configure Overseer email notifications](../howto/configure-overseer-email-notifications.md)
+  — the reliable, safe two-channel (Signal + email) operator-notification path, including
+  the anti-self-ingest Signal marker and the authenticated SMTP relay.

--- a/docs/howto/configure-overseer-email-notifications.md
+++ b/docs/howto/configure-overseer-email-notifications.md
@@ -1,0 +1,195 @@
+---
+title: How to configure Overseer email notifications
+description: >
+  Wire the Overseer's email channel to deliver operator notifications (merges, deploys,
+  and blocked "needs human review" goal escalations) to a real inbox via an authenticated
+  SMTP relay. Worked example uses smtp.office365.com:587 STARTTLS + AUTH LOGIN to reach
+  rysweet@microsoft.com, with the credentials set in the systemd unit (never hardcoded).
+  Covers the exact environment variables, the systemd drop-in, verification, and how the
+  Signal channel already provides the primary reliable path.
+last_updated: 2026-07-06
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+issues: ["#2631"]
+related:
+  - ../index.md
+  - ../reference/overseer-operator-notifications.md
+  - ./set-up-the-signal-channel.md
+  - ../reference/signal-conversation.md
+  - ../design/overseer.md
+  - ../concepts/operational-autonomy-model.md
+---
+
+# How to configure Overseer email notifications
+
+The Overseer notifies the operator on every merge, deploy, whisper, and — critically —
+every blocked **"needs human review"** goal escalation, on **both** Signal and email.
+Signal is
+the **primary reliable path**: once the [Signal channel](./set-up-the-signal-channel.md)
+is wired, the operator is always reached on their phone. This guide adds the **email**
+channel so the same notice also lands in an inbox.
+
+Delivering to a `microsoft.com` address requires an **authenticated SMTP relay**. This
+guide uses **office365** (`smtp.office365.com:587`, STARTTLS + AUTH LOGIN) as the worked
+example; an internal relay works the same way. All credentials come from the
+**environment** (set in the systemd unit) — never from source, never hardcoded.
+
+For the full delivery contract (channels, semantics, the Signal marker), see the
+[Overseer operator-notification reference](../reference/overseer-operator-notifications.md).
+
+## Prerequisites
+
+- [ ] The Signal channel is already wired (the primary path) — see
+      [Set up the Signal channel](./set-up-the-signal-channel.md). Email is additive.
+- [ ] A mailbox on the relay that is **authorized to send** (office365: a licensed
+      mailbox or one with SMTP AUTH enabled; e.g.
+      `simard-overseer@contoso.onmicrosoft.com`).
+- [ ] Its password or, preferably, an **app credential** for that mailbox.
+- [ ] The Overseer runs under systemd (this guide edits its unit).
+
+> **office365 note.** SMTP AUTH must be enabled for the sending mailbox (tenant-wide
+> "Authenticated SMTP" is off by default). If your tenant enforces modern auth only, use
+> an app credential or an internal relay that accepts the mailbox.
+
+## 1. The environment variables
+
+The email channel is configured **entirely from the environment**
+([`EmailConfig::from_env`](../reference/overseer-operator-notifications.md#environment-variables-the-complete-set)):
+
+| Variable | Value in this example |
+|----------|-----------------------|
+| `SIMARD_OVERSEER_EMAIL_TO` | `rysweet@microsoft.com` |
+| `SIMARD_OVERSEER_EMAIL_FROM` | `simard-overseer@contoso.onmicrosoft.com` |
+| `SMTP_HOST` | `smtp.office365.com` |
+| `SMTP_PORT` | `587` |
+| `SMTP_USER` | `simard-overseer@contoso.onmicrosoft.com` |
+| `SMTP_PASS` | *(the mailbox password / app credential — secret)* |
+
+Rules:
+
+- `SIMARD_OVERSEER_EMAIL_TO` may be a **comma-separated** list for multiple recipients.
+- When `SMTP_USER` **and** `SMTP_PASS` are both set, the channel uses the **STARTTLS +
+  AUTH LOGIN** sender (`StartTlsSmtpSender`) — encrypted and authenticated. Without them,
+  it falls back to a minimal plaintext sender for a local `:25` MTA.
+- **Never put the password in source, a committed file, or a shell history.** Set it only
+  in the systemd unit (below), ideally via a root-only credential file.
+
+## 2. Add the variables to the systemd unit
+
+Use a **drop-in** so you do not edit the shipped unit. Put the secret in a root-only
+environment file.
+
+Create `/etc/simard/overseer-email.env` (mode `0600`, owned by root):
+
+```ini
+SIMARD_OVERSEER_EMAIL_TO=rysweet@microsoft.com
+SIMARD_OVERSEER_EMAIL_FROM=simard-overseer@contoso.onmicrosoft.com
+SMTP_HOST=smtp.office365.com
+SMTP_PORT=587
+SMTP_USER=simard-overseer@contoso.onmicrosoft.com
+SMTP_PASS=<your-office365-app-password>
+```
+
+```bash
+sudo install -m 0600 /dev/stdin /etc/simard/overseer-email.env <<'EOF'
+SIMARD_OVERSEER_EMAIL_TO=rysweet@microsoft.com
+SIMARD_OVERSEER_EMAIL_FROM=simard-overseer@contoso.onmicrosoft.com
+SMTP_HOST=smtp.office365.com
+SMTP_PORT=587
+SMTP_USER=simard-overseer@contoso.onmicrosoft.com
+SMTP_PASS=<your-office365-app-password>
+EOF
+```
+
+Reference it from a drop-in — `systemctl edit simard-overseer.service`:
+
+```ini
+[Service]
+EnvironmentFile=/etc/simard/overseer-email.env
+```
+
+This single file holds every variable from step 1, so one `EnvironmentFile=` line is
+enough. If you prefer to keep non-secret defaults in their own file, add a **second** line
+with a leading `-`:
+
+```ini
+[Service]
+EnvironmentFile=-/etc/simard/overseer-email.service.env
+EnvironmentFile=/etc/simard/overseer-email.env
+```
+
+The leading `-` makes systemd treat that file as optional, so the unit still starts if you
+never create it. **Without the `-`, a missing `EnvironmentFile=` path is fatal and the
+Overseer service fails to start.**
+
+Reload and restart:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart simard-overseer.service
+```
+
+## 3. Verify delivery
+
+Trigger (or wait for) any operator notification — the easiest is a blocked-goal
+escalation, but a merge notification works too. Then check the structured delivery log on
+target `overseer::notify`:
+
+```bash
+journalctl -u simard-overseer.service -o cat | grep 'overseer::notify' | tail
+```
+
+A **successful both-channel** delivery shows:
+
+```text
+target: overseer::notify  dispatched=true all_sent=true  signal=Sent email=Sent kind=goal-blocked
+```
+
+If email is still queued or failing, you will instead see:
+
+```text
+target: overseer::notify  dispatched=true all_sent=false signal=Sent email=Queued kind=goal-blocked
+# or, on a transport/auth error:
+target: overseer::notify  dispatched=true all_sent=false signal=Sent email=Failed kind=goal-blocked
+```
+
+`dispatched=true` confirms the operator **was reached** (Signal delivered);
+`all_sent=false` is the honest report that email did not deliver yet. Then confirm the
+message arrived at `rysweet@microsoft.com`.
+
+## Understanding the result
+
+| You see | Meaning | Action |
+|---------|---------|--------|
+| `email=Sent` | The relay accepted the message. | Done — check the inbox. |
+| `email=Queued` | SMTP is not fully configured (missing host/from/recipient). | Re-check the six variables in step 1. |
+| `email=Failed` (auth) | The relay rejected `AUTH LOGIN`. | Verify `SMTP_USER`/`SMTP_PASS`; enable SMTP AUTH / use an app credential. |
+| `email=Failed` (STARTTLS) | The relay did not offer STARTTLS but credentials are set. | The sender **refuses** to send auth in the clear. Use a relay that supports STARTTLS on `587`. |
+
+> **Why email never "silently" fails.** An unconfigured channel is `Queued` (logged); a
+> transport error is `Failed` (logged). There is no path that drops the notification. And
+> because Signal is the wired primary path, the escalation is always **dispatched** even
+> before email works — see the
+> [semantics table](../reference/overseer-operator-notifications.md#part-c-delivery-semantics-all_sent-vs-dispatched).
+
+## Security notes
+
+- **Credentials are env-only.** `SMTP_USER` / `SMTP_PASS` live in the root-only
+  `EnvironmentFile`, never in source, a repo, or logs. The Overseer never logs the
+  password or the base64 AUTH payload.
+- **Encryption is mandatory when authenticating.** With credentials set, the sender uses
+  STARTTLS with standard certificate verification and **refuses** to fall back to
+  plaintext AUTH (base64 is not encryption).
+- **Header injection is blocked.** Subjects/headers derived from GitHub content (PR
+  titles) are sanitized (CR/LF stripped), so a crafted PR title cannot inject extra SMTP
+  headers.
+
+## Related reading
+
+- [Overseer operator-notification reference](../reference/overseer-operator-notifications.md)
+  — channels, the Signal marker, `all_sent` vs `dispatched`, and the API surface.
+- [Set up the Signal channel](./set-up-the-signal-channel.md) — the primary reliable
+  path (do this first).
+- [Overseer design](../design/overseer.md) — where the notifier sits in the merge/deploy
+  path.

--- a/docs/reference/overseer-operator-notifications.md
+++ b/docs/reference/overseer-operator-notifications.md
@@ -1,0 +1,442 @@
+---
+title: Overseer operator-notification reliability reference
+description: >
+  Reference for the Overseer's reliable, safe operator-notification path across BOTH
+  channels — Signal (primary, always-reliable) and email (authenticated SMTP relay). Covers
+  the anti-self-ingest Signal marker (OPERATOR_NOTIFY_MARKER) and its deterministic inbound
+  drop gate, the real STARTTLS + AUTH LOGIN email sender, the exact environment the operator
+  must set, the ChannelDelivery / NotifyReport semantics (all_sent vs dispatched), the
+  structured delivery telemetry, and the SMTP header-injection hardening.
+last_updated: 2026-07-06
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+issues: ["#2631"]
+related:
+  - ../index.md
+  - ../design/overseer.md
+  - ./signal-conversation.md
+  - ./conversation-channel-api.md
+  - ../howto/configure-overseer-email-notifications.md
+  - ../howto/set-up-the-signal-channel.md
+  - ../concepts/operational-autonomy-model.md
+  - ./cross-repo-merge-authority.md
+---
+
+# Overseer operator-notification reliability reference
+
+The Overseer notifies the operator on **every** merge, deploy, whisper, and — most
+importantly — every **blocked "needs human review" goal escalation**. That notification
+MUST actually reach a human. This reference documents the two-channel delivery contract
+that makes it **reliable** (the operator is always reached) and **safe** (Simard never
+re-ingests her own Signal notification as an operator command).
+
+The notifier lives in `src/overseer/notify.rs` (see the
+[Overseer design](../design/overseer.md)); the Signal anti-self-ingest marker and its
+inbound gate live in `src/signal_conversation/gating.rs` and
+`src/signal_conversation/channel.rs`.
+
+> **Two channels, always both.** [`DualChannelNotifier`] fires **every** channel on
+> **every** notification and records each outcome. There is no code path that drops a
+> notification on the floor: an unconfigured channel returns `Queued` (logged), a
+> transport error returns `Failed` (logged).
+
+## Channels at a glance
+
+| Channel | Role | Configured by | Unconfigured behavior |
+|---------|------|---------------|-----------------------|
+| **Signal** | **Primary reliable path.** When the `[signal]` transport is wired, the operator is always reached on their phone. | [Signal channel setup](../howto/set-up-the-signal-channel.md) | `Queued { reason: "Signal channel not wired …" }` |
+| **Email** | Secondary durable path via an **authenticated SMTP relay** (office365 or an internal relay). | Env vars (below) + the operator's systemd unit | `Queued { reason: "SMTP not configured …" }` |
+
+The Signal channel is the **primary** path precisely because it is already wired in
+production; email delivers in addition, once the operator adds relay credentials.
+
+---
+
+## Part A — Signal anti-self-ingest marker (primary safety control)
+
+### The problem
+
+Simard runs an **inbound** Signal processor: allowlisted operator messages become
+commands (`status`, `approve`, `merge #NNNN`) or meeting turns. On a single-number
+linked-device setup, Signal **syncs Simard's own outbound messages back** to the linked
+device as *sync-sent* transcripts. Without a deterministic guard, Simard could read her
+own operator notification as a new inbound command.
+
+The pre-existing echo suppression (`matches_recent_outbound`) is **exact-body match
+within a 5-minute window** — it is fragile: a late, quoted, or altered synced echo (e.g.
+prefixed with "You sent:") slips through. The marker removes that fragility.
+
+### The marker
+
+Every outbound Overseer→operator Signal notification is wrapped with a distinct,
+reserved sentinel so the inbound processor can **deterministically** recognize and skip
+it — independent of the echo window.
+
+```rust
+// src/signal_conversation/gating.rs — single source of truth
+pub const OPERATOR_NOTIFY_MARKER: &str = "🔔 SIMARD▶OPERATOR:";
+```
+
+- **Reserved.** The sentinel `🔔 SIMARD▶OPERATOR:` (bell emoji + `SIMARD▶OPERATOR:`) is
+  reserved. Operators MUST NOT send any message *containing* it — detection is a
+  **substring** test, not a prefix test. Its high-entropy glyph combination (`🔔` + `▶`
+  + the literal `OPERATOR:`) never occurs in a real operator command, so normal messages
+  are unaffected.
+- **Human-readable.** On the operator's phone the message reads as a pleasant, labelled
+  notice, followed by a plain footer.
+
+A human footer is appended for readability. It is **display only** and is NOT used for
+detection:
+
+```text
+— Simard automated notice · do not reply
+```
+
+### Formatting API
+
+```rust
+/// Wrap an operator-notification body in the reserved marker (+ footer).
+pub fn wrap_operator_notification(body: &str) -> String;
+
+/// True iff `text` carries the reserved marker anywhere in the message.
+pub fn is_operator_notification(text: &str) -> bool;
+```
+
+- `wrap_operator_notification(body)` returns
+  `format!("{OPERATOR_NOTIFY_MARKER} {body}{FOOTER}")` — the result **starts with** the
+  marker and **ends with** the footer.
+- `is_operator_notification(text)` is a **substring** test
+  (`text.contains(OPERATOR_NOTIFY_MARKER)`), NOT `starts_with`. Substring matching
+  survives a synced-echo prefix such as `"You sent: …"` or a quoted reply.
+
+A rendered notification the operator sees:
+
+```text
+🔔 SIMARD▶OPERATOR: The Overseer autonomously performed a goal-blocked in rysweet/Simard.
+
+Problem solved:
+  Goal `g-4821` is blocked and needs human review.
+  Reason: completion evidence rejected twice
+
+
+— Simard automated notice · do not reply
+```
+
+(`plain_text()` already ends in a newline and the footer begins with `\n\n`, so the
+rendered notice carries two blank lines before the footer.)
+
+### Where wrapping happens
+
+Only the Overseer **notification** path wraps its body. The wrap is applied in
+`SignalNotifyChannel::deliver` (in `notify.rs`) immediately before `send_text`:
+
+```rust
+fn deliver(&self, n: &OperatorNotification) -> ChannelDelivery {
+    match &self.sender {
+        None => ChannelDelivery::Queued { reason: "Signal channel not wired …".into() },
+        Some(sender) => {
+            // The marker helpers live in the `signal`-gated module, so the wrap
+            // call site is feature-gated too (see the build note below).
+            #[cfg(feature = "signal")]
+            let body = wrap_operator_notification(&n.plain_text());
+            #[cfg(not(feature = "signal"))]
+            let body = n.plain_text();
+            match sender.send_text(&body) { /* Sent / Failed */ }
+        }
+    }
+}
+```
+
+> **Feature-gating (keeps `--no-default-features` building).** `wrap_operator_notification`
+> lives in `src/signal_conversation/gating.rs`, which is compiled only behind
+> `#[cfg(feature = "signal")]`, whereas `src/overseer/notify.rs` is **always** compiled.
+> The wrap call site is therefore itself `#[cfg(feature = "signal")]`-gated. With the
+> `signal` feature off there is no inbound Signal processor that could self-ingest, and
+> `SignalNotifyChannel::from_env()` returns `sender = None` (so the channel always
+> `Queued`s and the wrapped branch is unreachable) — the marker import is compiled out
+> and the minimal build stays green. `gating.rs` remains the single source of truth for
+> the marker.
+
+Interactive replies (`status`, high-risk sign-off prompts, meeting turns) are **not**
+wrapped — they are short-lived, in-thread, and already covered by the existing
+device-1 / echo-suppression guards. The **email** body is never wrapped: the marker is a
+Signal-only anti-self-ingest device.
+
+### The inbound drop gate
+
+The inbound processor drops any marked message **before** it reaches allowlist
+authorization or command parsing. In `SignalConversation::recv`
+(`src/signal_conversation/channel.rs`), the check sits immediately after
+`parse_incoming` yields the parsed envelope and **before** the sync-sent / echo /
+allowlist logic:
+
+```rust
+let Some(parsed) = super::transport::parse_incoming(&line) else { continue; };
+
+// Fail-closed anti-self-ingest: a message bearing the reserved operator-notification
+// marker is one of Simard's OWN notifications synced back — never an operator command.
+if is_operator_notification(&parsed.body) {
+    tracing::debug!(target: "signal", "dropping self-notification echo (operator marker)");
+    continue;
+}
+
+// … existing sync-sent gate, echo suppression, allowlist, command parsing …
+```
+
+Properties:
+
+- **Deterministic & independent of the echo window.** A marked message is dropped even
+  if the synced echo arrives late, expired, altered, or quoted — the marker alone
+  suffices. It does **not** rely on `matches_recent_outbound`.
+- **Covers both paths.** The gate runs for both direct `dataMessage`s and sync-sent
+  Note-to-Self transcripts, because it precedes the `is_sync_sent` branch.
+- **Grants no privilege.** The marker only causes an inbound message to be *ignored*. It
+  never authorizes anything; the allowlist and high-risk sign-off gate are unchanged.
+- **Normal operator messages are unaffected.** A message without the marker flows
+  through exactly as before.
+
+---
+
+## Part B — Email delivery via an authenticated SMTP relay
+
+Delivering to a `microsoft.com` recipient requires an **authenticated SMTP relay**
+(office365 or an internal relay). The email channel performs a **real** SMTP send when
+host/port/user/pass are configured.
+
+### Environment variables (the complete set)
+
+Email is configured **entirely from the environment** — never from source, and never
+with hardcoded secrets. [`EmailConfig::from_env`] reads:
+
+| Variable | Meaning | Example |
+|----------|---------|---------|
+| `SIMARD_OVERSEER_EMAIL_TO` | Recipient(s), comma-separated. | `rysweet@microsoft.com` |
+| `SIMARD_OVERSEER_EMAIL_FROM` | Envelope + header `From` (an authorized sender on the relay). | `simard-overseer@contoso.onmicrosoft.com` |
+| `SMTP_HOST` | Relay host. | `smtp.office365.com` |
+| `SMTP_PORT` | Relay port (STARTTLS submission). Defaults to `25` if unset. | `587` |
+| `SMTP_USER` | Relay auth username (a mailbox). **Secret-adjacent.** | `simard-overseer@contoso.onmicrosoft.com` |
+| `SMTP_PASS` | Relay auth password / app credential. **Secret.** | *(set in the systemd unit)* |
+
+[`EmailConfig::is_configured`] is true iff a **host**, a **from**, and at least one
+**recipient** are known. When it is false, the channel returns
+`Queued { reason: "SMTP not configured …" }` — logged, never dropped.
+
+> **Never hardcode secrets.** `SMTP_USER` / `SMTP_PASS` are supplied only via the
+> environment (the operator sets them in the systemd unit). No credential literal appears
+> in source, tests, docs, or logs. See
+> [How to configure Overseer email notifications](../howto/configure-overseer-email-notifications.md)
+> for the worked office365 setup.
+
+### Transport selection
+
+[`EmailNotifyChannel::from_env`] selects the SMTP sender from the configured
+environment:
+
+| Condition | Sender | Security (example port) |
+|-----------|--------|-------------------------|
+| `SMTP_USER` **and** `SMTP_PASS` set | [`StartTlsSmtpSender`] — **STARTTLS + AUTH LOGIN** | encrypted + authenticated (e.g. `smtp.office365.com:587`) |
+| neither set | [`TcpSmtpSender`] — minimal plaintext | no TLS/AUTH (e.g. a local relay on `:25`) |
+
+Selection depends **only** on whether `SMTP_USER` **and** `SMTP_PASS` are both set; the
+actual port is whatever `SMTP_PORT` resolves to (default `25`). The ports above are the
+worked-example values, not a property the sender enforces.
+
+Both senders implement the object-safe [`EmailSender`] trait
+(`fn send(&self, msg: &EmailMessage) -> Result<(), String>`), so the channel logic is
+identical; only the wire transport differs.
+
+### The STARTTLS + AUTH LOGIN sender
+
+[`StartTlsSmtpSender`] speaks authenticated submission using **blocking `rustls`** (no
+async runtime) and `base64` for the AUTH LOGIN payload. The conversation:
+
+```text
+S: 220 …                         (greeting)
+C: EHLO simard-overseer
+S: 250-… 250-STARTTLS …          (STARTTLS advertised)
+C: STARTTLS
+S: 220 …
+        ── TLS handshake (rustls, default verifier, hostname = SMTP_HOST) ──
+C: EHLO simard-overseer          (re-issued inside TLS)
+S: 250-… 250-AUTH LOGIN …
+C: AUTH LOGIN
+S: 334 VXNlcm5hbWU6              (server's base64 prompt, e.g. "Username:")
+C: <base64(SMTP_USER)>           (client answers positionally, not by matching the prompt)
+S: 334 UGFzc3dvcmQ6              (server's base64 prompt, e.g. "Password:")
+C: <base64(SMTP_PASS)>
+S: 235 …                          (authenticated)
+C: MAIL FROM:<…> / RCPT TO:<…> / DATA / …
+C: QUIT
+```
+
+Security guarantees:
+
+- **Mandatory STARTTLS when authenticating (fail-closed).** If credentials are set but
+  the server does not advertise/complete STARTTLS, the sender returns
+  `Failed { reason }` — it NEVER falls back to sending `AUTH LOGIN` in the clear.
+  base64 is an encoding, not encryption; this blocks a STARTTLS-stripping MITM.
+- **Standard certificate verification.** Uses the stock `rustls` verifier with
+  `rustls-native-certs` (falling back to `webpki-roots`); the TLS peer name is validated
+  against `SMTP_HOST`. No `dangerous_configuration`, no cert bypass.
+- **Timeouts.** Read/write timeouts bound every reply read on the TLS stream (mirroring
+  the plaintext sender), so a stalled relay cannot hang the notifier.
+- **No credential leakage.** `SMTP_PASS`, the base64 AUTH payload, and the raw `AUTH`
+  line are never logged and never placed in an error string; only server reply text may
+  surface.
+
+### Hermetic testability
+
+The protocol is split from the TLS seam so it is unit-testable without a network:
+
+- `smtp_converse<S: Read + Write>(stream, msg, auth)` — a **pure** state machine driven
+  over any duplex stream. It is composed of two shared helpers,
+  `smtp_starttls_prelude` (greeting → EHLO → **require** STARTTLS → STARTTLS → `220`) and
+  `smtp_submit_authenticated` (EHLO → AUTH LOGIN → MAIL/RCPT/DATA → QUIT). Scripted
+  in-memory duplex tests assert that STARTTLS is requested, that AUTH LOGIN emits the
+  correct positional base64, that an injected subject/body is neutralized in the DATA
+  section, and that a credentialed send against a server that omits STARTTLS fails
+  **without** emitting any plaintext AUTH bytes.
+- `StartTlsSmtpSender` reuses those **same two helpers** with a real `rustls` handshake
+  spliced between them (prelude over the plain socket, submission over the TLS stream),
+  so only the TLS handshake itself is an untested seam — the wire protocol is exactly the
+  tested one.
+- A `FakeSmtp` at the [`EmailSender`] level exercises channel `Sent` / `Queued`
+  semantics.
+
+### SMTP header-injection hardening
+
+Notification content is partly GitHub-sourced (PR titles, headlines) and board-derived
+(goal ids in the Subject). The shared `sanitize_header_value()` and `dot_stuff_body()`
+(introduced in the plaintext sender) are applied by **both** senders when constructing
+the message, at the single transport choke point:
+
+- `sanitize_header_value()` — every control character (including CR/LF) in the `From`,
+  each recipient, and the Subject is replaced with a space and the value is byte-bounded
+  (≤ 512 octets, on a UTF-8 char boundary), so an injected `\r\n` cannot terminate the
+  line and smuggle an extra header (e.g. `Bcc:`) or SMTP verb.
+- `dot_stuff_body()` — the body is CRLF-normalized and any line beginning with `.` is
+  escaped (`.` → `..`), so a board-derived lone `.` line cannot prematurely close the
+  DATA section (RFC 5321 §4.5.2 transparency).
+
+This blocks SMTP header/command injection (CWE-93) from an attacker-influenced
+`pr_title` / `headline` / goal `reason` on both the plaintext and authenticated paths.
+
+---
+
+## Part C — Delivery semantics: `all_sent` vs `dispatched`
+
+Each channel returns a [`ChannelDelivery`]; the notifier aggregates them into a
+[`NotifyReport`].
+
+```rust
+pub enum ChannelDelivery {
+    Sent,                       // delivered to the transport
+    Queued { reason: String },  // not configured / degraded — logged, never dropped
+    Failed { reason: String },  // transport attempted but errored — logged
+}
+```
+
+```rust
+impl NotifyReport {
+    /// True iff there is at least one channel AND every channel delivered
+    /// (no `Queued`, no `Failed`). An empty report is `false`.
+    pub fn all_sent(&self) -> bool;
+    /// True iff at least one channel recorded an outcome (`per_channel` is
+    /// non-empty). It does NOT mean anything was successfully sent — a report
+    /// holding only `Queued`/`Failed` is still `dispatched`.
+    pub fn dispatched(&self) -> bool;
+}
+```
+
+The distinction is the crux of "reliable but honest":
+
+| Situation | `signal` | `email` | `dispatched()` | `all_sent()` |
+|-----------|----------|---------|:--------------:|:------------:|
+| Both configured, both deliver | `Sent` | `Sent` | ✅ | ✅ |
+| Signal wired, email relay not yet set | `Sent` | `Queued` | ✅ | ❌ |
+| Signal wired, relay auth wrong | `Sent` | `Failed` | ✅ | ❌ |
+| Signal not wired, email delivers | `Queued` | `Sent` | ✅ | ❌ |
+
+Because Signal is the wired primary path, **the operator is always reached** and the
+escalation is **dispatched** even when email SMTP is not yet configured. An escalation is
+therefore **never considered "lost"** merely because email is unconfigured; `all_sent()`
+simply reports the honest fact that not every channel delivered.
+
+### Observability
+
+Whenever a channel does not deliver, `log_degraded` already emits a `tracing::warn!` on
+target `overseer::notify` naming the **channel** and the **outcome** (the
+`Queued`/`Failed` variant, so unconfigured-vs-transport-error is distinguishable). In
+addition, [`DualChannelNotifier::notify`] emits one structured `tracing::info!` summary
+per notification:
+
+```text
+target: overseer::notify
+  dispatched = true
+  all_sent   = false
+  kind       = goal-blocked
+  channels   = signal=Sent email=Queued
+```
+
+The `channels` field carries a space-separated `name=Variant` list built from
+`delivery_variant` — the `ChannelDelivery` **variant name only** (`Sent` / `Queued` /
+`Failed`), not the `Debug` form — so no `reason` string ever lands in the one-line
+summary; the paired `log_degraded` warning still carries the full `?outcome` for
+diagnosis. This makes "Signal Sent + email Queued" plainly visible as
+**dispatched-but-not-all_sent**. No secret (password, base64 AUTH payload) is ever
+included in any log field.
+
+---
+
+## API surface
+
+All types live in `src/overseer/notify.rs` unless noted.
+
+| Symbol | Kind | Purpose |
+|--------|------|---------|
+| `OperatorNotification` | struct | Channel-agnostic notification (`kind`, `headline`, `problem`, `link`, `repo`, `autonomous`). Builders: `deploy`, `whisper`, `goal_blocked`; `MergeNotification::to_operator`. |
+| `ChannelDelivery` | enum | `Sent` \| `Queued { reason }` \| `Failed { reason }`. |
+| `NotifyReport` | struct | `per_channel: Vec<(String, ChannelDelivery)>`; `all_sent()`, `dispatched()`. |
+| `NotifyChannel` | trait | `name()`, `deliver(&OperatorNotification) -> ChannelDelivery`. |
+| `DualChannelNotifier` | struct | Fires every channel; `new`, `from_env`, `notify`. |
+| `OperatorNotifier` | trait | Object-safe seam (`notify`) so tests inject a fake. |
+| `EmailConfig` | struct | Env-driven SMTP config; `from_env`, `from_lookup`, `is_configured`, `use_authenticated`. |
+| `EmailMessage` | struct | `from`, `to`, `subject`, `body`. |
+| `EmailSender` | trait | `send(&EmailMessage) -> Result<(), String>`. |
+| `EmailNotifyChannel` | struct | Email channel; `from_env` selects the sender by config. |
+| `TcpSmtpSender` | struct | Minimal plaintext SMTP (`:25`, no TLS/AUTH). |
+| `StartTlsSmtpSender` | struct | **STARTTLS + AUTH LOGIN** authenticated relay sender. |
+| `smtp_converse` | fn | Pure SMTP state machine (`S: Read + Write`) for hermetic tests. |
+| `SmtpAuth` | struct | `user` / `pass` for AUTH LOGIN (no `Debug`; env-sourced, never hardcoded). |
+| `sanitize_header_value` / `dot_stuff_body` | fn | Shared CWE-93 header/body injection hardening (applied by both senders). |
+| `delivery_variant` | fn | Bare `ChannelDelivery` variant name for the structured summary (no `reason`). |
+| `SignalSender` | trait | `send_text(&str) -> Result<(), String>`. |
+| `ConversationSignalSender` | struct | Adapts any `ConversationChannel` into a `SignalSender`. |
+| `SignalNotifyChannel` | struct | Signal channel; wraps the body with the operator marker before sending. |
+| `OPERATOR_NOTIFY_MARKER` | const | Reserved sentinel (`gating.rs`). |
+| `wrap_operator_notification` | fn | Wrap a body in the marker + footer (`gating.rs`). |
+| `is_operator_notification` | fn | Substring marker detection (`gating.rs`). |
+
+## Dependencies
+
+The STARTTLS sender promotes these to direct dependencies, pinned to `Cargo.lock`, with
+`--no-default-features` still building:
+
+- `rustls` `0.23.38` (with the `ring` crypto provider enabled explicitly)
+- `rustls-native-certs` `0.8.3` (OS trust store)
+- `webpki-roots` `1.0.7` (compiled root fallback when the OS store is empty)
+- `base64` `0.22.1` (AUTH LOGIN payload encoding, inside TLS only)
+
+## Related reading
+
+- [Configure Overseer email notifications](../howto/configure-overseer-email-notifications.md)
+  — the office365 worked example and systemd unit.
+- [Set up the Signal channel](../howto/set-up-the-signal-channel.md) — wire the primary
+  reliable path.
+- [Signal channel reference](./signal-conversation.md) — the inbound command surface the
+  marker gate protects.
+- [Overseer design](../design/overseer.md) — where the notifier sits in the merge/deploy
+  path.
+- [Operational autonomy model](../concepts/operational-autonomy-model.md) — the
+  HIGH-RISK boundary the marker gate never weakens.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,6 +190,7 @@ nav:
     - Watch Overseer Activity: howto/watch-overseer-activity.md
     - Configure Overseer Goal-Board Health: howto/configure-overseer-goal-board-health.md
     - Configure Overseer Memory Recall: howto/configure-overseer-memory-recall.md
+    - Configure Overseer Email Notifications: howto/configure-overseer-email-notifications.md
     - Configure Cognitive-Thread Scheduling: howto/configure-cognitive-thread-scheduling.md
     - Add a New Cognitive Thread: howto/add-a-new-cognitive-thread.md
     - Configure the Creative Ideas Thread: howto/configure-creative-ideas-thread.md
@@ -203,6 +204,7 @@ nav:
     - Overseer Tick Details: reference/overseer-tick-details.md
     - Overseer Goal-Board Health API: reference/overseer-goal-board-health-api.md
     - Overseer Memory-Recall API: reference/overseer-memory-recall-api.md
+    - Overseer Operator Notifications: reference/overseer-operator-notifications.md
     - simard-engineer-step CLI: reference/simard-engineer-step.md
     - simard-tui Dashboard: reference/simard-tui.md
     - Journal API: reference/journal-api.md

--- a/src/overseer/notify.rs
+++ b/src/overseer/notify.rs
@@ -260,7 +260,7 @@ impl DualChannelNotifier {
     /// merge/deploy paths make; its `NotifyReport` proves the notification fired
     /// on both channels.
     pub fn notify(&self, notification: &OperatorNotification) -> NotifyReport {
-        let per_channel = self
+        let per_channel: Vec<(String, ChannelDelivery)> = self
             .channels
             .iter()
             .map(|c| {
@@ -272,7 +272,31 @@ impl DualChannelNotifier {
                 (c.name().to_string(), outcome)
             })
             .collect();
-        NotifyReport { per_channel }
+        let report = NotifyReport { per_channel };
+
+        // One structured, secret-safe summary per notification so the
+        // dispatched-but-not-all_sent state (e.g. Signal Sent + email Queued) is
+        // plainly observable. Each channel field carries only the bare
+        // ChannelDelivery variant name — never the `reason` string — so no
+        // credential-adjacent text can land in the summary. The paired
+        // `log_degraded` warning above still carries the full `?outcome` for
+        // diagnosis.
+        let channels = report
+            .per_channel
+            .iter()
+            .map(|(name, d)| format!("{name}={}", delivery_variant(d)))
+            .collect::<Vec<_>>()
+            .join(" ");
+        tracing::info!(
+            target: "overseer::notify",
+            dispatched = report.dispatched(),
+            all_sent = report.all_sent(),
+            kind = notification.kind,
+            channels = %channels,
+            "operator notification dispatched"
+        );
+
+        report
     }
 }
 
@@ -332,6 +356,14 @@ impl EmailConfig {
     pub fn is_configured(&self) -> bool {
         self.host.is_some() && self.from.is_some() && !self.to.is_empty()
     }
+
+    /// Whether an AUTHENTICATED STARTTLS relay should be used: true iff BOTH
+    /// `SMTP_USER` and `SMTP_PASS` are set. This is the sole selector
+    /// [`EmailNotifyChannel::from_env`] uses to pick [`StartTlsSmtpSender`] over
+    /// the plaintext [`TcpSmtpSender`]; it does not depend on the port.
+    pub fn use_authenticated(&self) -> bool {
+        self.user.is_some() && self.pass.is_some()
+    }
 }
 
 /// A minimal email message handed to an [`EmailSender`].
@@ -362,9 +394,18 @@ impl EmailNotifyChannel {
         Self { config, sender }
     }
 
-    /// Production channel: env config + a plaintext-SMTP transport.
+    /// Production channel: env config selects the SMTP transport. When `SMTP_USER`
+    /// and `SMTP_PASS` are both set ([`EmailConfig::use_authenticated`]) it uses
+    /// the STARTTLS + AUTH LOGIN [`StartTlsSmtpSender`] (e.g. office365); otherwise
+    /// it falls back to the minimal plaintext [`TcpSmtpSender`] for a local relay.
     pub fn from_env() -> Self {
-        Self::new(EmailConfig::from_env(), Box::new(TcpSmtpSender))
+        let config = EmailConfig::from_env();
+        let sender: Box<dyn EmailSender> = if config.use_authenticated() {
+            Box::new(StartTlsSmtpSender)
+        } else {
+            Box::new(TcpSmtpSender)
+        };
+        Self::new(config, sender)
     }
 }
 
@@ -530,6 +571,279 @@ fn smtp_send_plaintext(host: &str, port: u16, msg: &EmailMessage) -> Result<(), 
     Ok(())
 }
 
+// ─────────────── authenticated STARTTLS SMTP relay (issue #2631) ────────────
+//
+// Delivering to a microsoft.com recipient needs an AUTHENTICATED relay
+// (office365 / internal). When `SMTP_USER` + `SMTP_PASS` are set,
+// [`EmailNotifyChannel::from_env`] selects [`StartTlsSmtpSender`], which performs
+// a real STARTTLS + AUTH LOGIN submission. The wire protocol is split from the
+// TLS seam as [`smtp_converse`] so it is unit-testable without a network. See
+// docs/reference/overseer-operator-notifications.md (Part B).
+
+/// SMTP AUTH credentials, sourced from `SMTP_USER` / `SMTP_PASS` (never
+/// hardcoded). Intentionally derives NO `Debug`, so the password cannot leak via
+/// a `?`-formatted log line.
+pub struct SmtpAuth {
+    pub user: String,
+    pub pass: String,
+}
+
+/// Send one SMTP command line, CRLF-terminated (RFC 5321 requires CRLF — bare LF
+/// is rejected by strict relays such as office365). Kept as a `write_all` of an
+/// explicit `\r\n` so the fixed line endings are unambiguous.
+fn smtp_send_line<S: std::io::Write>(stream: &mut S, line: &str) -> Result<(), String> {
+    stream
+        .write_all(line.as_bytes())
+        .map_err(|e| e.to_string())?;
+    stream.write_all(b"\r\n").map_err(|e| e.to_string())
+}
+
+/// Read one CRLF-terminated line, byte-at-a-time so we never over-read past the
+/// terminator. This matters during the plaintext STARTTLS prelude: any byte
+/// consumed after the `220` would be stolen from the subsequent TLS handshake.
+/// The trailing CR/LF is stripped. An empty result signals end-of-stream.
+fn smtp_read_line<S: std::io::Read>(stream: &mut S) -> Result<String, String> {
+    let mut buf = Vec::with_capacity(128);
+    let mut byte = [0u8; 1];
+    loop {
+        let n = stream
+            .read(&mut byte)
+            .map_err(|e| format!("smtp read: {e}"))?;
+        if n == 0 || byte[0] == b'\n' {
+            break;
+        }
+        if byte[0] != b'\r' {
+            buf.push(byte[0]);
+        }
+        if buf.len() > 8192 {
+            return Err("smtp: reply line too long".to_string());
+        }
+    }
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Read a (possibly multi-line) SMTP reply, returning its 3-digit status code and
+/// the aggregated text of every continuation line. Continuation lines are
+/// `NNN-…`; the final line is `NNN …` (a space in the 4th column).
+fn smtp_read_reply<S: std::io::Read>(stream: &mut S) -> Result<(u16, String), String> {
+    let mut code = 0u16;
+    let mut text = String::new();
+    loop {
+        let line = smtp_read_line(stream)?;
+        if line.is_empty() {
+            return Err("smtp: unexpected end of stream while reading reply".to_string());
+        }
+        code = line
+            .get(..3)
+            .and_then(|p| p.parse::<u16>().ok())
+            .unwrap_or(code);
+        if !text.is_empty() {
+            text.push('\n');
+        }
+        text.push_str(&line);
+        // A '-' in the 4th column means more lines follow; anything else ends it.
+        if line.as_bytes().get(3) != Some(&b'-') {
+            break;
+        }
+    }
+    Ok((code, text))
+}
+
+/// Read a reply and require an exact status code. `step` names the phase for the
+/// error; the error carries only server-sent reply text — never a credential.
+fn smtp_expect<S: std::io::Read>(stream: &mut S, want: u16, step: &str) -> Result<String, String> {
+    let (code, text) = smtp_read_reply(stream)?;
+    if code == want {
+        Ok(text)
+    } else {
+        Err(format!(
+            "smtp {step}: expected {want}, got {code}: {}",
+            text.replace('\n', " ")
+        ))
+    }
+}
+
+/// The plaintext STARTTLS prelude, shared by the hermetic [`smtp_converse`] and
+/// the live [`StartTlsSmtpSender`]. Reads the greeting, sends EHLO, REQUIRES the
+/// server to advertise STARTTLS (fail-closed — we never authenticate in the
+/// clear), issues STARTTLS and consumes its `220`. On return the caller performs
+/// the real TLS handshake (production) or simply continues on the same in-memory
+/// stream (tests).
+fn smtp_starttls_prelude<S: std::io::Read + std::io::Write>(stream: &mut S) -> Result<(), String> {
+    smtp_expect(stream, 220, "greeting")?;
+    smtp_send_line(stream, "EHLO simard-overseer")?;
+    let caps = smtp_expect(stream, 250, "EHLO")?;
+    if !caps.to_ascii_uppercase().contains("STARTTLS") {
+        return Err(
+            "smtp: server does not advertise STARTTLS; refusing to authenticate in the clear"
+                .to_string(),
+        );
+    }
+    smtp_send_line(stream, "STARTTLS")?;
+    smtp_expect(stream, 220, "STARTTLS")?;
+    Ok(())
+}
+
+/// The authenticated submission that runs AFTER STARTTLS — over the TLS stream in
+/// production, over the same in-memory duplex in tests. Re-issues EHLO inside the
+/// secured session, performs AUTH LOGIN (positional base64 of user then pass),
+/// then MAIL / RCPT / DATA / QUIT. Header/envelope fields are sanitized and the
+/// body dot-stuffed to block CWE-93 injection.
+fn smtp_submit_authenticated<S: std::io::Read + std::io::Write>(
+    stream: &mut S,
+    msg: &EmailMessage,
+    auth: &SmtpAuth,
+) -> Result<(), String> {
+    use base64::Engine;
+    let b64 = base64::engine::general_purpose::STANDARD;
+
+    let from = sanitize_header_value(&msg.from);
+    let recipients: Vec<String> = msg.to.iter().map(|r| sanitize_header_value(r)).collect();
+    let subject = sanitize_header_value(&msg.subject);
+
+    // EHLO again inside the secured channel.
+    smtp_send_line(stream, "EHLO simard-overseer")?;
+    smtp_expect(stream, 250, "EHLO(tls)")?;
+
+    // AUTH LOGIN: the server prompts (base64 "Username:"/"Password:"); we answer
+    // positionally with base64(user) then base64(pass). base64 is an ENCODING,
+    // not encryption — safe only because we are now inside TLS.
+    smtp_send_line(stream, "AUTH LOGIN")?;
+    smtp_expect(stream, 334, "AUTH LOGIN")?;
+    smtp_send_line(stream, &b64.encode(auth.user.as_bytes()))?;
+    smtp_expect(stream, 334, "AUTH user")?;
+    smtp_send_line(stream, &b64.encode(auth.pass.as_bytes()))?;
+    smtp_expect(stream, 235, "AUTH pass")?;
+
+    smtp_send_line(stream, &format!("MAIL FROM:<{from}>"))?;
+    smtp_expect(stream, 250, "MAIL FROM")?;
+    for rcpt in &recipients {
+        smtp_send_line(stream, &format!("RCPT TO:<{rcpt}>"))?;
+        smtp_expect(stream, 250, "RCPT TO")?;
+    }
+    smtp_send_line(stream, "DATA")?;
+    smtp_expect(stream, 354, "DATA")?;
+    let data = format!(
+        "From: {}\r\nTo: {}\r\nSubject: {}\r\n\r\n{}\r\n.\r\n",
+        from,
+        recipients.join(", "),
+        subject,
+        dot_stuff_body(&msg.body),
+    );
+    stream
+        .write_all(data.as_bytes())
+        .map_err(|e| e.to_string())?;
+    smtp_expect(stream, 250, "end-of-DATA")?;
+    smtp_send_line(stream, "QUIT")?;
+    // A courteous QUIT; the server's 221 is best-effort (it may close first).
+    let _ = smtp_read_reply(stream);
+    Ok(())
+}
+
+/// The pure SMTP client state machine for an authenticated submission, driven
+/// over any duplex stream so it is hermetically testable. It requests STARTTLS
+/// and — only once TLS is in effect — performs AUTH LOGIN (positional base64 of
+/// user then pass) followed by MAIL / RCPT / DATA. It fails closed, NEVER
+/// emitting `AUTH` in the clear, if the server does not offer STARTTLS.
+///
+/// In tests the STARTTLS step is a plain protocol step over an in-memory duplex
+/// (no real handshake); production reuses the same [`smtp_starttls_prelude`] +
+/// [`smtp_submit_authenticated`] helpers with a genuine TLS upgrade spliced
+/// between them (see [`StartTlsSmtpSender::send`]).
+pub fn smtp_converse<S: std::io::Read + std::io::Write>(
+    stream: &mut S,
+    msg: &EmailMessage,
+    auth: &SmtpAuth,
+) -> Result<(), String> {
+    smtp_starttls_prelude(stream)?;
+    smtp_submit_authenticated(stream, msg, auth)
+}
+
+/// Build the rustls client config for the relay TLS upgrade: the stock verifier
+/// with the OS trust store (`rustls-native-certs`), falling back to the compiled
+/// `webpki-roots` bundle if the OS store yields nothing. Uses the `ring` crypto
+/// provider explicitly so we never depend on an ambiguous process-default
+/// provider. No `dangerous_configuration`; the peer name is validated by the
+/// caller against `SMTP_HOST`.
+fn tls_client_config() -> Result<rustls::ClientConfig, String> {
+    let mut roots = rustls::RootCertStore::empty();
+    let native = rustls_native_certs::load_native_certs();
+    for cert in native.certs {
+        // A partial store is fine; skip any individually-unparsable cert.
+        let _ = roots.add(cert);
+    }
+    if roots.is_empty() {
+        roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    }
+    let provider = std::sync::Arc::new(rustls::crypto::ring::default_provider());
+    let config = rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| format!("tls versions: {e}"))?
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    Ok(config)
+}
+
+/// A real STARTTLS + AUTH LOGIN relay sender (e.g. `smtp.office365.com:587`).
+/// Selected by [`EmailNotifyChannel::from_env`] when `SMTP_USER` + `SMTP_PASS`
+/// are set. Connection params and credentials are read from the environment
+/// (`SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASS`) so the sender carries
+/// no config of its own and no secret is ever hardcoded. The TLS handshake is the
+/// only seam not exercised by the pure [`smtp_converse`] tests.
+#[derive(Clone, Debug, Default)]
+pub struct StartTlsSmtpSender;
+
+impl EmailSender for StartTlsSmtpSender {
+    fn send(&self, msg: &EmailMessage) -> Result<(), String> {
+        use std::net::TcpStream;
+        use std::time::Duration;
+
+        let host = std::env::var("SMTP_HOST").map_err(|_| "SMTP_HOST unset".to_string())?;
+        let port = std::env::var("SMTP_PORT")
+            .ok()
+            .and_then(|s| s.trim().parse::<u16>().ok())
+            .unwrap_or(587);
+        let auth = SmtpAuth {
+            user: std::env::var("SMTP_USER").map_err(|_| "SMTP_USER unset".to_string())?,
+            pass: std::env::var("SMTP_PASS").map_err(|_| "SMTP_PASS unset".to_string())?,
+        };
+
+        let addr = format!("{host}:{port}");
+        let mut tcp =
+            TcpStream::connect(&addr).map_err(|e| format!("connect {addr} failed: {e}"))?;
+        tcp.set_read_timeout(Some(Duration::from_secs(30)))
+            .map_err(|e| e.to_string())?;
+        tcp.set_write_timeout(Some(Duration::from_secs(30)))
+            .map_err(|e| e.to_string())?;
+
+        // Plaintext prelude: greeting → EHLO → require STARTTLS → STARTTLS → 220.
+        smtp_starttls_prelude(&mut tcp)?;
+
+        // Upgrade the SAME socket to TLS, verifying the relay certificate against
+        // SMTP_HOST with the standard verifier.
+        let config = tls_client_config()?;
+        let server_name = rustls::pki_types::ServerName::try_from(host.clone())
+            .map_err(|e| format!("invalid SMTP_HOST '{host}': {e}"))?;
+        let conn = rustls::ClientConnection::new(std::sync::Arc::new(config), server_name)
+            .map_err(|e| format!("tls setup: {e}"))?;
+        let mut tls = rustls::StreamOwned::new(conn, tcp);
+
+        // Authenticated submission INSIDE TLS.
+        smtp_submit_authenticated(&mut tls, msg, &auth)
+    }
+}
+
+/// The [`ChannelDelivery`] variant name (`"Sent"` | `"Queued"` | `"Failed"`) with
+/// NO `reason` string — safe for a one-line structured summary that must never
+/// carry a secret-adjacent reason.
+pub fn delivery_variant(d: &ChannelDelivery) -> &'static str {
+    match d {
+        ChannelDelivery::Sent => "Sent",
+        ChannelDelivery::Queued { .. } => "Queued",
+        ChannelDelivery::Failed { .. } => "Failed",
+    }
+}
+
 // ─────────────────────────── Signal channel ────────────────────────────────
 
 /// The wire transport for Signal. Object-safe + `Send + Sync` so it can be
@@ -604,12 +918,32 @@ impl NotifyChannel for SignalNotifyChannel {
                 reason: "Signal channel not wired (configure the ConversationChannel transport)"
                     .to_string(),
             },
-            Some(sender) => match sender.send_text(&n.plain_text()) {
+            Some(sender) => match sender.send_text(&signal_wire_body(n)) {
                 Ok(()) => ChannelDelivery::Sent,
                 Err(e) => ChannelDelivery::Failed { reason: e },
             },
         }
     }
+}
+
+/// The exact text a Signal operator-notification puts on the wire. It wraps the
+/// plain body in the reserved anti-self-ingest marker so the INBOUND Signal
+/// processor deterministically skips Simard's own notification when it is synced
+/// back to a linked device (independent of the fragile echo window).
+///
+/// The marker constant lives in `signal_conversation::gating`, which is compiled
+/// only under the `signal` feature, so this wrap is feature-gated. With `signal`
+/// off there is no inbound Signal processor to self-ingest and
+/// `SignalNotifyChannel::from_env` wires no sender (always `Queued`), so the
+/// unwrapped branch is never reached in production.
+#[cfg(feature = "signal")]
+fn signal_wire_body(n: &OperatorNotification) -> String {
+    crate::signal_conversation::gating::wrap_operator_notification(&n.plain_text())
+}
+
+#[cfg(not(feature = "signal"))]
+fn signal_wire_body(n: &OperatorNotification) -> String {
+    n.plain_text()
 }
 
 #[cfg(test)]
@@ -906,5 +1240,358 @@ mod tests {
             ch.deliver(&sample()),
             ChannelDelivery::Queued { .. }
         ));
+    }
+
+    // ── Part A: Signal notifications carry the anti-self-ingest marker (#2631) ─
+
+    #[cfg(feature = "signal")]
+    #[test]
+    fn signal_channel_wraps_body_with_operator_marker() {
+        use crate::signal_conversation::gating::OPERATOR_NOTIFY_MARKER;
+        use std::sync::Arc;
+
+        // A recording SignalSender captures exactly what the channel would put on
+        // the wire, so we can assert the outbound notification is wrapped.
+        #[derive(Default)]
+        struct RecordingSignal {
+            sent: Mutex<Vec<String>>,
+        }
+        impl SignalSender for Arc<RecordingSignal> {
+            fn send_text(&self, text: &str) -> Result<(), String> {
+                self.sent.lock().unwrap().push(text.to_string());
+                Ok(())
+            }
+        }
+
+        let rec = Arc::new(RecordingSignal::default());
+        let ch = SignalNotifyChannel::new(Some(Box::new(Arc::clone(&rec))));
+
+        let out = ch.deliver(&sample());
+        assert_eq!(out, ChannelDelivery::Sent);
+
+        let sent = rec.sent.lock().unwrap();
+        assert_eq!(sent.len(), 1, "exactly one Signal message");
+        assert!(
+            sent[0].contains(OPERATOR_NOTIFY_MARKER),
+            "a Signal notification MUST carry the anti-self-ingest marker so the \
+             inbound processor skips its own echo: {:?}",
+            sent[0]
+        );
+        // The operator-readable problem text is still present.
+        assert!(
+            sent[0].contains("distillation parse-failure"),
+            "the human-readable body must be preserved: {:?}",
+            sent[0]
+        );
+    }
+
+    // ── Part B: authenticated STARTTLS + AUTH LOGIN SMTP (#2631) ──────────────
+
+    /// A scripted in-memory duplex: serves pre-canned server reply bytes on `read`
+    /// (SMTP is lock-step, so ordered replies suffice) and captures every client
+    /// byte on `write`. Lets [`smtp_converse`] be exercised with no network.
+    struct ScriptedDuplex {
+        to_client: std::io::Cursor<Vec<u8>>,
+        from_client: Vec<u8>,
+    }
+    impl ScriptedDuplex {
+        fn new(server_replies: &[&str]) -> Self {
+            Self {
+                to_client: std::io::Cursor::new(server_replies.concat().into_bytes()),
+                from_client: Vec::new(),
+            }
+        }
+        fn written(&self) -> String {
+            String::from_utf8_lossy(&self.from_client).into_owned()
+        }
+    }
+    impl std::io::Read for ScriptedDuplex {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            self.to_client.read(buf)
+        }
+    }
+    impl std::io::Write for ScriptedDuplex {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.from_client.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn office365_message() -> EmailMessage {
+        EmailMessage {
+            from: "overseer@contoso.onmicrosoft.com".to_string(),
+            to: vec!["rysweet@microsoft.com".to_string()],
+            subject: "[Overseer] goal-blocked: g-1 needs human review".to_string(),
+            body: "Goal `g-1` is blocked and needs human review.".to_string(),
+        }
+    }
+
+    #[test]
+    fn smtp_converse_negotiates_starttls_then_auth_login_and_sends() {
+        // Happy path: greeting → EHLO(STARTTLS) → STARTTLS → EHLO(AUTH) →
+        // AUTH LOGIN → base64(user) → base64(pass) → MAIL/RCPT/DATA → QUIT.
+        let server = [
+            "220 smtp.example.test ESMTP\r\n",
+            "250-smtp.example.test\r\n250-STARTTLS\r\n250 AUTH LOGIN\r\n",
+            "220 ready to start TLS\r\n",
+            "250-smtp.example.test\r\n250 AUTH LOGIN\r\n",
+            "334 VXNlcm5hbWU6\r\n", // base64("Username:")
+            "334 UGFzc3dvcmQ6\r\n", // base64("Password:")
+            "235 2.7.0 Authentication successful\r\n",
+            "250 2.1.0 Sender OK\r\n",
+            "250 2.1.5 Recipient OK\r\n",
+            "354 End data with <CR><LF>.<CR><LF>\r\n",
+            "250 2.0.0 OK queued\r\n",
+            "221 2.0.0 Service closing\r\n",
+        ];
+        let mut duplex = ScriptedDuplex::new(&server);
+        let msg = office365_message();
+        // Single-character credentials so the expected base64 is trivial and no
+        // real secret appears: base64("u") = "dQ==", base64("p") = "cA==".
+        let auth = SmtpAuth {
+            user: "u".to_string(),
+            pass: "p".to_string(),
+        };
+
+        let res = smtp_converse(&mut duplex, &msg, &auth);
+        assert!(
+            res.is_ok(),
+            "authenticated submission should succeed: {res:?}"
+        );
+
+        let wire = duplex.written();
+        assert!(
+            wire.contains("STARTTLS\r\n"),
+            "must request STARTTLS: {wire:?}"
+        );
+        assert!(wire.contains("AUTH LOGIN\r\n"), "must AUTH LOGIN: {wire:?}");
+        assert!(
+            wire.contains("dQ=="),
+            "must send base64(user) positionally after the first 334: {wire:?}"
+        );
+        assert!(
+            wire.contains("cA=="),
+            "must send base64(pass) positionally after the second 334: {wire:?}"
+        );
+        assert!(
+            wire.contains("MAIL FROM:<overseer@contoso.onmicrosoft.com>"),
+            "envelope sender: {wire:?}"
+        );
+        assert!(
+            wire.contains("RCPT TO:<rysweet@microsoft.com>"),
+            "envelope recipient: {wire:?}"
+        );
+        assert!(wire.contains("QUIT"), "must close with QUIT: {wire:?}");
+    }
+
+    #[test]
+    fn smtp_converse_fails_closed_and_leaks_no_auth_without_starttls() {
+        // The server does NOT advertise STARTTLS. With credentials configured the
+        // sender MUST fail rather than authenticate in the clear, and MUST NOT
+        // write any AUTH bytes (base64 is encoding, not encryption).
+        let server = [
+            "220 smtp.example.test ESMTP\r\n",
+            "250-smtp.example.test\r\n250 AUTH LOGIN\r\n", // EHLO reply, NO STARTTLS
+        ];
+        let mut duplex = ScriptedDuplex::new(&server);
+        let msg = office365_message();
+        let auth = SmtpAuth {
+            user: "u".to_string(),
+            pass: "p".to_string(),
+        };
+
+        let res = smtp_converse(&mut duplex, &msg, &auth);
+        assert!(
+            res.is_err(),
+            "must fail closed when STARTTLS is unavailable, not send credentials in clear"
+        );
+
+        let wire = duplex.written();
+        assert!(
+            !wire.contains("AUTH"),
+            "must NOT emit AUTH without TLS: {wire:?}"
+        );
+        assert!(
+            !wire.contains("dQ=="),
+            "must NOT emit the base64 username in clear: {wire:?}"
+        );
+        assert!(
+            !wire.contains("cA=="),
+            "must NOT emit the base64 password in clear: {wire:?}"
+        );
+    }
+
+    #[test]
+    fn email_config_use_authenticated_requires_both_user_and_pass() {
+        // office365 worked example: full auth config selects the STARTTLS sender.
+        let both = EmailConfig::from_lookup(|k| match k {
+            "SIMARD_OVERSEER_EMAIL_TO" => Some("rysweet@microsoft.com".to_string()),
+            "SIMARD_OVERSEER_EMAIL_FROM" => Some("overseer@contoso.onmicrosoft.com".to_string()),
+            "SMTP_HOST" => Some("smtp.office365.com".to_string()),
+            "SMTP_PORT" => Some("587".to_string()),
+            "SMTP_USER" => Some("overseer@contoso.onmicrosoft.com".to_string()),
+            "SMTP_PASS" => Some("<app-password-placeholder>".to_string()),
+            _ => None,
+        });
+        assert!(both.is_configured());
+        assert_eq!(both.port, 587);
+        assert!(
+            both.use_authenticated(),
+            "SMTP_USER + SMTP_PASS ⇒ authenticated STARTTLS sender"
+        );
+
+        // Missing the password ⇒ plaintext sender selection.
+        let no_pass = EmailConfig::from_lookup(|k| match k {
+            "SIMARD_OVERSEER_EMAIL_TO" => Some("ops@example.test".to_string()),
+            "SIMARD_OVERSEER_EMAIL_FROM" => Some("o@example.test".to_string()),
+            "SMTP_HOST" => Some("localhost".to_string()),
+            "SMTP_USER" => Some("u".to_string()),
+            _ => None,
+        });
+        assert!(
+            !no_pass.use_authenticated(),
+            "without SMTP_PASS the authenticated relay must not be selected"
+        );
+    }
+
+    #[test]
+    fn start_tls_sender_is_an_email_sender() {
+        // Compile-time contract: the authenticated relay implements the injectable
+        // EmailSender seam (the live TLS send itself is the untested seam).
+        let _sender: Box<dyn EmailSender> = Box::new(StartTlsSmtpSender);
+    }
+
+    #[test]
+    fn smtp_converse_sanitizes_header_and_body_injection_in_auth_path() {
+        // A CRLF-injected subject and a lone-dot body line must be neutralized in
+        // the authenticated submission too: the STARTTLS path reuses the shared
+        // sanitize_header_value + dot_stuff_body hardening (CWE-93).
+        let server = [
+            "220 smtp.example.test ESMTP\r\n",
+            "250-smtp.example.test\r\n250-STARTTLS\r\n250 AUTH LOGIN\r\n",
+            "220 ready to start TLS\r\n",
+            "250-smtp.example.test\r\n250 AUTH LOGIN\r\n",
+            "334 VXNlcm5hbWU6\r\n",
+            "334 UGFzc3dvcmQ6\r\n",
+            "235 2.7.0 Authentication successful\r\n",
+            "250 2.1.0 Sender OK\r\n",
+            "250 2.1.5 Recipient OK\r\n",
+            "354 End data\r\n",
+            "250 2.0.0 OK queued\r\n",
+            "221 2.0.0 bye\r\n",
+        ];
+        let mut duplex = ScriptedDuplex::new(&server);
+        let msg = EmailMessage {
+            from: "overseer@contoso.onmicrosoft.com".to_string(),
+            to: vec!["rysweet@microsoft.com".to_string()],
+            subject: "goal-blocked\r\nBcc: attacker@evil.test".to_string(),
+            body: "Goal blocked.\n.\nMAIL FROM:<spoof@evil.test>".to_string(),
+        };
+        let auth = SmtpAuth {
+            user: "u".to_string(),
+            pass: "p".to_string(),
+        };
+        assert!(smtp_converse(&mut duplex, &msg, &auth).is_ok());
+        let wire = duplex.written();
+        // The injected header cannot begin its own line in the DATA section.
+        assert!(
+            !wire.contains("\r\nBcc: attacker@evil.test"),
+            "header injection neutralized: {wire:?}"
+        );
+        // The lone-dot body line is dot-stuffed so it cannot close DATA early and
+        // smuggle the spoofed MAIL FROM as an SMTP command.
+        assert!(
+            !wire.contains("\r\n.\r\nMAIL FROM:<spoof@evil.test>"),
+            "body dot-stuffed: {wire:?}"
+        );
+    }
+
+    // ── Part C: all_sent vs dispatched, observably distinguishable (#2631) ────
+
+    #[test]
+    fn delivery_variant_names_omit_the_reason_string() {
+        assert_eq!(delivery_variant(&ChannelDelivery::Sent), "Sent");
+        assert_eq!(
+            delivery_variant(&ChannelDelivery::Queued {
+                reason: "SMTP not configured".to_string()
+            }),
+            "Queued"
+        );
+        assert_eq!(
+            delivery_variant(&ChannelDelivery::Failed {
+                reason: "smtp boom".to_string()
+            }),
+            "Failed"
+        );
+        // The bare variant name must never carry the (secret-adjacent) reason.
+        assert!(
+            !delivery_variant(&ChannelDelivery::Failed {
+                reason: "topsecret".to_string()
+            })
+            .contains("topsecret")
+        );
+    }
+
+    #[test]
+    fn dispatched_but_not_all_sent_when_signal_delivers_and_email_queues() {
+        // The crux of Part C: Signal (the wired primary path) reaches the operator,
+        // so the escalation is DISPATCHED even though email is not yet configured —
+        // it is never considered "lost". `all_sent()` honestly reports the gap.
+        let notifier = DualChannelNotifier::new(vec![
+            Box::new(RecordingChannel {
+                name: "signal".to_string(),
+                outcome: Some(ChannelDelivery::Sent),
+                ..Default::default()
+            }),
+            Box::new(RecordingChannel {
+                name: "email".to_string(),
+                outcome: Some(ChannelDelivery::Queued {
+                    reason: "SMTP not configured".to_string(),
+                }),
+                ..Default::default()
+            }),
+        ]);
+        let report = notifier.notify(&sample());
+        assert!(report.dispatched(), "reached the operator via Signal");
+        assert!(!report.all_sent(), "email did not deliver");
+
+        let by = |name: &str| {
+            report
+                .per_channel
+                .iter()
+                .find(|(c, _)| c == name)
+                .map(|(_, d)| d.clone())
+                .unwrap()
+        };
+        assert_eq!(by("signal"), ChannelDelivery::Sent);
+        assert!(
+            matches!(by("email"), ChannelDelivery::Queued { reason } if reason.contains("SMTP")),
+            "the queued email must identify the channel AND the reason"
+        );
+    }
+
+    #[test]
+    fn all_sent_true_only_when_both_channels_deliver() {
+        let notifier = DualChannelNotifier::new(vec![
+            Box::new(RecordingChannel {
+                name: "signal".to_string(),
+                outcome: Some(ChannelDelivery::Sent),
+                ..Default::default()
+            }),
+            Box::new(RecordingChannel {
+                name: "email".to_string(),
+                outcome: Some(ChannelDelivery::Sent),
+                ..Default::default()
+            }),
+        ]);
+        let report = notifier.notify(&sample());
+        assert!(report.dispatched());
+        assert!(
+            report.all_sent(),
+            "all_sent is true only when every channel delivered"
+        );
     }
 }

--- a/src/signal_conversation/channel.rs
+++ b/src/signal_conversation/channel.rs
@@ -246,6 +246,21 @@ impl<T: SignalTransport + Send, H: SignalCommandHandler> ConversationChannel
                 continue; // JSON-RPC responses, receipts, unparseable lines.
             };
 
+            // Anti-self-ingest (#2631): a message carrying the reserved
+            // operator-notification marker is one of Simard's OWN notifications
+            // synced back to a linked device — never an operator command. Drop it
+            // DETERMINISTICALLY here, before the sync-sent gate, echo suppression,
+            // allowlist, or command parsing, so the marker alone suffices even if
+            // the synced echo arrives late, altered, or quoted (it does not rely
+            // on the exact-body `matches_recent_outbound` echo window).
+            if super::gating::is_operator_notification(&parsed.body) {
+                tracing::debug!(
+                    target: "signal",
+                    "ignoring inbound message bearing the operator-notification marker (self-notification)"
+                );
+                continue;
+            }
+
             // Loop prevention for sync-sent (Note-to-Self) messages, issue #2575.
             // A linked device receives sync-sent transcripts of BOTH the operator's
             // Note-to-Self commands AND Simard's own replies; only the former (from
@@ -1115,5 +1130,91 @@ mod tests {
         let (mut ch, _state) = note_channel(vec![receipt, "not json".to_string()], None);
         assert!(block_on(ch.recv()).unwrap().is_none());
         assert!(ch.transport.sent.is_empty());
+    }
+
+    // ── operator-notification marker: anti-self-ingest inbound gate (#2631) ──
+    //
+    // Outbound Overseer→operator notifications carry a reserved marker
+    // (`gating::OPERATOR_NOTIFY_MARKER`) so the inbound processor DETERMINISTICALLY
+    // skips Simard's OWN notifications synced back to a linked device — NEVER
+    // parsing them as an operator command or a meeting turn — independent of the
+    // exact-body/time-window echo suppression.
+
+    use crate::signal_conversation::gating::OPERATOR_NOTIFY_MARKER;
+
+    /// A marked notification body as it would arrive back on the inbound path. The
+    /// literal marker constant is used (not the wrap helper) so the test input is
+    /// independent of the formatter under test.
+    fn marked(body: &str) -> String {
+        format!("{OPERATOR_NOTIFY_MARKER} {body}")
+    }
+
+    #[test]
+    fn marked_direct_message_is_dropped_never_processed() {
+        // A marked message delivered as a normal dataMessage (e.g. synced back on a
+        // multi-device account) is dropped before allowlist/command parsing: recv
+        // reaches EOF with no reply and nothing executed — not even a meeting turn.
+        let (mut ch, state) = channel(vec![receive_line(OPERATOR, &marked("status"))], false);
+        assert!(
+            block_on(ch.recv()).unwrap().is_none(),
+            "a marked self-notification must never yield an inbound turn"
+        );
+        assert!(
+            ch.transport.sent.is_empty(),
+            "Simard must not reply to her own notification"
+        );
+        assert!(state.lock().unwrap().executed.is_empty());
+    }
+
+    #[test]
+    fn marked_message_is_dropped_even_with_altered_prefix_outside_echo_window() {
+        // The marker alone suffices — even if the synced echo is altered/quoted with
+        // a leading transcript prefix, and even though NO matching outbound was ever
+        // recorded (so it is outside any echo-suppression window). This proves the
+        // gate does not rely on `matches_recent_outbound`.
+        let echoed = format!("You sent: {}", marked("merge #42"));
+        let (mut ch, state) = channel(vec![receive_line(OPERATOR, &echoed)], false);
+        assert!(block_on(ch.recv()).unwrap().is_none());
+        assert!(
+            ch.transport.sent.is_empty(),
+            "a self-notification must not trigger a HIGH-RISK sign-off prompt"
+        );
+        assert!(
+            state.lock().unwrap().executed.is_empty(),
+            "a self-notification must never execute a command"
+        );
+    }
+
+    #[test]
+    fn marked_sync_sent_note_to_self_is_dropped_from_primary_phone() {
+        // Even a marked message arriving via the genuine Note-to-Self (device 1)
+        // path — which clears `should_accept_sync_sent` — is dropped by the marker
+        // gate, because the gate precedes the sync-sent branch.
+        let (mut ch, _state) = note_channel(
+            vec![sync_sent_line(1, ACCOUNT, &marked("let's plan"))],
+            None,
+        );
+        assert!(block_on(ch.recv()).unwrap().is_none());
+        assert!(ch.transport.sent.is_empty());
+    }
+
+    #[test]
+    fn unmarked_operator_conversation_is_unaffected_by_the_gate() {
+        // Regression: a normal operator turn without the marker still flows through
+        // and is bound to the authorized sender.
+        let (mut ch, _state) = channel(vec![receive_line(OPERATOR, "let's chat")], false);
+        let inbound = block_on(ch.recv()).unwrap().expect("a conversation turn");
+        assert_eq!(inbound.text, "let's chat");
+        assert!(inbound.from.authorized);
+    }
+
+    #[test]
+    fn unmarked_operator_command_still_executes() {
+        // Regression: a normal `status` command (no marker) still replies.
+        let (mut ch, _state) = channel(vec![receive_line(OPERATOR, "status")], false);
+        assert!(block_on(ch.recv()).unwrap().is_none());
+        assert_eq!(ch.transport.sent.len(), 1);
+        let (_to, msg) = sent(&ch.transport.sent[0]);
+        assert!(msg.contains("STATUS"), "got {msg}");
     }
 }

--- a/src/signal_conversation/gating.rs
+++ b/src/signal_conversation/gating.rs
@@ -115,3 +115,118 @@ pub fn gate(cmd: &InboundCommand) -> GateDecision {
         RiskClass::HighRisk => GateDecision::PendingSignOff,
     }
 }
+
+// ───────────── operator-notification anti-self-ingest marker (#2631) ─────────
+//
+// Every outbound Overseer→operator Signal notification is wrapped in a reserved
+// sentinel so the INBOUND processor can DETERMINISTICALLY recognize and SKIP
+// Simard's own notifications synced back to a linked device — independent of the
+// fragile exact-body/time-window echo suppression (`matches_recent_outbound`).
+// See docs/reference/overseer-operator-notifications.md (Part A).
+
+/// Reserved sentinel prefixing every Overseer→operator Signal notification. Its
+/// bell glyph + `▶` + the literal `OPERATOR:` never occur in a real operator
+/// command, so detection is a substring test that leaves normal messages
+/// untouched. Operators MUST NOT send any message *containing* this sentinel.
+pub const OPERATOR_NOTIFY_MARKER: &str = "🔔 SIMARD▶OPERATOR:";
+
+/// Human-readable footer appended to a wrapped notification so the message reads
+/// pleasantly on the operator's phone. Display only — it is NEVER used for
+/// detection.
+pub const OPERATOR_NOTIFY_FOOTER: &str = "\n\n— Simard automated notice · do not reply";
+
+/// Wrap an operator-notification `body` in the reserved marker (+ footer) so the
+/// inbound processor can deterministically skip it. The result STARTS WITH
+/// [`OPERATOR_NOTIFY_MARKER`] and ENDS WITH [`OPERATOR_NOTIFY_FOOTER`].
+pub fn wrap_operator_notification(body: &str) -> String {
+    format!("{OPERATOR_NOTIFY_MARKER} {body}{OPERATOR_NOTIFY_FOOTER}")
+}
+
+/// True iff `text` carries the reserved [`OPERATOR_NOTIFY_MARKER`] anywhere in
+/// the message — a SUBSTRING test, NOT `starts_with`, so a synced echo with an
+/// added transcript prefix (e.g. `"You sent: …"`) or a quoted reply is still
+/// recognized. The marker only causes an inbound message to be IGNORED; it never
+/// authorizes anything.
+pub fn is_operator_notification(text: &str) -> bool {
+    text.contains(OPERATOR_NOTIFY_MARKER)
+}
+
+#[cfg(test)]
+mod marker_tests {
+    use super::*;
+
+    #[test]
+    fn wrap_starts_with_marker_and_ends_with_footer() {
+        let body = "The Overseer autonomously performed a goal-blocked in rysweet/Simard.\n";
+        let wrapped = wrap_operator_notification(body);
+        assert!(
+            wrapped.starts_with(OPERATOR_NOTIFY_MARKER),
+            "wrapped notice must lead with the marker: {wrapped:?}"
+        );
+        assert!(
+            wrapped.contains(body),
+            "the operator-readable body must be preserved verbatim: {wrapped:?}"
+        );
+        assert!(
+            wrapped.ends_with(OPERATOR_NOTIFY_FOOTER),
+            "the human footer must trail the notice: {wrapped:?}"
+        );
+    }
+
+    #[test]
+    fn is_operator_notification_detects_a_wrapped_body() {
+        let wrapped = wrap_operator_notification("goal g-1 needs human review");
+        assert!(
+            is_operator_notification(&wrapped),
+            "a freshly wrapped notification must be recognized"
+        );
+    }
+
+    #[test]
+    fn is_operator_notification_is_substring_not_prefix() {
+        // A synced-back echo can arrive with a leading transcript prefix or as a
+        // quote; substring detection must still recognize the marker so the gate
+        // does not depend on the exact-body echo window.
+        let with_prefix = format!("You sent: {OPERATOR_NOTIFY_MARKER} merge #42 …");
+        assert!(
+            is_operator_notification(&with_prefix),
+            "must detect the marker mid-string: {with_prefix:?}"
+        );
+        let quoted = format!("> {OPERATOR_NOTIFY_MARKER} deploy");
+        assert!(
+            is_operator_notification(&quoted),
+            "must detect a quoted marker"
+        );
+    }
+
+    #[test]
+    fn normal_operator_messages_are_never_flagged() {
+        // The vocabulary of real operator commands and ordinary turns must never
+        // be mistaken for a self-notification (no false positives).
+        for msg in [
+            "status",
+            "pause",
+            "approve",
+            "deploy",
+            "merge #42",
+            "let's plan the release",
+            "SIMARD is great",
+            "",
+        ] {
+            assert!(
+                !is_operator_notification(msg),
+                "false positive on a normal message: {msg:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn wrap_then_detect_round_trips() {
+        let wrapped =
+            wrap_operator_notification("Goal `g-4821` is blocked and needs human review.");
+        assert!(
+            is_operator_notification(&wrapped),
+            "wrap → detect must round-trip so the inbound gate always drops our own notices"
+        );
+    }
+}


### PR DESCRIPTION
Closes #2631.

Makes the Overseer's operator notifications **reliable** (the operator is always reached) and **safe** (Simard never re-ingests her own Signal notification as a command), across **both** channels — Signal as the primary reliable path, email wired for a real authenticated relay.

## Part A — Signal anti-self-ingest marker (primary safety control)
- Every outbound Overseer→operator Signal notification is wrapped in a reserved sentinel `🔔 SIMARD▶OPERATOR:` (+ a human "do not reply" footer) via `gating::wrap_operator_notification`.
- `SignalConversation::recv` drops any inbound message bearing the marker **before** the sync-sent gate, echo suppression, allowlist, and command parsing — **deterministic and independent** of the fragile exact-body `matches_recent_outbound` echo window. Detection is a substring test on a token that never appears in a real command, so **normal operator messages are unaffected**.

## Part B — real authenticated email delivery
- New `StartTlsSmtpSender` performs a genuine **STARTTLS + AUTH LOGIN** submission (rustls `ring` provider, `rustls-native-certs`→`webpki-roots` trust, `base64` AUTH **inside TLS only**). **Fails closed** if STARTTLS is not offered — never sends `AUTH` in the clear.
- `EmailNotifyChannel::from_env` selects it when `SMTP_USER`+`SMTP_PASS` are set (`EmailConfig::use_authenticated`), else the plaintext sender.
- Wire protocol split into hermetic helpers (`smtp_converse` + `smtp_starttls_prelude` + `smtp_submit_authenticated`) reused by both the tests and the live TLS path. Reuses the shared `sanitize_header_value` / `dot_stuff_body` CWE-93 hardening. **All config from env — no hardcoded secrets.**

## Part C — observable `all_sent` vs `dispatched`
- `DualChannelNotifier::notify` emits one structured `info!` summary (`dispatched`, `all_sent`, `kind`, per-channel bare variant via `delivery_variant`) so "Signal `Sent` + email `Queued`" is plainly **dispatched-but-not-all_sent**. No `reason` string (secret-adjacent) in the summary; degraded channels still `warn!` the full outcome. Escalations are **never "lost"** when only email is unconfigured.

## Docs
- Reference: `docs/reference/overseer-operator-notifications.md` (delivery contract, marker + inbound gate, SMTP, `all_sent`/`dispatched`, observability, injection hardening).
- How-to: `docs/howto/configure-overseer-email-notifications.md` (office365 worked example, systemd unit, exact env: `SIMARD_OVERSEER_EMAIL_{TO,FROM}` / `SMTP_{HOST,PORT,USER,PASS}`).
- Wired into `docs/design/overseer.md` + `mkdocs.yml` nav.

## Tests (hermetic)
- Marker wrap/detect + inbound gate: direct message, altered-prefix outside echo window, sync-sent Note-to-Self, plus regressions that unmarked commands/turns still flow.
- STARTTLS + AUTH LOGIN happy path (asserts base64 AUTH, MAIL/RCPT/QUIT) and fail-closed (no AUTH bytes without STARTTLS).
- Header/body injection neutralized in the authenticated path; sender selection by config; dispatched-vs-all_sent semantics.

## Coordination
Rebased onto latest `origin/main`; standardized on main's `sanitize_header_value` + `dot_stuff_body` (dropped a redundant scaffold sanitizer) so this merges cleanly within the overseer tier alongside the concurrent overseer PRs.

Local: `cargo fmt`, `cargo clippy --all-targets --all-features --locked -D warnings`, targeted tests, and `--no-default-features` build all green.