### PR TITLE
feat(creative-ideas): fully wire the Creative Ideas self-improvement subsystem (M2–M5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=2266cc247d66c773c33300546a97502d53497c20#2266cc247d66c773c33300546a97502d53497c20"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=e005a5963b38bc02610fa5b0bef7e52625dcd092#e005a5963b38bc02610fa5b0bef7e52625dcd092"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -1208,7 +1208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3086,7 +3086,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3418,7 +3418,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3431,7 +3431,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3490,7 +3490,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4193,7 +4193,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5124,7 +5124,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,9 +78,18 @@ path = "src/bin/simard_tui/main.rs"
 # `cognitive_memory::metrics::precision_at_k` now delegates to it, and the
 # fixed-corpus recall-precision benchmark + live rail both score through the same
 # upstream primitive (issue #2491 / #2494). No lbug/engine change, so the store
-# format stays v41. The pin points at an upstream-`main` commit (not a feature
-# branch), so the build can never be frozen against an unmerged, GC-able ref.
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "2266cc247d66c773c33300546a97502d53497c20", features = ["persistent"] }
+# format stays v41.
+#
+# Bumped again to the squash-merge commit of amplihack-memory-lib PR #120 on
+# `main` (which lands directly on top of PR #121), adding the first-class
+# `creative_idea` prospective memory type (CreativeIdeaStatus lifecycle state
+# machine + typed MemoryLink/MemoryLinkKind edges incl. Goal; guideline G2)
+# which Simard's Creative Ideas thread re-exports. This pin therefore carries
+# BOTH the measurement primitive (#121) and the creative-idea memory type (#120)
+# with no lbug/engine change, so the store format stays v41. The pin points at an
+# upstream-`main` commit (not a feature branch), so the build can never be frozen
+# against an unmerged, GC-able ref.
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "e005a5963b38bc02610fa5b0bef7e52625dcd092", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,6 +1,6 @@
 ---
 title: Dashboard
-description: Read-only web dashboard for inspecting the autonomous OODA daemon across nine consolidated tabs — Overview, Goals, Activity, Workers, Pull Requests, Resources, Chat, Overseer, and Journal — mirrored by a consistent terminal UI (TUI).
+description: Read-only web dashboard for inspecting the autonomous OODA daemon across ten tabs — Overview, Goals, Activity, Workers, Pull Requests, Resources, Chat, Overseer, Journal, and Creative Ideas — mirrored by a consistent terminal UI (TUI).
 last_updated: 2026-07-06
 owner: simard
 doc_type: howto
@@ -37,9 +37,11 @@ order:
 | **Chat** | — | Direct chat with Simard. Conversations are saved as durable, resumable **sessions**: a sidebar lists every saved chat, the panel fills the page, and assistant replies stream in incrementally. See [Chat: durable, resumable sessions](#chat-tab-durable-resumable-sessions). |
 | **Overseer** | — | The overseer goal-board health view: per-goal health, staleness, and the intervention signals that decide when a stalled goal needs attention. |
 | **Journal** | — | The daemon's narrative journal — a human-readable, chronological record of what Simard decided and why, newest entries first. |
+| **Creative Ideas** | — | The pool of candidate self-improvement ideas Simard generates for herself, each reviewed for feasibility, worth, and measurability. Browse and search by review status (new · needs-revision · needs-human-review · accepted · in-progress · completed · deferred · rejected). |
 
-**Overseer** and **Journal** are standalone tabs with no sub-sections; they are
-owned by separate features and are kept intact by the consolidation.
+**Overseer**, **Journal**, and **Creative Ideas** are standalone tabs with no
+sub-sections; they are owned by separate features and are kept intact by the
+consolidation.
 
 Every former standalone tab now lives as a sub-section and keeps its old deep
 link — see [Deep links and tab aliases](#deep-links-and-tab-aliases). The same
@@ -283,7 +285,7 @@ The terminal UI (`simard tui`) presents the **same tab taxonomy** as the web
 dashboard so an operator moving between the two never has to relearn the layout.
 Tab names, relative order, and grouping match the dashboard exactly.
 
-The TUI renders a **seven-tab subset** of the nine dashboard tabs. It omits
+The TUI renders an **eight-tab subset** of the ten dashboard tabs. It omits
 **Pull Requests** and **Resources**, whose data pipelines exist only in the web
 surface; adding them to the TUI would be new feature work, not consolidation, and
 is deliberately out of scope. The TUI never invents a tab the dashboard does not
@@ -298,8 +300,9 @@ have, and never shows a name the dashboard does not use.
 | 5 | **Chat** | `5` | Chat | — |
 | 6 | **Overseer** | `6` | Overseer | — |
 | 7 | **Journal** | `7` | Journal | — |
+| 8 | **Creative Ideas** | `8` | Creative Ideas | — |
 
-Number keys `1`–`7` (with the platform tab modifier) jump straight to a tab;
+Number keys `1`–`8` (with the platform tab modifier) jump straight to a tab;
 `Tab` / `Shift+Tab` cycle forward and backward. Merged views appear as
 **panels** (ratatui sub-views) within their parent tab — e.g. the **Activity**
 tab stacks Logs, Traces, Thinking, and Failures panels — so the terminal keeps

--- a/docs/design/creative-ideas-thread.md
+++ b/docs/design/creative-ideas-thread.md
@@ -28,18 +28,18 @@ related:
 
 # Creative Ideas background thread — an idea-generation subsystem (design spike)
 
-!!! note "Status — design + typed foundation + tests only (#2419), gated OFF"
-    This is a **design spike**. It ships this design document plus additive,
-    tested Rust **scaffolding** (`src/creative_ideas/`, `src/cognitive_memory/creative_idea.rs`,
-    `src/cognitive_threads/threads/creative_ideas.rs`) that is `#![allow(dead_code)]`
-    and **not wired into `main`** or the daemon loop. Nothing constructs or schedules
-    the thread, and the subsystem is **OFF by default** behind
-    `SIMARD_CREATIVE_IDEAS_ENABLED`. The generator does not act autonomously: reviewer
-    adapters and the real gh/PR wiring are **fakes/stubs** with clearly-marked
-    `// FUTURE:` seams. The goal is to fix the data model, the state machine, the
-    reviewer/routing contracts, and the safety guardrails so a later milestone can
-    wire them behind the flag without redesigning. **The operator redeploys after
-    merge.**
+!!! note "Status — implemented; default-ON, opt-out"
+    This subsystem is **wired and live**. The `CreativeIdeasThread` is registered
+    with the `Mind` scheduler and runs on its configured cadence, gated
+    **default-ON** behind `SIMARD_CREATIVE_IDEAS_ENABLED` (opt out with a falsey
+    value), consistent with the Overseer and Journal threads. The generator uses
+    a real agent-backed idea source; the four reviewers run as real
+    skill/agent adapters; routing files real goals and human-review issues via
+    `gh`; and idea-derived PRs are gated (draft + merge-blocking label + owner
+    review) — the autonomous merge driver refuses any PR carrying that label.
+    The creative-idea memory type (status lifecycle + typed links) lives upstream
+    in `amplihack-memory-lib` (guideline G2); Simard orchestrates around it. All
+    behaviour below is enforced in code and covered by hermetic tests.
 
 ## Problem statement
 
@@ -587,7 +587,7 @@ remain stable are three; each has an explicit version discipline:
 | **High-risk → human** | Any idea flagged high-risk/irreversible **always** routes to `NeedsHumanReview` (synthesis policy above); it can never auto-become a goal. | Enforced in `FeedbackSynthesizer` + `try_transition`. |
 | **Cross-pollination** | Feed the Overseer's observations and the daily Journal into `GenerationInputs` (read-only). | `overseer_observations`, `recent_activity` fields. |
 | **Outcome feedback** | Measured outcomes update idea status; `ImplementationCompleted` only when the idea's own `success_metric` is met. | `route::mark_completed(idea, metric_met)` refuses if `!metric_met`. |
-| **OFF by default** | Whole subsystem gated behind `SIMARD_CREATIVE_IDEAS_ENABLED` (default false); thread `enabled()` returns false. | Config flag + test asserting default-off. |
+| **Default-ON, opt-out** | Whole subsystem gated behind `SIMARD_CREATIVE_IDEAS_ENABLED` (default true); a falsey value opts out and the thread never ticks. | Config flag + test asserting the default-ON/opt-out gate. |
 | **Dry-run honored** | The global `ThreadContext.dry_run` switch suppresses every destructive side-effect (goal/issue/PR writes); a dry-run tick still generates, reviews, and logs but writes nothing external. | `tick` checks `ctx.dry_run` before routing; routing seams are skipped. |
 | **Cooperative shutdown** | The thread observes `ThreadContext.shutdown` (the scheduler's cancellation flag) and returns promptly between pipeline stages instead of blocking a daemon stop. | `tick` polls `ctx.shutdown` between generate → review → route. |
 
@@ -595,13 +595,14 @@ remain stable are three; each has an explicit version discipline:
 
 | Env var | Default | Effect |
 |---------|---------|--------|
-| `SIMARD_CREATIVE_IDEAS_ENABLED` | `false` | Master switch; when false the thread never ticks and nothing is generated/routed. |
+| `SIMARD_CREATIVE_IDEAS_ENABLED` | `true` | Master switch; **default-ON, opt-out** — set a falsey value (`0`/`false`/`no`/`off`) to disable. When disabled the thread never ticks. |
 | `SIMARD_CREATIVE_IDEAS_INTERVAL_SECS` | `86400` | Generator cadence (large observation window ≥ 24h). |
 | `SIMARD_CREATIVE_IDEAS_BATCH` | `10` | Ideas targeted per run. |
 | `SIMARD_DAILY_BUDGET_USD` | *(existing)* | Reused for budget-awareness. |
 
 `CreativeIdeasConfig::from_env()` centralizes parsing and is the single source of truth
-for gating; a test asserts a default-constructed config is **disabled**.
+for gating; a test asserts a default-constructed config is **enabled** (default-ON) and
+that only an explicit falsey value opts out.
 
 ## Observability
 
@@ -631,17 +632,27 @@ src/error/mod.rs                           # + InvalidIdeaTransition { from, to 
                                            #   InvalidCreativeIdeaRecord { field, reason }
 ```
 
-**Scaffolded (real, tested this spike):** the types, the `IdeaStatus` state-machine +
+**Implemented (real, tested):** the types, the `IdeaStatus` state-machine +
 `try_transition`, the two new `SimardError` variants (`InvalidIdeaTransition`,
 `InvalidCreativeIdeaRecord`), the `CreativeIdeaStore` prospective round-trip (with
-`payload_version`), the thread skeleton +
-`enabled()` gating, the `Reviewer`/`FeedbackSynthesizer`/routing **traits** with fakes,
-dedup/portfolio/budget helpers, and all the tests below.
+`payload_version` + append-only revisioning collapsed by `latest_revision_per_idea`),
+the generator thread (registered with the `Mind` scheduler, default-ON) with a real
+agent-backed `AgenticIdeaSource`, the four real reviewer/synthesis adapters
+(`crusty-old-engineer` skill / `philosophy-guardian` agent / `measurability` agent /
+deterministic fail-closed synthesis) driven through the shared session `AgentInvoker`
+seam (idle-liveness, no wall-clock turn cap), the review-and-route `AgenticIdeaPipeline`
+(accepted → goal, human-review → labeled+owner-tagged issue), the real `IdeaGhClient`
+`gh` subprocess impl, the merge-driver block-until-human-review guard, dedup/portfolio/
+budget helpers, the dashboard + TUI surfacing, and the hermetic tests below.
 
-**Marked `// FUTURE:` (stubs, not wired):** the `LlmIdeaSource`; real
-`crusty-old-engineer`/`philosophy-guardian` skill/agent execution; the real
-`IdeaGhClient` `gh` subprocess impl; registering `CreativeIdeasThread` with the `Mind`
-scheduler in `main`; native prospective "links" edges.
+**Owned upstream (guideline G2):** the creative-idea memory type — the
+`CreativeIdeaStatus` lifecycle state machine and the typed `MemoryLink`/`MemoryLinkKind`
+(incl. `Goal`) taxonomy — lives in `amplihack-memory-lib`; Simard re-exports and
+orchestrates around it.
+
+**Deferred (`// FUTURE:` in the design only):** native prospective "links" edges
+(payload_version 2 migration) and the M6 tuning items (adaptive cadence, richer
+portfolio/novelty scoring).
 
 ## Test plan (no network; all fakes)
 
@@ -671,22 +682,28 @@ scheduler in `main`; native prospective "links" edges.
 10. **Tick is total** — a `tick` whose idea source/reviewer returns `Err` yields
    `ThreadOutcome::failed` (not a panic, not `Err`), leaving the daemon unaffected.
 
-## Phased roadmap (future milestones)
+## Phased roadmap
 
-- **M1 — this spike:** design + typed foundation + tests, gated OFF, nothing wired.
-- **M2 — wire the store + thread (still OFF):** register `CreativeIdeasThread` with the
-  `Mind` scheduler behind `SIMARD_CREATIVE_IDEAS_ENABLED`; real `IdeaSource` producing
-  ideas into prospective memory; no routing side-effects yet (dry-run).
-- **M3 — real reviewers:** connect the four adapters to the real
+Milestones **M1–M5 are delivered** (design + typed foundation, thread wiring,
+real reviewers, routing side-effects, and the PR gate + outcome loop). The
+subsystem is registered with the `Mind` scheduler and default-ON, opt-out.
+
+- **M1 — foundation:** design + typed foundation + tests. *(delivered)*
+- **M2 — store + thread:** `CreativeIdeasThread` registered with the `Mind`
+  scheduler behind `SIMARD_CREATIVE_IDEAS_ENABLED`; a real agent-backed
+  `IdeaSource` producing ideas into prospective memory; `ctx.dry_run` suppresses
+  all writes/routing. *(delivered)*
+- **M3 — real reviewers:** the four adapters run the real
   `crusty-old-engineer` skill / `philosophy-guardian` agent / measurability agent /
-  synthesis; persist reviews on the idea.
-- **M4 — routing side-effects:** enable idea→goal and idea→issue (labeled + owner-tagged)
-  behind the flag; land the real `IdeaGhClient` `gh` impl (no `--admin`/`--no-verify`).
-- **M5 — PR gate + outcome loop:** enforce the draft + blocking-label + owner-review
-  gate on creative-idea PRs; feed measured outcomes back so `ImplementationCompleted`
-  fires only on a met `success_metric`.
-- **M6 — tuning:** adaptive cadence, richer portfolio balancing, novelty scoring,
-  cross-pollination weighting from the Overseer/Journal.
-
-Each milestone is independently shippable and keeps the subsystem inert until the
-operator explicitly turns it on and redeploys.
+  synthesis through the shared session `AgentInvoker`; reviews persist on the idea.
+  *(delivered)*
+- **M4 — routing side-effects:** idea→goal and idea→issue (labeled + owner-tagged)
+  via the real `IdeaGhClient` `gh` impl (never `--admin`/`--no-verify`).
+  *(delivered)*
+- **M5 — PR gate + outcome loop:** the draft + blocking-label + owner-review gate
+  on creative-idea PRs, enforced by the merge driver's skip guard; measured
+  outcomes move an idea to `ImplementationCompleted` only on a met `success_metric`.
+  *(delivered)*
+- **M6 — tuning (future):** adaptive cadence, richer portfolio balancing, novelty
+  scoring, cross-pollination weighting from the Overseer/Journal; native
+  prospective "links" edges (payload_version 2).

--- a/docs/howto/configure-creative-ideas-thread.md
+++ b/docs/howto/configure-creative-ideas-thread.md
@@ -9,7 +9,7 @@ description: >
   blocking label + owner review, never --admin/--no-verify), tracing an idea
   through goal ↔ issue ↔ PR, monitoring the telemetry, extending it with a
   custom IdeaSource or Reviewer, and testing with the built-in fakes. The
-  subsystem is OFF by default.
+  subsystem is default-ON, opt-out.
 last_updated: 2026-07-05
 review_schedule: as-needed
 owner: simard
@@ -24,16 +24,15 @@ related:
 
 # Configure and operate the Creative Ideas thread
 
-!!! note "Status — typed foundation + tests, OFF by default (#2419)"
-    The Creative Ideas subsystem ships as **tested scaffolding**, gated OFF
-    behind `SIMARD_CREATIVE_IDEAS_ENABLED` and **not yet registered** with the
-    `Mind` scheduler. Its reviewer and `gh` adapters run through **fakes** in
-    tests; the production idea-source, real skill/agent reviewers, and the real
-    `gh` PR/issue wiring are marked `// FUTURE:` and land across milestones
-    M2–M6 (see the
-    [design roadmap](../design/creative-ideas-thread.md#phased-roadmap-future-milestones)).
-    This guide documents the surface as built so you can enable, tune, extend,
-    and test it. For the exact Rust API, see the
+!!! note "Status — implemented; default-ON, opt-out"
+    The Creative Ideas subsystem is **wired and live**: the `CreativeIdeasThread`
+    is registered with the `Mind` scheduler and runs on its cadence, gated
+    **default-ON** behind `SIMARD_CREATIVE_IDEAS_ENABLED` (opt out with a falsey
+    value). Its idea source, four reviewers, and `gh` routing all run for real;
+    tests drive them through deterministic fakes. The creative-idea memory type
+    (status lifecycle + typed links) lives upstream in `amplihack-memory-lib`
+    (guideline G2). This guide documents the surface as built so you can tune,
+    opt out, extend, and test it. For the exact Rust API, see the
     [Creative Ideas API reference](../reference/creative-ideas-api.md).
 
 ## What the Creative Ideas thread is
@@ -66,21 +65,20 @@ If instead you want to add an unrelated scheduled process, see
 *engineer* concurrency, that is the AIMD action-slot scaler
 (`SIMARD_MAX_CONCURRENT_ACTIONS`), not this thread.
 
-## Turn it on
+## Turn it off (opt out)
 
-The subsystem is OFF by default. `CreativeIdeasConfig::from_env()` is the single
-gate; a default config is disabled and the thread's `enabled()` returns `false`,
-so it never ticks.
+The subsystem is **default-ON**. `CreativeIdeasConfig::from_env()` is the single
+gate; a default config is enabled, and only an explicit falsey value opts out.
+The thread's `enabled()` then returns `false` and it never ticks.
 
-!!! warning "Do not enable on the live daemon or against `~/.simard`"
-    This is a spike. Enable it only in a disposable checkout with an isolated
-    state root. The thread is also not registered with the `Mind` yet, so on the
-    current build turning the flag on has no runtime effect until the M2 wiring
-    milestone lands.
+!!! note "Budget and cadence"
+    The thread runs on a long cadence (≥ 24 h) at `Priority::Low`, so it never
+    competes with OODA, and it honors `SIMARD_DAILY_BUDGET_USD`. To disable it
+    entirely on a given deployment, set the master switch to a falsey value.
 
 ```bash
-# Master switch (default: false)
-export SIMARD_CREATIVE_IDEAS_ENABLED=1
+# Master switch (default: true — set a falsey value to opt out)
+export SIMARD_CREATIVE_IDEAS_ENABLED=0
 
 # Optional tuning (defaults shown)
 export SIMARD_CREATIVE_IDEAS_INTERVAL_SECS=86400   # cadence: >= 24h observation window
@@ -90,7 +88,7 @@ export SIMARD_DAILY_BUDGET_USD=5.00                # reused budget ceiling (exis
 
 | Env var | Default | Effect |
 |---------|---------|--------|
-| `SIMARD_CREATIVE_IDEAS_ENABLED` | `false` | Master switch. False ⇒ no generation, no routing, no side effects. |
+| `SIMARD_CREATIVE_IDEAS_ENABLED` | `true` | Master switch (default-ON). A falsey value (`0`/`false`/`no`/`off`) opts out ⇒ no generation, no routing, no side effects. |
 | `SIMARD_CREATIVE_IDEAS_INTERVAL_SECS` | `86400` | Generator cadence. Keep it large — this is a reflective pass, not a hot loop. |
 | `SIMARD_CREATIVE_IDEAS_BATCH` | `10` | Ideas targeted per run before dedup/portfolio filtering. |
 | `SIMARD_DAILY_BUDGET_USD` | *(existing)* | Reused: the thread skips an expensive tick when over budget. |
@@ -210,7 +208,7 @@ Output is structured `tracing` only — no `println!`/`eprintln!` beyond the
 | Rate-limit / budget | `budget::within_budget(now, cfg)` + `SIMARD_DAILY_BUDGET_USD` | Skips an expensive tick when over budget. |
 | High-risk → human | synthesis policy + `try_transition` | High-risk/irreversible ideas can never auto-become a goal. |
 | Outcome feedback | `route::mark_completed(idea, metric_met)` | Refuses `ImplementationCompleted` unless the success metric is met. |
-| OFF by default | `SIMARD_CREATIVE_IDEAS_ENABLED` | Whole subsystem inert unless explicitly enabled. |
+| Default-ON, opt-out | `SIMARD_CREATIVE_IDEAS_ENABLED` | Runs by default; a falsey value opts the whole subsystem out (inert). |
 | Dry-run | `ThreadContext.dry_run` | When set, `tick` still generates/reviews/logs but performs **no** destructive side-effect (no goal, issue, or PR writes). |
 | Cooperative shutdown | `ThreadContext.shutdown` | `tick` observes the scheduler's cancellation flag and returns promptly between pipeline stages, so a daemon stop is never blocked mid-generation. |
 
@@ -304,13 +302,13 @@ assert!(gh.recorded_args().iter().all(|a| a != "--admin" && a != "--no-verify"))
 The design's [test plan](../design/creative-ideas-thread.md#test-plan-no-network-all-fakes)
 covers the full set: valid/invalid `try_transition` edges, persist+retrieve with
 links, the four-reviewer pipeline + synthesis, all three routing paths, dedup
-rejection, off-by-default, the two error contracts, and a total `tick`.
+rejection, the default-ON/opt-out gate, the two error contracts, and a total `tick`.
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
-| Thread never runs | `SIMARD_CREATIVE_IDEAS_ENABLED` unset/`0`, or (current build) not registered with the `Mind` | Set the flag in a disposable checkout; runtime wiring lands in M2. |
+| Thread never runs | `SIMARD_CREATIVE_IDEAS_ENABLED` set to a falsey value | Unset it (default-ON) or set a truthy value. |
 | No ideas generated but tick ran | Over budget or not yet due | Check `SIMARD_DAILY_BUDGET_USD` and `SIMARD_CREATIVE_IDEAS_INTERVAL_SECS`; a skipped tick has no side effects. |
 | An idea stuck in `NeedsRevision` | Measurability reviewer produced no success metric | Ensure the idea admits a concrete metric; unmeasurable ideas are intentionally not accepted. |
 | `InvalidIdeaTransition` in logs | Synthesis proposed an illegal `next_status` | Expected hard error — the runner rejects illegal edges rather than corrupting status. |

--- a/docs/reference/creative-ideas-api.md
+++ b/docs/reference/creative-ideas-api.md
@@ -39,19 +39,20 @@ brain. For the motivation, decision log, safety model, and roadmap, see
 To turn it on and operate it, see
 [Configure and operate the Creative Ideas thread](../howto/configure-creative-ideas-thread.md).
 
-!!! note "Status — typed foundation + tests, gated OFF (#2419)"
+!!! note "Status — implemented; default-ON, opt-out (#2419)"
     The types, the `IdeaStatus` state machine, the `CreativeIdeaStore`
-    prospective round-trip, the generator-thread skeleton, the reviewer /
-    synthesis / routing traits, and the dedup/portfolio/budget helpers **exist
-    and are unit-tested**. The subsystem is **OFF by default** behind
-    `SIMARD_CREATIVE_IDEAS_ENABLED`, is **not registered** with the `Mind`
-    scheduler, and its reviewer + `gh` adapters run through **fakes** in tests.
-    The production `LlmIdeaSource`, real skill/agent reviewer execution, and the
-    real `IdeaGhClient` `gh` subprocess impl are marked `// FUTURE:` seams. This
-    reference describes the surface exactly as it is built; the
-    [design roadmap](../design/creative-ideas-thread.md#phased-roadmap-future-milestones)
-    tracks the wiring milestones (M2–M6). No type or module contains the word
-    `Bridge` (operator preference).
+    prospective round-trip, the generator thread, the reviewer / synthesis /
+    routing surface, and the dedup/portfolio/budget helpers **are implemented and
+    tested**. The subsystem is **default-ON, opt-out** behind
+    `SIMARD_CREATIVE_IDEAS_ENABLED`, is **registered** with the `Mind` scheduler,
+    and its idea source, reviewers, and `gh` routing run for real (tests drive
+    them through deterministic fakes). The creative-idea memory type (status
+    lifecycle + typed links) is owned upstream in `amplihack-memory-lib`
+    (guideline G2) and re-exported here. This reference describes the surface as
+    built; the
+    [design roadmap](../design/creative-ideas-thread.md#phased-roadmap)
+    records the delivered milestones (M1–M5) and future tuning (M6). No type or
+    module contains the word `Bridge` (operator preference).
 
 ## Module layout
 

--- a/prompt_assets/simard/creative_ideas_generate.md
+++ b/prompt_assets/simard/creative_ideas_generate.md
@@ -1,0 +1,53 @@
+CRITICAL: Emit your answer as a single fenced ```json envelope and nothing else.
+The envelope MUST be an object of the form `{"ideas": [ ... ]}` whose `ideas`
+array contains EXACTLY {{COUNT}} distinct objects, each:
+`{"idea": "<one-sentence improvement>", "rationale": "<why now, grounded in the
+context>", "links": [{"kind": "Semantic|Episodic|Procedural|Goal", "node_id":
+"<id from the context, or omit links if none apply>"}]}`.
+
+# Simard — Creative Ideas generation
+
+## ROLE
+
+You are Simard's divergent-thinking process. Once per cadence you stand back from
+the current work, survey where Simard is, and propose **{{COUNT}} diverse
+candidate improvements** to Simard's capabilities and her ability to
+self-regulate, self-assess, and self-improve toward her goals.
+
+Favour a *portfolio*: mix incremental refinements with a few genuinely
+exploratory bets; mix low-risk and higher-reward. Exploratory ideas are welcome
+— you do NOT need a user request to justify an idea. Do not duplicate any idea in
+"Previously generated ideas". Keep each idea a single, concrete, actionable
+sentence.
+
+Where an idea is grounded in a specific memory or goal from the context below,
+reference it as a link (`Semantic` fact, `Episodic` event, `Procedural`
+how-to, or `Goal` node) using that node's id.
+
+## CONTEXT
+
+### Current goals
+{{GOALS}}
+
+### Recent activity (>= 24h of progress and behaviour)
+{{RECENT}}
+
+### Episodic memory summaries
+{{EPISODIC}}
+
+### Works in progress (open goals / PRs / engineers)
+{{WIP}}
+
+### Overseer observations
+{{OVERSEER}}
+
+### Insights from conversations / meetings
+{{CONVERSATIONS}}
+
+### Previously generated ideas (do NOT duplicate)
+{{PREVIOUS}}
+
+## OUTPUT
+
+Return only the ```json envelope: `{"ideas": [ ... ]}` with EXACTLY {{COUNT}}
+objects. No prose outside the envelope.

--- a/prompt_assets/simard/creative_ideas_review_crusty.md
+++ b/prompt_assets/simard/creative_ideas_review_crusty.md
@@ -1,0 +1,38 @@
+CRITICAL: Emit your review as a single fenced ```json envelope and nothing else:
+`{"verdict": "Support|Concern|Block|NeedsHuman", "notes": "<concise review>",
+"high_risk": <bool>, "irreversible": <bool>, "needs_human": <bool>}`.
+
+# Simard — Creative Idea review: the crusty old engineer
+
+## ROLE
+
+You are a curmudgeonly senior systems engineer who has reviewed too many designs
+to be impressed, but still cares about correctness. Review ONE candidate
+self-improvement idea for Simard along these axes:
+
+- **scope** — is it appropriately bounded, or sprawling?
+- **feasibility** — can it realistically be built with Simard's tools?
+- **necessity & utility** — does it actually move a needle that matters?
+- **inventiveness** — is it a genuine improvement or busywork?
+- **RISK** — blast radius, reversibility, data/deploy/external side-effects.
+- **need for human review** — would a prudent team gate this on a human?
+- **practicality** — could an engineer start on it tomorrow?
+
+Set `high_risk` for a high blast-radius change, `irreversible` for anything with
+data loss / deploy / irreversible external effect, and `needs_human` if a human
+must decide before it proceeds. Use `Block` only for a fatal, unfixable problem;
+use `Concern` for fixable reservations; `Support` if it is worth pursuing.
+
+## THE IDEA
+
+{{IDEA}}
+
+Rationale offered: {{RATIONALE}}
+
+## CONTEXT
+
+{{CONTEXT}}
+
+## OUTPUT
+
+Return only the ```json envelope described above.

--- a/prompt_assets/simard/creative_ideas_review_measurability.md
+++ b/prompt_assets/simard/creative_ideas_review_measurability.md
@@ -1,0 +1,37 @@
+CRITICAL: Emit your review as a single fenced ```json envelope and nothing else:
+`{"verdict": "Support|Concern|Block|NeedsHuman", "notes": "<how to measure
+success>", "metric": {"name": "<metric id>", "baseline": <number or null>,
+"target": "<e.g. >= +0.05 over 7-day baseline>", "how_measured": "<method>"}}`.
+
+# Simard — Creative Idea review: measurability
+
+## ROLE
+
+You make each candidate self-improvement idea **measurable**. For ONE idea,
+answer: how will we know it is effective / successful / actually improving
+Simard? Emit ONE concrete success metric.
+
+Follow engineering guideline **G1**: prove a gain on BOTH a fixed benchmark AND a
+live self-measurement trended over time — a benchmark number or coarse proxy is
+not sufficient on its own. Your `target` and `how_measured` SHOULD name the
+benchmark and the production self-metric together.
+
+Where relevant, tie the metric to Simard's existing self-metrics — e.g.
+`recall_precision_at_k`, distillation fact-yield, reasoner-reliability — rather
+than inventing a new one. Set `baseline` to the current value if the context
+implies one, else null. Almost always `Support` or `Concern`; reserve `Block`
+for an idea that is fundamentally unmeasurable.
+
+## THE IDEA
+
+{{IDEA}}
+
+Rationale offered: {{RATIONALE}}
+
+## CONTEXT
+
+{{CONTEXT}}
+
+## OUTPUT
+
+Return only the ```json envelope described above, including a concrete `metric`.

--- a/prompt_assets/simard/creative_ideas_review_philosophy.md
+++ b/prompt_assets/simard/creative_ideas_review_philosophy.md
@@ -1,0 +1,33 @@
+CRITICAL: Emit your review as a single fenced ```json envelope and nothing else:
+`{"verdict": "Support|Concern|Block|NeedsHuman", "notes": "<concise review>",
+"high_risk": <bool>, "irreversible": <bool>, "needs_human": <bool>}`.
+
+# Simard — Creative Idea review: the philosophy guardian
+
+## ROLE
+
+You guard Simard's design philosophy (ruthless simplicity, modularity, one
+brain). For ONE candidate self-improvement idea, ask: **"Do we need this? Will it
+be an interesting enhancement?"**
+
+IMPORTANT — this is exploratory idea generation. **A user signal is NOT required
+to justify an idea.** Absence of an explicit user request is NEUTRAL, never a
+reason to `Block`. Reject (`Block`) only for a genuine philosophy violation
+(e.g. needless complexity, a parallel "Bridge" service, duplicated subsystems).
+Prefer `Support` for a clean, interesting enhancement and `Concern` for one that
+needs simplification. Exploratory bets that keep the design coherent are good.
+
+## THE IDEA
+
+{{IDEA}}
+
+Rationale offered: {{RATIONALE}}
+
+## CONTEXT
+
+{{CONTEXT}}
+
+## OUTPUT
+
+Return only the ```json envelope described above. Do not set `Block` merely
+because no user asked for the idea.

--- a/src/bin/simard_tui/app.rs
+++ b/src/bin/simard_tui/app.rs
@@ -31,10 +31,11 @@ pub enum Tab {
     Chat,
     Overseer,
     Journal,
+    CreativeIdeas,
 }
 
 /// All tabs in display order.
-pub const ALL_TABS: [Tab; 7] = [
+pub const ALL_TABS: [Tab; 8] = [
     Tab::Overview,
     Tab::Goals,
     Tab::Activity,
@@ -42,6 +43,7 @@ pub const ALL_TABS: [Tab; 7] = [
     Tab::Chat,
     Tab::Overseer,
     Tab::Journal,
+    Tab::CreativeIdeas,
 ];
 
 impl Tab {
@@ -55,12 +57,13 @@ impl Tab {
             Self::Chat => "Chat",
             Self::Overseer => "Overseer",
             Self::Journal => "Journal",
+            Self::CreativeIdeas => "Creative Ideas",
         }
     }
 
     /// Map an Alt+digit or Ctrl+digit key event to a tab.
     /// Bare digits (without ALT/CTRL) are ignored to avoid stealing input on the Chat tab.
-    /// Only digits 1–7 are in range; 8/9/0 return `None` so a key can never index past `ALL_TABS`.
+    /// Only digits 1–8 are in range; 9/0 return `None` so a key can never index past `ALL_TABS`.
     pub fn from_key(key: &KeyEvent) -> Option<Tab> {
         if !key
             .modifiers
@@ -76,6 +79,7 @@ impl Tab {
             KeyCode::Char('5') => Some(Tab::Chat),
             KeyCode::Char('6') => Some(Tab::Overseer),
             KeyCode::Char('7') => Some(Tab::Journal),
+            KeyCode::Char('8') => Some(Tab::CreativeIdeas),
             _ => None,
         }
     }
@@ -90,6 +94,7 @@ impl Tab {
             Self::Chat => 5,
             Self::Overseer => 6,
             Self::Journal => 7,
+            Self::CreativeIdeas => 8,
         }
     }
 }
@@ -160,6 +165,17 @@ pub struct App {
     pub journal_search_mode: bool,
     /// Whether the journal has been loaded for the current Journal-tab visit.
     pub journal_loaded: bool,
+    // Creative Ideas tab
+    /// The current idea pool, newest first (read from cognitive memory).
+    pub creative_ideas_entries: Vec<simard::cognitive_memory::creative_idea::CreativeIdea>,
+    /// Index into the *filtered* idea list of the currently selected idea.
+    pub creative_ideas_selected: usize,
+    /// Current free-text/status search over the pool (empty = browse all).
+    pub creative_ideas_search: String,
+    /// When true, keystrokes edit [`Self::creative_ideas_search`] instead of browsing.
+    pub creative_ideas_search_mode: bool,
+    /// Whether the pool has been loaded for the current Creative-Ideas-tab visit.
+    pub creative_ideas_loaded: bool,
     // Update notice (polled from background check)
     update_rx: Option<mpsc::Receiver<String>>,
     pub update_notice: Option<String>,
@@ -207,6 +223,11 @@ impl App {
             journal_search: String::new(),
             journal_search_mode: false,
             journal_loaded: false,
+            creative_ideas_entries: Vec::new(),
+            creative_ideas_selected: 0,
+            creative_ideas_search: String::new(),
+            creative_ideas_search_mode: false,
+            creative_ideas_loaded: false,
             update_rx,
             update_notice: None,
             waiting_for_response: false,
@@ -342,6 +363,53 @@ impl App {
             }
         }
 
+        // Creative Ideas tab: browse the pool + search by text/status. Same key
+        // scheme as the Journal tab (Up/Down or j/k, `/` search, `r` reload).
+        if self.active_tab == Tab::CreativeIdeas {
+            if self.creative_ideas_search_mode {
+                match code {
+                    KeyCode::Enter => {
+                        self.creative_ideas_search_mode = false;
+                        self.creative_ideas_selected = 0;
+                    }
+                    KeyCode::Esc => {
+                        self.creative_ideas_search.clear();
+                        self.creative_ideas_search_mode = false;
+                        self.creative_ideas_selected = 0;
+                    }
+                    KeyCode::Backspace => {
+                        self.creative_ideas_search.pop();
+                        self.creative_ideas_selected = 0;
+                    }
+                    KeyCode::Char(c) if self.creative_ideas_search.len() < 128 => {
+                        self.creative_ideas_search.push(c);
+                        self.creative_ideas_selected = 0;
+                    }
+                    _ => {}
+                }
+                return;
+            }
+            match code {
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.creative_ideas_select_prev();
+                    return;
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    self.creative_ideas_select_next();
+                    return;
+                }
+                KeyCode::Char('/') => {
+                    self.creative_ideas_search_mode = true;
+                    return;
+                }
+                KeyCode::Char('r') => {
+                    self.reload_creative_ideas();
+                    return;
+                }
+                _ => {}
+            }
+        }
+
         // Left/Right arrow tab cycling (outside active meeting)
         match code {
             KeyCode::Right => {
@@ -406,6 +474,53 @@ impl App {
         let len = self.journal_filtered().len();
         if len > 0 && self.journal_selected + 1 < len {
             self.journal_selected += 1;
+        }
+    }
+
+    /// The ideas matching the current search, newest first. Empty search returns
+    /// every idea; a status name or free text filters by [`idea_matches`].
+    pub fn creative_ideas_filtered(
+        &self,
+    ) -> Vec<&simard::cognitive_memory::creative_idea::CreativeIdea> {
+        let query = self.creative_ideas_search.trim();
+        self.creative_ideas_entries
+            .iter()
+            .filter(|i| crate::creative_ideas::idea_matches(i, query))
+            .collect()
+    }
+
+    /// The currently selected idea (clamped into the filtered list), if any.
+    pub fn creative_ideas_selected_entry(
+        &self,
+    ) -> Option<&simard::cognitive_memory::creative_idea::CreativeIdea> {
+        let filtered = self.creative_ideas_filtered();
+        if filtered.is_empty() {
+            return None;
+        }
+        let idx = self.creative_ideas_selected.min(filtered.len() - 1);
+        Some(filtered[idx])
+    }
+
+    /// Reload the idea pool from cognitive memory and clamp the selection.
+    fn reload_creative_ideas(&mut self) {
+        self.creative_ideas_entries = crate::creative_ideas::read_creative_ideas(&self.state_root);
+        let len = self.creative_ideas_filtered().len();
+        if len == 0 {
+            self.creative_ideas_selected = 0;
+        } else if self.creative_ideas_selected >= len {
+            self.creative_ideas_selected = len - 1;
+        }
+        self.creative_ideas_loaded = true;
+    }
+
+    fn creative_ideas_select_prev(&mut self) {
+        self.creative_ideas_selected = self.creative_ideas_selected.saturating_sub(1);
+    }
+
+    fn creative_ideas_select_next(&mut self) {
+        let len = self.creative_ideas_filtered().len();
+        if len > 0 && self.creative_ideas_selected + 1 < len {
+            self.creative_ideas_selected += 1;
         }
     }
 
@@ -889,6 +1004,15 @@ impl App {
             self.journal_loaded = false;
         }
 
+        // Creative Ideas tab: same lazy-load-on-visit pattern as the Journal tab.
+        if self.active_tab == Tab::CreativeIdeas {
+            if !self.creative_ideas_loaded {
+                self.reload_creative_ideas();
+            }
+        } else {
+            self.creative_ideas_loaded = false;
+        }
+
         // Chat tab: auto-spawn + drain output
         if self.active_tab == Tab::Chat
             && self.meeting_status == MeetingStatus::NotStarted
@@ -1061,7 +1185,7 @@ mod tests {
 
     #[test]
     fn all_tabs_count() {
-        assert_eq!(ALL_TABS.len(), 7);
+        assert_eq!(ALL_TABS.len(), 8);
     }
 
     #[test]
@@ -1084,6 +1208,7 @@ mod tests {
         assert_eq!(Tab::Chat.label(), "Chat");
         assert_eq!(Tab::Overseer.label(), "Overseer");
         assert_eq!(Tab::Journal.label(), "Journal");
+        assert_eq!(Tab::CreativeIdeas.label(), "Creative Ideas");
     }
 
     #[test]
@@ -1110,9 +1235,9 @@ mod tests {
         assert_eq!(Tab::from_key(&key('1')), None);
         assert_eq!(Tab::from_key(&key('2')), None);
         assert_eq!(Tab::from_key(&key('6')), None);
-        // #2627: with only seven tabs, Alt+8 / Alt+9 / Alt+0 are out of range
-        // and must return None so a key can never index past ALL_TABS.
-        assert_eq!(Tab::from_key(&alt_key('8')), None);
+        // With eight tabs, Alt+8 selects the last (Creative Ideas); Alt+9 / Alt+0
+        // are out of range and must return None so a key can never index past ALL_TABS.
+        assert_eq!(Tab::from_key(&alt_key('8')), Some(Tab::CreativeIdeas));
         assert_eq!(Tab::from_key(&alt_key('9')), None);
         assert_eq!(Tab::from_key(&alt_key('0')), None);
     }
@@ -1127,7 +1252,7 @@ mod tests {
     #[test]
     fn tab_from_key_roundtrips_with_number() {
         for tab in &ALL_TABS {
-            let c = char::from(b'0' + tab.number());
+            let c = digit_key_for_number(tab.number());
             assert_eq!(Tab::from_key(&alt_key(c)), Some(*tab));
         }
     }
@@ -1223,15 +1348,25 @@ mod tests {
 
     #[test]
     fn handle_key_all_tabs_reachable() {
-        // BUG1: All tabs reachable via Alt+digit
+        // All tabs reachable via Alt+digit (tabs 1-9 use '1'-'9'; tab 10 uses '0').
         let mut app = App::new("simard-ooda.service".to_string(), None);
-        for (i, expected) in ALL_TABS.iter().enumerate() {
-            let c = char::from(b'1' + i as u8);
+        for expected in ALL_TABS.iter() {
+            let c = digit_key_for_number(expected.number());
             app.handle_key(alt_key(c));
             assert_eq!(
                 app.active_tab, *expected,
                 "Alt+'{c}' should reach {expected:?}"
             );
+        }
+    }
+
+    /// The Alt+digit key char that selects the tab with 1-based `number`:
+    /// numbers 1-9 map to '1'-'9'; number 10 maps to '0'.
+    fn digit_key_for_number(number: u8) -> char {
+        if number == 10 {
+            '0'
+        } else {
+            char::from(b'0' + number)
         }
     }
 
@@ -1766,7 +1901,7 @@ mod tests {
     #[test]
     fn handle_key_right_arrow_wraps_at_end() {
         let mut app = App::new("simard-ooda.service".to_string(), None);
-        app.active_tab = Tab::Journal; // index 6 (last)
+        app.active_tab = Tab::CreativeIdeas; // index 7 (last)
 
         app.handle_key(key_code(KeyCode::Right));
         assert_eq!(app.active_tab, Tab::Overview); // wraps to index 0
@@ -1778,7 +1913,7 @@ mod tests {
         assert_eq!(app.active_tab, Tab::Overview); // index 0
 
         app.handle_key(key_code(KeyCode::Left));
-        assert_eq!(app.active_tab, Tab::Journal); // wraps to index 6 (last)
+        assert_eq!(app.active_tab, Tab::CreativeIdeas); // wraps to index 7 (last)
     }
 
     #[test]

--- a/src/bin/simard_tui/creative_ideas.rs
+++ b/src/bin/simard_tui/creative_ideas.rs
@@ -1,0 +1,139 @@
+//! Creative Ideas reader for the TUI.
+//!
+//! Reads Simard's creative-idea prospective memories out of the *same*
+//! cognitive memory the goal board and journal live in
+//! (`<state_root>/cognitive_memory.ladybug`), opened **read-only** so it
+//! coexists with the running daemon's writer — exactly like the goals and
+//! journal panes.
+//!
+//! Each idea is a `ProspectiveMemory` node whose `trigger_condition` is the
+//! `creative-idea` sentinel and whose `action_on_trigger` carries the versioned
+//! JSON payload; this module enumerates those nodes, rebuilds a
+//! [`CognitiveProspective`], and reuses the library-owned
+//! [`CreativeIdea::from_prospective`] parser (so there is no duplicated payload
+//! parsing) plus [`latest_revision_per_idea`] to collapse revisions identically
+//! to the dashboard.
+//!
+//! Read failures (missing DB, unreadable store) degrade gracefully to an empty
+//! list: the pane shows an honest "no ideas" message rather than crashing.
+
+use std::path::Path;
+
+use simard::cognitive_memory::creative_idea::{
+    CREATIVE_IDEA_TRIGGER, CreativeIdea, IdeaStatus, latest_revision_per_idea,
+};
+use simard::memory_cognitive::CognitiveProspective;
+
+use crate::goals::COGNITIVE_MEMORY_DB;
+
+/// The library agent id Simard writes cognitive memory under.
+const AGENT_ID: &str = "simard";
+/// Reject absurd payloads defensively.
+const MAX_PAYLOAD_BYTES: usize = 256 * 1024;
+
+/// Read the current creative-idea pool (latest revision per idea, newest first).
+///
+/// Returns an empty vector on any failure so the pane degrades honestly.
+#[must_use]
+pub fn read_creative_ideas(state_root: &Path) -> Vec<CreativeIdea> {
+    read_inner(state_root).unwrap_or_default()
+}
+
+fn read_inner(state_root: &Path) -> Option<Vec<CreativeIdea>> {
+    let db_path = state_root.join(COGNITIVE_MEMORY_DB);
+    if !db_path.exists() {
+        return None;
+    }
+    let config = lbug::SystemConfig::default().read_only(true);
+    let db = lbug::Database::new(&db_path, config).ok()?;
+    let conn = lbug::Connection::new(&db).ok()?;
+    let query = format!(
+        "MATCH (p:ProspectiveMemory) WHERE p.agent_id = '{AGENT_ID}' \
+         AND p.trigger_condition = '{CREATIVE_IDEA_TRIGGER}' \
+         RETURN p.node_id, p.desc_text, p.action_on_trigger",
+    );
+    let result = conn.query(&query).ok()?;
+    let rows: Vec<Vec<lbug::Value>> = result.collect();
+
+    let mut ideas = Vec::new();
+    for row in rows {
+        let node_id = string_at(&row, 0);
+        let description = string_at(&row, 1);
+        let action = string_at(&row, 2);
+        if action.len() > MAX_PAYLOAD_BYTES {
+            continue;
+        }
+        let node = CognitiveProspective {
+            node_id,
+            description,
+            trigger_condition: CREATIVE_IDEA_TRIGGER.to_string(),
+            action_on_trigger: action,
+            status: "pending".to_string(),
+            priority: 0,
+        };
+        // Reuse the library-owned parser; a corrupt row is skipped, not fatal.
+        if let Ok(idea) = CreativeIdea::from_prospective(&node) {
+            ideas.push(idea);
+        }
+    }
+    Some(latest_revision_per_idea(ideas))
+}
+
+fn string_at(row: &[lbug::Value], idx: usize) -> String {
+    match row.get(idx) {
+        Some(lbug::Value::String(s)) => s.clone(),
+        _ => String::new(),
+    }
+}
+
+/// A short, layperson label for a status (for the pane).
+#[must_use]
+pub fn status_label(status: IdeaStatus) -> &'static str {
+    match status {
+        IdeaStatus::New => "new",
+        IdeaStatus::NeedsRevision => "needs revision",
+        IdeaStatus::NeedsHumanReview => "needs human review",
+        IdeaStatus::AcceptedForImplementation => "accepted",
+        IdeaStatus::Rejected => "rejected",
+        IdeaStatus::Deferred => "deferred",
+        IdeaStatus::ImplementationStarted => "in progress",
+        IdeaStatus::ImplementationCompleted => "completed",
+    }
+}
+
+/// Case-insensitive match of an idea against a free-text `query` (idea + rationale).
+#[must_use]
+pub fn idea_matches(idea: &CreativeIdea, query: &str) -> bool {
+    let q = query.trim().to_ascii_lowercase();
+    if q.is_empty() {
+        return true;
+    }
+    idea.idea.to_ascii_lowercase().contains(&q)
+        || idea.context.rationale.to_ascii_lowercase().contains(&q)
+        || status_label(idea.status).contains(&q)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_on_text_and_status() {
+        let mut idea = CreativeIdea::new("improve recall ranking", ctx(), 1);
+        assert!(idea_matches(&idea, "recall"));
+        assert!(idea_matches(&idea, "")); // empty matches all
+        assert!(idea_matches(&idea, "new")); // status label
+        assert!(!idea_matches(&idea, "zzz-not-present"));
+        idea.status = IdeaStatus::Rejected;
+        assert!(idea_matches(&idea, "rejected"));
+    }
+
+    fn ctx() -> simard::cognitive_memory::creative_idea::IdeaContext {
+        simard::cognitive_memory::creative_idea::IdeaContext {
+            source: "t".into(),
+            goals_snapshot: vec![],
+            observation_digest: String::new(),
+            rationale: "grounded rationale".into(),
+        }
+    }
+}

--- a/src/bin/simard_tui/main.rs
+++ b/src/bin/simard_tui/main.rs
@@ -4,6 +4,7 @@
 //! Tabs switch with Alt+1–7 / ←→ arrow keys, auto-refreshes every 2s, quit with q.
 
 mod app;
+mod creative_ideas;
 mod goals;
 mod journal;
 mod system;

--- a/src/bin/simard_tui/tabs/creative_ideas.rs
+++ b/src/bin/simard_tui/tabs/creative_ideas.rs
@@ -1,0 +1,218 @@
+//! Creative Ideas tab: browse Simard's self-improvement idea pool and search it
+//! by review status or free text.
+//!
+//! Layout mirrors the Journal tab: a newest-first idea list on the left (the
+//! selected idea highlighted, each tagged with its review status) and the
+//! selected idea's detail on the right (text, status, rationale, review and
+//! link counts, and its success metric when one has been set). `/` starts a
+//! search whose query filters the list by text **or** status; an empty pool
+//! renders an honest "no ideas" message.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+
+use crate::app::App;
+use crate::creative_ideas::status_label;
+
+/// Render the Creative Ideas tab content within the given area.
+pub fn draw(f: &mut Frame, app: &App, area: Rect) {
+    let filtered = app.creative_ideas_filtered();
+
+    if filtered.is_empty() {
+        let msg = if app.creative_ideas_entries.is_empty() {
+            "No creative ideas yet — Simard fills this pool as its Creative Ideas thread runs.\n\n\
+             Press 'r' to refresh."
+                .to_string()
+        } else {
+            format!(
+                "No ideas match \"{}\".\n\nPress '/' to edit the search, Esc to clear it.",
+                app.creative_ideas_search
+            )
+        };
+        let p = Paragraph::new(msg)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(search_title(app)),
+            )
+            .wrap(Wrap { trim: false });
+        f.render_widget(p, area);
+        return;
+    }
+
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(40), Constraint::Min(20)])
+        .split(area);
+
+    // ── Left: idea list, selected highlighted, status-tagged ────────────
+    let selected = app.creative_ideas_selected.min(filtered.len() - 1);
+    let items: Vec<ListItem> = filtered
+        .iter()
+        .enumerate()
+        .map(|(i, idea)| {
+            let marker = if i == selected { "▶ " } else { "  " };
+            let line = format!("{marker}[{}] {}", status_label(idea.status), idea.idea);
+            let style = if i == selected {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(status_color(idea.status))
+            };
+            ListItem::new(Line::from(line)).style(style)
+        })
+        .collect();
+
+    let list = List::new(items).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(search_title(app)),
+    );
+    f.render_widget(list, chunks[0]);
+
+    // ── Right: the selected idea's detail ───────────────────────────────
+    let detail_lines: Vec<Line> = match app.creative_ideas_selected_entry() {
+        Some(idea) => {
+            let mut lines = vec![
+                Line::from(idea.idea.clone()),
+                Line::from(""),
+                Line::from(format!("Status: {}", status_label(idea.status))),
+                Line::from(format!(
+                    "Reviews: {}   Links: {}",
+                    idea.reviews.len(),
+                    idea.links.len()
+                )),
+            ];
+            if let Some(metric) = &idea.success_metric {
+                lines.push(Line::from(format!(
+                    "Success metric: {} — target {}",
+                    metric.name, metric.target
+                )));
+            }
+            if !idea.context.rationale.trim().is_empty() {
+                lines.push(Line::from(""));
+                lines.push(Line::from("Why:"));
+                lines.push(Line::from(idea.context.rationale.clone()));
+            }
+            lines
+        }
+        None => vec![Line::from("Select an idea to read its detail.")],
+    };
+    let detail = Paragraph::new(detail_lines)
+        .block(Block::default().borders(Borders::ALL).title("Idea"))
+        .wrap(Wrap { trim: false });
+    f.render_widget(detail, chunks[1]);
+}
+
+/// Title for the list block, reflecting search state and key hints.
+fn search_title(app: &App) -> String {
+    if app.creative_ideas_search_mode {
+        format!("Search: {}_ (Enter/Esc)", app.creative_ideas_search)
+    } else if app.creative_ideas_search.trim().is_empty() {
+        "Creative Ideas — ↑/↓ idea · / search · r reload".to_string()
+    } else {
+        format!("Creative Ideas — filter: {}", app.creative_ideas_search)
+    }
+}
+
+fn status_color(status: simard::cognitive_memory::creative_idea::IdeaStatus) -> Color {
+    use simard::cognitive_memory::creative_idea::IdeaStatus;
+    match status {
+        IdeaStatus::New => Color::Cyan,
+        IdeaStatus::NeedsRevision => Color::Yellow,
+        IdeaStatus::NeedsHumanReview => Color::LightRed,
+        IdeaStatus::AcceptedForImplementation | IdeaStatus::ImplementationStarted => Color::Green,
+        IdeaStatus::ImplementationCompleted => Color::LightGreen,
+        IdeaStatus::Deferred => Color::Gray,
+        IdeaStatus::Rejected => Color::Red,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use simard::cognitive_memory::creative_idea::{CreativeIdea, IdeaContext, IdeaStatus};
+
+    fn ctx() -> IdeaContext {
+        IdeaContext {
+            source: "creative-ideas-thread".into(),
+            goals_snapshot: vec![],
+            observation_digest: String::new(),
+            rationale: "recall precision plateaued for three days".into(),
+        }
+    }
+
+    fn idea(text: &str, status: IdeaStatus) -> CreativeIdea {
+        let mut i = CreativeIdea::new(text, ctx(), 1);
+        i.status = status;
+        i
+    }
+
+    fn render_text(app: &App) -> String {
+        let backend = TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| draw(f, app, Rect::new(0, 0, 100, 30)))
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let mut out = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                if let Some(cell) = buf.cell((x, y)) {
+                    out.push_str(cell.symbol());
+                }
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    #[test]
+    fn pane_renders_ideas_with_status() {
+        let mut app = App::new("simard-ooda.service".to_string(), None);
+        app.creative_ideas_entries = vec![idea("improve recall ranking", IdeaStatus::New)];
+        app.creative_ideas_loaded = true;
+
+        let text = render_text(&app);
+        assert!(
+            text.contains("improve recall ranking"),
+            "idea text shown: {text}"
+        );
+        assert!(text.contains("new"), "status label shown");
+        assert!(
+            text.contains("recall precision plateaued"),
+            "rationale shown"
+        );
+    }
+
+    #[test]
+    fn pane_no_ideas_is_honest() {
+        let app = App::new("simard-ooda.service".to_string(), None);
+        let text = render_text(&app);
+        assert!(
+            text.contains("No creative ideas yet"),
+            "honest empty state: {text}"
+        );
+    }
+
+    #[test]
+    fn search_filters_by_status() {
+        let mut app = App::new("simard-ooda.service".to_string(), None);
+        app.creative_ideas_entries = vec![
+            idea("keep exploring recall", IdeaStatus::New),
+            idea("risky worktree cleanup", IdeaStatus::NeedsHumanReview),
+        ];
+        app.creative_ideas_loaded = true;
+
+        app.creative_ideas_search = "human".to_string();
+        let filtered = app.creative_ideas_filtered();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].status, IdeaStatus::NeedsHumanReview);
+    }
+}

--- a/src/bin/simard_tui/tabs/mod.rs
+++ b/src/bin/simard_tui/tabs/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod activity;
 pub mod chat;
+pub mod creative_ideas;
 pub mod goals;
 pub mod journal;
 pub mod overseer;

--- a/src/bin/simard_tui/ui.rs
+++ b/src/bin/simard_tui/ui.rs
@@ -51,6 +51,7 @@ pub fn draw(f: &mut Frame, app: &App) {
         Tab::Chat => tabs::chat::draw(f, app, chunks[1]),
         Tab::Overseer => tabs::overseer::draw(f, app, chunks[1]),
         Tab::Journal => tabs::journal::draw(f, app, chunks[1]),
+        Tab::CreativeIdeas => tabs::creative_ideas::draw(f, app, chunks[1]),
     }
 
     // If an update notice is available, show it in the footer area
@@ -127,8 +128,8 @@ mod tests {
     /// consolidated view becomes unreachable. Verified purely from the
     /// in-memory buffer — no PTY required.
     #[test]
-    fn tab_bar_lists_all_seven_tabs_without_pty() {
-        const W: u16 = 100;
+    fn tab_bar_lists_all_tabs_without_pty() {
+        const W: u16 = 140;
         const H: u16 = 40;
 
         let app = App::new("simard-ooda.service".to_string(), None);

--- a/src/cognitive_memory/creative_idea.rs
+++ b/src/cognitive_memory/creative_idea.rs
@@ -26,156 +26,27 @@ use crate::creative_ideas::synthesis::SuccessMetric;
 use crate::error::{SimardError, SimardResult};
 use crate::memory_cognitive::CognitiveProspective;
 
-/// Prospective node-type sentinel written to `trigger_condition`. This is the
-/// retrieval key for every stored creative-idea row, so it is a **stable
-/// identifier** — renaming it is a breaking migration, not an edit.
-pub const CREATIVE_IDEA_TRIGGER: &str = "creative-idea";
+// The creative-idea *memory-model* types — the lifecycle state machine and the
+// typed memory-link taxonomy — are owned upstream by `amplihack-memory-lib`
+// (engineering guideline G2: memory-architecture work belongs in the library,
+// not forked into Simard). Simard re-exports them and orchestrates around them:
+// it persists the idea payload through the existing prospective primitive, runs
+// the reviewer pipeline, and routes accepted ideas — all Simard-domain concerns.
+pub use amplihack_memory::creative_idea::{
+    CREATIVE_IDEA_PAYLOAD_VERSION, CREATIVE_IDEA_TRIGGER, CreativeIdeaStatus as IdeaStatus,
+    MemoryLink, MemoryLinkKind,
+};
 
-/// On-disk payload schema version. A row whose `payload_version` is **newer**
-/// than the reader understands is a hard [`SimardError::InvalidCreativeIdeaRecord`]
-/// (fail-closed), never a silent default. Starts at `1`; a future native-links
-/// migration bumps it to `2`.
-pub const CREATIVE_IDEA_PAYLOAD_VERSION: u16 = 1;
-
-/// The lifecycle status of a creative idea.
+/// Parse a persisted idea-status string into an [`IdeaStatus`], mapping the
+/// library's fail-closed parse error into [`SimardError::InvalidCreativeIdeaRecord`].
 ///
-/// `status` changes only through [`CreativeIdea::try_transition`]; see
-/// [`IdeaStatus::can_transition_to`] for the allowed edges.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum IdeaStatus {
-    /// Freshly generated, not yet reviewed.
-    New,
-    /// Synthesis asked for a rewrite before acceptance.
-    NeedsRevision,
-    /// High-risk / flagged: a human must decide.
-    NeedsHumanReview,
-    /// Reviewed and accepted; may be promoted to a goal.
-    AcceptedForImplementation,
-    /// Terminal: rejected.
-    Rejected,
-    /// Parked; may be reconsidered later.
-    Deferred,
-    /// A goal/PR is in flight.
-    ImplementationStarted,
-    /// Terminal: completed — reachable ONLY when the success metric is met.
-    ImplementationCompleted,
-}
-
-impl IdeaStatus {
-    /// Stable string form (matches the serde variant names) used both in the
-    /// mirrored prospective `status` field and in the JSON payload.
-    #[must_use]
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::New => "New",
-            Self::NeedsRevision => "NeedsRevision",
-            Self::NeedsHumanReview => "NeedsHumanReview",
-            Self::AcceptedForImplementation => "AcceptedForImplementation",
-            Self::Rejected => "Rejected",
-            Self::Deferred => "Deferred",
-            Self::ImplementationStarted => "ImplementationStarted",
-            Self::ImplementationCompleted => "ImplementationCompleted",
-        }
-    }
-
-    /// Terminal states have no outgoing transitions.
-    #[must_use]
-    pub fn is_terminal(&self) -> bool {
-        matches!(self, Self::Rejected | Self::ImplementationCompleted)
-    }
-
-    /// Whether `self -> to` is an allowed edge of the state machine.
-    ///
-    /// The full table (anything not listed is rejected):
-    ///
-    /// | From | To |
-    /// |------|----|
-    /// | `New` | `AcceptedForImplementation`, `Rejected`, `Deferred`, `NeedsRevision`, `NeedsHumanReview` |
-    /// | `NeedsRevision` | `New`, `Rejected`, `Deferred` |
-    /// | `NeedsHumanReview` | `AcceptedForImplementation`, `Rejected`, `Deferred` |
-    /// | `Deferred` | `New`, `Rejected` |
-    /// | `AcceptedForImplementation` | `ImplementationStarted`, `Deferred`, `Rejected` |
-    /// | `ImplementationStarted` | `ImplementationCompleted`, `NeedsRevision`, `Rejected` |
-    /// | `Rejected` / `ImplementationCompleted` | *(terminal)* |
-    #[must_use]
-    pub fn can_transition_to(&self, to: Self) -> bool {
-        use IdeaStatus::{
-            AcceptedForImplementation, Deferred, ImplementationCompleted, ImplementationStarted,
-            NeedsHumanReview, NeedsRevision, New, Rejected,
-        };
-        matches!(
-            (self, to),
-            (New, AcceptedForImplementation)
-                | (New, Rejected)
-                | (New, Deferred)
-                | (New, NeedsRevision)
-                | (New, NeedsHumanReview)
-                | (NeedsRevision, New)
-                | (NeedsRevision, Rejected)
-                | (NeedsRevision, Deferred)
-                | (NeedsHumanReview, AcceptedForImplementation)
-                | (NeedsHumanReview, Rejected)
-                | (NeedsHumanReview, Deferred)
-                | (Deferred, New)
-                | (Deferred, Rejected)
-                | (AcceptedForImplementation, ImplementationStarted)
-                | (AcceptedForImplementation, Deferred)
-                | (AcceptedForImplementation, Rejected)
-                | (ImplementationStarted, ImplementationCompleted)
-                | (ImplementationStarted, NeedsRevision)
-                | (ImplementationStarted, Rejected)
-        )
-    }
-}
-
-impl std::str::FromStr for IdeaStatus {
-    type Err = SimardError;
-
-    /// Parse a status string. **Fail-closed**: an unknown value yields
-    /// [`SimardError::InvalidCreativeIdeaRecord`] rather than a silent default.
-    fn from_str(s: &str) -> SimardResult<Self> {
-        match s {
-            "New" => Ok(Self::New),
-            "NeedsRevision" => Ok(Self::NeedsRevision),
-            "NeedsHumanReview" => Ok(Self::NeedsHumanReview),
-            "AcceptedForImplementation" => Ok(Self::AcceptedForImplementation),
-            "Rejected" => Ok(Self::Rejected),
-            "Deferred" => Ok(Self::Deferred),
-            "ImplementationStarted" => Ok(Self::ImplementationStarted),
-            "ImplementationCompleted" => Ok(Self::ImplementationCompleted),
-            other => Err(SimardError::InvalidCreativeIdeaRecord {
-                field: "status".to_string(),
-                reason: format!("unknown idea status '{other}'"),
-            }),
-        }
-    }
-}
-
-impl std::fmt::Display for IdeaStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-/// The kind of memory node a [`MemoryLink`] points at.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum MemoryLinkKind {
-    /// A distilled semantic fact.
-    Semantic,
-    /// An autobiographical episode.
-    Episodic,
-    /// A reusable procedure.
-    Procedural,
-}
-
-/// A typed edge from a [`CreativeIdea`] to another memory node that
-/// supports/resources it.
-///
-/// FUTURE: promote links to native prospective edges (payload_version 2).
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct MemoryLink {
-    pub kind: MemoryLinkKind,
-    pub node_id: String,
+/// **Fail-closed**: an unknown value is a hard error, never a silent default.
+pub fn parse_idea_status(s: &str) -> SimardResult<IdeaStatus> {
+    s.parse::<IdeaStatus>()
+        .map_err(|e| SimardError::InvalidCreativeIdeaRecord {
+            field: "status".to_string(),
+            reason: e.to_string(),
+        })
 }
 
 /// Provenance + situational context captured at generation time.
@@ -194,7 +65,15 @@ pub struct IdeaContext {
 /// A candidate self-improvement idea, stored as a prospective-memory node.
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct CreativeIdea {
-    /// Prospective `node_id` (`""` until stored).
+    /// Stable identity that survives status updates. Prospective memory is
+    /// append-only (no in-place UPDATE), so an update appends a new node with
+    /// the **same** `idea_id`; [`CreativeIdeaStore::list`] then keeps the latest
+    /// node per `idea_id`. Mirrors the goal-store append+dedupe pattern.
+    pub idea_id: String,
+    /// Monotonic revision, bumped by [`CreativeIdeaStore::update`]. Makes
+    /// "keep the latest revision" robust independent of node-id ordering.
+    pub revision: u64,
+    /// Prospective `node_id` of the most-recent revision (`""` until stored).
     pub node_id: String,
     /// The idea text (-> prospective `description`).
     pub idea: String,
@@ -202,7 +81,7 @@ pub struct CreativeIdea {
     pub status: IdeaStatus,
     /// Provenance/situational context (-> payload).
     pub context: IdeaContext,
-    /// Supporting semantic/episodic/procedural nodes (-> payload).
+    /// Supporting semantic/episodic/procedural/goal nodes (-> payload).
     pub links: Vec<MemoryLink>,
     /// Accumulated reviewer output (-> payload).
     pub reviews: Vec<Review>,
@@ -214,10 +93,13 @@ pub struct CreativeIdea {
 }
 
 impl CreativeIdea {
-    /// Build a fresh `New` idea with no reviews/metric yet.
+    /// Build a fresh `New` idea with no reviews/metric yet and a freshly-minted
+    /// stable [`Self::idea_id`].
     #[must_use]
     pub fn new(idea: impl Into<String>, context: IdeaContext, created_epoch: u64) -> Self {
         Self {
+            idea_id: uuid::Uuid::new_v4().to_string(),
+            revision: 0,
             node_id: String::new(),
             idea: idea.into(),
             status: IdeaStatus::New,
@@ -259,6 +141,8 @@ impl CreativeIdea {
     pub fn to_action_payload(&self) -> SimardResult<String> {
         let payload = StoredPayload {
             payload_version: CREATIVE_IDEA_PAYLOAD_VERSION,
+            idea_id: self.idea_id.clone(),
+            revision: self.revision,
             status: self.status,
             context: self.context.clone(),
             links: self.links.clone(),
@@ -312,7 +196,16 @@ impl CreativeIdea {
             .into_iter()
             .map(PersistedReview::into_review)
             .collect::<SimardResult<Vec<_>>>()?;
+        // Legacy rows written before `idea_id` existed fall back to the node_id
+        // as a stable-enough identity (each such row is its own idea).
+        let idea_id = if payload.idea_id.is_empty() {
+            node.node_id.clone()
+        } else {
+            payload.idea_id
+        };
         Ok(Self {
+            idea_id,
+            revision: payload.revision,
             node_id: node.node_id.clone(),
             idea: node.description.clone(),
             status: payload.status,
@@ -329,6 +222,10 @@ impl CreativeIdea {
 #[derive(Serialize, Deserialize)]
 struct StoredPayload {
     payload_version: u16,
+    #[serde(default)]
+    idea_id: String,
+    #[serde(default)]
+    revision: u64,
     status: IdeaStatus,
     context: IdeaContext,
     links: Vec<MemoryLink>,
@@ -382,15 +279,54 @@ impl PersistedReview {
 ///
 /// The production adapter is [`ProspectiveCreativeIdeaStore`]; tests use an
 /// in-memory fake. No new storage backend is introduced.
+///
+/// Prospective memory is append-only, so [`Self::update`] appends a new node
+/// carrying the same [`CreativeIdea::idea_id`]; [`Self::list`] then collapses
+/// each `idea_id` to its most-recent node so an idea appears **once** at its
+/// current status.
 pub trait CreativeIdeaStore {
     /// Persist a new idea; returns its prospective `node_id`.
     fn store(&self, idea: &CreativeIdea) -> SimardResult<String>;
-    /// Re-serialize an existing idea's payload/status.
+    /// Append an updated revision of an existing idea (same `idea_id`).
     fn update(&self, idea: &CreativeIdea) -> SimardResult<()>;
-    /// List up to `limit` stored creative ideas (filtered by the sentinel).
+    /// List up to `limit` current creative ideas (latest revision per `idea_id`).
     fn list(&self, limit: u32) -> SimardResult<Vec<CreativeIdea>>;
-    /// Fetch one idea by `node_id`.
+    /// Fetch one idea by its current `node_id`.
     fn get(&self, node_id: &str) -> SimardResult<Option<CreativeIdea>>;
+    /// List current ideas whose status equals `status` (enumerable-by-status).
+    fn list_by_status(&self, status: IdeaStatus, limit: u32) -> SimardResult<Vec<CreativeIdea>> {
+        Ok(self
+            .list(limit)?
+            .into_iter()
+            .filter(|idea| idea.status == status)
+            .collect())
+    }
+}
+
+/// Collapse an append-only stream of creative-idea revisions to the current
+/// state: for each `idea_id`, keep the row with the greatest `(revision,
+/// node_id)`. The monotonic `revision` (bumped by [`CreativeIdeaStore::update`])
+/// makes this robust independent of `node_id` ordering. Public so read-only
+/// consumers (the dashboard, the TUI) collapse revisions identically.
+#[must_use]
+pub fn latest_revision_per_idea(mut ideas: Vec<CreativeIdea>) -> Vec<CreativeIdea> {
+    use std::collections::HashMap;
+    fn rank(i: &CreativeIdea) -> (u64, &str) {
+        (i.revision, i.node_id.as_str())
+    }
+    let mut latest: HashMap<String, CreativeIdea> = HashMap::new();
+    for idea in ideas.drain(..) {
+        match latest.get(&idea.idea_id) {
+            Some(existing) if rank(existing) >= rank(&idea) => {}
+            _ => {
+                latest.insert(idea.idea_id.clone(), idea);
+            }
+        }
+    }
+    let mut out: Vec<CreativeIdea> = latest.into_values().collect();
+    // Deterministic order: highest revision (newest) first.
+    out.sort_by(|a, b| rank(b).cmp(&rank(a)));
+    out
 }
 
 /// Production [`CreativeIdeaStore`] over [`CognitiveMemoryOps`] — thin, no new
@@ -405,6 +341,17 @@ impl<'a> ProspectiveCreativeIdeaStore<'a> {
     pub fn new(mem: &'a dyn CognitiveMemoryOps) -> Self {
         Self { mem }
     }
+
+    /// Every stored revision (no dedupe) filtered by the sentinel — the raw
+    /// append-only stream. Used internally by [`Self::list`] and by tests.
+    fn all_revisions(&self, limit: u32) -> SimardResult<Vec<CreativeIdea>> {
+        let nodes = self.mem.list_all_prospective(limit)?;
+        nodes
+            .iter()
+            .filter(|n| n.trigger_condition == CREATIVE_IDEA_TRIGGER)
+            .map(CreativeIdea::from_prospective)
+            .collect()
+    }
 }
 
 impl CreativeIdeaStore for ProspectiveCreativeIdeaStore<'_> {
@@ -415,22 +362,26 @@ impl CreativeIdeaStore for ProspectiveCreativeIdeaStore<'_> {
     }
 
     fn update(&self, idea: &CreativeIdea) -> SimardResult<()> {
-        // FUTURE (M2): a real upsert-by-node_id in the memory layer. During the
-        // spike `store_prospective` is the only write seam, so `update`
-        // re-persists the payload; callers treat ideas as append-only for now.
-        let action = idea.to_action_payload()?;
+        // Append-only backend: re-persist under the same `idea_id` at the next
+        // revision. Computing the revision from the current max makes "latest
+        // wins" robust without any caller bookkeeping.
+        let next_revision = self
+            .all_revisions(u32::MAX)?
+            .iter()
+            .filter(|i| i.idea_id == idea.idea_id)
+            .map(|i| i.revision)
+            .max()
+            .map_or(1, |m| m.saturating_add(1));
+        let mut to_store = idea.clone();
+        to_store.revision = next_revision;
+        let action = to_store.to_action_payload()?;
         self.mem
             .store_prospective(&idea.idea, CREATIVE_IDEA_TRIGGER, &action, idea.priority())?;
         Ok(())
     }
 
     fn list(&self, limit: u32) -> SimardResult<Vec<CreativeIdea>> {
-        let nodes = self.mem.list_all_prospective(limit)?;
-        nodes
-            .iter()
-            .filter(|n| n.trigger_condition == CREATIVE_IDEA_TRIGGER)
-            .map(CreativeIdea::from_prospective)
-            .collect()
+        Ok(latest_revision_per_idea(self.all_revisions(limit)?))
     }
 
     fn get(&self, node_id: &str) -> SimardResult<Option<CreativeIdea>> {

--- a/src/cognitive_threads/threads/creative_ideas.rs
+++ b/src/cognitive_threads/threads/creative_ideas.rs
@@ -29,10 +29,19 @@ use crate::cognitive_memory::creative_idea::{
 };
 use crate::creative_ideas::CreativeIdeasConfig;
 use crate::creative_ideas::dedup;
+use crate::creative_ideas::pipeline::{AgenticIdeaPipeline, IdeaPipeline, RouteOutcome};
+use crate::creative_ideas::source::AgenticIdeaSource;
 use crate::error::{SimardError, SimardResult};
 
 /// Stable telemetry id.
 pub const CREATIVE_IDEAS_ID: &str = "creative_ideas";
+
+/// How many recent episodes/entries to fold into the observation window.
+const OBSERVATION_LIMIT: usize = 20;
+/// How many stored episodes to scan for the observation window.
+const EPISODE_SCAN_LIMIT: u32 = 200;
+/// How many previously-generated ideas to load for dedup/novelty.
+const PREVIOUS_IDEAS_LIMIT: u32 = 256;
 
 /// A >= 24h window of recent progress & behavior (from the Journal / OODA).
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -115,26 +124,11 @@ impl IdeaSource for FakeIdeaSource {
     }
 }
 
-/// Production idea source — a marked `// FUTURE:` stub for the spike.
-///
-/// FUTURE (M2): the real LLM-backed generator producing diverse ideas from the
-/// observation window. Until then `generate` returns
-/// [`SimardError::ReviewUnavailable`]; the thread is gated OFF so it never runs.
-#[derive(Clone, Debug, Default)]
-pub struct LlmIdeaSource;
-
-impl IdeaSource for LlmIdeaSource {
-    fn generate(&self, _inputs: &GenerationInputs, _n: usize) -> SimardResult<Vec<RawIdea>> {
-        Err(SimardError::ReviewUnavailable {
-            reason: "LlmIdeaSource is not wired during the spike (M2)".to_string(),
-        })
-    }
-}
-
 /// The Creative Ideas generator cognitive thread.
 pub struct CreativeIdeasThread {
     cfg: CreativeIdeasConfig,
     source: Box<dyn IdeaSource>,
+    pipeline: Box<dyn IdeaPipeline>,
     last_run_epoch: Option<u64>,
     next_run_epoch: Option<u64>,
     last_success: Option<bool>,
@@ -142,12 +136,25 @@ pub struct CreativeIdeasThread {
 }
 
 impl CreativeIdeasThread {
-    /// Build the thread from an explicit config + idea source (test seam).
+    /// Build the thread from an explicit config + idea source, defaulting to the
+    /// production review/route pipeline (test seam).
     #[must_use]
     pub fn new(cfg: CreativeIdeasConfig, source: Box<dyn IdeaSource>) -> Self {
+        Self::with_pipeline(cfg, source, Box::new(AgenticIdeaPipeline::from_env()))
+    }
+
+    /// Build with an explicit config, idea source, and review/route pipeline
+    /// (the fully-injectable test seam).
+    #[must_use]
+    pub fn with_pipeline(
+        cfg: CreativeIdeasConfig,
+        source: Box<dyn IdeaSource>,
+        pipeline: Box<dyn IdeaPipeline>,
+    ) -> Self {
         Self {
             cfg,
             source,
+            pipeline,
             last_run_epoch: None,
             next_run_epoch: None,
             last_success: None,
@@ -155,10 +162,14 @@ impl CreativeIdeasThread {
         }
     }
 
-    /// Build from the environment with the production (FUTURE) idea source.
+    /// Build from the environment with the production idea source + pipeline.
     #[must_use]
     pub fn from_env() -> Self {
-        Self::new(CreativeIdeasConfig::from_env(), Box::new(LlmIdeaSource))
+        Self::with_pipeline(
+            CreativeIdeasConfig::from_env(),
+            Box::new(AgenticIdeaSource::from_env()),
+            Box::new(AgenticIdeaPipeline::from_env()),
+        )
     }
 
     /// The core, fallible tick body. `tick` wraps this and folds any `Err` into
@@ -174,34 +185,180 @@ impl CreativeIdeasThread {
         let selected = dedup::select_balanced(deduped, self.cfg.batch);
         let surviving = selected.len();
 
-        let mut persisted = 0usize;
-        if !ctx.dry_run {
-            let store = ProspectiveCreativeIdeaStore::new(ctx.memory);
-            for raw_idea in &selected {
-                if ctx.shutdown.load(Ordering::Relaxed) {
-                    break;
+        let mut report = GenerationReport {
+            generated,
+            surviving,
+            persisted: 0,
+            reviewed: 0,
+            routed_goal: 0,
+            routed_issue: 0,
+            review_errors: 0,
+            dry_run: ctx.dry_run,
+        };
+
+        for raw_idea in &selected {
+            if ctx.shutdown.load(Ordering::Relaxed) {
+                break;
+            }
+            let mut idea = raw_to_creative_idea(raw_idea, &inputs, ctx.now_epoch);
+
+            // Persist the freshly-generated `New` idea (skipped under dry-run).
+            if !ctx.dry_run {
+                let store = ProspectiveCreativeIdeaStore::new(ctx.memory);
+                idea.node_id = store.store(&idea)?;
+                report.persisted += 1;
+            }
+
+            // Review + route. A single idea's failure is logged (explicit
+            // telemetry — no silent fallback) and never aborts the batch.
+            match self.pipeline.review_and_route(&mut idea, &inputs, ctx) {
+                Ok(RouteOutcome::Goal) => {
+                    report.reviewed += 1;
+                    report.routed_goal += 1;
                 }
-                let idea = raw_to_creative_idea(raw_idea, &inputs, ctx.now_epoch);
-                store.store(&idea)?;
-                persisted += 1;
+                Ok(RouteOutcome::Issue) => {
+                    report.reviewed += 1;
+                    report.routed_issue += 1;
+                }
+                Ok(RouteOutcome::Parked | RouteOutcome::DryRun) => {
+                    report.reviewed += 1;
+                }
+                Err(error) => {
+                    report.review_errors += 1;
+                    tracing::warn!(
+                        target: "creative_ideas",
+                        error = %error,
+                        idea_id = %idea.idea_id,
+                        "[simard] creative-ideas review/route failed for one idea"
+                    );
+                }
             }
         }
 
-        Ok(GenerationReport {
-            generated,
-            surviving,
-            persisted,
-            dry_run: ctx.dry_run,
-        })
+        Ok(report)
     }
 
-    /// Assemble the (read-only) observation window.
+    /// Assemble the (read-only) observation window from the goal board, recent
+    /// journal/OODA activity, episodic memory, the Overseer's observations,
+    /// conversation insights, and previously-generated ideas.
     ///
-    /// FUTURE (M2): populate from the goal store / Journal / OODA / Overseer /
-    /// conversation insights / previous ideas. During the spike this is empty
-    /// so the gated-OFF thread has no external reads.
-    fn assemble_inputs(&self, _ctx: &ThreadContext<'_>) -> GenerationInputs {
-        GenerationInputs::default()
+    /// Best-effort: each source that fails to read emits explicit `tracing`
+    /// telemetry (never a silent fallback) and generation proceeds on whatever
+    /// context is available — the generator reasons about partial context.
+    fn assemble_inputs(&self, ctx: &ThreadContext<'_>) -> GenerationInputs {
+        let mut inputs = GenerationInputs::default();
+
+        match crate::goal_curation::load_goal_board(ctx.memory) {
+            Ok(board) => {
+                inputs.current_goals = board
+                    .active
+                    .iter()
+                    .map(|g| g.description.clone())
+                    .chain(board.backlog.iter().map(|b| b.description.clone()))
+                    .filter(|d| !d.trim().is_empty())
+                    .collect();
+                inputs.works_in_progress = board
+                    .active
+                    .iter()
+                    .filter_map(|g| {
+                        let assignee = g.assigned_to.as_deref()?;
+                        let activity = g.current_activity.as_deref().unwrap_or("in progress");
+                        Some(format!("{} — {assignee}: {activity}", g.description))
+                    })
+                    .collect();
+            }
+            Err(error) => tracing::warn!(
+                target: "creative_ideas",
+                error = %error,
+                "[simard] creative-ideas could not load the goal board for inputs"
+            ),
+        }
+
+        match ctx.memory.list_all_episodes(EPISODE_SCAN_LIMIT) {
+            Ok(episodes) => {
+                inputs.episodic_summaries = episodes
+                    .iter()
+                    .take(OBSERVATION_LIMIT)
+                    .map(|e| e.content.clone())
+                    .filter(|c| !c.trim().is_empty())
+                    .collect();
+            }
+            Err(error) => tracing::warn!(
+                target: "creative_ideas",
+                error = %error,
+                "[simard] creative-ideas could not read episodic memory for inputs"
+            ),
+        }
+
+        match crate::journal::store::all_entries(ctx.memory) {
+            Ok(entries) => {
+                let mut window = ActivityWindow {
+                    window_secs: self.cfg.interval_secs,
+                    entries: Vec::new(),
+                };
+                window.entries = entries
+                    .iter()
+                    .rev()
+                    .take(OBSERVATION_LIMIT)
+                    .filter(|e| !e.quiet_day && !e.narrative.trim().is_empty())
+                    .map(|e| format!("{}: {}", e.date, e.narrative))
+                    .collect();
+                inputs.recent_activity = window;
+            }
+            Err(error) => tracing::warn!(
+                target: "creative_ideas",
+                error = %error,
+                "[simard] creative-ideas could not read the journal for inputs"
+            ),
+        }
+
+        let activity_path = ctx.state_root.join("overseer").join("activity.json");
+        if let Some(activity) = crate::overseer::activity::read(&activity_path) {
+            inputs.overseer_observations = activity
+                .recent
+                .iter()
+                .take(OBSERVATION_LIMIT)
+                .filter_map(|record| {
+                    serde_json::to_string(&record.report)
+                        .ok()
+                        .map(|report| format!("{}: {report}", record.timestamp))
+                })
+                .collect();
+        }
+
+        match ctx.memory.search_episodes_by_keywords(
+            &[
+                "meeting".to_string(),
+                "conversation".to_string(),
+                "decision".to_string(),
+            ],
+            OBSERVATION_LIMIT as u32,
+        ) {
+            Ok(episodes) => {
+                inputs.conversation_insights = episodes
+                    .iter()
+                    .map(|e| e.content.clone())
+                    .filter(|c| !c.trim().is_empty())
+                    .collect();
+            }
+            Err(error) => tracing::warn!(
+                target: "creative_ideas",
+                error = %error,
+                "[simard] creative-ideas could not read conversation insights for inputs"
+            ),
+        }
+
+        let store = ProspectiveCreativeIdeaStore::new(ctx.memory);
+        match store.list(PREVIOUS_IDEAS_LIMIT) {
+            Ok(previous) => inputs.previous_ideas = previous,
+            Err(error) => tracing::warn!(
+                target: "creative_ideas",
+                error = %error,
+                "[simard] creative-ideas could not load previous ideas for dedup"
+            ),
+        }
+
+        inputs
     }
 
     fn record_success(&mut self, now_epoch: u64) {
@@ -224,6 +381,10 @@ struct GenerationReport {
     generated: usize,
     surviving: usize,
     persisted: usize,
+    reviewed: usize,
+    routed_goal: usize,
+    routed_issue: usize,
+    review_errors: usize,
     dry_run: bool,
 }
 
@@ -269,13 +430,24 @@ impl CognitiveThread for CreativeIdeasThread {
                     "generated"
                 };
                 let summary = format!(
-                    "creative_ideas: {verb} {} idea(s), {} survived dedup, {} persisted",
-                    report.generated, report.surviving, report.persisted,
+                    "creative_ideas: {verb} {} idea(s), {} survived dedup, {} persisted, \
+                     {} reviewed ({} → goal, {} → issue), {} review error(s)",
+                    report.generated,
+                    report.surviving,
+                    report.persisted,
+                    report.reviewed,
+                    report.routed_goal,
+                    report.routed_issue,
+                    report.review_errors,
                 );
                 let detail = json!({
                     "generated": report.generated,
                     "surviving": report.surviving,
                     "persisted": report.persisted,
+                    "reviewed": report.reviewed,
+                    "routed_goal": report.routed_goal,
+                    "routed_issue": report.routed_issue,
+                    "review_errors": report.review_errors,
                     "dry_run": report.dry_run,
                 });
                 ThreadOutcome::ok(summary, start.elapsed()).with_detail(detail)
@@ -321,13 +493,16 @@ fn raw_to_creative_idea(raw: &RawIdea, inputs: &GenerationInputs, now_epoch: u64
     idea
 }
 
-/// Register the thread with the `Mind` scheduler.
+/// Register the Creative Ideas thread with the `Mind` scheduler.
 ///
-/// FUTURE (M2): call site in the daemon `main`, still behind
-/// `SIMARD_CREATIVE_IDEAS_ENABLED`. **NOT** called during the spike; the
-/// production idea source ([`LlmIdeaSource`]) is itself a not-wired stub, so a
-/// registered-but-enabled thread would only ever emit `ThreadOutcome::failed`.
+/// Called from the daemon startup path behind `SIMARD_CREATIVE_IDEAS_ENABLED`
+/// (default-ON, opt-out). Builds the production idea source + review/route
+/// pipeline; the thread's `enabled()` gate still makes an opted-out thread inert.
 pub fn register(mind: &mut Mind, config: CreativeIdeasConfig) {
-    let thread = CreativeIdeasThread::new(config, Box::new(LlmIdeaSource));
+    let thread = CreativeIdeasThread::with_pipeline(
+        config,
+        Box::new(AgenticIdeaSource::from_env()),
+        Box::new(AgenticIdeaPipeline::from_env()),
+    );
     mind.register(Box::new(thread));
 }

--- a/src/creative_ideas/mod.rs
+++ b/src/creative_ideas/mod.rs
@@ -17,8 +17,11 @@
 #![allow(dead_code)]
 
 pub mod dedup;
+pub mod pipeline;
+pub mod prompt;
 pub mod reviewers;
 pub mod routing;
+pub mod source;
 pub mod synthesis;
 
 #[cfg(test)]
@@ -46,11 +49,12 @@ pub const CREATIVE_IDEA_OWNER: &str = "rysweet";
 
 /// Configuration + gating for the Creative Ideas subsystem.
 ///
-/// A default-constructed config is **disabled**. [`Self::from_env`] is the
-/// single source of truth for gating and cadence.
+/// A default-constructed config is **enabled** (default-ON, opt-out) —
+/// consistent with the Overseer and Journal cognitive threads.
+/// [`Self::from_env`] is the single source of truth for gating and cadence.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreativeIdeasConfig {
-    /// `SIMARD_CREATIVE_IDEAS_ENABLED` (default `false`).
+    /// `SIMARD_CREATIVE_IDEAS_ENABLED` (default `true`; opt-out via a falsey value).
     pub enabled: bool,
     /// `SIMARD_CREATIVE_IDEAS_INTERVAL_SECS` (default `86_400`).
     pub interval_secs: u64,
@@ -61,7 +65,7 @@ pub struct CreativeIdeasConfig {
 impl Default for CreativeIdeasConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             interval_secs: DEFAULT_INTERVAL_SECS,
             batch: DEFAULT_BATCH,
         }
@@ -77,14 +81,15 @@ impl CreativeIdeasConfig {
 
     /// Parse from an arbitrary env resolver (test seam).
     ///
-    /// The truthy check mirrors the Overseer's gate: only an explicit truthy
-    /// value enables the subsystem; unset/empty/garbage leaves it OFF.
+    /// The gate mirrors the Overseer/Journal pattern: the subsystem is
+    /// **default-ON** and only an explicit *falsey* value opts out; unset/empty
+    /// leaves it enabled.
     #[must_use]
     pub fn from_lookup(lookup: impl Fn(&str) -> Option<String>) -> Self {
-        let enabled = lookup(ENABLED_ENV)
+        let enabled = !lookup(ENABLED_ENV)
             .as_deref()
             .map(str::trim)
-            .is_some_and(is_truthy);
+            .is_some_and(is_falsey);
         let interval_secs = lookup(INTERVAL_SECS_ENV)
             .as_deref()
             .map(str::trim)
@@ -104,15 +109,18 @@ impl CreativeIdeasConfig {
         }
     }
 
-    /// True only when the master switch is truthy.
+    /// True unless the master switch was explicitly set to a falsey value.
     #[must_use]
     pub fn enabled(&self) -> bool {
         self.enabled
     }
 }
 
-/// Recognise an explicit truthy env value (case-insensitive; trimmed). Anything
-/// else — including `0`/`false`/empty/unset — is falsey.
-fn is_truthy(v: &str) -> bool {
-    matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+/// Recognise an explicit falsey env value (case-insensitive; trimmed). Anything
+/// else — including unset/empty and truthy values — leaves the subsystem ON.
+fn is_falsey(v: &str) -> bool {
+    matches!(
+        v.to_ascii_lowercase().as_str(),
+        "0" | "false" | "no" | "off"
+    )
 }

--- a/src/creative_ideas/pipeline.rs
+++ b/src/creative_ideas/pipeline.rs
@@ -1,0 +1,174 @@
+//! The review-and-route pipeline for one freshly-generated idea.
+//!
+//! [`IdeaPipeline`] is the seam the generator thread uses to turn a `New` idea
+//! into a reviewed, routed one: it runs the four-reviewer pipeline, lets
+//! [`DefaultSynthesizer`] set the terminal status (via the fail-closed
+//! state machine), then routes per that status — accepted → a **goal**,
+//! human-review-flagged → a labeled + owner-tagged **issue** — and persists the
+//! reviewed revision. The production [`AgenticIdeaPipeline`] wires the real
+//! agent reviewers, the real `gh` seam, and the production goal store; tests
+//! inject fakes.
+//!
+//! Destructive side-effects (goal/issue writes and the memory update) are
+//! suppressed under `ctx.dry_run`: a dry-run still generates and reviews, but
+//! writes nothing.
+#![allow(dead_code)]
+
+use std::path::Path;
+
+use crate::cognitive_memory::creative_idea::{
+    CreativeIdea, CreativeIdeaStore, IdeaStatus, ProspectiveCreativeIdeaStore,
+};
+use crate::cognitive_threads::ThreadContext;
+use crate::cognitive_threads::threads::creative_ideas::GenerationInputs;
+use crate::creative_ideas::reviewers::{
+    AgentInvoker, CrustyOldEngineerReviewer, MeasurabilityReviewer, PhilosophyGuardianReviewer,
+    Reviewer, SessionAgentInvoker, run_review_pipeline,
+};
+use crate::creative_ideas::routing::{
+    IdeaGhClient, RealIdeaGhClient, route_idea_to_goal, route_idea_to_issue,
+};
+use crate::creative_ideas::synthesis::DefaultSynthesizer;
+use crate::error::SimardResult;
+use crate::goals::{CognitiveMemoryGoalStore, GoalStore};
+
+/// Env var overriding the `owner/name` repo slug the routing seam targets.
+pub const REPO_ENV: &str = "SIMARD_REPO";
+/// Default repo slug (matches the operator-CLI / stewardship default).
+pub const DEFAULT_REPO: &str = "rysweet/Simard";
+
+/// Resolve the `owner/name` repo slug from the environment.
+#[must_use]
+pub fn repo_slug_from_env() -> String {
+    std::env::var(REPO_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_REPO.to_string())
+}
+
+/// Where an idea was routed after review (for telemetry).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RouteOutcome {
+    /// Accepted → a `Proposed` goal was created; idea → `ImplementationStarted`.
+    Goal,
+    /// Human-review-flagged → a labeled, owner-tagged issue was filed.
+    Issue,
+    /// Reviewed to a non-routing status (rejected / deferred / needs-revision).
+    Parked,
+    /// Dry-run: reviewed but nothing was written or routed.
+    DryRun,
+}
+
+/// One idea's review-and-route step.
+pub trait IdeaPipeline: Send {
+    /// Review `idea` (mutating its reviews/status via the fail-closed state
+    /// machine) and, unless `ctx.dry_run`, route it and persist the revision.
+    fn review_and_route(
+        &self,
+        idea: &mut CreativeIdea,
+        inputs: &GenerationInputs,
+        ctx: &ThreadContext<'_>,
+    ) -> SimardResult<RouteOutcome>;
+}
+
+/// Opens the production goal store for a given state root. A seam so tests can
+/// inject an in-memory store without touching disk.
+pub trait GoalStoreFactory: Send {
+    /// Open a goal store rooted at `state_root`.
+    fn open(&self, state_root: &Path) -> SimardResult<Box<dyn GoalStore>>;
+}
+
+/// Production factory: the cognitive-memory-backed goal store (the same store
+/// the engineer/overseer pipeline consumes).
+#[derive(Default)]
+pub struct CognitiveMemoryGoalStoreFactory;
+
+impl GoalStoreFactory for CognitiveMemoryGoalStoreFactory {
+    fn open(&self, state_root: &Path) -> SimardResult<Box<dyn GoalStore>> {
+        Ok(Box::new(CognitiveMemoryGoalStore::new(
+            state_root.to_path_buf(),
+        )?))
+    }
+}
+
+/// Production [`IdeaPipeline`]: real agent reviewers + real `gh` + goal store.
+pub struct AgenticIdeaPipeline {
+    invoker: Box<dyn AgentInvoker + Send>,
+    gh: Box<dyn IdeaGhClient + Send>,
+    goals: Box<dyn GoalStoreFactory>,
+    repo: String,
+}
+
+impl AgenticIdeaPipeline {
+    /// Build with explicit seams (test seam).
+    #[must_use]
+    pub fn new(
+        invoker: Box<dyn AgentInvoker + Send>,
+        gh: Box<dyn IdeaGhClient + Send>,
+        goals: Box<dyn GoalStoreFactory>,
+        repo: String,
+    ) -> Self {
+        Self {
+            invoker,
+            gh,
+            goals,
+            repo,
+        }
+    }
+
+    /// Build the production pipeline (real session invoker, real `gh`, real goal
+    /// store, repo slug from the environment).
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self::new(
+            Box::new(SessionAgentInvoker::new()),
+            Box::new(RealIdeaGhClient::new()),
+            Box::new(CognitiveMemoryGoalStoreFactory),
+            repo_slug_from_env(),
+        )
+    }
+}
+
+impl IdeaPipeline for AgenticIdeaPipeline {
+    fn review_and_route(
+        &self,
+        idea: &mut CreativeIdea,
+        inputs: &GenerationInputs,
+        ctx: &ThreadContext<'_>,
+    ) -> SimardResult<RouteOutcome> {
+        // 1. Review: all four reviewers contribute, synthesis sets the status.
+        let invoker = self.invoker.as_ref();
+        let crusty = CrustyOldEngineerReviewer::new(invoker);
+        let philosophy = PhilosophyGuardianReviewer::new(invoker);
+        let measurability = MeasurabilityReviewer::new(invoker);
+        let reviewers: [&dyn Reviewer; 3] = [&crusty, &philosophy, &measurability];
+        run_review_pipeline(idea, inputs, &reviewers, &DefaultSynthesizer)?;
+
+        // 2. Dry-run: reviewed, but write and route nothing.
+        if ctx.dry_run {
+            return Ok(RouteOutcome::DryRun);
+        }
+
+        // 3. Route per the synthesized status.
+        let outcome = match idea.status {
+            IdeaStatus::AcceptedForImplementation => {
+                let goals = self.goals.open(ctx.state_root)?;
+                route_idea_to_goal(idea, goals.as_ref(), ctx.now_epoch)?;
+                // The idea moves into flight once the goal exists.
+                idea.try_transition(IdeaStatus::ImplementationStarted)?;
+                RouteOutcome::Goal
+            }
+            IdeaStatus::NeedsHumanReview => {
+                route_idea_to_issue(idea, self.gh.as_ref(), &self.repo)?;
+                RouteOutcome::Issue
+            }
+            _ => RouteOutcome::Parked,
+        };
+
+        // 4. Persist the reviewed (and possibly transitioned) revision.
+        let store = ProspectiveCreativeIdeaStore::new(ctx.memory);
+        store.update(idea)?;
+        Ok(outcome)
+    }
+}

--- a/src/creative_ideas/prompt.rs
+++ b/src/creative_ideas/prompt.rs
@@ -1,0 +1,189 @@
+//! Prompt rendering + tolerant JSON extraction for the Creative Ideas agents.
+//!
+//! The idea source and the reviewer adapters follow guideline **G3**: they ship
+//! a prompt asset with an explicit JSON output contract, invoke an agent, and
+//! extract the structured envelope tolerantly (fenced ```json block, or the
+//! widest brace/bracket span) rather than brittle line parsing. Extraction is
+//! **fail-closed** at the call site: a response with no JSON envelope is a hard
+//! error, never a silent default.
+#![allow(dead_code)]
+
+use crate::cognitive_threads::threads::creative_ideas::GenerationInputs;
+
+/// Maximum entries rendered per context section (keeps prompts bounded).
+const MAX_SECTION_ENTRIES: usize = 12;
+
+/// Extract the first parseable JSON value from an agent's raw response.
+///
+/// Tries, in order: fenced code blocks, the widest `{...}` object span, the
+/// widest `[...]` array span, then the whole trimmed string. Returns `None`
+/// when nothing parses — callers treat that as a fail-closed error.
+#[must_use]
+pub fn extract_json_value(raw: &str) -> Option<serde_json::Value> {
+    for block in fenced_blocks(raw) {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(block.trim()) {
+            return Some(v);
+        }
+    }
+    // Prefer whichever structure opens first (outermost), falling back to the
+    // other so an inner object inside an array is not mistaken for the whole.
+    let obj_start = raw.find('{');
+    let arr_start = raw.find('[');
+    let object = || widest_span(raw, '{', '}');
+    let array = || widest_span(raw, '[', ']');
+    let (first, second): (
+        &dyn Fn() -> Option<serde_json::Value>,
+        &dyn Fn() -> Option<serde_json::Value>,
+    ) = match (obj_start, arr_start) {
+        (Some(o), Some(a)) if a < o => (&array, &object),
+        _ => (&object, &array),
+    };
+    if let Some(v) = first() {
+        return Some(v);
+    }
+    if let Some(v) = second() {
+        return Some(v);
+    }
+    serde_json::from_str::<serde_json::Value>(raw.trim()).ok()
+}
+
+/// Yield the bodies of ```` ``` ````-fenced blocks (with any leading `json`
+/// info-string stripped), longest-looking first is not required — callers try
+/// each in order.
+fn fenced_blocks(raw: &str) -> Vec<String> {
+    let mut blocks = Vec::new();
+    let mut rest = raw;
+    while let Some(open) = rest.find("```") {
+        let after_open = &rest[open + 3..];
+        let Some(close_rel) = after_open.find("```") else {
+            break;
+        };
+        let body = &after_open[..close_rel];
+        // Strip an optional info string on the same line as the opening fence.
+        let body = match body.split_once('\n') {
+            Some((first, tail)) if first.trim().chars().all(|c| c.is_alphanumeric()) => tail,
+            _ => body,
+        };
+        blocks.push(body.to_string());
+        rest = &after_open[close_rel + 3..];
+    }
+    blocks
+}
+
+/// Parse the widest balanced span delimited by `open`/`close` as JSON.
+fn widest_span(raw: &str, open: char, close: char) -> Option<serde_json::Value> {
+    let start = raw.find(open)?;
+    let end = raw.rfind(close)?;
+    if end <= start {
+        return None;
+    }
+    serde_json::from_str::<serde_json::Value>(&raw[start..=end]).ok()
+}
+
+/// Render the review context block from the generation inputs (bounded).
+#[must_use]
+pub fn render_review_context(inputs: &GenerationInputs) -> String {
+    let mut out = String::new();
+    section(&mut out, "Current goals", &inputs.current_goals);
+    section(&mut out, "Recent activity", &inputs.recent_activity.entries);
+    section(&mut out, "Episodic summaries", &inputs.episodic_summaries);
+    section(&mut out, "Works in progress", &inputs.works_in_progress);
+    section(
+        &mut out,
+        "Overseer observations",
+        &inputs.overseer_observations,
+    );
+    section(
+        &mut out,
+        "Conversation insights",
+        &inputs.conversation_insights,
+    );
+    if out.is_empty() {
+        out.push_str("(no additional context available)\n");
+    }
+    out
+}
+
+/// Render the full generation prompt from a template + inputs, targeting
+/// `count` ideas.
+#[must_use]
+pub fn render_generation_prompt(template: &str, inputs: &GenerationInputs, count: usize) -> String {
+    let previous: Vec<String> = inputs
+        .previous_ideas
+        .iter()
+        .map(|i| i.idea.clone())
+        .collect();
+    template
+        .replace("{{COUNT}}", &count.to_string())
+        .replace("{{GOALS}}", &bullet_list(&inputs.current_goals))
+        .replace("{{RECENT}}", &bullet_list(&inputs.recent_activity.entries))
+        .replace("{{EPISODIC}}", &bullet_list(&inputs.episodic_summaries))
+        .replace("{{WIP}}", &bullet_list(&inputs.works_in_progress))
+        .replace("{{OVERSEER}}", &bullet_list(&inputs.overseer_observations))
+        .replace(
+            "{{CONVERSATIONS}}",
+            &bullet_list(&inputs.conversation_insights),
+        )
+        .replace("{{PREVIOUS}}", &bullet_list(&previous))
+}
+
+fn section(out: &mut String, heading: &str, entries: &[String]) {
+    let items: Vec<&String> = entries.iter().filter(|e| !e.trim().is_empty()).collect();
+    if items.is_empty() {
+        return;
+    }
+    out.push_str("### ");
+    out.push_str(heading);
+    out.push('\n');
+    for item in items.iter().take(MAX_SECTION_ENTRIES) {
+        out.push_str("- ");
+        out.push_str(item.trim());
+        out.push('\n');
+    }
+    out.push('\n');
+}
+
+fn bullet_list(entries: &[String]) -> String {
+    let items: Vec<String> = entries
+        .iter()
+        .filter(|e| !e.trim().is_empty())
+        .take(MAX_SECTION_ENTRIES)
+        .map(|e| format!("- {}", e.trim()))
+        .collect();
+    if items.is_empty() {
+        "(none)".to_string()
+    } else {
+        items.join("\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_fenced_json_object() {
+        let raw = "some preamble\n```json\n{\"verdict\": \"Support\"}\n```\ntrailer";
+        let v = extract_json_value(raw).expect("json");
+        assert_eq!(v["verdict"], "Support");
+    }
+
+    #[test]
+    fn extracts_bare_object_span() {
+        let raw = "noise {\"a\": 1, \"b\": [2,3]} noise";
+        let v = extract_json_value(raw).expect("json");
+        assert_eq!(v["a"], 1);
+    }
+
+    #[test]
+    fn extracts_bare_array() {
+        let raw = "here: [ {\"idea\": \"x\"} ] done";
+        let v = extract_json_value(raw).expect("json");
+        assert!(v.is_array());
+    }
+
+    #[test]
+    fn returns_none_without_json() {
+        assert!(extract_json_value("no structured output here").is_none());
+    }
+}

--- a/src/creative_ideas/reviewers.rs
+++ b/src/creative_ideas/reviewers.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::cognitive_memory::creative_idea::CreativeIdea;
 use crate::cognitive_threads::threads::creative_ideas::GenerationInputs;
+use crate::creative_ideas::prompt::{extract_json_value, render_review_context};
 use crate::creative_ideas::synthesis::{FeedbackSynthesizer, SuccessMetric, SynthesisOutcome};
 use crate::error::{SimardError, SimardResult};
 
@@ -100,23 +101,127 @@ pub trait Reviewer {
     fn review(&self, ctx: &ReviewContext<'_>) -> SimardResult<Review>;
 }
 
-/// The amplihack skill/agent invocation seam.
+/// The amplihack agent/skill invocation seam.
 ///
-/// FUTURE (M3): the real implementation shells out to the amplihack binary
-/// (`SIMARD_AMPLIHACK_BIN`) to run the `crusty-old-engineer` skill /
-/// `philosophy-guardian` agent / measurability agent. During the spike the
-/// production adapters below build the prompt and call this seam, but do not
-/// interpret the response; all tests inject fakes.
+/// The production adapter ([`SessionAgentInvoker`]) runs a real agentic turn via
+/// the same session path the OODA brain uses (idle-liveness only — **no
+/// wall-clock timeout** on the turn). Tests inject a deterministic fake.
 pub trait AgentInvoker {
     /// Invoke an agent/skill with `prompt` and return its raw text response.
     fn invoke(&self, prompt: &str) -> SimardResult<String>;
 }
 
-/// Production adapter for the `crusty-old-engineer` skill.
+impl<T: AgentInvoker + ?Sized> AgentInvoker for &T {
+    fn invoke(&self, prompt: &str) -> SimardResult<String> {
+        (**self).invoke(prompt)
+    }
+}
+
+/// Production [`AgentInvoker`] backed by the shared session submitter (the same
+/// blessed agentic path the OODA brain uses, so it inherits idle-liveness and
+/// carries **no wall-clock turn cap**).
 ///
-/// FUTURE (M3): parse the skill response into a [`Review`]. Until then
-/// `review` returns [`SimardError::ReviewUnavailable`]; the spike drives the
-/// pipeline through fakes.
+/// The LLM provider is resolved lazily on each [`Self::invoke`] so a
+/// misconfigured provider surfaces as an explicit per-tick error (folded into
+/// telemetry / `ThreadOutcome::failed`) rather than a construction-time panic
+/// or a silent no-op.
+#[derive(Default)]
+pub struct SessionAgentInvoker;
+
+impl SessionAgentInvoker {
+    /// Construct the production invoker.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl AgentInvoker for SessionAgentInvoker {
+    fn invoke(&self, prompt: &str) -> SimardResult<String> {
+        use crate::ooda_brain::LlmSubmitter;
+        let provider = crate::session_builder::LlmProvider::resolve()?;
+        let submitter = crate::ooda_brain::SessionLlmSubmitter::new(provider);
+        submitter.submit(prompt)
+    }
+}
+
+/// The `crusty-old-engineer` skill prompt (scope/feasibility/necessity/utility/
+/// inventiveness/RISK/need-for-human-review/practicality).
+const CRUSTY_PROMPT: &str =
+    include_str!("../../prompt_assets/simard/creative_ideas_review_crusty.md");
+/// The `philosophy-guardian` agent prompt ("do we need this?"; no user signal required).
+const PHILOSOPHY_PROMPT: &str =
+    include_str!("../../prompt_assets/simard/creative_ideas_review_philosophy.md");
+/// The `measurability` agent prompt (emit a concrete success metric; G1).
+const MEASURABILITY_PROMPT: &str =
+    include_str!("../../prompt_assets/simard/creative_ideas_review_measurability.md");
+
+/// Render a review prompt from a template + the idea/context (simple, explicit
+/// placeholder substitution — no templating engine).
+fn render_review_prompt(template: &str, ctx: &ReviewContext<'_>) -> String {
+    template
+        .replace("{{IDEA}}", &ctx.idea.idea)
+        .replace("{{RATIONALE}}", &ctx.idea.context.rationale)
+        .replace("{{CONTEXT}}", &render_review_context(ctx.inputs))
+}
+
+/// The wire shape a reviewer agent returns (parsed tolerantly from its JSON
+/// envelope). Verdict is validated fail-closed; unknown flags default to false.
+#[derive(Debug, Deserialize)]
+struct ReviewJson {
+    verdict: String,
+    #[serde(default)]
+    notes: String,
+    #[serde(default)]
+    high_risk: bool,
+    #[serde(default)]
+    irreversible: bool,
+    #[serde(default)]
+    needs_human: bool,
+    #[serde(default)]
+    metric: Option<SuccessMetric>,
+}
+
+/// Parse a reviewer's raw response into a [`Review`], fail-closed.
+///
+/// An unparseable envelope or an unknown verdict is a hard
+/// [`SimardError::ReviewUnavailable`] — never a silent default review.
+fn parse_review(reviewer: &'static str, raw: &str) -> SimardResult<Review> {
+    let value = extract_json_value(raw).ok_or_else(|| SimardError::ReviewUnavailable {
+        reason: format!("{reviewer}: response contained no JSON envelope"),
+    })?;
+    let parsed: ReviewJson =
+        serde_json::from_value(value).map_err(|e| SimardError::ReviewUnavailable {
+            reason: format!("{reviewer}: could not parse review JSON: {e}"),
+        })?;
+    let verdict = parse_verdict(reviewer, &parsed.verdict)?;
+    Ok(Review {
+        reviewer,
+        verdict,
+        notes: parsed.notes,
+        flags: ReviewFlags {
+            high_risk: parsed.high_risk,
+            irreversible: parsed.irreversible,
+            needs_human: parsed.needs_human,
+        },
+        proposed_metric: parsed.metric,
+    })
+}
+
+/// Fail-closed verdict parse.
+fn parse_verdict(reviewer: &'static str, s: &str) -> SimardResult<ReviewVerdict> {
+    match s.trim() {
+        "Support" => Ok(ReviewVerdict::Support),
+        "Concern" => Ok(ReviewVerdict::Concern),
+        "Block" => Ok(ReviewVerdict::Block),
+        "NeedsHuman" => Ok(ReviewVerdict::NeedsHuman),
+        other => Err(SimardError::ReviewUnavailable {
+            reason: format!("{reviewer}: unknown verdict '{other}'"),
+        }),
+    }
+}
+
+/// Production adapter for the `crusty-old-engineer` skill.
 pub struct CrustyOldEngineerReviewer<I: AgentInvoker> {
     invoker: I,
 }
@@ -126,13 +231,6 @@ impl<I: AgentInvoker> CrustyOldEngineerReviewer<I> {
     pub fn new(invoker: I) -> Self {
         Self { invoker }
     }
-
-    fn build_prompt(_ctx: &ReviewContext<'_>) -> String {
-        // FUTURE (M3): render the real crusty-old-engineer skill prompt from
-        // the idea + observation window (scope/feasibility/necessity/utility/
-        // inventiveness/RISK/need-for-human-review/practicality).
-        String::from("FUTURE: crusty-old-engineer review prompt")
-    }
 }
 
 impl<I: AgentInvoker> Reviewer for CrustyOldEngineerReviewer<I> {
@@ -140,18 +238,16 @@ impl<I: AgentInvoker> Reviewer for CrustyOldEngineerReviewer<I> {
         CRUSTY_OLD_ENGINEER_ID
     }
     fn review(&self, ctx: &ReviewContext<'_>) -> SimardResult<Review> {
-        let prompt = Self::build_prompt(ctx);
-        let _raw = self.invoker.invoke(&prompt)?;
-        Err(SimardError::ReviewUnavailable {
-            reason: "crusty-old-engineer reviewer is not wired during the spike (M3)".to_string(),
-        })
+        let prompt = render_review_prompt(CRUSTY_PROMPT, ctx);
+        let raw = self.invoker.invoke(&prompt)?;
+        parse_review(CRUSTY_OLD_ENGINEER_ID, &raw)
     }
 }
 
 /// Production adapter for the `philosophy-guardian` agent.
 ///
-/// Explicitly, **a user signal is NOT required** to justify an idea; absence of
-/// one is neutral, never a `Block`. FUTURE (M3): parse the agent response.
+/// Explicitly, **a user signal is NOT required** to justify an idea; the prompt
+/// treats absence of one as neutral, never a `Block`.
 pub struct PhilosophyGuardianReviewer<I: AgentInvoker> {
     invoker: I,
 }
@@ -161,12 +257,6 @@ impl<I: AgentInvoker> PhilosophyGuardianReviewer<I> {
     pub fn new(invoker: I) -> Self {
         Self { invoker }
     }
-
-    fn build_prompt(_ctx: &ReviewContext<'_>) -> String {
-        // FUTURE (M3): "do we need this? will it be an interesting
-        // enhancement?" — treat missing user signal as neutral.
-        String::from("FUTURE: philosophy-guardian review prompt")
-    }
 }
 
 impl<I: AgentInvoker> Reviewer for PhilosophyGuardianReviewer<I> {
@@ -174,18 +264,16 @@ impl<I: AgentInvoker> Reviewer for PhilosophyGuardianReviewer<I> {
         PHILOSOPHY_GUARDIAN_ID
     }
     fn review(&self, ctx: &ReviewContext<'_>) -> SimardResult<Review> {
-        let prompt = Self::build_prompt(ctx);
-        let _raw = self.invoker.invoke(&prompt)?;
-        Err(SimardError::ReviewUnavailable {
-            reason: "philosophy-guardian reviewer is not wired during the spike (M3)".to_string(),
-        })
+        let prompt = render_review_prompt(PHILOSOPHY_PROMPT, ctx);
+        let raw = self.invoker.invoke(&prompt)?;
+        parse_review(PHILOSOPHY_GUARDIAN_ID, &raw)
     }
 }
 
 /// Production adapter for the new `measurability` reviewer agent.
 ///
-/// FUTURE (M3): parse the agent response into a concrete [`SuccessMetric`]
-/// tied where relevant to existing self-metrics.
+/// Emits a concrete [`SuccessMetric`] tied where relevant to existing
+/// self-metrics (guideline G1: benchmark + live self-measurement).
 pub struct MeasurabilityReviewer<I: AgentInvoker> {
     invoker: I,
 }
@@ -195,13 +283,6 @@ impl<I: AgentInvoker> MeasurabilityReviewer<I> {
     pub fn new(invoker: I) -> Self {
         Self { invoker }
     }
-
-    fn build_prompt(_ctx: &ReviewContext<'_>) -> String {
-        // FUTURE (M3): ask for a concrete metric (name/baseline/target/
-        // how_measured), preferring recall_precision_at_k / distill fact-yield
-        // / reasoner-reliability where relevant.
-        String::from("FUTURE: measurability review prompt")
-    }
 }
 
 impl<I: AgentInvoker> Reviewer for MeasurabilityReviewer<I> {
@@ -209,11 +290,9 @@ impl<I: AgentInvoker> Reviewer for MeasurabilityReviewer<I> {
         MEASURABILITY_ID
     }
     fn review(&self, ctx: &ReviewContext<'_>) -> SimardResult<Review> {
-        let prompt = Self::build_prompt(ctx);
-        let _raw = self.invoker.invoke(&prompt)?;
-        Err(SimardError::ReviewUnavailable {
-            reason: "measurability reviewer is not wired during the spike (M3)".to_string(),
-        })
+        let prompt = render_review_prompt(MEASURABILITY_PROMPT, ctx);
+        let raw = self.invoker.invoke(&prompt)?;
+        parse_review(MEASURABILITY_ID, &raw)
     }
 }
 

--- a/src/creative_ideas/routing.rs
+++ b/src/creative_ideas/routing.rs
@@ -262,23 +262,41 @@ pub fn gh_pr_add_reviewer_argv(repo: &str, pr: u64, reviewer: &str) -> Vec<Strin
     ]
 }
 
-/// Production [`IdeaGhClient`] — a marked `// FUTURE:` stub for the spike.
-///
-/// FUTURE (M4): run the real `gh` subprocess (reusing the
-/// [`RealGhClient`](crate::stewardship::gh_client::RealGhClient) pattern) using
-/// the pure argv builders above. It must **never** emit `--admin`/`--no-verify`.
-/// During the spike every method builds its argv and returns
-/// [`SimardError::ActionExecutionFailed`] (not-wired) so nothing touches the
-/// network; tests exercise [`super::routing`] through a fake instead.
+/// Production [`IdeaGhClient`] that shells out to the `gh` binary using the pure
+/// argv builders above. It **never** emits `--admin`/`--no-verify` (asserted by
+/// a unit test over the argv builders); the human-review gate is enforced only
+/// by standard GitHub mechanisms (draft + label + requested review).
 #[derive(Default)]
 pub struct RealIdeaGhClient;
 
 impl RealIdeaGhClient {
-    /// Construct the not-yet-wired production client.
+    /// Construct the production client.
     #[must_use]
     pub fn new() -> Self {
         Self
     }
+}
+
+/// Run `gh` with `argv`, returning its output or an [`SimardError`].
+fn run_gh(action: &str, argv: &[String]) -> SimardResult<std::process::Output> {
+    let output = std::process::Command::new("gh")
+        .args(argv)
+        .output()
+        .map_err(|e| SimardError::ActionExecutionFailed {
+            action: action.to_string(),
+            reason: format!("failed to spawn `{action}`: {e}"),
+        })?;
+    if !output.status.success() {
+        return Err(SimardError::ActionExecutionFailed {
+            action: action.to_string(),
+            reason: format!(
+                "`{action}` exited {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        });
+    }
+    Ok(output)
 }
 
 impl IdeaGhClient for RealIdeaGhClient {
@@ -290,29 +308,56 @@ impl IdeaGhClient for RealIdeaGhClient {
         labels: &[&str],
         assignees: &[&str],
     ) -> SimardResult<GhIssue> {
-        let _argv = gh_issue_create_argv(repo, title, body, labels, assignees);
-        Err(not_wired("gh issue create"))
+        let argv = gh_issue_create_argv(repo, title, body, labels, assignees);
+        let output = run_gh("gh issue create", &argv)?;
+        let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let number: u64 = url
+            .rsplit('/')
+            .next()
+            .and_then(|n| n.parse().ok())
+            .ok_or_else(|| SimardError::ActionExecutionFailed {
+                action: "gh issue create".to_string(),
+                reason: format!("`gh issue create` returned non-URL output: {url:?}"),
+            })?;
+        Ok(GhIssue {
+            number,
+            url,
+            title: title.to_string(),
+            body: body.to_string(),
+        })
     }
 
-    fn set_pr_draft(&self, repo: &str, pr: u64, _draft: bool) -> SimardResult<()> {
-        let _argv = gh_pr_draft_argv(repo, pr);
-        Err(not_wired("gh pr ready --undo"))
+    fn set_pr_draft(&self, repo: &str, pr: u64, draft: bool) -> SimardResult<()> {
+        // `draft = true` marks the PR back to draft (`gh pr ready --undo`);
+        // `draft = false` marks it ready. Our gate only ever drafts.
+        if draft {
+            run_gh("gh pr ready --undo", &gh_pr_draft_argv(repo, pr))?;
+        } else {
+            let argv = vec![
+                "pr".to_string(),
+                "ready".to_string(),
+                pr.to_string(),
+                "-R".to_string(),
+                repo.to_string(),
+            ];
+            run_gh("gh pr ready", &argv)?;
+        }
+        Ok(())
     }
 
     fn add_pr_label(&self, repo: &str, pr: u64, label: &str) -> SimardResult<()> {
-        let _argv = gh_pr_add_label_argv(repo, pr, label);
-        Err(not_wired("gh pr edit --add-label"))
+        run_gh(
+            "gh pr edit --add-label",
+            &gh_pr_add_label_argv(repo, pr, label),
+        )?;
+        Ok(())
     }
 
     fn request_pr_review(&self, repo: &str, pr: u64, reviewer: &str) -> SimardResult<()> {
-        let _argv = gh_pr_add_reviewer_argv(repo, pr, reviewer);
-        Err(not_wired("gh pr edit --add-reviewer"))
-    }
-}
-
-fn not_wired(action: &str) -> SimardError {
-    SimardError::ActionExecutionFailed {
-        action: action.to_string(),
-        reason: "creative-idea gh routing is not wired during the spike (M4)".to_string(),
+        run_gh(
+            "gh pr edit --add-reviewer",
+            &gh_pr_add_reviewer_argv(repo, pr, reviewer),
+        )?;
+        Ok(())
     }
 }

--- a/src/creative_ideas/source.rs
+++ b/src/creative_ideas/source.rs
@@ -1,0 +1,158 @@
+//! The production, agent-backed idea source (guideline G3).
+//!
+//! [`AgenticIdeaSource`] renders the generation prompt asset, runs one agentic
+//! turn through the shared [`AgentInvoker`] seam (idle-liveness only — no
+//! wall-clock cap), and extracts the structured JSON envelope into
+//! [`RawIdea`]s. It is **fail-closed**: a response with no JSON envelope is a
+//! hard error, never a silent empty batch.
+#![allow(dead_code)]
+
+use crate::cognitive_memory::creative_idea::{MemoryLink, MemoryLinkKind};
+use crate::cognitive_threads::threads::creative_ideas::{GenerationInputs, IdeaSource, RawIdea};
+use crate::creative_ideas::prompt::{extract_json_value, render_generation_prompt};
+use crate::creative_ideas::reviewers::AgentInvoker;
+use crate::error::{SimardError, SimardResult};
+
+/// The idea-generation prompt asset (produces a JSON array of ten ideas).
+const GENERATE_PROMPT: &str = include_str!("../../prompt_assets/simard/creative_ideas_generate.md");
+
+/// Production [`IdeaSource`] backed by an [`AgentInvoker`].
+pub struct AgenticIdeaSource<I: AgentInvoker + Send> {
+    invoker: I,
+}
+
+impl<I: AgentInvoker + Send> AgenticIdeaSource<I> {
+    /// Wrap an agent invoker (test seam).
+    pub fn new(invoker: I) -> Self {
+        Self { invoker }
+    }
+}
+
+impl AgenticIdeaSource<crate::creative_ideas::reviewers::SessionAgentInvoker> {
+    /// Build the production source (the LLM provider is resolved lazily per turn).
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self::new(crate::creative_ideas::reviewers::SessionAgentInvoker::new())
+    }
+}
+
+impl<I: AgentInvoker + Send> IdeaSource for AgenticIdeaSource<I> {
+    fn generate(&self, inputs: &GenerationInputs, n: usize) -> SimardResult<Vec<RawIdea>> {
+        let prompt = render_generation_prompt(GENERATE_PROMPT, inputs, n);
+        let raw = self.invoker.invoke(&prompt)?;
+        let value = extract_json_value(&raw).ok_or_else(|| SimardError::ReviewUnavailable {
+            reason: "creative-ideas generation: response contained no JSON envelope".to_string(),
+        })?;
+        parse_ideas(&value, n)
+    }
+}
+
+/// Parse the generation envelope into raw ideas (fail-closed on shape).
+fn parse_ideas(value: &serde_json::Value, n: usize) -> SimardResult<Vec<RawIdea>> {
+    let arr = value
+        .get("ideas")
+        .and_then(serde_json::Value::as_array)
+        .or_else(|| value.as_array())
+        .ok_or_else(|| SimardError::ReviewUnavailable {
+            reason: "creative-ideas generation: envelope had no `ideas` array".to_string(),
+        })?;
+
+    let mut ideas = Vec::with_capacity(arr.len().min(n));
+    for entry in arr.iter().take(n) {
+        let Some(text) = entry
+            .get("idea")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        else {
+            // An entry with no idea text is not a valid idea; drop it rather
+            // than fabricate one. (Not a fallback — malformed input handling.)
+            continue;
+        };
+        let rationale = entry
+            .get("rationale")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        let links = parse_links(entry.get("links"));
+        ideas.push(RawIdea {
+            idea: text.to_string(),
+            links,
+            rationale,
+        });
+    }
+    Ok(ideas)
+}
+
+/// Parse the optional `links` array. Malformed link kinds are skipped (links are
+/// optional supporting references); a link with an empty `node_id` is skipped.
+fn parse_links(links: Option<&serde_json::Value>) -> Vec<MemoryLink> {
+    let Some(arr) = links.and_then(serde_json::Value::as_array) else {
+        return Vec::new();
+    };
+    arr.iter()
+        .filter_map(|l| {
+            let kind_str = l.get("kind").and_then(serde_json::Value::as_str)?;
+            let kind: MemoryLinkKind = kind_str.parse().ok()?;
+            let node_id = l
+                .get("node_id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|s| !s.is_empty())?;
+            Some(MemoryLink::new(kind, node_id))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    struct CannedInvoker {
+        response: String,
+        prompts: RefCell<Vec<String>>,
+    }
+
+    impl AgentInvoker for CannedInvoker {
+        fn invoke(&self, prompt: &str) -> SimardResult<String> {
+            self.prompts.borrow_mut().push(prompt.to_string());
+            Ok(self.response.clone())
+        }
+    }
+
+    #[test]
+    fn parses_ten_ideas_with_links() {
+        let mut ideas_json = Vec::new();
+        for i in 0..10 {
+            ideas_json.push(format!(
+                "{{\"idea\": \"idea {i}\", \"rationale\": \"because {i}\", \"links\": [{{\"kind\": \"Goal\", \"node_id\": \"g{i}\"}}]}}"
+            ));
+        }
+        let response = format!("```json\n{{\"ideas\": [{}]}}\n```", ideas_json.join(","));
+        let source = AgenticIdeaSource::new(CannedInvoker {
+            response,
+            prompts: RefCell::new(Vec::new()),
+        });
+        let out = source
+            .generate(&GenerationInputs::default(), 10)
+            .expect("gen");
+        assert_eq!(out.len(), 10);
+        assert_eq!(out[0].idea, "idea 0");
+        assert_eq!(out[0].links.len(), 1);
+        assert_eq!(out[0].links[0].kind, MemoryLinkKind::Goal);
+    }
+
+    #[test]
+    fn no_json_envelope_fails_closed() {
+        let source = AgenticIdeaSource::new(CannedInvoker {
+            response: "I could not generate ideas.".to_string(),
+            prompts: RefCell::new(Vec::new()),
+        });
+        assert!(matches!(
+            source.generate(&GenerationInputs::default(), 10),
+            Err(SimardError::ReviewUnavailable { .. })
+        ));
+    }
+}

--- a/src/creative_ideas/tests.rs
+++ b/src/creative_ideas/tests.rs
@@ -7,7 +7,6 @@
 //! the safety gates, and the OFF-by-default contract.
 
 use std::cell::RefCell;
-use std::str::FromStr;
 use std::sync::atomic::AtomicBool;
 
 use serde_json::Value;
@@ -600,31 +599,38 @@ fn dedup_rejects_near_duplicate_of_prior_idea() {
 }
 
 // ---------------------------------------------------------------------------
-// 8. Off by default
+// 8. Default-ON, opt-out
 // ---------------------------------------------------------------------------
 
 #[test]
-fn subsystem_is_off_by_default() {
-    assert!(!CreativeIdeasConfig::default().enabled());
-    // An empty environment leaves it OFF.
-    assert!(!CreativeIdeasConfig::from_lookup(|_| None).enabled());
-    // A falsey value leaves it OFF.
+fn subsystem_is_on_by_default_opt_out() {
+    // Default-ON, consistent with the Overseer/Journal cognitive threads.
+    assert!(CreativeIdeasConfig::default().enabled());
+    // An empty environment leaves it ON.
+    assert!(CreativeIdeasConfig::from_lookup(|_| None).enabled());
+    // Only an explicit falsey value opts out.
     assert!(
         !CreativeIdeasConfig::from_lookup(|k| (k == super::ENABLED_ENV).then(|| "0".to_string()))
             .enabled()
     );
-    // Only an explicit truthy value enables it.
+    assert!(
+        !CreativeIdeasConfig::from_lookup(
+            |k| (k == super::ENABLED_ENV).then(|| "false".to_string())
+        )
+        .enabled()
+    );
+    // A truthy value keeps it ON.
     assert!(
         CreativeIdeasConfig::from_lookup(|k| (k == super::ENABLED_ENV).then(|| "true".to_string()))
             .enabled()
     );
 
-    // The thread reports disabled by default and never ticks.
+    // The thread reports enabled by default and reuses the BackgroundThought kind.
     let thread = CreativeIdeasThread::new(
         CreativeIdeasConfig::default(),
         Box::new(FakeIdeaSource::default()),
     );
-    assert!(!thread.enabled());
+    assert!(thread.enabled());
     assert_eq!(thread.kind(), ThreadKind::BackgroundThought);
 }
 
@@ -648,11 +654,12 @@ fn illegal_transition_returns_invalid_idea_transition() {
 
 #[test]
 fn unknown_status_string_is_rejected_not_defaulted() {
-    let err = IdeaStatus::from_str("Bogus").unwrap_err();
+    use crate::cognitive_memory::creative_idea::parse_idea_status;
+    let err = parse_idea_status("Bogus").unwrap_err();
     assert!(matches!(err, SimardError::InvalidCreativeIdeaRecord { .. }));
     // A known one round-trips.
     assert_eq!(
-        IdeaStatus::from_str("NeedsHumanReview").expect("known"),
+        parse_idea_status("NeedsHumanReview").expect("known"),
         IdeaStatus::NeedsHumanReview
     );
 }
@@ -745,13 +752,14 @@ fn tick_is_total_when_idea_source_errors() {
 #[test]
 fn disabled_tick_is_skipped() {
     let env = TickEnv::new();
-    let mut thread = CreativeIdeasThread::new(
-        CreativeIdeasConfig::default(),
-        Box::new(FakeIdeaSource::failing()),
-    );
+    let disabled = CreativeIdeasConfig {
+        enabled: false,
+        ..CreativeIdeasConfig::default()
+    };
+    let mut thread = CreativeIdeasThread::new(disabled, Box::new(FakeIdeaSource::failing()));
     let mut ctx = env.ctx(1_000, true);
     let outcome = thread.tick(&mut ctx);
-    assert!(!outcome.ran, "a disabled thread does no work");
+    assert!(!outcome.ran, "an explicitly-disabled thread does no work");
     assert!(outcome.success);
 }
 
@@ -783,4 +791,394 @@ fn mark_completed_requires_started_and_metric_met() {
         mark_completed(&mut idea3, true),
         Err(SimardError::InvalidIdeaTransition { .. })
     ));
+}
+
+// ---------------------------------------------------------------------------
+// 12. Wired generation + review/route pipeline (hermetic, all fakes)
+// ---------------------------------------------------------------------------
+
+use super::pipeline::{AgenticIdeaPipeline, GoalStoreFactory, IdeaPipeline, RouteOutcome};
+use super::reviewers::AgentInvoker;
+use crate::goals::GoalRecord;
+
+/// A review/route pipeline that leaves ideas untouched — isolates the
+/// generation step for the "ten new ideas" assertion.
+struct NoopPipeline;
+
+impl IdeaPipeline for NoopPipeline {
+    fn review_and_route(
+        &self,
+        _idea: &mut CreativeIdea,
+        _inputs: &GenerationInputs,
+        _ctx: &ThreadContext<'_>,
+    ) -> SimardResult<RouteOutcome> {
+        Ok(RouteOutcome::Parked)
+    }
+}
+
+/// An [`AgentInvoker`] returning a fixed JSON envelope for every prompt.
+struct CannedInvoker {
+    response: String,
+}
+
+impl AgentInvoker for CannedInvoker {
+    fn invoke(&self, _prompt: &str) -> SimardResult<String> {
+        Ok(self.response.clone())
+    }
+}
+
+/// A `gh` fake that records into shared `Arc<Mutex<..>>` handles so the test can
+/// inspect it after the pipeline (which owns the boxed client) has run.
+#[derive(Clone, Default)]
+struct SharedGh {
+    issues: std::sync::Arc<std::sync::Mutex<Vec<RecordedIssue>>>,
+    pr_ops: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+impl IdeaGhClient for SharedGh {
+    fn create_labeled_issue(
+        &self,
+        _repo: &str,
+        title: &str,
+        body: &str,
+        labels: &[&str],
+        assignees: &[&str],
+    ) -> SimardResult<GhIssue> {
+        self.issues.lock().unwrap().push(RecordedIssue {
+            labels: labels.iter().map(|s| (*s).to_string()).collect(),
+            assignees: assignees.iter().map(|s| (*s).to_string()).collect(),
+            body: body.to_string(),
+        });
+        Ok(GhIssue {
+            number: 999,
+            url: "https://example.test/issues/999".to_string(),
+            title: title.to_string(),
+            body: body.to_string(),
+        })
+    }
+    fn set_pr_draft(&self, _repo: &str, pr: u64, draft: bool) -> SimardResult<()> {
+        self.pr_ops
+            .lock()
+            .unwrap()
+            .push(format!("set_pr_draft:{pr}:{draft}"));
+        Ok(())
+    }
+    fn add_pr_label(&self, _repo: &str, pr: u64, label: &str) -> SimardResult<()> {
+        self.pr_ops
+            .lock()
+            .unwrap()
+            .push(format!("add_pr_label:{pr}:{label}"));
+        Ok(())
+    }
+    fn request_pr_review(&self, _repo: &str, pr: u64, reviewer: &str) -> SimardResult<()> {
+        self.pr_ops
+            .lock()
+            .unwrap()
+            .push(format!("request_pr_review:{pr}:{reviewer}"));
+        Ok(())
+    }
+}
+
+/// A shared in-memory goal store exposed as a [`GoalStore`] and a factory.
+struct SharedGoalStore(std::sync::Arc<InMemoryGoalStore>);
+
+impl GoalStore for SharedGoalStore {
+    fn descriptor(&self) -> crate::metadata::BackendDescriptor {
+        self.0.descriptor()
+    }
+    fn put(&self, record: GoalRecord) -> SimardResult<()> {
+        self.0.put(record)
+    }
+    fn list(&self) -> SimardResult<Vec<GoalRecord>> {
+        self.0.list()
+    }
+    fn top_goals_by_status(
+        &self,
+        status: GoalStatus,
+        limit: usize,
+    ) -> SimardResult<Vec<GoalRecord>> {
+        self.0.top_goals_by_status(status, limit)
+    }
+    fn active_top_goals(&self, limit: usize) -> SimardResult<Vec<GoalRecord>> {
+        self.0.active_top_goals(limit)
+    }
+}
+
+struct SharedGoalStoreFactory(std::sync::Arc<InMemoryGoalStore>);
+
+impl GoalStoreFactory for SharedGoalStoreFactory {
+    fn open(&self, _state_root: &std::path::Path) -> SimardResult<Box<dyn GoalStore>> {
+        Ok(Box::new(SharedGoalStore(std::sync::Arc::clone(&self.0))))
+    }
+}
+
+fn support_metric_response() -> String {
+    r#"```json
+{"verdict": "Support", "notes": "ok", "metric": {"name": "recall_precision_at_k", "baseline": 0.71, "target": ">= +0.05 over 7-day baseline and a live trend", "how_measured": "nightly recall eval + production self-metric"}}
+```"#
+    .to_string()
+}
+
+#[test]
+fn generation_run_produces_ten_new_ideas_with_links() {
+    let env = TickEnv::new();
+    let mut raws = Vec::new();
+    for i in 0..10 {
+        raws.push(RawIdea {
+            idea: format!("distinct self-improvement idea number {i}"),
+            links: vec![MemoryLink {
+                kind: MemoryLinkKind::Goal,
+                node_id: format!("g{i}"),
+            }],
+            rationale: format!("grounded rationale {i}"),
+        });
+    }
+    let cfg = CreativeIdeasConfig {
+        enabled: true,
+        batch: 10,
+        ..CreativeIdeasConfig::default()
+    };
+    let mut thread = CreativeIdeasThread::with_pipeline(
+        cfg,
+        Box::new(FakeIdeaSource::with_ideas(raws)),
+        Box::new(NoopPipeline),
+    );
+    let mut ctx = env.ctx(1_000, /* dry_run */ false);
+    let outcome = thread.tick(&mut ctx);
+    assert!(outcome.ran && outcome.success, "{}", outcome.summary);
+
+    let store = ProspectiveCreativeIdeaStore::new(&env.mem);
+    let ideas = store.list(u32::MAX).expect("list ideas");
+    assert_eq!(ideas.len(), 10, "exactly ten idea prospective-memories");
+    for idea in &ideas {
+        assert_eq!(idea.status, IdeaStatus::New, "each generated idea is New");
+        assert!(!idea.links.is_empty(), "each idea has populated links");
+    }
+}
+
+#[test]
+fn wired_pipeline_accepts_idea_creates_goal_and_persists_reviews() {
+    let env = TickEnv::new();
+    let goal_store = std::sync::Arc::new(InMemoryGoalStore::try_default().expect("goals"));
+    let gh = SharedGh::default();
+
+    let pipeline = AgenticIdeaPipeline::new(
+        Box::new(CannedInvoker {
+            response: support_metric_response(),
+        }),
+        Box::new(gh.clone()),
+        Box::new(SharedGoalStoreFactory(std::sync::Arc::clone(&goal_store))),
+        "rysweet/Simard".to_string(),
+    );
+
+    let mut idea = CreativeIdea::new("cache distilled facts by concept", sample_context(), 42);
+    let store = ProspectiveCreativeIdeaStore::new(&env.mem);
+    idea.node_id = store.store(&idea).expect("persist New");
+
+    let ctx = env.ctx(1234, /* dry_run */ false);
+    let outcome = pipeline
+        .review_and_route(&mut idea, &GenerationInputs::default(), &ctx)
+        .expect("pipeline");
+
+    assert_eq!(outcome, RouteOutcome::Goal);
+    assert_eq!(idea.reviews.len(), 3, "all three reviewers contributed");
+    assert_eq!(idea.status, IdeaStatus::ImplementationStarted);
+
+    let goals = goal_store.list().expect("goals list");
+    assert!(
+        goals
+            .iter()
+            .any(|g| g.status == GoalStatus::Proposed && g.title == idea.idea),
+        "an accepted idea creates a Proposed goal on the board"
+    );
+
+    let current = store
+        .list(u32::MAX)
+        .expect("list")
+        .into_iter()
+        .find(|i| i.idea_id == idea.idea_id)
+        .expect("reviewed idea present");
+    assert_eq!(current.status, IdeaStatus::ImplementationStarted);
+    assert_eq!(current.reviews.len(), 3, "reviews persisted on the idea");
+    assert!(
+        gh.issues.lock().unwrap().is_empty(),
+        "accepted idea files no issue"
+    );
+}
+
+#[test]
+fn wired_pipeline_human_review_files_issue_with_label_and_owner() {
+    let env = TickEnv::new();
+    let goal_store = std::sync::Arc::new(InMemoryGoalStore::try_default().expect("goals"));
+    let gh = SharedGh::default();
+
+    let human_response = "```json\n{\"verdict\": \"NeedsHuman\", \"notes\": \"risky\", \"needs_human\": true, \"high_risk\": true}\n```".to_string();
+    let pipeline = AgenticIdeaPipeline::new(
+        Box::new(CannedInvoker {
+            response: human_response,
+        }),
+        Box::new(gh.clone()),
+        Box::new(SharedGoalStoreFactory(std::sync::Arc::clone(&goal_store))),
+        "rysweet/Simard".to_string(),
+    );
+
+    let mut idea = CreativeIdea::new(
+        "auto-delete stale worktrees on a schedule",
+        sample_context(),
+        7,
+    );
+    let store = ProspectiveCreativeIdeaStore::new(&env.mem);
+    idea.node_id = store.store(&idea).expect("persist New");
+
+    let ctx = env.ctx(555, /* dry_run */ false);
+    let outcome = pipeline
+        .review_and_route(&mut idea, &GenerationInputs::default(), &ctx)
+        .expect("pipeline");
+
+    assert_eq!(outcome, RouteOutcome::Issue);
+    assert_eq!(idea.status, IdeaStatus::NeedsHumanReview);
+
+    let issues = gh.issues.lock().unwrap();
+    assert_eq!(
+        issues.len(),
+        1,
+        "a human-review idea files exactly one issue"
+    );
+    assert!(
+        issues[0]
+            .labels
+            .iter()
+            .any(|l| l == CREATIVE_IDEA_ISSUE_LABEL),
+        "issue carries the creative-idea label"
+    );
+    assert!(
+        issues[0].assignees.iter().any(|a| a == CREATIVE_IDEA_OWNER),
+        "issue tags the repo owner"
+    );
+    assert!(
+        goal_store.list().expect("goals").is_empty(),
+        "a human-review idea does not auto-create a goal"
+    );
+}
+
+#[test]
+fn dry_run_reviews_but_writes_and_routes_nothing() {
+    let env = TickEnv::new();
+    let goal_store = std::sync::Arc::new(InMemoryGoalStore::try_default().expect("goals"));
+    let gh = SharedGh::default();
+    let pipeline = AgenticIdeaPipeline::new(
+        Box::new(CannedInvoker {
+            response: support_metric_response(),
+        }),
+        Box::new(gh.clone()),
+        Box::new(SharedGoalStoreFactory(std::sync::Arc::clone(&goal_store))),
+        "rysweet/Simard".to_string(),
+    );
+    let mut idea = CreativeIdea::new("a dry-run idea", sample_context(), 1);
+    let ctx = env.ctx(1, /* dry_run */ true);
+    let outcome = pipeline
+        .review_and_route(&mut idea, &GenerationInputs::default(), &ctx)
+        .expect("pipeline");
+    assert_eq!(outcome, RouteOutcome::DryRun);
+    assert_eq!(idea.reviews.len(), 3, "dry-run still reviews");
+    assert!(
+        goal_store.list().expect("goals").is_empty(),
+        "dry-run writes no goal"
+    );
+    let store = ProspectiveCreativeIdeaStore::new(&env.mem);
+    assert!(
+        store.list(u32::MAX).expect("list").is_empty(),
+        "dry-run persists nothing"
+    );
+}
+
+#[test]
+fn ideas_are_enumerable_and_searchable_by_status() {
+    let mem = LibraryCognitiveMemory::in_memory().expect("in-memory store");
+    let store = ProspectiveCreativeIdeaStore::new(&mem);
+
+    // One idea in each of several statuses (all legal transitions from New).
+    let targets = [
+        IdeaStatus::New,
+        IdeaStatus::Rejected,
+        IdeaStatus::Deferred,
+        IdeaStatus::NeedsHumanReview,
+    ];
+    for (i, &status) in targets.iter().enumerate() {
+        let mut idea =
+            CreativeIdea::new(format!("idea for status {i}"), sample_context(), i as u64);
+        idea.node_id = store.store(&idea).expect("store New");
+        if status != IdeaStatus::New {
+            idea.try_transition(status).expect("transition");
+            store.update(&idea).expect("update");
+        }
+    }
+
+    for &status in &targets {
+        let hits = store.list_by_status(status, u32::MAX).expect("by status");
+        assert_eq!(hits.len(), 1, "exactly one idea in status {status}");
+        assert_eq!(hits[0].status, status);
+    }
+    // No duplicate rows leak through despite the append-only updates.
+    assert_eq!(store.list(u32::MAX).expect("list").len(), targets.len());
+}
+
+#[test]
+fn wired_thread_tick_generates_reviews_and_routes() {
+    let env = TickEnv::new();
+    let goal_store = std::sync::Arc::new(InMemoryGoalStore::try_default().expect("goals"));
+    let gh = SharedGh::default();
+
+    let raws: Vec<RawIdea> = (0..10)
+        .map(|i| RawIdea {
+            idea: format!("wired idea {i}"),
+            links: vec![MemoryLink {
+                kind: MemoryLinkKind::Semantic,
+                node_id: format!("s{i}"),
+            }],
+            rationale: format!("rationale {i}"),
+        })
+        .collect();
+
+    let pipeline = AgenticIdeaPipeline::new(
+        Box::new(CannedInvoker {
+            response: support_metric_response(),
+        }),
+        Box::new(gh.clone()),
+        Box::new(SharedGoalStoreFactory(std::sync::Arc::clone(&goal_store))),
+        "rysweet/Simard".to_string(),
+    );
+    let cfg = CreativeIdeasConfig {
+        enabled: true,
+        batch: 10,
+        ..CreativeIdeasConfig::default()
+    };
+    let mut thread = CreativeIdeasThread::with_pipeline(
+        cfg,
+        Box::new(FakeIdeaSource::with_ideas(raws)),
+        Box::new(pipeline),
+    );
+
+    let mut ctx = env.ctx(2_000, /* dry_run */ false);
+    let outcome = thread.tick(&mut ctx);
+    assert!(outcome.ran && outcome.success, "{}", outcome.summary);
+
+    // All ten accepted ideas became Proposed goals on the board.
+    let goals = goal_store.list().expect("goals");
+    assert_eq!(goals.len(), 10, "each accepted idea created a goal");
+    assert!(goals.iter().all(|g| g.status == GoalStatus::Proposed));
+
+    // The ideas are now searchable at their post-review status.
+    let store = ProspectiveCreativeIdeaStore::new(&env.mem);
+    let started = store
+        .list_by_status(IdeaStatus::ImplementationStarted, u32::MAX)
+        .expect("by status");
+    assert_eq!(
+        started.len(),
+        10,
+        "all ten routed to a goal and moved in-flight"
+    );
+    for idea in &started {
+        assert_eq!(idea.reviews.len(), 3);
+    }
 }

--- a/src/memory_ipc/mod.rs
+++ b/src/memory_ipc/mod.rs
@@ -349,6 +349,12 @@ impl CognitiveMemoryOps for SharedMemory {
     fn resolve_prospective(&self, node_id: &str) -> SimardResult<()> {
         self.0.resolve_prospective(node_id)
     }
+    fn list_all_prospective(&self, limit: u32) -> SimardResult<Vec<CognitiveProspective>> {
+        self.0.list_all_prospective(limit)
+    }
+    fn list_all_episodes(&self, limit: u32) -> SimardResult<Vec<CognitiveEpisode>> {
+        self.0.list_all_episodes(limit)
+    }
     fn get_statistics(&self) -> SimardResult<CognitiveStatistics> {
         self.0.get_statistics()
     }

--- a/src/operator_commands_dashboard/creative_ideas.rs
+++ b/src/operator_commands_dashboard/creative_ideas.rs
@@ -1,0 +1,225 @@
+//! Dashboard **Creative Ideas** tab handlers.
+//!
+//! Two read-only endpoints back the Creative Ideas tab, reading the durable
+//! creative-idea prospective memories out of the *same* cognitive-memory store
+//! the rest of the dashboard reads (via [`open_reader_bridge`]) — no parallel
+//! datastore:
+//!
+//! * `GET  /api/creative-ideas`        — the current idea pool (latest revision
+//!   per idea), newest first, plus a per-status count summary.
+//! * `POST /api/creative-ideas/search` — filter the pool by status and/or a
+//!   free-text query over the idea text and rationale.
+//!
+//! The pool is browseable and **searchable by status**: every [`IdeaStatus`]
+//! value is enumerable.
+
+use std::path::Path;
+
+use axum::Json;
+use serde_json::{Value, json};
+
+use super::routes::resolve_state_root;
+use crate::cognitive_memory::creative_idea::{
+    CreativeIdea, CreativeIdeaStore, IdeaStatus, ProspectiveCreativeIdeaStore, parse_idea_status,
+};
+use crate::error::SimardResult;
+use crate::memory_ipc::open_reader_bridge;
+
+/// Read window for the idea pool (bounded; the pool stays modest).
+const IDEA_LIST_LIMIT: u32 = 512;
+
+/// `GET /api/creative-ideas` — the current idea pool, newest first, with a
+/// per-status count summary.
+pub(crate) async fn creative_ideas() -> Json<Value> {
+    let state_root = resolve_state_root();
+    match load_ideas(&state_root) {
+        Ok(ideas) => Json(json!({
+            "counts": status_counts(&ideas),
+            "ideas": ideas.iter().map(idea_summary).collect::<Vec<_>>(),
+        })),
+        Err(e) => Json(json!({ "error": e.to_string(), "ideas": [], "counts": {} })),
+    }
+}
+
+/// `POST /api/creative-ideas/search` — filter the pool by `status` (one of the
+/// [`IdeaStatus`] names) and/or a free-text `query`. Body: `{status?, query?}`.
+pub(crate) async fn creative_ideas_search(Json(body): Json<Value>) -> Json<Value> {
+    let status = body.get("status").and_then(Value::as_str).map(str::trim);
+    let query = body
+        .get("query")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    let state_root = resolve_state_root();
+
+    // An explicit but unknown status is a fail-closed error (never silently
+    // treated as "all").
+    let status_filter = match status {
+        Some(s) if !s.is_empty() => match parse_idea_status(s) {
+            Ok(v) => Some(v),
+            Err(e) => return Json(json!({ "error": e.to_string(), "results": [] })),
+        },
+        _ => None,
+    };
+
+    match load_ideas(&state_root) {
+        Ok(ideas) => {
+            let results: Vec<Value> = ideas
+                .iter()
+                .filter(|i| status_filter.is_none_or(|s| i.status == s))
+                .filter(|i| query.is_empty() || idea_matches(i, &query))
+                .map(idea_summary)
+                .collect();
+            Json(json!({ "results": results }))
+        }
+        Err(e) => Json(json!({ "error": e.to_string(), "results": [] })),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (state_root injected) — the async handlers are thin shells over
+// these so they are unit-testable against a hermetic store.
+// ---------------------------------------------------------------------------
+
+/// Load the current idea pool (latest revision per idea, newest first).
+fn load_ideas(state_root: &Path) -> SimardResult<Vec<CreativeIdea>> {
+    let reader = open_reader_bridge(state_root)?;
+    let store = ProspectiveCreativeIdeaStore::new(reader.ops());
+    store.list(IDEA_LIST_LIMIT)
+}
+
+/// Per-status count map over every [`IdeaStatus`] value (zero-filled).
+fn status_counts(ideas: &[CreativeIdea]) -> Value {
+    let mut map = serde_json::Map::new();
+    for status in IdeaStatus::ALL {
+        let n = ideas.iter().filter(|i| i.status == status).count();
+        map.insert(status.as_str().to_string(), json!(n));
+    }
+    Value::Object(map)
+}
+
+/// Compact per-idea summary for the pool list.
+fn idea_summary(idea: &CreativeIdea) -> Value {
+    json!({
+        "idea_id": idea.idea_id,
+        "idea": idea.idea,
+        "status": idea.status.as_str(),
+        "rationale": idea.context.rationale,
+        "links": idea.links.len(),
+        "reviews": idea.reviews.len(),
+        "has_metric": idea.success_metric.is_some(),
+        "metric": idea.success_metric.as_ref().map(|m| m.name.clone()),
+        "created_epoch": idea.created_epoch,
+    })
+}
+
+/// Case-insensitive match over the idea text + rationale (`query` is lowercased).
+fn idea_matches(idea: &CreativeIdea, query: &str) -> bool {
+    idea.idea.to_ascii_lowercase().contains(query)
+        || idea.context.rationale.to_ascii_lowercase().contains(query)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::cognitive_memory::creative_idea::IdeaContext;
+    use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
+    use crate::memory_ipc::{clear_in_process_writer, register_in_process_writer};
+    use crate::test_support::HermeticState;
+
+    struct MemGuard {
+        writer: Arc<dyn CognitiveMemoryOps>,
+    }
+
+    impl MemGuard {
+        fn register(state: &HermeticState) -> Self {
+            let writer: Arc<dyn CognitiveMemoryOps> =
+                Arc::new(LibraryCognitiveMemory::open(state.state_root()).expect("open store"));
+            register_in_process_writer(state.state_root().to_path_buf(), Arc::clone(&writer));
+            Self { writer }
+        }
+        fn ops(&self) -> &dyn CognitiveMemoryOps {
+            self.writer.as_ref()
+        }
+    }
+
+    impl Drop for MemGuard {
+        fn drop(&mut self) {
+            clear_in_process_writer();
+        }
+    }
+
+    fn ctx() -> IdeaContext {
+        IdeaContext {
+            source: "creative-ideas-thread".to_string(),
+            goals_snapshot: vec![],
+            observation_digest: "d".to_string(),
+            rationale: "recall precision plateaued".to_string(),
+        }
+    }
+
+    fn seed(ops: &dyn CognitiveMemoryOps, text: &str, status: IdeaStatus) {
+        let store = ProspectiveCreativeIdeaStore::new(ops);
+        let mut idea = CreativeIdea::new(text, ctx(), 1);
+        idea.node_id = store.store(&idea).expect("store");
+        if status != IdeaStatus::New {
+            idea.try_transition(status).expect("transition");
+            store.update(&idea).expect("update");
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(cognitive_memory)]
+    async fn lists_pool_with_status_counts() {
+        let state = HermeticState::new();
+        let mem = MemGuard::register(&state);
+        seed(mem.ops(), "improve recall ranking", IdeaStatus::New);
+        seed(
+            mem.ops(),
+            "auto-delete stale worktrees",
+            IdeaStatus::NeedsHumanReview,
+        );
+        seed(mem.ops(), "a rejected idea", IdeaStatus::Rejected);
+
+        let Json(v) = creative_ideas().await;
+        assert_eq!(v["ideas"].as_array().expect("ideas").len(), 3);
+        assert_eq!(v["counts"]["New"], 1);
+        assert_eq!(v["counts"]["NeedsHumanReview"], 1);
+        assert_eq!(v["counts"]["Rejected"], 1);
+        assert_eq!(v["counts"]["Deferred"], 0);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(cognitive_memory)]
+    async fn search_filters_by_status_and_text() {
+        let state = HermeticState::new();
+        let mem = MemGuard::register(&state);
+        seed(mem.ops(), "improve recall ranking", IdeaStatus::New);
+        seed(
+            mem.ops(),
+            "auto-delete stale worktrees",
+            IdeaStatus::NeedsHumanReview,
+        );
+        seed(mem.ops(), "another new recall idea", IdeaStatus::New);
+
+        // By status.
+        let Json(new_only) = creative_ideas_search(Json(json!({ "status": "New" }))).await;
+        assert_eq!(new_only["results"].as_array().expect("arr").len(), 2);
+
+        // By status + text.
+        let Json(both) =
+            creative_ideas_search(Json(json!({ "status": "New", "query": "ranking" }))).await;
+        assert_eq!(both["results"].as_array().expect("arr").len(), 1);
+
+        // Text only, across statuses.
+        let Json(text) = creative_ideas_search(Json(json!({ "query": "worktrees" }))).await;
+        assert_eq!(text["results"].as_array().expect("arr").len(), 1);
+
+        // An unknown status is a fail-closed error, not "all".
+        let Json(bad) = creative_ideas_search(Json(json!({ "status": "Bogus" }))).await;
+        assert!(bad.get("error").is_some());
+    }
+}

--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -220,6 +220,96 @@ pub(crate) const PART_01: &str = r#"
     })();
   </script>
 
+  <div class="tab-content" id="tab-creative-ideas">
+    <h1 class="page-h1">Creative Ideas</h1>
+    <p class="page-lede">A pool of candidate improvements Simard dreams up for herself, each reviewed for feasibility, worth, and how to measure success. Browse and search by their review status, from brand-new to accepted or parked.</p>
+    <div class="card" style="max-width:1100px">
+      <div style="display:flex;gap:.5rem;align-items:center;margin-bottom:.75rem;flex-wrap:wrap">
+        <input id="ci-search-input" placeholder="Search ideas…" style="flex:1;min-width:200px;padding:6px;background:#1a1a2e;border:1px solid #333;color:#e0e0e0;border-radius:4px">
+        <select id="ci-status-filter" style="padding:6px;background:#1a1a2e;border:1px solid #333;color:#e0e0e0;border-radius:4px">
+          <option value="">All statuses</option>
+          <option value="New">New</option>
+          <option value="NeedsRevision">Needs revision</option>
+          <option value="NeedsHumanReview">Needs human review</option>
+          <option value="AcceptedForImplementation">Accepted</option>
+          <option value="ImplementationStarted">Implementation started</option>
+          <option value="ImplementationCompleted">Completed</option>
+          <option value="Deferred">Deferred</option>
+          <option value="Rejected">Rejected</option>
+        </select>
+        <button class="btn" onclick="searchCreativeIdeas()">Search</button>
+        <button class="btn" onclick="loadCreativeIdeas()">Refresh</button>
+      </div>
+      <div id="ci-counts" data-testid="ci-counts" style="display:flex;gap:.4rem;flex-wrap:wrap;margin-bottom:.75rem"></div>
+      <div id="ci-list" data-testid="ci-list" style="min-height:220px"><span class="loading">Loading…</span></div>
+    </div>
+  </div>
+  <script>
+    /* --- Creative Ideas tab --- */
+    (function(){
+      let ciLoaded=false;
+      function statusColor(s){
+        return ({
+          New:'#58a6ff', NeedsRevision:'#d29922', NeedsHumanReview:'#f0883e',
+          AcceptedForImplementation:'#3fb950', ImplementationStarted:'#2ea043',
+          ImplementationCompleted:'#238636', Deferred:'#8b949e', Rejected:'#f85149'
+        })[s]||'#8b949e';
+      }
+      function renderCounts(counts){
+        const box=document.getElementById('ci-counts');
+        if(!counts){box.innerHTML='';return;}
+        box.innerHTML=Object.keys(counts).map(k=>
+          '<span style="font-size:.72rem;padding:.15rem .45rem;border-radius:10px;border:1px solid '+statusColor(k)+';color:'+statusColor(k)+'">'+esc(k)+': '+esc(String(counts[k]))+'</span>'
+        ).join('');
+      }
+      function renderIdeas(items){
+        const box=document.getElementById('ci-list');
+        if(!items||!items.length){box.innerHTML='<span style="color:#8b949e">No ideas match. Simard fills this pool as the Creative Ideas thread runs.</span>';return;}
+        box.innerHTML=items.map(it=>{
+          const c=statusColor(it.status);
+          const metric=it.has_metric?'<span style="color:#3fb950;font-size:.7rem"> · metric: '+esc(it.metric||'yes')+'</span>':'';
+          return '<div style="padding:.5rem .6rem;border:1px solid #21262d;border-radius:6px;margin-bottom:.5rem">'
+            +'<div style="display:flex;justify-content:space-between;gap:.5rem;align-items:center">'
+            +'<strong>'+esc(it.idea)+'</strong>'
+            +'<span style="font-size:.7rem;padding:.1rem .4rem;border-radius:10px;background:'+c+'22;color:'+c+';border:1px solid '+c+'">'+esc(it.status)+'</span>'
+            +'</div>'
+            +'<div style="color:#8b949e;font-size:.78rem;margin-top:.25rem">'+esc(it.rationale||'')+'</div>'
+            +'<div style="color:#6e7681;font-size:.7rem;margin-top:.25rem">'+esc(String(it.reviews))+' review(s) · '+esc(String(it.links))+' link(s)'+metric+'</div>'
+            +'</div>';
+        }).join('');
+      }
+      async function loadCreativeIdeas(){
+        const box=document.getElementById('ci-list');
+        box.innerHTML='<span class="loading">Loading…</span>';
+        try{
+          const d=await apiFetch('/api/creative-ideas');
+          renderCounts(d.counts);
+          renderIdeas(d.ideas||[]);
+          ciLoaded=true;
+        }catch(e){box.innerHTML='<span class="err">Could not load ideas — check /api/creative-ideas</span>';}
+      }
+      async function searchCreativeIdeas(){
+        const q=(document.getElementById('ci-search-input').value||'').trim();
+        const status=document.getElementById('ci-status-filter').value||'';
+        const box=document.getElementById('ci-list');
+        box.innerHTML='<span class="loading">Searching…</span>';
+        try{
+          const d=await apiFetch('/api/creative-ideas/search',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({query:q,status:status})});
+          if(d.error){box.innerHTML='<span class="err">'+esc(d.error)+'</span>';return;}
+          renderIdeas(d.results||[]);
+        }catch(e){box.innerHTML='<span class="err">Search failed — check /api/creative-ideas/search</span>';}
+      }
+      window.loadCreativeIdeas=loadCreativeIdeas;
+      window.searchCreativeIdeas=searchCreativeIdeas;
+      const ct=document.querySelector('.tab[data-tab="creative-ideas"]');
+      if(ct) ct.addEventListener('click',()=>{ if(!ciLoaded) loadCreativeIdeas(); });
+      const cs=document.getElementById('ci-search-input');
+      if(cs) cs.addEventListener('keypress',e=>{if(e.key==='Enter')searchCreativeIdeas();});
+      const cf=document.getElementById('ci-status-filter');
+      if(cf) cf.addEventListener('change',()=>searchCreativeIdeas());
+    })();
+  </script>
+
   {{TAB_META_JS}}
   <script>
     /* --- Helpers --- */
@@ -551,13 +641,13 @@ pub(crate) const PART_01: &str = r#"
       if(meta && meta.title) document.title=meta.title;
     }
 
-    /* #2627 consolidation: the nine canonical tabs, plus TAB_ALIASES mapping
-       every retired 17-tab slug to the parent tab that now hosts it as a
-       sub-section. TAB_ALIASES is a fixed allowlist; a #hash deep link is
+    /* #2627 consolidation: the canonical tabs (nine consolidated tabs plus the
+       standalone Creative Ideas tab), plus TAB_ALIASES mapping every retired
+       17-tab slug to the parent tab that now hosts it as a sub-section. TAB_ALIASES is a fixed allowlist; a #hash deep link is
        validated against ^[a-z-]+$, matched against the allowlist, and falls
        back to 'overview' on any miss. The hash is never concatenated into a
        DOM selector, so a crafted hash cannot inject markup. */
-    const CANONICAL_TABS=['overview','goals','activity','workers','pull-requests','resources','chat','overseer','journal'];
+    const CANONICAL_TABS=['overview','goals','activity','workers','pull-requests','resources','chat','overseer','journal','creative-ideas'];
     const TAB_ALIASES={"status":"overview","workboard":"goals","logs":"activity","traces":"activity","thinking":"activity","brain-failures":"activity","processes":"workers","terminal":"workers","merge-decisions":"pull-requests","pr-readiness":"pull-requests","memory":"resources","costs":"resources"};
 
     /* Kick off the data fetches for every sub-section a consolidated tab now
@@ -573,6 +663,7 @@ pub(crate) const PART_01: &str = r#"
       if(slug==='chat'){loadChatSessions();}
       if(slug==='overseer'){fetchOverseer();tabRefreshTimers.overseer=setInterval(fetchOverseer,30000);}
       if(slug==='journal'&&typeof loadJournal==='function'){loadJournal();}
+      if(slug==='creative-ideas'&&typeof loadCreativeIdeas==='function'){loadCreativeIdeas();}
     }
 
     /* Activate a canonical tab by slug. `slug` is always one of CANONICAL_TABS

--- a/src/operator_commands_dashboard/index_html/tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tab_meta.rs
@@ -145,6 +145,14 @@ pub const TAB_METADATA: &[TabMeta] = &[
         lede: "A plain-language daily diary of what Simard and its steward the Overseer did each day, with a simple table of the code changes proposed. Browse by date and search the full history.",
         tooltip: "A plain-language daily diary of what Simard did, browseable by date",
     },
+    TabMeta {
+        slug: "creative-ideas",
+        label: "Creative Ideas",
+        title: "Creative Ideas · Simard",
+        h1: "Creative Ideas",
+        lede: "A pool of candidate improvements Simard dreams up for herself, each reviewed for feasibility, worth, and how to measure success. Browse and search by their review status, from brand-new to accepted or parked.",
+        tooltip: "Simard's pool of self-improvement ideas, searchable by review status",
+    },
 ];
 
 /// Browser title shown on first page load. The client-side tab handler

--- a/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
@@ -21,7 +21,7 @@ fn tab_meta_slugs_unique() {
             t.slug
         );
     }
-    assert_eq!(TAB_METADATA.len(), 9, "expected 9 tabs");
+    assert_eq!(TAB_METADATA.len(), 10, "expected 10 tabs");
 }
 
 #[test]
@@ -780,6 +780,7 @@ const CANONICAL_TABS: &[(&str, &str)] = &[
     ("chat", "Chat"),
     ("overseer", "Overseer"),
     ("journal", "Journal"),
+    ("creative-ideas", "Creative Ideas"),
 ];
 
 /// Slugs that were real top-level tabs in the 17-tab set and must NOT survive
@@ -851,14 +852,39 @@ fn tab_meta_uses_no_bridge_names() {
 }
 
 #[test]
-fn rendered_html_has_exactly_nine_page_h1s() {
-    // Invariant 2 across the consolidated set: each tab panel owns exactly one
-    // `<h1 class="page-h1">`, so the rendered HTML has exactly nine of them.
-    // Sub-sections must use `<h2>`, never a second page-h1.
+fn js_canonical_tabs_allowlist_includes_every_tab() {
+    // Regression guard: the client-side `activateTab`/`resolveHashTab` allowlist
+    // (`const CANONICAL_TABS=[...]` in the rendered JS) MUST list every top-level
+    // tab. A slug present in `TAB_METADATA` but missing from the JS allowlist
+    // renders a nav button whose panel never becomes visible (activateTab falls
+    // back to Overview) — exactly the e2e tab-identity failure this catches at
+    // the unit level.
+    let start = INDEX_HTML
+        .find("const CANONICAL_TABS=[")
+        .expect("rendered HTML has the CANONICAL_TABS JS allowlist");
+    let tail = &INDEX_HTML[start..];
+    let end = tail.find("];").expect("CANONICAL_TABS array is closed");
+    let array = &tail[..end];
+    for t in TAB_METADATA {
+        let needle = format!("'{}'", t.slug);
+        assert!(
+            array.contains(&needle),
+            "JS CANONICAL_TABS allowlist is missing tab slug {:?}; its panel would \
+             never activate. Array was: {array}",
+            t.slug
+        );
+    }
+}
+
+#[test]
+fn rendered_html_has_exactly_ten_page_h1s() {
+    // Invariant 2 across the consolidated set plus the Creative Ideas tab: each
+    // tab panel owns exactly one `<h1 class="page-h1">`, so the rendered HTML has
+    // exactly ten of them. Sub-sections must use `<h2>`, never a second page-h1.
     let count = INDEX_HTML.matches(r#"<h1 class="page-h1">"#).count();
     assert_eq!(
-        count, 9,
-        "expected exactly 9 page-h1 headings (one per consolidated tab), found {count}; \
+        count, 10,
+        "expected exactly 10 page-h1 headings (one per tab), found {count}; \
          a stray page-h1 usually means an absorbed panel kept its old <h1> instead of \
          being demoted to an <h2 class=\"subsection\">"
     );

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -4,6 +4,7 @@ mod auth;
 mod brain_failures;
 mod chat;
 mod chat_store;
+mod creative_ideas;
 mod current_work;
 mod cycle_source;
 mod distributed;

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -10,6 +10,7 @@ use super::auth::{login, login_page, require_auth};
 use super::brain_failures::brain_failures;
 use super::chat::ws_chat_handler;
 use super::chat_store::{chat_session_by_id, chat_sessions};
+use super::creative_ideas::{creative_ideas, creative_ideas_search};
 use super::current_work::current_work;
 use super::distributed::{distributed, vacate_vm};
 use super::feedback::{feedback_status, feedback_submit};
@@ -91,6 +92,8 @@ pub fn build_router() -> Router {
         .route("/api/journal/search", post(journal_search))
         .route("/api/journal/entry/{date}", get(journal_entry))
         .route("/api/journal/render/{date}", get(journal_render))
+        .route("/api/creative-ideas", get(creative_ideas))
+        .route("/api/creative-ideas/search", post(creative_ideas_search))
         .route("/api/status/snapshot", get(status_snapshot))
         .route("/api/feedback", post(feedback_submit))
         .route("/api/feedback/status/{id}", get(feedback_status))

--- a/src/operator_commands_dashboard/tests_routes_a.rs
+++ b/src/operator_commands_dashboard/tests_routes_a.rs
@@ -729,13 +729,13 @@ mod tests {
     fn index_html_has_exactly_eleven_page_intros() {
         let count = INDEX_HTML.matches(r#"class="page-lede""#).count();
         assert_eq!(
-            count, 9,
-            "expected exactly 9 page-lede paragraphs (one per top-level tab), got {count}"
+            count, 10,
+            "expected exactly 10 page-lede paragraphs (one per top-level tab), got {count}"
         );
         let h1_count = INDEX_HTML.matches(r#"class="page-h1""#).count();
         assert_eq!(
-            h1_count, 9,
-            "expected exactly 9 page-h1 headings (one per top-level tab), got {h1_count}"
+            h1_count, 10,
+            "expected exactly 10 page-h1 headings (one per top-level tab), got {h1_count}"
         );
     }
 

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -612,6 +612,14 @@ pub fn run_ooda_daemon(
         mind.register(Box::new(
             crate::cognitive_threads::EngineerLogAnalysisThread::from_env(),
         ));
+        // Creative Ideas generator thread (issue #2606-adjacent): a divergent
+        // idea-generation background thread, default-ON opt-out via
+        // `SIMARD_CREATIVE_IDEAS_ENABLED` (its `enabled()` gate keeps an
+        // opted-out thread inert). Reuses `ThreadKind::BackgroundThought`.
+        crate::cognitive_threads::threads::creative_ideas::register(
+            &mut mind,
+            crate::creative_ideas::CreativeIdeasConfig::from_env(),
+        );
         // NOTE: the Overseer M1 read-only observer sensor that previously
         // registered here (default-OFF, `SIMARD_OVERSEER_ENABLED` truthy) is
         // SUPERSEDED by the acting Overseer periodic task driven below in the

--- a/src/overseer/merge_ops.rs
+++ b/src/overseer/merge_ops.rs
@@ -591,6 +591,7 @@ mod tests {
             review_decision: "APPROVED".to_string(),
             checks,
             base_ref_name: "main".to_string(),
+            labels: Vec::new(),
         }
     }
 

--- a/src/overseer/tests_m2.rs
+++ b/src/overseer/tests_m2.rs
@@ -71,6 +71,7 @@ impl PrGhClient for Arc<GreenGh> {
                 state: "SUCCESS".to_string(),
             }],
             base_ref_name: "main".to_string(),
+            labels: Vec::new(),
         })
     }
     fn squash_merge(&self, _repo: &str, _pr: u32) -> crate::error::SimardResult<()> {

--- a/src/stewardship/merge_authority.rs
+++ b/src/stewardship/merge_authority.rs
@@ -51,7 +51,7 @@ pub enum MergeOutcome {
     Refused { pr_number: u32, reason: String },
 }
 
-/// Snapshot of `gh pr view --json body,statusCheckRollup,mergeable,reviewDecision,baseRefName`.
+/// Snapshot of `gh pr view --json body,statusCheckRollup,mergeable,reviewDecision,baseRefName,labels`.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct PrSnapshot {
     pub body: String,
@@ -62,6 +62,10 @@ pub struct PrSnapshot {
     /// Compared against [`base_allowlist_from_env`] by the first gate so PRs
     /// targeting stale or wrong base branches are refused early.
     pub base_ref_name: String,
+    /// `labels` (names) from `gh pr view`. Drives the creative-idea
+    /// human-review gate: a PR carrying
+    /// [`crate::creative_ideas::CREATIVE_IDEA_PR_LABEL`] is never auto-merged.
+    pub labels: Vec<String>,
 }
 
 /// One row from `statusCheckRollup`. Both check runs and statuses get
@@ -105,6 +109,7 @@ impl OpenPrSummary {
             review_decision: String::new(),
             checks: self.checks.clone(),
             base_ref_name: self.base_ref_name.clone(),
+            labels: Vec::new(),
         }
     }
 }
@@ -259,7 +264,7 @@ impl PrGhClient for RealPrGhClient {
                     "--repo",
                     repo,
                     "--json",
-                    "body,statusCheckRollup,mergeable,reviewDecision,baseRefName",
+                    "body,statusCheckRollup,mergeable,reviewDecision,baseRefName,labels",
                 ],
             )?;
             parse_pr_view_json(&stdout)
@@ -327,6 +332,13 @@ pub fn parse_pr_view_json(stdout: &[u8]) -> SimardResult<PrSnapshot> {
         status_check_rollup: Vec<RawCheck>,
         #[serde(default, rename = "baseRefName")]
         base_ref_name: String,
+        #[serde(default)]
+        labels: Vec<RawLabel>,
+    }
+    #[derive(serde::Deserialize)]
+    struct RawLabel {
+        #[serde(default)]
+        name: String,
     }
     #[derive(serde::Deserialize)]
     struct RawCheck {
@@ -374,6 +386,12 @@ pub fn parse_pr_view_json(stdout: &[u8]) -> SimardResult<PrSnapshot> {
         review_decision: raw.review_decision,
         checks,
         base_ref_name: raw.base_ref_name,
+        labels: raw
+            .labels
+            .into_iter()
+            .map(|l| l.name)
+            .filter(|n| !n.is_empty())
+            .collect(),
     })
 }
 
@@ -601,6 +619,24 @@ pub fn merge_pr_if_merge_ready_with_judge(
     judge: &dyn MergeJudge,
 ) -> SimardResult<MergeOutcome> {
     let snapshot = gh.view_pr(repo, pr_number)?;
+    // Creative-idea human-review gate: never auto-merge a PR that carries the
+    // block-until-human-review label. The idea-derived PR stays gated (draft +
+    // label + owner review requested) until @rysweet approves and clears it.
+    // Enforced WITHOUT `--admin`/`--no-verify` — we simply skip the merge.
+    if snapshot
+        .labels
+        .iter()
+        .any(|l| l == crate::creative_ideas::CREATIVE_IDEA_PR_LABEL)
+    {
+        return Ok(MergeOutcome::Refused {
+            pr_number,
+            reason: format!(
+                "PR carries the merge-blocking label `{}` — a creative-idea PR awaiting human review (@{}); skipped.",
+                crate::creative_ideas::CREATIVE_IDEA_PR_LABEL,
+                crate::creative_ideas::CREATIVE_IDEA_OWNER,
+            ),
+        });
+    }
     if let Err(reason) = evaluate_objective_gates(&snapshot, base_allowlist) {
         return Ok(MergeOutcome::Refused { pr_number, reason });
     }
@@ -679,6 +715,7 @@ mod tests {
                 },
             ],
             base_ref_name: "main".to_string(),
+            labels: Vec::new(),
         }
     }
 
@@ -845,7 +882,70 @@ mod tests {
         assert_eq!(judge.call_count(), 1, "judge must be called exactly once");
     }
 
-    // ─── Cross-repo: the same gated authority merges PRs in any governed repo ─
+    // ─── Creative-idea gate: a block-until-human-review PR is never merged ─
+
+    #[test]
+    fn refuses_to_merge_a_creative_idea_pr_awaiting_human_review() {
+        // A PR carrying the block-until-human-review label must be SKIPPED by
+        // the autonomous merge driver even when every other gate (and the judge)
+        // would pass — and without ever invoking the merge command or the judge.
+        let gh = FakePrGhClient::new();
+        let mut snap = good_snapshot();
+        snap.labels = vec![crate::creative_ideas::CREATIVE_IDEA_PR_LABEL.to_string()];
+        gh.seed_view(Ok(snap));
+        gh.seed_merge(Ok(()));
+        let judge = FakeMergeJudge::ready();
+
+        let outcome = run(4242, "rysweet/Simard", &gh, &default_allowlist(), &judge).unwrap();
+
+        match outcome {
+            MergeOutcome::Refused { pr_number, reason } => {
+                assert_eq!(pr_number, 4242);
+                assert!(
+                    reason.contains(crate::creative_ideas::CREATIVE_IDEA_PR_LABEL),
+                    "refusal must name the blocking label: {reason}"
+                );
+            }
+            other => panic!("expected Refused, got {other:?}"),
+        }
+        assert_eq!(
+            gh.merge_call_count(),
+            0,
+            "a creative-idea PR must never be squash-merged autonomously"
+        );
+        assert_eq!(
+            judge.call_count(),
+            0,
+            "the label guard short-circuits before the judge is even consulted"
+        );
+    }
+
+    #[test]
+    fn creative_idea_gate_argv_never_uses_admin_or_no_verify() {
+        // The whole creative-idea merge posture forbids privilege bypass: the
+        // driver skips the PR (above) and the routing seam's gh argv never carry
+        // --admin/--no-verify.
+        use crate::creative_ideas::routing::{
+            gh_pr_add_label_argv, gh_pr_add_reviewer_argv, gh_pr_draft_argv,
+        };
+        let argvs = [
+            gh_pr_draft_argv("rysweet/Simard", 7),
+            gh_pr_add_label_argv(
+                "rysweet/Simard",
+                7,
+                crate::creative_ideas::CREATIVE_IDEA_PR_LABEL,
+            ),
+            gh_pr_add_reviewer_argv(
+                "rysweet/Simard",
+                7,
+                crate::creative_ideas::CREATIVE_IDEA_OWNER,
+            ),
+        ];
+        for argv in &argvs {
+            assert!(!argv.iter().any(|a| a == "--admin"));
+            assert!(!argv.iter().any(|a| a == "--no-verify"));
+        }
+    }
 
     #[test]
     fn merges_cross_repo_pr_through_the_same_gated_authority() {

--- a/src/stewardship/merge_judge.rs
+++ b/src/stewardship/merge_judge.rs
@@ -402,6 +402,7 @@ mod tests {
             review_decision: "APPROVED".into(),
             checks: vec![],
             base_ref_name: "main".into(),
+            labels: vec![],
         }
     }
 

--- a/tests/issue_2626_amplihack_pin_bump.rs
+++ b/tests/issue_2626_amplihack_pin_bump.rs
@@ -9,10 +9,10 @@
 //! `main` and run the new code. The pins are advanced as upstream lands work:
 //!
 //!   * `amplihack-agent-eval`  59548a96… → **2a93441d…** (amplihack-rs main)
-//!   * `amplihack-memory`       f8003708… → **2266cc24…** (memory-lib main —
-//!     the squash-merge of PR #121, which lands the decoupled
-//!     `measurement::precision_at_k` recall-quality primitive that Simard's
-//!     hybrid measurement surface delegates to, on top of the #2626 bump)
+//!   * `amplihack-memory`       f8003708… → **e005a596…** (memory-lib main —
+//!     the squash-merge of PR #120, which lands the first-class `creative_idea`
+//!     prospective memory type on top of PR #121's `measurement::precision_at_k`
+//!     recall-quality primitive, so the single pin carries both)
 //!
 //! These are the exact 40-char SHAs verified against `git ls-remote … main`
 //! at authoring time.
@@ -43,9 +43,12 @@ use std::path::PathBuf;
 /// amplihack-rs `main` HEAD carrying the `amplihack-agent-eval` crate to adopt.
 const AGENT_EVAL_TARGET_REV: &str = "2a93441d1837f9f853d5dddc56cc1088353a8872";
 /// amplihack-memory-lib `main` commit carrying the `amplihack-memory` crate:
-/// PR #121's squash-merge (the `measurement::precision_at_k` primitive, on top
-/// of the #2626 pin), which Simard's hybrid measurement surface delegates to.
-const MEMORY_TARGET_REV: &str = "2266cc247d66c773c33300546a97502d53497c20";
+/// PR #120's squash-merge (the first-class `creative_idea` prospective memory
+/// type — CreativeIdeaStatus lifecycle + typed MemoryLink/MemoryLinkKind — which
+/// Simard's Creative Ideas thread re-exports), which lands directly on top of
+/// PR #121's `measurement::precision_at_k` primitive, so this single rev carries
+/// BOTH upstream additions.
+const MEMORY_TARGET_REV: &str = "e005a5963b38bc02610fa5b0bef7e52625dcd092";
 
 /// The stale revs the bump must move *off of* (anti-regression sentinels).
 const AGENT_EVAL_STALE_REV: &str = "59548a96049ab8d558110bcaf9c82a4316f1bbf0";


### PR DESCRIPTION
## Summary

Turns the gated-OFF Creative Ideas **design spike** (#2613) into a **live,
default-ON** subsystem: a background cognitive thread that periodically dreams
up **ten** candidate self-improvement ideas, has **four reviewers** vet each,
and **routes** accepted ideas to goals or human-review issues — behind a hard
human-review gate on every idea-derived PR. One brain (cognitive thread +
reviewers), no "Bridge".

Follows the merged design at `docs/design/creative-ideas-thread.md`; delivers
roadmap milestones **M2–M5**.

## What lands

**Generation thread (wired, default-ON opt-out)**
- `CreativeIdeasThread` registered with the `Mind` scheduler; gated **default-ON**
  behind `SIMARD_CREATIVE_IDEAS_ENABLED` (opt out with a falsey value), consistent
  with the Overseer/Journal threads. `Priority::Low`, ≥24h cadence.
- Real observation window: current goals, journal/recent activity, episodic
  summaries, works-in-progress, Overseer observations, conversation insights, and
  previously-generated ideas — **best-effort with explicit telemetry** on any read
  failure (no silent fallback).

**Real agentic generation + review (G3)**
- `AgenticIdeaSource` and four real reviewers — `crusty-old-engineer` skill,
  `philosophy-guardian` agent, a new `measurability` agent, and deterministic
  fail-closed synthesis — run through the shared session `AgentInvoker` (the OODA
  brain's blessed path: **idle-liveness only, NO wall-clock turn cap**). Prompt
  assets ship a strict **JSON output contract**; extraction is tolerant + fail-closed.

**Routing + safety gate**
- Accepted (non-flagged) → a **Proposed goal** on the goal board.
- Human-review-flagged → a **GitHub issue** labeled `creative-idea` and tagging
  **@rysweet**.
- Idea-derived PRs are gated: **draft + `creative-idea-needs-human-review` label +
  owner review requested**. Real `IdeaGhClient` `gh` subprocess; **never**
  `--admin`/`--no-verify`.
- The autonomous **merge driver skips** any PR carrying the block-until-human-review
  label (`PrSnapshot` now reads `labels`).

**Memory model upstream (G2)**
- `amplihack-memory-lib` gains the first-class **creative-idea memory type** —
  `CreativeIdeaStatus` lifecycle state machine + typed `MemoryLink`/`MemoryLinkKind`
  (incl. `Goal`) — via rysweet/amplihack-memory-lib#120 (merged). Simard **re-exports**
  it and bumps its pinned dep in lockstep (`cargo build` links exactly one memory lib).
- Append-only prospective **revisioning** (stable `idea_id` + monotonic `revision`)
  collapses to the latest revision so ideas are **searchable/enumerable by status**
  without duplicate rows.

**Surfacing**
- A **Creative Ideas dashboard tab** and a **TUI pane**, both browseable and
  **searchable by status**. Also fixes a real bug: `SharedMemory` (the dashboard
  reader bridge) didn't delegate `list_all_prospective`/`list_all_episodes`, so
  prospective-memory reads through the bridge silently returned empty.

**Docs**
- Durable design/howto/reference docs updated to describe the implemented,
  default-ON subsystem (no point-in-time snapshot). `mkdocs build --strict` passes.

## Tests (hermetic, no network)

Generation produces exactly ten `New` ideas with populated links; every reviewer
contributes and synthesis assigns a terminal status; accepted → goal; human-review
→ issue carrying the label + owner tag; the idea-PR label **blocks the merge driver**
(and constructed gh argv never contain `--admin`/`--no-verify`); ideas are searchable
by every status; dry-run reviews but writes/routes nothing; `tick` is total.

## Constraints honored

Off latest `origin/main`; default-workflow; never `git --no-verify` / `gh pr merge
--admin`; no "Bridge" names; no stray `println!`/`eprintln!` in production code; no
silent fallbacks; no wall-clock timeouts on agentic turns (idle-liveness); memory-arch
upstream (G2); agentic-over-brittle-parsing / prompts (G3); durable docs only.

Companion (merged): rysweet/amplihack-memory-lib#120.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>