### PR TITLE
fix(distill): read facts from a dedicated agent-written file, not stdout (#2622/#2619)

### DIFF
--- a/docs/architecture/episode-distillation.md
+++ b/docs/architecture/episode-distillation.md
@@ -81,7 +81,7 @@ Batch of up to 50 episodes where distilled = 0
   ├─ if batch.len() < 20  →  skip pass, no LLM call, no markers
   │
   ▼
-Serialize as JSON, invoke recipe-runner-rs
+Serialize as JSON, invoke recipe-runner-rs (agent writes facts_output_path file)
   │
   ▼
 prompt_assets/simard/recipes/distill-episodes.yaml
@@ -91,7 +91,8 @@ prompt_assets/simard/recipes/distill-episodes.yaml
   │    - lesson-learned    (decisions, tradeoffs, things that surprised the engineer)
   │    - skip              (truly low-signal — startup logs, retries, etc.)
   ▼
-Recipe output: { "facts": [ { concept, content, source_episode_id }, ... ] }
+Read the dedicated facts file the agent WROTE (never stdout):
+  { "facts": [ { concept, content, source_episode_id }, ... ], "procedures": [ ... ] }
   │
   ▼
 For each fact:
@@ -167,32 +168,42 @@ recipe with a single LLM agent. It follows the same shape as
   recipe only needs ordering, not human-readable time, so no
   `chrono::DateTime` conversion is performed at the boundary.
 - **Prompt**: instructs the agent to classify each episode into one
-  of the three concept labels (or `skip`) and emit a JSON object
+  of the three concept labels (or `skip`) and **write** a JSON object
   `{ "facts": [ { "concept": "...", "content": "...",
-  "source_episode_id": "..." } ], "procedures": [ ... ] }`.
-- **Output**: the runner is invoked with `--output-format json`, so the
-  agent's JSON object arrives inside `recipe-runner-rs`'s structured
-  envelope at `step_results[].output`. The Rust caller extracts it with a
-  tolerant three-tier parser; non-conforming output or a failed run
-  causes the caller to return `Err` (which then triggers the "no markers
-  set" retry behaviour above). See
+  "source_episode_id": "..." } ], "procedures": [ ... ] }` to a
+  dedicated facts file.
+- **Output**: the agent WRITES its JSON envelope to a dedicated
+  per-invocation facts file whose absolute path is passed to the recipe
+  as `-c facts_output_path=<tmp>` and interpolated into the prompt as
+  `{{facts_output_path}}`. After the runner exits, the Rust caller reads
+  **that file** and deserializes it — stdout is never the result channel,
+  so the copilot launcher banner and log lines can no longer contaminate
+  the parse (issues [#2622](https://github.com/rysweet/Simard/issues/2622)
+  / [#2619](https://github.com/rysweet/Simard/issues/2619)). A missing,
+  empty, or unparseable facts file — or a failed run — causes the caller
+  to return `Err` (which then triggers the "no markers set" retry
+  behaviour above); there is **no** stdout fallback (a silent fallback is a
+  silent failure). See
   [Distill recipe output capture](../reference/distill-recipe-output-capture.md)
-  for the full envelope contract, the parser, and failure semantics.
+  for the file-channel contract, the parser, and failure semantics.
 
 The Rust-side invocation shells out to `recipe-runner-rs` with an
-argv-vector (no shell): the recipe path as a positional arg,
-`--output-format json`, and the episodes batch inlined as a single
-`-c episodes=<json>` context entry, with `AMPLIHACK_AGENT_BINARY` in the
-environment. `--output-format json` is **required** — in the default
-`text` mode the runner's stdout is only a human status banner and the
-agent's facts object never reaches the caller, which is exactly the
-latent bug that
-[#2401](https://github.com/rysweet/Simard/issues/2401) fixes. The same
-`Command::new("recipe-runner-rs")` argv construction — minus
-`--output-format json` — is used by
+argv-vector (no shell): the recipe path as a positional arg, the episodes
+batch inlined as a single `-c episodes=<json>` context entry, and the
+facts file path as `-c facts_output_path=<tmp>`, with
+`AMPLIHACK_AGENT_BINARY` in the environment. `--output-format json` is
+still passed so a runner-level failure surfaces a structured error on
+stdout for the terminal-failure message, but the distill **result** is
+read from the facts file, never stdout — the file channel is what closes
+the latent silent no-op that
+[#2401](https://github.com/rysweet/Simard/issues/2401) first fixed via
+stdout capture and that [#2622](https://github.com/rysweet/Simard/issues/2622)
+/ [#2619](https://github.com/rysweet/Simard/issues/2619) hardened against
+launcher-banner contamination. The sibling
 `stewardship::recipe_merge_judge::RecipeMergeJudge` and
-`goal_curation::recipe_progress_checker::RecipeProgressChecker`, which
-still parse the default text banner and are intentionally left unchanged.
+`goal_curation::recipe_progress_checker::RecipeProgressChecker` still parse
+the runner's text/stdout output and are intentionally left unchanged (they
+do not carry the distill agent's large structured payload).
 
 The recipe is loaded with the same resolution order Simard uses
 elsewhere:
@@ -434,10 +445,10 @@ end-to-end LLM yield. The numbers are a property of the fixed corpus
 labels), not a global production delta.
 
 `src/memory_consolidation/distillation_fact_yield_bench.rs` runs a fixed
-batch of 25 episodes and a fixed recipe-output envelope of 13 candidate
+batch of 25 episodes and a fixed facts document of 13 candidate
 facts (canonical, surface-form-variant, off-spec, ungrounded, and
 empty-content cases) through the real production path
-(`parse_recipe_output_full` + `assess_fact_reliability`). It embeds an
+(`parse_facts_document` + `assess_fact_reliability`). It embeds an
 exact-match baseline oracle so the before/after comparison is
 self-contained: reverting the concept canonicalization collapses
 `improved` to `baseline` and fails the strict-improvement assertion.
@@ -529,14 +540,12 @@ of passes that actually reached output parsing (`parse_attempted == true`), so
 its plain mean is exactly successes-vs-attempts — no post-hoc filtering of
 `distill_success_rate` events is needed (the older `parse_attempted` /
 `parse_success` context flags remain for back-compatible derivation). It
-isolates the "recipe exited 0 but its output was unparseable" mode
-(`failure_class = parse-failure`, t=7517 — including the #2512
-launch-banner-prefixed *envelope*) from the "recipe process exited non-zero"
-mode (`copilot-terminal-failure`, t=7411) and the "exited 0 but no step output"
-mode (`recipe-reported-failure`), which never reached parsing and emit **no**
-parse-rate event. This is the rate the launch-banner parse fixes (#2496/#2504/
-#2512) drive toward `1.0`, mirroring how #2504 was validated for the
-decide/orient brain. Because the data lives in `metrics.jsonl` (operator
+isolates the "recipe exited 0 but the agent's facts document was
+missing/empty/unparseable" mode (`failure_class = parse-failure`, issues
+#2622/#2619) from the "recipe process exited non-zero" mode
+(`copilot-terminal-failure`), which never reached parsing and emits **no**
+parse-rate event. This is the rate the file-channel fix (#2622/#2619) drives
+toward `1.0`. Because the data lives in `metrics.jsonl` (operator
 runtime state, queryable via `self_metrics::query_metrics`), the rates are
 computed over a rolling window — no point-in-time findings doc is committed.
 
@@ -587,8 +596,8 @@ distill: 8 episodes pulled, below min 20, skipped
 
 ### Example 3 — recipe error
 
-The runner exits non-zero, the envelope reports `success: false`, or the
-captured `step_results[].output` carries no parseable facts object:
+The runner exits non-zero, or the agent's dedicated facts file is
+missing, empty, or carries no parseable facts object:
 
 ```
 distill: 40 episodes pulled, recipe error: <message>, no markers set, retry next pass

--- a/docs/reference/distill-recipe-output-capture.md
+++ b/docs/reference/distill-recipe-output-capture.md
@@ -1,7 +1,7 @@
 ---
 title: Distill recipe output capture
-description: How Simard's distillation pass reliably captures the distill agent's { "facts": [...], "procedures": [...] } JSON from recipe-runner-rs — the --output-format json invocation, the RecipeRunnerEnvelope / RecipeRunnerStepResult deserialization types, the three-tier parser in parse_recipe_output_full, the agent-step selection rule, failure semantics, and the redeploy-local.sh recipe-asset sync that keeps the hot-reload path current.
-last_updated: 2026-06-29
+description: How Simard's distillation pass reliably captures the distill agent's { "facts": [...], "procedures": [...] } JSON — the dedicated facts-file channel (facts_output_path), the parse_facts_document / parse_facts parser, field-tolerant deserialization, failure semantics, and the redeploy-local.sh recipe-asset sync that keeps the hot-reload path current.
+last_updated: 2026-07-06
 owner: simard
 doc_type: reference
 related:
@@ -16,398 +16,150 @@ related:
 # Distill recipe output capture
 
 > **Status — implements the
-> [#2401](https://github.com/rysweet/Simard/issues/2401) fix.**
-> The `recipe-runner-rs` 0.3.6 envelope shape documented below is **verified**
-> against the installed binary, and the Simard-side invocation, parser, and
-> deserialization types described here are **implemented** in this PR. Present
-> tense below describes the shipped behavior. Locations:
+> [#2622](https://github.com/rysweet/Simard/issues/2622) /
+> [#2619](https://github.com/rysweet/Simard/issues/2619) fix.**
+> The distill agent's answer is captured from a **dedicated facts file** the
+> agent writes, not from `recipe-runner-rs` stdout. Present tense below
+> describes the shipped behavior. Locations:
 > parser + invocation `src/memory_consolidation/distillation.rs`;
-> tests `src/memory_consolidation/distillation_tests.rs`;
+> tests `src/memory_consolidation/distillation_tests.rs` and the hermetic
+> `issue_2622_file_channel_tests` in `distillation.rs`;
 > recipe `prompt_assets/simard/recipes/distill-episodes.yaml`;
 > asset sync `scripts/redeploy-local.sh`.
 
 The episode-distillation pass turns batches of episodic memory into
 semantic **facts** and reusable **procedures** by shelling out to
-`recipe-runner-rs` and parsing the distill agent's JSON output. This
-page documents the **output-capture contract** between Simard and
-`recipe-runner-rs` 0.3.6: how the agent's
-`{ "facts": [...], "procedures": [...] }` object is reliably extracted
-from the recipe runner's structured envelope, what happens on failure,
-and how the recipe asset reaches the running daemon.
+`recipe-runner-rs` and reading the distill agent's JSON output. This page
+documents the **output-capture contract** between Simard and the distill
+agent: how the agent's `{ "facts": [...], "procedures": [...] }` object is
+reliably captured, what happens on failure, and how the recipe asset reaches
+the running daemon.
 
-For the surrounding pipeline (when the pass fires, the threshold gate,
-how facts are stored), see
+For the surrounding pipeline (when the pass fires, the threshold gate, how
+facts are stored), see
 [Episode distillation](../architecture/episode-distillation.md). For the
 automatic scheduler and the procedures extension, see the
 [automatic distillation scheduler API](./automatic-distillation-scheduler.md).
 
 ---
 
-## Why this contract exists
+## Why this contract exists — the file channel
 
-`recipe-runner-rs` runs the `distill-episodes` recipe — a single
-`distill` agent step that asks the LLM to return
-`{ "facts": [...], "procedures": [...] }` and nothing else. Simard
-captures that object from the subprocess's **stdout**.
+`recipe-runner-rs` runs the `distill-episodes` recipe — a single `distill`
+agent step that asks the LLM to produce `{ "facts": [...], "procedures": [...] }`.
 
-The runner has **two** stdout formats, selected by `--output-format`:
+Capturing that object from the subprocess's **stdout** is brittle: the
+copilot binary prints a launcher banner and log lines to the inherited
+stdout *before and around* the agent's answer, e.g.
 
-| Format          | Stdout content                                                                 |
-|-----------------|--------------------------------------------------------------------------------|
-| `text` (default) | A human status banner only. The agent step's output is **not** on stdout.     |
-| `json`          | A structured envelope whose `step_results[].output` holds the agent's output. |
-
-In `text` mode, stdout is just:
-
-```
-Recipe: distill-episodes (v1.0.0)
-Steps: 1
-Recipe 'distill-episodes': SUCCESS (18.0s)
-  [completed] distill (18.0s)
+```text
+2026-07-06T02:45:12Z  INFO launching copilot binary=/home/.../copilot version="GitHub Copilot CLI 1.0.69-1."
+ℹ NODE_OPTIONS=--max-old-space-size=32768 (saved preference)
+Run 'copilot update' to update
 ```
 
-The agent's actual `{ "facts": [...] }` payload is absent. Any parser
-that scans this banner for a facts object fails on **every** cycle, even
-though the recipe step itself succeeded (the LLM ran for 18–28s). That
-failure is non-fatal — no markers are set, the batch retries — so the
-pass silently no-ops forever and distillation produces zero facts in
-production.
+Live daemon logs (02:45–02:47) confirmed the failure mode: the captured
+step "output" was literally this launcher banner, and a stdout scan for a
+`{ "facts": [...] }` object matched the banner instead of the answer — every
+distill pass failed with `class="parse-failure"` and memory fact-yield was
+near zero.
 
-The fix is to invoke the runner with `--output-format json` and parse
-the **envelope**. This page pins the envelope shape to the real 0.3.6
-output and specifies the tolerant parser that extracts the agent payload
-from it.
-
----
-
-## The recipe-runner-rs 0.3.6 JSON envelope
-
-With `--output-format json`, `recipe-runner-rs` writes a single JSON
-object to stdout. Captured verbatim from the installed
-`recipe-runner 0.3.6` binary:
-
-```json
-{
-  "recipe_name": "distill-episodes",
-  "success": true,
-  "step_results": [
-    {
-      "step_id": "distill",
-      "status": "completed",
-      "output": "{\"facts\":[{\"concept\":\"bug-pattern\",\"content\":\"…\",\"source_episode_id\":\"e1\"}],\"procedures\":[]}",
-      "error": "",
-      "duration": 18.04
-    }
-  ],
-  "duration": 18.05
-}
-```
-
-Field reference:
-
-| Field                     | Type            | Meaning                                                                 |
-|---------------------------|-----------------|-------------------------------------------------------------------------|
-| `recipe_name`             | string          | The recipe's `name` (`distill-episodes`).                               |
-| `success`                 | bool            | `true` only if every step succeeded. `false` if any step failed.        |
-| `step_results`            | array           | One entry per executed step, in order.                                  |
-| `step_results[].step_id`  | string          | The recipe step's `id` (`distill`).                                     |
-| `step_results[].status`   | string          | `completed` on success, `failed` on error.                             |
-| `step_results[].output`   | string          | The step's captured stdout. For the `distill` agent step this is the agent's `{ "facts": …, "procedures": … }` JSON **as a string** (escaped inside the envelope). |
-| `step_results[].error`    | string          | Empty (`""`) on success; a diagnostic message on failure.              |
-| `step_results[].duration` | number          | Step wall-clock seconds.                                               |
-| `duration`                | number          | Total recipe wall-clock seconds.                                       |
-
-> **The agent payload lives in `step_results[].output` as a string.**
-> The parser must select the right step, read `output`, then parse the
-> facts object out of that string. The runner does **not** merge the
-> agent JSON into the envelope's top level.
-
-### Failure envelope
-
-When a step fails, the runner still emits a well-formed envelope **and**
-exits with a non-zero process code:
-
-```json
-{
-  "recipe_name": "distill-episodes",
-  "success": false,
-  "step_results": [
-    {
-      "step_id": "distill",
-      "status": "failed",
-      "output": "",
-      "error": "Step 'distill' failed: …",
-      "duration": 0.004
-    }
-  ],
-  "duration": 0.004
-}
-```
-
-| Condition          | Process exit code | `success` | `status`     |
-|--------------------|-------------------|-----------|--------------|
-| All steps OK       | `0`               | `true`    | `completed`  |
-| A step failed      | `1`               | `false`   | `failed`     |
-
-Both signals are present, but they are checked on **different layers**, and
-the order matters:
-
-- **`invoke_recipe` checks the process exit code first.** A failed run exits
-  non-zero, so `invoke_recipe` returns `Err` *before the parser ever sees the
-  envelope*. This is the path that actually fires in production — see
-  [Example 2](#example-2-failed-recipe-run), whose log line is
-  `recipe exited with status 1`.
-- **The parser's `success == false` guard is defense-in-depth.** Because the
-  exit-code guard fires first, the parser's check is effectively unreachable
-  today; it only matters if a future `recipe-runner-rs` emits
-  `success == false` while still exiting `0`. It is retained deliberately so a
-  failed run can never yield facts even if the exit-code contract changes.
-
-Either way, the parser never extracts facts from a failed run.
+The fix removes stdout from the result path entirely. The agent **writes**
+its JSON envelope to a private, per-invocation file whose absolute path is
+handed to the recipe as a context variable. Simard reads **that file** after
+the runner exits. A launcher banner on stdout can no longer contaminate the
+parse, because stdout is never read as the result.
 
 ---
 
 ## Invocation
 
-The production runner is `RecipeRunnerSubprocess::invoke_recipe`
-(`src/memory_consolidation/distillation.rs`). It already builds the argv as a
-vector (no shell) and serializes the episode batch to compact JSON. The #2401
-change adds `--output-format json` to that existing invocation so the agent
-payload reaches stdout:
+The Rust-side invocation shells out to `recipe-runner-rs` with an
+argv-vector (no shell):
 
 ```text
-recipe-runner-rs <recipe_path> \
-  --output-format json \
-  -c episodes=<compact-json-array>
+recipe-runner-rs <recipe_path>
+    --output-format json
+    -c episodes=<compact-json-array>
+    -c strict_json_instruction=<empty | retry-reinforcement>
+    -c facts_output_path=<absolute path to a fresh tempdir/facts.json>
 ```
 
-with the agent binary supplied via the environment:
+with `AMPLIHACK_AGENT_BINARY` in the environment.
 
-```text
-AMPLIHACK_AGENT_BINARY=<copilot|claude|codex|…>
-```
+- `facts_output_path` is a fresh, mode-`0700` tempdir (`tempfile` crate) plus
+  a `facts.json` filename, unique per invocation. The recipe interpolates it
+  into the prompt via `{{facts_output_path}}` and instructs the agent to write
+  **only** the JSON envelope there.
+- `--output-format json` is retained only so that a **runner-level** failure
+  surfaces a structured error on stdout for the terminal-failure message. The
+  distill **result** is never read from stdout.
+- After the runner exits, Simard reads `facts_output_path`, and the tempdir
+  (and its contents) is removed when the invocation returns.
 
-Notes:
-
-- **`--output-format json` is required.** Without it the agent payload
-  never reaches stdout (see [Why this contract exists](#why-this-contract-exists)).
-- **The agent binary is selected via the `AMPLIHACK_AGENT_BINARY`
-  environment variable**, resolved by
-  `session_builder::LlmProvider::resolve_agent_binary()`. This is the
-  same mechanism that already made the recipe step *run* successfully in
-  production, so it is retained unchanged. The equivalent
-  `--agent-binary` flag is **not** added — one configuration surface is
-  enough, and adding a second risks the two disagreeing.
-- **The episodes payload is passed as a single `-c episodes=<json>`
-  argument** using `Command::new(...).arg(...)` argv construction — never
-  interpolated into a shell line. Episode content cannot break out of the
-  argument into flags, the recipe path, or the binary name. See
-  [Security](#security).
-- **Failures are surfaced, never swallowed.** A non-zero exit returns a
-  non-fatal `Err` carrying a truncated excerpt of both stderr and stdout
-  (the structured error lives in the JSON envelope on stdout), and the
-  parser's error messages are truncated to ≤ 200 chars. An explicit
-  captured-stdout byte cap is a recommended follow-up (see
-  [Security](#security)), not part of this fix.
-
-The recipe path is resolved with Simard's standard hot-reload-first
-order (see [Recipe asset sync](#recipe-asset-sync)):
-
-1. `~/.simard/prompt_assets/simard/recipes/distill-episodes.yaml` (hot-reload / user override)
-2. `<repo>/prompt_assets/simard/recipes/distill-episodes.yaml` (in-tree default)
+`invoke_recipe` builds the argv; `harvest_facts_file` post-processes the
+finished `std::process::Output`: a non-zero exit is an explicit terminal
+error carrying truncated stderr/stdout; a clean run reads the facts file.
+`harvest_facts_file` is factored out so the "stdout noise is ignored"
+contract is hermetically testable without spawning a subprocess.
 
 ---
 
 ## Parser API
 
-The captured stdout is parsed by two functions in
-`src/memory_consolidation/distillation.rs`, both `pub(crate)` so the
-test module can exercise them directly:
+Two `pub(crate)` functions parse the **facts document** (the file contents):
 
-```rust
-/// Parse recipe-runner-rs stdout into facts AND procedures.
-///
-/// Three-tier strategy (see below). Returns `Err` on a failed recipe
-/// run or when no facts object can be located — the caller treats `Err`
-/// as the retry-safe "no markers set" path.
-pub(crate) fn parse_recipe_output_full(raw: &str) -> SimardResult<DistillOutput>;
+- `parse_facts_document(document: &str) -> SimardResult<DistillOutput>` — the
+  full parser (facts AND procedures).
+- `parse_facts(document: &str) -> SimardResult<Vec<DistilledFact>>` — a thin
+  facts-only wrapper over `parse_facts_document`, retained for the legacy
+  `DistillRecipeRunner::run` entry point.
 
-/// Facts-only wrapper retained for the legacy `DistillRecipeRunner::run`
-/// entry point and its unit tests.
-pub(crate) fn parse_recipe_output(raw: &str) -> SimardResult<Vec<DistilledFact>>;
-```
+`parse_facts_document`:
 
-`parse_recipe_output` delegates to `parse_recipe_output_full` and
-returns only `output.facts`.
+1. An **empty** document ⇒ explicit `Err` (the agent produced no output;
+   never a hollow `Ok`; no stdout fallback).
+2. Otherwise `scan_cleaned_for_facts` deserializes the
+   `{ "facts": [...], "procedures": [...] }` envelope. Because the file is a
+   clean channel, this is a strict `serde` parse with only light **format**
+   leniency: an LLM may wrap the answer in a Markdown code fence or a little
+   leading/trailing prose in the file, so the parser prefers the last balanced
+   `{...}` object that carries a grounded fact. This is field/format leniency
+   on a clean channel — **not** the launcher-banner stdout scraping this fix
+   removed.
+3. If no facts object is present ⇒ explicit `Err`.
 
-### Deserialization types
+### Field-tolerant deserialization
 
-Two transient structs model the 0.3.6 envelope. They are distinct from
-the inner `RecipeEnvelope` (which models the agent's
-`{ "facts": …, "procedures": … }` object) so there is no name collision:
-
-```rust
-/// recipe-runner-rs 0.3.6 top-level JSON envelope.
-#[derive(serde::Deserialize)]
-struct RecipeRunnerEnvelope {
-    success: bool,                            // REQUIRED — no serde default
-    step_results: Vec<RecipeRunnerStepResult>, // REQUIRED — no serde default
-}
-
-/// One entry of `step_results`.
-#[derive(serde::Deserialize)]
-struct RecipeRunnerStepResult {
-    #[serde(default)]
-    step_id: String,
-    #[serde(default)]
-    status: String,
-    /// `serde_json::Value` so a String output (0.3.6) OR a future
-    /// object output both deserialize without a contract break.
-    #[serde(default)]
-    output: serde_json::Value,
-}
-```
-
-`success` and `step_results` are **required** (no `#[serde(default)]`):
-text from the old human banner, a bare facts object, or any other
-non-envelope payload fails Tier 1 deserialization cleanly and falls
-through to Tier 2. `output` is typed as `serde_json::Value` to tolerate
-both a JSON **string** (the 0.3.6 contract) and a future JSON **object**.
-
-### Three-tier parse strategy
-
-`parse_recipe_output_full` tries three tiers in order and stops at the
-first that yields a facts object:
-
-**Tier 1 — runner envelope (the production path).**
-
-1. Deserialize stdout as `RecipeRunnerEnvelope`.
-   - **Tier 1a (fast path):** parse the trimmed stdout directly. Clean
-     production output (the envelope is the first byte) parses here with zero
-     extra work.
-   - **Tier 1b (noise-tolerant recovery, [#2512](https://github.com/rysweet/Simard/issues/2512)):**
-     if the direct parse fails, recover the envelope through the **shared**
-     `recipe_output` chokepoint (`recover_runner_envelope`). The copilot
-     subprocess prints its launch banner (`ℹ NODE_OPTIONS=…`,
-     `launching copilot binary=… version="GitHub Copilot CLI …"`,
-     `Run 'copilot update'…`) and intermittent ANSI tracing lines to the
-     **inherited stdout *before*** recipe-runner-rs emits its JSON envelope, so
-     the captured stdout **begins with the banner instead of the `{`** and the
-     Tier-1a parse rejects it — losing the envelope and its escaped facts
-     payload. Tier 1b strips that preamble (the same `strip_recipe_noise` +
-     `strip_ansi` dual view + string-aware `balanced_objects` end-first scan the
-     inner step-output path uses) and recovers the envelope. This is the
-     *outer-envelope* analog of the inner step-output banner stripping below,
-     and of the #2504 decide/orient launch-banner fix. A leading non-envelope
-     log record (e.g. `{"level":"info",…}`) lacks `success`/`step_results`, so
-     it is never mistaken for the envelope.
-2. If `success == false`, return `Err` immediately — never extract facts
-   from a failed run. (Defense-in-depth: a failed run already exits non-zero,
-   so `invoke_recipe`'s exit-code guard normally returns `Err` before this
-   point — see [Failure semantics](#failure-semantics).) A banner-prefixed
-   `success == false` envelope recovered by Tier 1b still routes here (it is
-   *committed to* once recovered), so it surfaces a `RecipeReportedFailure`,
-   never a silent drop.
-3. Select the step: the entry with `step_id == "distill"`; if absent,
-   the **last** entry with `status == "completed"`. (The `step_id` rule
-   pins to the recipe's named step; the last-completed fallback tolerates
-   a future step rename.)
-4. Read that step's `output`:
-   - If `output` is a **string**, scan it for the balanced
-     `{ "facts": … }` object (see [`scan_for_facts_object`](#scan_for_facts_object)).
-   - If `output` is already an **object** containing `"facts"`,
-     deserialize it directly.
-5. Filter and return the facts/procedures (concept allow-list +
-   procedure validity, identical to the existing inner parser).
-
-**Tier 2 — tolerant raw scan (backward compatibility).**
-
-If stdout does not parse as a `RecipeRunnerEnvelope` at all (e.g. a unit
-test or mock that emits a bare `{ "facts": … }` object, or prose with the
-object embedded), scan the **raw stdout** directly for a balanced
-`{ "facts": … }` object. This keeps all existing `DistillRecipeRunner`
-mock tests and the plain-object / prose-wrapped tests green.
-
-**Tier 3 — explicit failure.**
-
-If neither tier locates a parseable facts object — or Tier 1 saw
-`success == false` or no completed `distill` step — return an explicit
-`Err` whose message includes a **truncated** (≤ 200 char) excerpt of the
-stdout. No full payloads are placed in `info`/`warn` logs; only the
-truncated excerpt surfaces, and full stdout appears only at `debug`
-level.
-
-```
-distill: recipe run did not yield a parseable { "facts": [...] } object: <≤200-char excerpt>
-```
-
-The truncation keeps the error bounded (the
-`parser_error_does_not_leak_full_payload` test asserts the message stays
-short and never echoes content past the truncation window).
-
-There is **no silent degradation**: every failure path returns `Err` and
-is surfaced upstream.
-
-### `scan_for_facts_object`
-
-Tiers 1 and 2 share one helper:
-
-```rust
-/// Locate and parse a balanced `{ "facts": … }` object in `s`, returning the
-/// facts from the LAST balanced object that parses (so a leading banner or
-/// thinking object does not shadow the agent's answer — issue #2461).
-/// Iterative (no recursion in the scan itself), so deeply nested input cannot
-/// grow the stack; each candidate parse is bounded by `serde_json`'s own
-/// recursion limit, which rejects pathological nesting.
-fn scan_for_facts_object(s: &str) -> Option<DistillOutput>;
-```
-
-It first tries the fast path (the whole string is the object), then collects
-every balanced top-level `{...}` substring with a **string-aware** brace
-scan (braces inside JSON string literals are ignored, so a brace in a fact's
-`content` cannot corrupt depth accounting) and returns the facts from the
-**last non-empty** one that parses (falling back to an empty `{"facts":[]}`
-only when no object carries facts/procedures). The scan is linear in the input
-length; pathologically nested braces parse to an `Err` (via serde's recursion
-limit) rather than panicking — see `parser_tolerates_deeply_nested_input_without_panic`.
-
-> **Shared noise stripping ([#2496](https://github.com/rysweet/Simard/issues/2496)).**
-> Before scanning, the distill parser strips ANSI codes and non-payload lines
-> through the **shared** `recipe_output::strip_recipe_noise` chokepoint — the
-> same `is_noise_line` predicate the OODA brains use — rather than a distill-private
-> cleaner. This is what lets the parser survive the Copilot CLI launch-log
-> preamble (`ℹ NODE_OPTIONS=…`, `launching copilot binary=… version="GitHub
-> Copilot CLI …"`, `Run 'copilot update'…`) that PR
-> [#2500](https://github.com/rysweet/Simard/pull/2500) first pinned as a distill
-> regression. Because the launcher-shape detection now lives at the single
-> chokepoint, hardening it once re-hardens distill **and** decide/orient/
-> lifecycle/merge-judge together; distill carries **no** parallel launcher
-> cleaner. See
-> [Text-parsing wire formats § Protocol 0](./text-parsing-wire-formats.md#protocol-0-shared-noise-pre-stripping-recipe_output)
-> and [Concept: Copilot launch-log preamble stripping](../concepts/copilot-launcher-preamble-stripping.md).
+Individual `facts[]` fields are deserialized with `de_lenient_string`: a
+missing / `null` / bare-scalar field (a common LLM deviation) coerces to the
+empty string rather than sinking the whole envelope. Off-spec concepts are
+dropped by `RecipeEnvelope::into_facts` (concept allow-list, with surface-form
+canonicalization); an empty/ungrounded fact is later quarantined by the ISAO
+reliability gate (`assess_fact_reliability`). One malformed fact never sinks
+its well-formed siblings.
 
 ---
 
 ## Failure semantics
 
-The output-capture fix **preserves** the existing graceful-skip and
-non-fatal-error contract. Distillation never blocks or crashes the OODA
-cycle.
+Every failure is explicit — never silent degradation.
+`classify_distill_error` buckets each failure by the stable leading prefix of
+its message:
 
-| Situation                                              | Layer that returns the result                          | Pass outcome                                   |
-|--------------------------------------------------------|--------------------------------------------------------|------------------------------------------------|
-| Runner missing / no agent binary / recipe file absent  | runner not constructed (`RecipeRunnerSubprocess::new`) | `Ok(DistillReport::skipped())`, no LLM call    |
-| Process exits non-zero (the production failure path)   | `invoke_recipe` exit-code guard → `Err`                | non-fatal; no markers set; retry next pass     |
-| Envelope `success == false` *with* exit `0`            | parser Tier 1 guard → `Err` (defense-in-depth)         | non-fatal; no markers set; retry next pass     |
-| No completed `distill` step                            | parser Tier 1 → `Err`                                  | non-fatal; no markers set; retry next pass     |
-| `output` present but no parseable facts object         | parser Tier 3 → `Err`                                  | non-fatal; no markers set; retry next pass     |
-| Launch-banner / ANSI noise **before** the envelope `{` | parser Tier 1b recovery → `Ok(DistillOutput { … })`    | facts stored ([#2512](https://github.com/rysweet/Simard/issues/2512)) |
-| Valid envelope, facts extracted                        | parser Tier 1 → `Ok(DistillOutput { … })`              | facts stored; **every** input episode marked   |
+| Class                     | Trigger                                                                 | Retried in-cycle? |
+|---------------------------|-------------------------------------------------------------------------|-------------------|
+| `SpawnFailure`            | `recipe-runner-rs` not spawnable, or facts tempdir not creatable        | no                |
+| `CopilotTerminalFailure`  | the recipe **process** exited non-zero                                  | yes               |
+| `ParseFailure`            | process exited 0 but the facts file was **missing / empty / unparseable** | yes             |
+| `SerializeFailure`        | the episodes payload failed to serialize                                | no                |
+| `Other`                   | anything else                                                           | no                |
 
-Every `Err` is mapped to a non-fatal log line at
-`src/ooda_actions/simple_actions.rs` (`distill failed (non-fatal): {e}`).
-No `distilled` markers are written on failure, so the same batch is fully
-eligible on the next pass — distillation is idempotent and retry-safe.
+Transient classes (`ParseFailure`, `CopilotTerminalFailure`) are retried once
+in-cycle (`DISTILL_PARSE_RETRY_MAX`) with JSON-format reinforcement threaded
+into the recipe. On final failure the pass returns `Err` **without** marking
+any episode, so the batch stays fully retry-eligible next pass. `ParseFailure`
+is the class the healthy-path fix drives toward zero.
 
 ---
 
@@ -415,268 +167,134 @@ eligible on the next pass — distillation is idempotent and retry-safe.
 
 ### Example 1 — successful capture
 
-The daemon pulls 25 undistilled episodes and invokes the runner:
-
-```text
-recipe-runner-rs ~/.simard/prompt_assets/simard/recipes/distill-episodes.yaml \
-  --output-format json \
-  -c episodes=[{"id":"e1",…}, …]      # AMPLIHACK_AGENT_BINARY=copilot
-```
-
-Stdout (envelope, agent ran ~20s):
+The runner's stdout carries a launcher banner; the agent wrote a clean
+envelope to `facts_output_path`. Simard reads the file and yields facts:
 
 ```json
-{
-  "recipe_name": "distill-episodes",
-  "success": true,
-  "step_results": [
-    {
-      "step_id": "distill",
-      "status": "completed",
-      "output": "{\"facts\":[{\"concept\":\"pr-pattern\",\"content\":\"CI flakes on lbug pin bumps until cache is warmed\",\"source_episode_id\":\"e7\"},{\"concept\":\"lesson-learned\",\"content\":\"Stale worktrees mask deploy drift\",\"source_episode_id\":\"e12\"}],\"procedures\":[{\"name\":\"ci-fix:auto\",\"steps\":[\"re-run failed job\",\"warm shared target cache\",\"re-push --no-verify\"],\"source_episode_ids\":[\"e7\",\"e9\"]}]}",
-      "error": "",
-      "duration": 19.7
-    }
-  ],
-  "duration": 19.8
-}
+{ "facts": [ { "concept": "pr-pattern", "content": "warm the shared cache before lbug pin bumps", "source_episode_id": "epi_1" } ], "procedures": [] }
 ```
 
-Tier 1 selects the `distill` step, reads `output` (a string), scans it,
-and yields:
+### Example 2 — missing facts file (no stdout fallback)
 
-```text
-DistillOutput {
-  facts:      [ pr-pattern(e7), lesson-learned(e12) ],
-  procedures: [ ci-fix:auto from (e7, e9) ],
-}
-```
+The process exits 0 but the agent never wrote the file — even if stdout
+happens to carry a well-formed facts object, it is **not** scraped. The pass
+returns an explicit `ParseFailure` and retries.
 
-Result: 2 facts and 1 procedure stored; all 25 episodes marked
-distilled.
+### Example 3 — nothing worth distilling
 
-```
-[simard] distill: 25 episodes → 2 facts, 1 procedures, 25 marked
-```
-
-### Example 2 — failed recipe run
-
-The agent step errors (e.g. the LLM call times out). The runner exits
-`1` and emits `success: false`:
-
-```json
-{ "recipe_name": "distill-episodes", "success": false,
-  "step_results": [ { "step_id": "distill", "status": "failed",
-    "output": "", "error": "Step 'distill' failed: …", "duration": 0.9 } ],
-  "duration": 0.9 }
-```
-
-`parse_recipe_output_full` returns `Err`. No markers are set; the batch
-retries next pass:
-
-```
-[simard] distill failed (non-fatal): distill: recipe exited with status 1: Step 'distill' failed: …
-```
-
-### Example 3 — legacy / mock output (Tier 2)
-
-A unit test (or any caller that emits a bare facts object, not a runner
-envelope):
-
-```json
-{ "facts": [ { "concept": "bug-pattern", "content": "…", "source_episode_id": "e3" } ], "procedures": [] }
-```
-
-This is not a `RecipeRunnerEnvelope` (missing `success` /
-`step_results`), so Tier 1 fails and Tier 2 scans the raw string,
-extracting the single fact. Existing mock tests stay green with no
-change.
-
----
-
-## Tutorial: capture a real envelope by hand
-
-To reproduce the production output-capture path against the live binary
-(this invokes the configured LLM once — safe; it touches no Simard
-store):
-
-```bash
-export PATH="$HOME/.local/bin:$PATH"
-export AMPLIHACK_AGENT_BINARY=copilot   # or claude / codex
-
-recipe-runner-rs \
-  prompt_assets/simard/recipes/distill-episodes.yaml \
-  --output-format json \
-  -c episodes='[
-    {"id":"e1","source_label":"ci","temporal_index":1,
-     "content":"CI failed; re-ran job after warming shared target cache; passed"},
-    {"id":"e2","source_label":"ci","temporal_index":2,
-     "content":"CI failed again on lbug pin bump; warmed cache; re-pushed --no-verify; passed"}
-  ]'
-```
-
-You will see the envelope on stdout. The `step_results[0].output` string
-holds the agent's `{ "facts": …, "procedures": … }` JSON — exactly what
-`parse_recipe_output_full` extracts.
-
-To confirm the envelope structure quickly **without** an LLM call, run a
-trivial bash-step recipe. The recipe is passed as a **file path**
-positional argument (the runner treats a bare `-` as a recipe *name* to
-look up, not as stdin):
-
-```bash
-cat > /tmp/probe.yaml <<'YAML'
-name: probe
-version: "1.0.0"
-steps:
-  - id: distill
-    type: bash
-    command: "printf '%s' '{\"facts\":[],\"procedures\":[]}'"
-YAML
-recipe-runner-rs /tmp/probe.yaml --output-format json
-```
-
-The `step_results[0].output` field will contain
-`{"facts":[],"procedures":[]}` as a string, demonstrating the
-string-typed payload the parser scans.
+A valid `{ "facts": [], "procedures": [] }` document is a **success** (zero
+facts), never a parse failure.
 
 ---
 
 ## Recipe asset sync
 
 The daemon resolves the recipe hot-reload-first from
-`~/.simard/prompt_assets/simard/recipes/`. If that directory is missing
-the `distill-episodes.yaml` asset, the runner falls back to the in-tree
-copy — but on the deployed VM the daemon's working directory is a
-worktree, so a missing hot-reload asset previously left the daemon
-running a recipe set that did not match the deployed code.
+`~/.simard/prompt_assets/simard/recipes/`. If that directory is missing the
+`distill-episodes.yaml` asset, the runner falls back to the in-tree copy — but
+on the deployed VM the daemon's working directory is a worktree, so a missing
+hot-reload asset previously left the daemon running a recipe set that did not
+match the deployed code.
 
-`scripts/redeploy-local.sh` **already** syncs **all** prompt assets — including
-`prompt_assets/simard/recipes/*.yaml` — into
-`~/.simard/prompt_assets/simard/` on every redeploy via a single scoped
-`cp -rf`, and enumerates the synced top-level `*.md` prompt files so an
-operator can confirm the sync:
-
-```text
-[redeploy] synced prompt assets → /home/azureuser/.simard/prompt_assets
-[redeploy]   prompt: ooda-decide.md
-…
-```
-
-The recipe `.yaml` files live one directory down in `recipes/`, so before
-this change they were copied but **not** individually verified. The #2401
-change adds an explicit recipe-sync verification block after the `cp`: it
-lists every synced `recipes/*.yaml`, reports a synced-vs-source **count**,
-**fails the redeploy** (`exit 1`) if zero recipes reached the hot-reload
-path, and **warns** on any count drift. An operator can now confirm
-`distill-episodes.yaml` actually reached the hot-reload path:
+`scripts/redeploy-local.sh` syncs **all** prompt assets — including
+`prompt_assets/simard/recipes/*.yaml` — into `~/.simard/prompt_assets/simard/`
+on every redeploy via a scoped `cp -rf`, then lists every synced
+`recipes/*.yaml`, reports a synced-vs-source **count**, **fails the redeploy**
+(`exit 1`) if zero recipes reached the hot-reload path, and **warns** on count
+drift:
 
 ```text
 [redeploy] synced 7/7 recipe asset(s) → /home/azureuser/.simard/prompt_assets/simard/recipes
-[redeploy]   recipe: disk-health-check.yaml
 [redeploy]   recipe: distill-episodes.yaml
-[redeploy]   recipe: merge-readiness-judge.yaml
 …
 ```
 
-The sync is confined to `prompt_assets/simard/**` → the corresponding
-`~/.simard/prompt_assets/simard/` paths, with quoted path variables and a
-scoped `cp` (no `eval`, no unquoted globs). It never touches the live
-cognitive-memory store or the daemon's data directory. The compile-time
-embedded recipe set remains a safety net if the source tree is absent.
-
-> **Operational note.** A stale hot-reload directory can compound this
-> bug: if `~/.simard/prompt_assets/simard/recipes/` is missing (or has an
-> out-of-date copy of) `distill-episodes.yaml`, the daemon silently runs
-> the in-tree fallback recipe instead of the deployed one. Combined with
-> the parsing bug, every result was swallowed without a trace. Verify the
-> deployed set with
-> `ls ~/.simard/prompt_assets/simard/recipes/`. The sync fix ensures
-> redeploys keep the hot-reload recipe set current; the output-capture fix
-> ensures the captured result is actually parsed.
+> **Operational note.** Verify the deployed set with
+> `ls ~/.simard/prompt_assets/simard/recipes/`. A stale hot-reload
+> `distill-episodes.yaml` will run the in-tree fallback recipe; the sync fix
+> keeps the hot-reload recipe set current, and the file-channel fix ensures the
+> captured result is actually parsed.
 
 ---
 
 ## Security
 
 - **No command injection.** The argv is built with
-  `Command::new("recipe-runner-rs").arg(...)`; the episodes payload is a
-  single `episodes=<json>` argument. Content is never interpolated into a
-  shell line, a flag, the recipe path, or the binary name. This argv-only
-  construction must be preserved.
-- **Bounded error output.** The brace scanner is linear in input length
-  and iterative (no recursion in the scan), so deeply nested input cannot
-  grow the stack; each candidate parse is bounded by `serde_json`'s own
-  recursion limit. Error messages reuse `truncate(…, 200)`, so a large
-  hostile stdout never echoes its full content. An explicit captured-stdout
-  byte cap (rejecting multi-MiB stdout before parsing) is a recommended
-  follow-up; today an unbounded stdout would be read into memory once before
-  the linear scan, which is acceptable for the runner's small envelopes.
-- **Strict typing.** `success` and `step_results` are required fields. A
-  failed run (`success == false`) never yields facts.
-- **No payload leakage in routine logs.** Error messages reuse
-  `truncate(…, 200)` and a generic message. Full stdout, episode content,
-  and facts payloads appear only at `debug` level — never at `info` or
-  `warn`.
-- **Process visibility (known limitation).** `episodes=<json>` is passed
-  on the argv, so it is visible via `ps`/`/proc` on a shared host. Moving
-  the payload to stdin or a `0600` temp file is a recommended follow-up if
-  a future `recipe-runner-rs` supports it; it does not block this fix.
+  `Command::new("recipe-runner-rs").arg(...)`; the episodes payload and the
+  facts path are single `-c key=value` arguments. Content is never interpolated
+  into a shell line. This argv-only construction must be preserved.
+- **Private result file.** `facts_output_path` is inside a mode-`0700`
+  per-invocation tempdir and is removed when the invocation returns; the
+  agent's answer never lands on a shared stdout stream.
+- **Bounded error output.** The brace scan is linear/iterative and each
+  candidate parse is bounded by `serde_json`'s recursion limit; error messages
+  reuse `truncate(…, 200)`, so a large hostile document never echoes its full
+  content.
+- **No stdout fallback.** A missing/empty/unparseable facts file is an
+  explicit `Err`; stdout is never scraped as a backup result channel (a silent
+  fallback is a silent failure).
+- **Process visibility (known limitation).** `episodes=<json>` is passed on the
+  argv, so it is visible via `ps`/`/proc` on a shared host. Moving the payload
+  off the argv is a recommended follow-up if a future `recipe-runner-rs`
+  supports it.
 
 ---
 
 ## Code location
 
-| Item                                            | File                                                 | #2401 change                          |
-|-------------------------------------------------|------------------------------------------------------|---------------------------------------|
-| `invoke_recipe`                                 | `src/memory_consolidation/distillation.rs`           | modified — add `--output-format json` |
-| `RecipeRunnerEnvelope` / `RecipeRunnerStepResult` | `src/memory_consolidation/distillation.rs`         | new                                   |
-| `parse_recipe_output_full`                      | `src/memory_consolidation/distillation.rs`           | modified — 2-tier → 3-tier            |
-| `parse_recipe_output` (facts-only wrapper)      | `src/memory_consolidation/distillation.rs`           | unchanged                             |
-| `scan_for_facts_object`                         | `src/memory_consolidation/distillation.rs`           | new                                   |
-| Non-fatal upstream mapping                      | `src/ooda_actions/simple_actions.rs`                 | unchanged                             |
-| Recipe                                          | `prompt_assets/simard/recipes/distill-episodes.yaml` | unchanged                             |
-| Recipe asset sync                               | `scripts/redeploy-local.sh`                          | modified — list + verify synced recipes (count, fail-on-zero) |
-| Tests                                           | `src/memory_consolidation/distillation_tests.rs`     | new tests added                       |
+| Item                                   | File                                                 |
+|----------------------------------------|------------------------------------------------------|
+| `invoke_recipe` (adds `facts_output_path`) | `src/memory_consolidation/distillation.rs`       |
+| `harvest_facts_file` (read file / terminal error) | `src/memory_consolidation/distillation.rs` |
+| `parse_facts_document` / `parse_facts`  | `src/memory_consolidation/distillation.rs`           |
+| `scan_cleaned_for_facts`, `RecipeEnvelope`, `de_lenient_string` | `src/memory_consolidation/distillation.rs` |
+| Recipe (writes `{{facts_output_path}}`) | `prompt_assets/simard/recipes/distill-episodes.yaml` |
+| Recipe asset sync                       | `scripts/redeploy-local.sh`                          |
+| Tests                                   | `src/memory_consolidation/distillation_tests.rs` + `issue_2622_file_channel_tests` |
 
 ---
 
 ## Testing
 
-The fix adds these tests to `src/memory_consolidation/distillation_tests.rs`:
+The file-channel behavior is pinned by the hermetic `issue_2622_file_channel_tests`
+(in `distillation.rs`) and the document-parse tests in `distillation_tests.rs`:
 
-| Test                                                              | Coverage                                                                                  |
-|------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
-| `parser_extracts_facts_from_verbatim_real_envelope`              | A verbatim `recipe-runner 0.3.6` envelope (captured from the binary via a bash probe) parses its `step_results[].output` string into facts. |
-| `parser_extracts_facts_and_procedures_from_real_prose_prefixed_envelope` | A **verbatim real agent** envelope — `output` carries a `NODE_OPTIONS` banner *before* the JSON — parses to **both** facts and procedures. This is the production-faithful proof. |
-| `parser_extracts_facts_and_procedures_from_distill_step_output`  | A synthetic real-shaped envelope yields both facts and procedures with provenance intact.  |
-| `parser_selects_distill_step_among_multiple_steps`               | Step selection picks `step_id == "distill"` even when other completed steps precede it.    |
-| `parser_falls_back_to_last_completed_step_when_no_distill_id`    | Falls back to the last `completed` step when no `distill` step exists.                      |
-| `parser_drops_unknown_concepts_inside_envelope`                  | The concept allow-list still applies when extracting from the envelope.                     |
-| `parser_tolerates_output_as_json_object`                         | A future `output` emitted as a JSON object (not a string) still yields facts.               |
-| `facts_only_wrapper_reads_runner_envelope` / `…_real_prose_prefixed_envelope` | The facts-only `parse_recipe_output` wrapper also reads the envelope.          |
-| `parser_returns_err_on_failure_envelope` / `parser_does_not_extract_facts_from_failed_run` | `success == false` returns `Err`; no facts extracted, even with a payload present. |
-| `parser_errors_on_text_mode_status_banner`                       | The `--output-format text` banner (the production failure input) returns an explicit `Err`. |
-| `parser_tolerant_fallback_accepts_bare_facts_object` / `…_extracts_facts_from_prose` | Tier 2 still parses a bare / prose-wrapped `{ "facts": … }` object. |
-| `parser_error_does_not_leak_full_payload`                        | The Tier 3 error message is truncated and carries no content past the truncation window.    |
-| `parser_tolerates_deeply_nested_input_without_panic`             | Pathologically nested braces terminate with `Err` (no stack blowup).                        |
-| `parser_handles_large_valid_envelope`                            | A large valid envelope (1 000 facts) extracts every fact — the linear scan handles size.    |
+| Test                                                    | Coverage                                                                                   |
+|---------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| `launcher_banner_on_stdout_does_not_cause_parse_failure` | A launcher banner on stdout + a valid facts file ⇒ **success** with facts (the headline).  |
+| `missing_facts_file_is_parse_failure_never_stdout_fallback` | A missing file ⇒ `ParseFailure`, even when stdout carries a facts object.                |
+| `nonzero_exit_is_terminal_failure_with_context`         | A non-zero exit ⇒ explicit `CopilotTerminalFailure`.                                        |
+| `clean_run_reads_facts_verbatim_from_file`              | A clean run reads the envelope from the file.                                               |
+| `empty_facts_document_is_parse_failure` / `banner_only_document_is_parse_failure` | Empty / answerless documents error explicitly.                   |
+| `fenced_facts_document_still_parses`                    | A Markdown-fenced document still parses (clean-channel format leniency).                    |
+| `document_yields_facts_and_procedures`                  | Facts + procedures with provenance intact.                                                 |
+| `document_drops_unknown_concepts`                       | The concept allow-list still applies.                                                       |
+| `document_error_does_not_leak_full_payload` / `document_tolerates_deeply_nested_input_without_panic` | Bounded, panic-free error output.             |
+| `document_handles_large_valid_input`                    | A large valid document (1 000 facts) extracts every fact.                                   |
 
-All existing `DistillRecipeRunner` mock tests
-(`parse_recipe_output_accepts_plain_object`,
-`parse_recipe_output_extracts_json_from_prose`,
-`parse_recipe_output_drops_unknown_concepts`,
-`parse_recipe_output_errors_when_no_object`) remain green via Tier 2.
+---
+
+## History — the retired stdout-envelope capture
+
+Before this fix the distill result was scraped from `recipe-runner-rs`'s
+`--output-format json` **stdout envelope** (`{ "success", "step_results":
+[{ "output": "…" }] }`), with a tolerant multi-tier parser
+(`parse_recipe_output_full`, `RecipeRunnerEnvelope`, `scan_for_facts_object`)
+and shared launcher-banner stripping. That approach (issues #2401, #2461,
+#2496, #2504, #2512, #2517, #2570) chased banner/ANSI/log contamination on
+stdout with ever-more-defensive string scanning. Issues #2622/#2619 replaced
+it with the file channel: the agent writes a clean file and stdout is no longer
+the result, so the entire class of launcher-banner parse failures is
+structurally eliminated rather than post-processed. The runner-envelope
+deserialization types and their stdout-scraping tiers were retired.
 
 ---
 
 ## Out of scope
 
-- **Sibling recipe shims** (`recipe_merge_judge`,
-  `recipe_progress_checker`) parse their own text banners and are **not**
-  affected by this change. They are intentionally left untouched.
-- **Subprocess wall-clock timeout** for a hung agent step is a
-  recommended follow-up (spawn + timed wait/kill so a stuck LLM cannot
-  stall the OODA pass); it is not required for the output-capture fix.
-- **Moving the episodes payload off the argv** (stdin / `0600` temp file)
-  is a follow-up hardening, contingent on `recipe-runner-rs` support.
+- **Sibling recipe shims** (`recipe_merge_judge`, `recipe_progress_checker`)
+  parse their own text output and are **not** affected by this change.
+- **Subprocess wall-clock timeout** for a hung agent step is a recommended
+  follow-up.
+- **Moving the episodes payload off the argv** (stdin / `0600` temp file) is a
+  follow-up hardening, contingent on `recipe-runner-rs` support.

--- a/prompt_assets/simard/recipes/distill-episodes.yaml
+++ b/prompt_assets/simard/recipes/distill-episodes.yaml
@@ -7,13 +7,19 @@
 # Context vars (passed via -c):
 #   episodes — JSON array of objects with
 #     { id, source_label, temporal_index, content }
+#   facts_output_path — ABSOLUTE path to the file the agent MUST write its JSON
+#     envelope to (issues #2622/#2619). This is the ONLY channel Simard reads the
+#     result from; stdout is ignored, so the copilot launcher banner and log
+#     lines can never contaminate the parse.
 #   strict_json_instruction — format-reinforcement sentence appended to the
 #     prompt on an in-cycle retry after a transient parse miss (issue #2468).
-#     Empty on the first attempt; set to a "respond with ONLY the JSON object"
-#     reminder on retry. Interpolated via the pure `{{strict_json_instruction}}`
-#     substitution, so no conditional templating is required.
+#     Empty on the first attempt; set to a "write ONLY the JSON object to the
+#     facts file" reminder on retry. Interpolated via the pure
+#     `{{strict_json_instruction}}` substitution, so no conditional templating
+#     is required.
 #
-# Output: agent stdout containing a single JSON object of the form:
+# Output: the agent WRITES a single JSON object of the form below to the file at
+# `{{facts_output_path}}` (NOT to stdout):
 #   {
 #     "facts": [
 #       { "concept": "pr-pattern" | "bug-pattern" | "lesson-learned",
@@ -45,6 +51,11 @@ context:
   # transient parse miss (issue #2468). Declared so the `{{strict_json_instruction}}`
   # substitution always resolves, even when the recipe is run without the override.
   strict_json_instruction: ""
+  # Empty by default; the distill subprocess overrides this with the absolute
+  # path of the per-invocation facts file the agent must write (issues
+  # #2622/#2619). Declared so the `{{facts_output_path}}` substitution always
+  # resolves, even when the recipe is run without the override.
+  facts_output_path: ""
 
 steps:
   - id: "distill"
@@ -117,8 +128,17 @@ steps:
 
       ## Output
 
-      Return **only** the following JSON object — no surrounding prose,
-      no markdown fence, no commentary:
+      **Write** the following JSON object — and NOTHING else — to the file at
+      the absolute path:
+
+      ```
+      {{facts_output_path}}
+      ```
+
+      Use your file-writing tool to create/overwrite that exact file with a
+      single JSON object. Do NOT print the JSON to the terminal as your answer,
+      and do NOT wrap it in prose or a markdown fence inside the file — the file
+      must contain only the JSON object:
 
       ```json
       {
@@ -139,11 +159,12 @@ steps:
       }
       ```
 
-      If nothing in the batch is worth keeping, emit
-      `{"facts": [], "procedures": []}`.
+      This file is the ONLY channel that is read: anything you print to the
+      terminal is ignored. If nothing in the batch is worth keeping, still write
+      the file with `{"facts": [], "procedures": []}`.
 
-      Do not invent new concept labels. Do not invent episode ids. Do
-      not include the literal string `skip` in the `concept` field —
-      skipped episodes simply contribute no entry to the `facts` array.
+      Do not invent new concept labels. Do not invent episode ids. Do not
+      include the literal string `skip` in the `concept` field — skipped
+      episodes simply contribute no entry to the `facts` array.
 
       {{strict_json_instruction}}

--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -76,7 +76,7 @@ pub const KNOWN_DISTILL_CONCEPTS: &[&str] = &["pr-pattern", "bug-pattern", "less
 /// JSON-format reinforcement threaded into the recipe (see
 /// [`DistillRecipeRunner::run_all_reinforced`]), recovers most of these within
 /// the same pass, turning a dropped batch into stored facts. Structural classes
-/// (`SpawnFailure`, `SerializeFailure`, `RecipeReportedFailure`) are NOT retried
+/// (`SpawnFailure`, `SerializeFailure`, and `Other`) are NOT retried
 /// — they escalate immediately. Kept at `1` so the recovery stays bounded and a
 /// genuinely broken recipe still surfaces promptly.
 pub const DISTILL_PARSE_RETRY_MAX: u32 = 1;
@@ -720,23 +720,22 @@ fn record_reliability_gate_metric(candidate_facts: u32, quarantined: u32, promot
 
 /// Machine-readable class of a distillation failure, derived from the stable
 /// leading prefix of the `SimardError::BridgeError` message emitted at each
-/// runner/parse site in this module. Covers every `Err` `run_all` can surface,
-/// including the **production** `--output-format json` envelope path (where a
-/// parse failure manifests as a *step-output* parse error, not the legacy
-/// bare-stdout one).
+/// runner/parse site in this module. Covers every `Err` `run_all` can surface.
+/// Post-#2622/#2619 the distill result is read from the agent's dedicated facts
+/// file, so a parse failure now manifests as a *missing / empty / unparseable
+/// facts document* rather than a stdout scan miss.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DistillFailureClass {
-    /// `recipe-runner-rs` could not be spawned (binary missing/structural).
+    /// `recipe-runner-rs` could not be spawned (binary missing/structural), or
+    /// the per-invocation facts output tempdir could not be created.
     SpawnFailure,
     /// The recipe **process** exited non-zero (#2461 t=7411 case).
     CopilotTerminalFailure,
-    /// The recipe process exited 0 but the run did not yield a usable
-    /// completed `distill` step (envelope `success=false`, or no completed
-    /// step). The recipe ran but produced no parseable agent output to parse.
-    RecipeReportedFailure,
-    /// The recipe process exited 0 and a step ran, but its output had no
-    /// parseable `{ "facts": [...] }` object (#2461 t=7517 case). This is the
-    /// only failure class that actually *reached* output parsing.
+    /// The recipe process exited 0 but the agent's facts document was missing,
+    /// empty, or not a parseable `{ "facts": [...] }` object (issues
+    /// #2622/#2619). This is the only failure class that actually *reached* the
+    /// agent output, so it is the denominator gate for
+    /// `distill_parse_success_rate`.
     ParseFailure,
     /// The episodes payload failed to serialize (structural; ~unreachable
     /// since the payload is built from infallible `json!` values).
@@ -751,7 +750,6 @@ impl DistillFailureClass {
         match self {
             Self::SpawnFailure => "spawn-failure",
             Self::CopilotTerminalFailure => "copilot-terminal-failure",
-            Self::RecipeReportedFailure => "recipe-reported-failure",
             Self::ParseFailure => "parse-failure",
             Self::SerializeFailure => "serialize-failure",
             Self::Other => "other",
@@ -761,23 +759,22 @@ impl DistillFailureClass {
     /// `true` when the recipe **process** exited 0. False for spawn/terminal
     /// (never started / non-zero exit) and serialize (never spawned).
     pub fn recipe_exited_ok(self) -> bool {
-        matches!(self, Self::ParseFailure | Self::RecipeReportedFailure)
+        matches!(self, Self::ParseFailure)
     }
 
-    /// `true` when the run actually *reached output parsing* (a step ran and
-    /// its output was parsed). This is the denominator gate for
-    /// `distill_parse_success_rate` — only `ParseFailure` qualifies among
-    /// failures (`RecipeReportedFailure` exited 0 but produced no step output
-    /// to parse).
+    /// `true` when the run actually *reached* the agent's facts document (the
+    /// process exited 0 and we tried to read + parse the file). This is the
+    /// denominator gate for `distill_parse_success_rate` — only `ParseFailure`
+    /// qualifies among failures.
     pub fn reached_parsing(self) -> bool {
         matches!(self, Self::ParseFailure)
     }
 
     /// `true` for failure classes worth a bounded in-cycle retry (issue #2468):
-    /// a parse miss (exited 0, output unparseable) or a non-zero recipe exit.
-    /// These are observed to recover on a second attempt — often with JSON
-    /// format reinforcement. Structural classes (spawn/serialize/recipe-reported
-    /// failure, and `Other`) are deterministic and escalate immediately instead.
+    /// a parse miss (exited 0, facts document missing/empty/unparseable) or a
+    /// non-zero recipe exit. These are observed to recover on a second attempt —
+    /// often with JSON format reinforcement. Structural classes
+    /// (spawn/serialize, and `Other`) are deterministic and escalate immediately.
     pub fn is_transient(self) -> bool {
         matches!(self, Self::ParseFailure | Self::CopilotTerminalFailure)
     }
@@ -789,31 +786,28 @@ impl DistillFailureClass {
 /// for each class (`SimardError::BridgeError(msg)` → `msg.starts_with(...)`),
 /// NOT on `contains`. Several messages embed foreign text (terminal failures
 /// carry up to 200 chars each of recipe stderr/stdout; parse failures carry the
-/// agent output excerpt), and that variable tail always trails the fixed prefix
-/// — so anchoring keeps a non-zero exit from being misread as a parse-failure
-/// and corrupting `distill_parse_success_rate`.
+/// facts-document excerpt), and that variable tail always trails the fixed
+/// prefix — so anchoring keeps a non-zero exit from being misread as a
+/// parse-failure and corrupting `distill_parse_success_rate`.
 ///
-/// The prefixes mirror the seven `BridgeError` sites in this file; the
-/// production `--output-format json` path's step-output parse error
-/// (`distill: \`distill\` step output did not contain a parseable …`) is the
-/// t=7517 manifestation and MUST map to `ParseFailure`, since production never
-/// reaches the legacy bare-stdout `did not yield a parseable` path.
+/// The prefixes mirror the `BridgeError` sites in this file. Post-#2622/#2619 a
+/// parse failure surfaces as a missing / empty / unparseable **facts document**
+/// (the agent's dedicated file), all of which map to `ParseFailure`.
 pub fn classify_distill_error(err: &SimardError) -> DistillFailureClass {
     let SimardError::BridgeError(msg) = err else {
         return DistillFailureClass::Other;
     };
-    if msg.starts_with("distill: recipe-runner-rs spawn failed") {
+    if msg.starts_with("distill: recipe-runner-rs spawn failed")
+        || msg.starts_with("distill: failed to create facts output tempdir")
+    {
         DistillFailureClass::SpawnFailure
     } else if msg.starts_with("distill: recipe exited with") {
         DistillFailureClass::CopilotTerminalFailure
     } else if msg.starts_with("distill: failed to serialize episodes payload") {
         DistillFailureClass::SerializeFailure
-    } else if msg.starts_with("distill: recipe-runner reported failure")
-        || msg.starts_with("distill: recipe envelope had no completed")
-    {
-        DistillFailureClass::RecipeReportedFailure
-    } else if msg.starts_with("distill: `distill` step output did not contain a parseable")
-        || msg.starts_with("distill: recipe run did not yield a parseable")
+    } else if msg.starts_with("distill: facts output file was not written")
+        || msg.starts_with("distill: facts document was empty")
+        || msg.starts_with("distill: facts document did not contain a parseable")
     {
         DistillFailureClass::ParseFailure
     } else {
@@ -966,9 +960,10 @@ const RECIPE_FILENAME: &str = "distill-episodes.yaml";
 /// Format-reinforcement sentence threaded into the distill recipe on a retry
 /// after a transient parse miss (issue #2468). Interpolated into the recipe via
 /// the `{{strict_json_instruction}}` substitution; empty on the first attempt.
-const STRICT_JSON_INSTRUCTION: &str = "Your previous reply was not parseable. Respond with ONLY the JSON object \
-     {\"facts\":[...]} (and \"procedures\" if any) — no prose, no markdown fence, \
-     no thinking, nothing before or after the object.";
+const STRICT_JSON_INSTRUCTION: &str = "Your previous attempt did not leave a parseable facts file. Write ONLY the JSON object \
+     {\"facts\":[...]} (and \"procedures\" if any) to the facts file whose path is given above — \
+     no prose, no markdown fence, no thinking, nothing before or after the object, and do \
+     not rely on printing to the terminal.";
 
 fn resolve_recipe_path(repo_root: &Path) -> Option<std::path::PathBuf> {
     if let Some(home) = dirs::home_dir() {
@@ -1028,15 +1023,15 @@ impl RecipeRunnerSubprocess {
 
 impl DistillRecipeRunner for RecipeRunnerSubprocess {
     fn run(&self, episodes: &[CognitiveEpisode]) -> SimardResult<Vec<DistilledFact>> {
-        let raw = self.invoke_recipe(episodes, false)?;
-        let parsed = parse_recipe_output(&raw);
+        let document = self.invoke_recipe(episodes, false)?;
+        let parsed = parse_facts(&document);
         crate::recipe_output::record_parse_outcome("distill", parsed.is_ok());
         parsed
     }
 
     fn run_all(&self, episodes: &[CognitiveEpisode]) -> SimardResult<DistillOutput> {
-        let raw = self.invoke_recipe(episodes, false)?;
-        let parsed = parse_recipe_output_full(&raw);
+        let document = self.invoke_recipe(episodes, false)?;
+        let parsed = parse_facts_document(&document);
         crate::recipe_output::record_parse_outcome("distill", parsed.is_ok());
         parsed
     }
@@ -1048,10 +1043,10 @@ impl DistillRecipeRunner for RecipeRunnerSubprocess {
     ) -> SimardResult<DistillOutput> {
         // Issue #2468: on a retry (`strict_json = true`) thread a non-empty
         // `strict_json_instruction` context var into the recipe so the agent
-        // reply is reinforced to be ONLY the `{ "facts": [...] }` object.
+        // writes ONLY the `{ "facts": [...] }` object to the facts file.
         //
         // Delegates to the capturing variant so the parse + metric logic lives in
-        // exactly one place; the harvested raw is simply dropped here.
+        // exactly one place; the harvested document is simply dropped here.
         self.run_all_reinforced_capturing(episodes, strict_json)
             .result
     }
@@ -1061,10 +1056,10 @@ impl DistillRecipeRunner for RecipeRunnerSubprocess {
         episodes: &[CognitiveEpisode],
         strict_json: bool,
     ) -> DistillAttemptOutcome {
-        // A spawn/terminal failure never produced parseable stdout, so there is
-        // nothing to harvest — surface the error with no raw.
-        let raw = match self.invoke_recipe(episodes, strict_json) {
-            Ok(raw) => raw,
+        // A spawn/terminal/missing-file failure produced no facts document, so
+        // there is nothing to harvest — surface the error with no raw.
+        let document = match self.invoke_recipe(episodes, strict_json) {
+            Ok(document) => document,
             Err(e) => {
                 return DistillAttemptOutcome {
                     result: Err(e),
@@ -1072,11 +1067,15 @@ impl DistillRecipeRunner for RecipeRunnerSubprocess {
                 };
             }
         };
-        let parsed = parse_recipe_output_full(&raw);
+        let parsed = parse_facts_document(&document);
         crate::recipe_output::record_parse_outcome("distill", parsed.is_ok());
-        // On a parse failure keep the exact bytes the extractor saw so Wave 1
-        // raw-capture can persist a real currently-failing sample.
-        let raw_on_failure = if parsed.is_err() { Some(raw) } else { None };
+        // On a parse failure keep the exact facts-file bytes the parser saw so
+        // Wave 1 raw-capture can persist a real currently-failing sample.
+        let raw_on_failure = if parsed.is_err() {
+            Some(document)
+        } else {
+            None
+        };
         DistillAttemptOutcome {
             result: parsed,
             raw_on_failure,
@@ -1090,11 +1089,21 @@ impl RecipeRunnerSubprocess {
     /// and [`run_all`](DistillRecipeRunner::run_all).
     ///
     /// `strict_json` (issue #2468) threads a `strict_json_instruction` context
-    /// var into the recipe: empty on the first attempt, and a "respond with ONLY
-    /// the `{ \"facts\": [...] }` object" reinforcement sentence on a retry after
-    /// a transient parse miss. The recipe interpolates it via the pure
-    /// `{{strict_json_instruction}}` substitution, so no conditional templating
-    /// engine is needed.
+    /// var into the recipe: empty on the first attempt, and a "write ONLY the
+    /// `{ \"facts\": [...] }` object to the facts file" reinforcement sentence on
+    /// a retry after a transient parse miss. The recipe interpolates it via the
+    /// pure `{{strict_json_instruction}}` substitution, so no conditional
+    /// templating engine is needed.
+    ///
+    /// Returns the **contents of the dedicated facts file** the distill agent was
+    /// instructed to write — NOT the recipe's stdout. This is the issues
+    /// #2622/#2619 fix: the copilot launcher banner (`… launching copilot
+    /// binary=… version="GitHub Copilot CLI …"`) and other log noise land on
+    /// stdout and were previously captured AS the distill step's `output`, so a
+    /// stdout scan for `{ "facts": [...] }` matched the banner and every pass
+    /// failed with `parse-failure`. Routing the agent's answer through a private
+    /// file (`-c facts_output_path=…`) makes that contamination structurally
+    /// impossible: stdout is never read for the result.
     fn invoke_recipe(
         &self,
         episodes: &[CognitiveEpisode],
@@ -1120,17 +1129,31 @@ impl RecipeRunnerSubprocess {
             ))
         })?;
 
-        // `--output-format json` is REQUIRED: in the default `text` mode the
-        // runner's stdout is only a human status banner and the distill agent's
-        // `{ "facts": [...] }` payload never reaches us, so every parse fails and
-        // the pass silently no-ops (issue #2401). In `json` mode stdout carries a
-        // structured envelope whose `step_results[].output` holds the agent's
-        // output, which `parse_recipe_output_full` mines. The agent binary is
-        // still selected via the proven `AMPLIHACK_AGENT_BINARY` env var.
-        //
+        // Dedicated, per-invocation facts file the distill agent writes its JSON
+        // envelope to (issues #2622/#2619). A fresh tempdir (mode 0700 via the
+        // `tempfile` crate) gives a unique absolute path with no cross-invocation
+        // races; the directory and its contents are removed when `facts_dir`
+        // drops at the end of this call, AFTER we have read the file. The agent
+        // is told this absolute path via `-c facts_output_path=…` and the recipe
+        // prompt instructs it to write ONLY the envelope there.
+        let facts_dir = tempfile::Builder::new()
+            .prefix("simard-distill-")
+            .tempdir()
+            .map_err(|e| {
+                SimardError::BridgeError(format!(
+                    "distill: failed to create facts output tempdir: {e}"
+                ))
+            })?;
+        let facts_path = facts_dir.path().join("facts.json");
+        let facts_path_arg = facts_path.to_string_lossy().into_owned();
+
         // `strict_json_instruction` (issue #2468) is always passed so the
         // recipe's `{{strict_json_instruction}}` substitution resolves: empty on
-        // the first attempt, and a format-reinforcement sentence on a retry.
+        // the first attempt, and a format-reinforcement sentence on a retry. The
+        // agent binary is still selected via the proven `AMPLIHACK_AGENT_BINARY`
+        // env var. `--output-format json` is retained only so a runner-level
+        // failure surfaces a structured error on stdout for the message below;
+        // the distill result itself is read from `facts_path`, never stdout.
         let strict_json_instruction = if strict_json {
             STRICT_JSON_INSTRUCTION
         } else {
@@ -1145,27 +1168,51 @@ impl RecipeRunnerSubprocess {
             .arg(format!("episodes={payload_json}"))
             .arg("-c")
             .arg(format!("strict_json_instruction={strict_json_instruction}"))
+            .arg("-c")
+            .arg(format!("facts_output_path={facts_path_arg}"))
             .output()
             .map_err(|e| {
                 SimardError::BridgeError(format!("distill: recipe-runner-rs spawn failed: {e}"))
             })?;
 
-        if !output.status.success() {
-            // On failure the runner exits non-zero AND emits the structured
-            // error inside the JSON envelope on stdout (stderr may be empty), so
-            // surface both — never a silent or context-free failure.
-            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-            return Err(SimardError::BridgeError(format!(
-                "distill: recipe exited with {}: stderr={} stdout={}",
-                output.status,
-                truncate(stderr.trim(), 200),
-                truncate(stdout.trim(), 200)
-            )));
-        }
-
-        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        harvest_facts_file(&output, &facts_path)
     }
+}
+
+/// Post-process a finished `recipe-runner-rs` invocation into the distill
+/// agent's facts document, reading it from the dedicated facts file — NEVER from
+/// stdout (issues #2622/#2619).
+///
+/// * A non-zero exit is surfaced as an explicit terminal error carrying both the
+///   truncated stderr and stdout, so a failed run is never silent.
+/// * On a clean (exit-0) run the agent's answer is read from `facts_path`. A
+///   missing file means the agent produced no output this attempt — an explicit,
+///   retry-eligible error. There is deliberately NO stdout fallback: scraping
+///   stdout is exactly the launcher-banner contamination this fix removes.
+///
+/// Split out of [`RecipeRunnerSubprocess::invoke_recipe`] so the "stdout noise is
+/// ignored" contract is hermetically testable without spawning a subprocess.
+fn harvest_facts_file(output: &std::process::Output, facts_path: &Path) -> SimardResult<String> {
+    if !output.status.success() {
+        // On failure the runner exits non-zero AND emits the structured error
+        // inside the JSON envelope on stdout (stderr may be empty), so surface
+        // both — never a silent or context-free failure.
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        return Err(SimardError::BridgeError(format!(
+            "distill: recipe exited with {}: stderr={} stdout={}",
+            output.status,
+            truncate(stderr.trim(), 200),
+            truncate(stdout.trim(), 200)
+        )));
+    }
+
+    std::fs::read_to_string(facts_path).map_err(|e| {
+        SimardError::BridgeError(format!(
+            "distill: facts output file was not written by the agent ({}): {e}",
+            facts_path.display()
+        ))
+    })
 }
 
 fn truncate(s: &str, max: usize) -> String {
@@ -1177,279 +1224,50 @@ fn truncate(s: &str, max: usize) -> String {
     }
 }
 
-/// Parse the recipe's stdout into a list of [`DistilledFact`].
+/// Parse the distill agent's facts document into a list of [`DistilledFact`].
 ///
-/// Thin facts-only wrapper over [`parse_recipe_output_full`] retained for the
-/// legacy [`DistillRecipeRunner::run`] entry point and its unit tests.
-pub(crate) fn parse_recipe_output(raw: &str) -> SimardResult<Vec<DistilledFact>> {
-    parse_recipe_output_full(raw).map(|o| o.facts)
+/// Thin facts-only wrapper over [`parse_facts_document`] retained for the legacy
+/// [`DistillRecipeRunner::run`] entry point and its unit tests.
+pub(crate) fn parse_facts(document: &str) -> SimardResult<Vec<DistilledFact>> {
+    parse_facts_document(document).map(|o| o.facts)
 }
 
-/// Parse `recipe-runner-rs`'s stdout into a [`DistillOutput`] (facts AND
-/// procedures).
+/// Parse the distill agent's **facts document** into a [`DistillOutput`] (facts
+/// AND procedures).
 ///
-/// Three tolerant tiers, in order (issue #2401):
+/// `document` is the contents of the dedicated facts file the distill agent was
+/// instructed to write (`-c facts_output_path=…`), NOT recipe-runner stdout.
+/// Because the agent writes ONLY its JSON envelope to that private file, the
+/// copilot launcher banner and log lines that contaminate stdout can never reach
+/// here — this is the structural fix for the issues #2622/#2619 `parse-failure`
+/// mode where the launcher banner was captured as the distill step output and a
+/// stdout scan for `{ "facts": [...] }` matched the banner instead of the answer.
 ///
-/// 1. **Runner envelope (production path).** With `--output-format json` the
-///    runner emits `{ "recipe_name", "success", "step_results": [...], ... }`.
-///    We require `success == true`, select the `distill` step (or, if renamed,
-///    the last `completed` step), and mine the agent payload out of that
-///    step's `output` — which is itself a JSON *string* that may carry leading
-///    prose (e.g. a `NODE_OPTIONS` banner) before the `{ "facts": ... }`
-///    object, so we balanced-brace scan it. A future runner that emits `output`
-///    as a JSON object is handled too. The envelope itself is recovered even
-///    when the captured stdout **begins with** a Copilot CLI launch banner /
-///    ANSI / tracing-log preamble *before* the JSON (issues #2512, #2517) —
-///    see [`recover_distill_output`].
-/// 2. **Bare-object fallback.** If stdout is not a runner envelope, scan it
-///    directly for an embedded `{ "facts": ... }` object. Keeps the legacy
-///    fact-only mock/unit-test contract (and prose-wrapped agent output)
-///    working.
-/// 3. **Explicit failure.** If neither tier yields a facts object — including
-///    the `--output-format text` status banner and any `success == false`
-///    envelope — return `Err`. The caller treats `Err` as the retry-safe
-///    "no markers set" path; there is never a hollow `Ok`.
-pub(crate) fn parse_recipe_output_full(raw: &str) -> SimardResult<DistillOutput> {
-    let trimmed = raw.trim();
-
-    // Tier 1a — fast path: stdout IS the recipe-runner JSON envelope (clean
-    // production output). `RecipeRunnerEnvelope` requires both `success` and
-    // `step_results`, so a bare `{ "facts": ... }` object (which has neither)
-    // fails this parse and falls through to Tier 2.
-    if let Ok(envelope) = serde_json::from_str::<RecipeRunnerEnvelope>(trimmed) {
-        return envelope.into_distill_output();
+/// Parsing is deliberately simple, reflecting the clean channel:
+///
+/// 1. An empty document means the agent produced no output — an explicit,
+///    retry-eligible `Err` (never a hollow `Ok`; no silent stdout fallback).
+/// 2. Otherwise [`scan_cleaned_for_facts`] deserializes the
+///    `{ "facts": [...], "procedures": [...] }` envelope, tolerating a Markdown
+///    code fence or a little leading/trailing prose the agent may wrap around its
+///    own answer in the file (field/format leniency on a clean channel — NOT the
+///    launcher-banner stdout scraping this fix removed).
+/// 3. If no facts object is present, return `Err`; the caller treats `Err` as
+///    the retry-safe "no markers set" path.
+pub(crate) fn parse_facts_document(document: &str) -> SimardResult<DistillOutput> {
+    let trimmed = document.trim();
+    if trimmed.is_empty() {
+        return Err(SimardError::BridgeError(
+            "distill: facts document was empty; the agent produced no output".to_string(),
+        ));
     }
-
-    // Tier 1b — noise-tolerant envelope recovery (issues #2512 + #2517). The
-    // copilot subprocess prints its `NODE_OPTIONS` / `launching copilot binary`
-    // launch banner (and, intermittently, ANSI-coloured tracing lines) to the
-    // inherited stdout *before* recipe-runner-rs emits its JSON envelope, so the
-    // captured stdout begins with the banner instead of the `{`. The fast Tier-1a
-    // `serde_json::from_str` rejects that leading banner and the whole envelope —
-    // including its escaped `{ "facts": [...] }` payload — was otherwise lost,
-    // producing the recurring `distill failed (non-fatal): … did not yield a
-    // parseable { "facts": [...] } object` and silently deferring the batch. We
-    // recover the envelope through the SAME shared `recipe_output` chokepoint the
-    // inner step-output scan uses (the #2504 launch-banner fix), evaluating BOTH
-    // cleaned views and committing to the one that actually yields a populated
-    // `DistillOutput` — so the line-dropping view can no longer gut a
-    // pretty-printed envelope's escaped `output` line to `null` (#2517) and
-    // swallow the facts/procedures a line-preserving view would recover.
-    // Committing to a recovered `success == false` envelope preserves the
-    // `RecipeReportedFailure` contract for a banner-prefixed failed run.
-    if let Some(result) = recover_distill_output(trimmed) {
-        return result;
-    }
-
-    // Tier 2 — tolerant fallback: an embedded bare `{ "facts": ... }` object in
-    // arbitrary prose (legacy contract; also covers any non-envelope stdout).
-    if let Some(output) = scan_for_facts_object(trimmed) {
+    if let Some(output) = scan_cleaned_for_facts(trimmed) {
         return Ok(output);
     }
-
-    // Tier 3 — explicit, bounded failure.
     Err(SimardError::BridgeError(format!(
-        "distill: recipe run did not yield a parseable {{ \"facts\": [...] }} object: {}",
-        truncate(raw, 200)
+        "distill: facts document did not contain a parseable {{ \"facts\": [...] }} object: {}",
+        truncate(trimmed, 200)
     )))
-}
-
-/// Recover a [`DistillOutput`] from recipe-runner stdout whose JSON envelope is
-/// buried behind a Copilot CLI launch-banner / ANSI / tracing-log preamble
-/// (issues #2512, #2517).
-///
-/// In production the copilot agent subprocess prints its launch banner — the
-/// `ℹ … NODE_OPTIONS=… (saved preference)` marker, the `… launching copilot
-/// binary=… version="GitHub Copilot CLI …"` line, and the `Run 'copilot update'
-/// …` nag (Copilot CLI `1.0.66-2`) — to the inherited stdout *before* the
-/// recipe-runner emits its `{ "recipe_name", "success", "step_results": … }`
-/// envelope. The captured stdout therefore begins with the banner, so the fast
-/// `serde_json::from_str::<RecipeRunnerEnvelope>` in [`parse_recipe_output_full`]
-/// rejects it and the envelope (with its escaped facts payload) is lost. This is
-/// the *outer-envelope* analog of the inner step-output banner contamination
-/// that [`scan_for_facts_object`] already strips.
-///
-/// Recovery walks the SAME shared `recipe_output` chokepoint (the #2504
-/// `is_copilot_launcher_line` / `strip_recipe_noise` fix) via
-/// [`candidate_runner_envelopes`], then **commits to the candidate that actually
-/// yields a populated [`DistillOutput`]** rather than the first that merely
-/// deserializes. This is the #2517 fix: recipe-runner-rs `--output-format json`
-/// emits a **pretty-printed** envelope, and the distill agent's own launch
-/// banner lands *inside* the escaped `output` string. The line-dropping view
-/// ([`strip_recipe_noise`](crate::recipe_output::strip_recipe_noise)) then drops
-/// the whole `"output": "…launching copilot binary=…"` line, leaving a
-/// structurally-valid but **gutted** envelope whose `output` defaults to `null`
-/// — a first-match scan committed to it, `extract_step_output` returned `None`,
-/// and the facts/procedures were swallowed. The line-preserving view
-/// ([`strip_ansi`](crate::recipe_output::strip_ansi)) keeps that line, so its
-/// intact envelope recovers the payload; preferring the populated candidate
-/// stops the gutted view from shadowing it.
-///
-/// Post-#2570: the shared `is_copilot_launcher_line` guard now exempts any
-/// `{`/`"`/`[`-leading JSON line, so `strip_recipe_noise` no longer drops that
-/// `"output": …` member line — the line-dropping view recovers this pretty
-/// shape on its own. Candidate selection remains as defence-in-depth for shapes
-/// the line-dropping view can still gut (e.g. a compact envelope sharing a
-/// physical line with a leading banner token, which is dropped wholesale).
-///
-/// Selection precedence:
-/// 1. the first candidate whose `into_distill_output()` is `Ok` **and** carries
-///    facts or procedures — the intact, populated recovery;
-/// 2. otherwise a `success == false` candidate, surfaced as the
-///    `RecipeReportedFailure` `Err` (a failed run is authoritative and must
-///    never be silently dropped);
-/// 3. otherwise an empty `Ok` ("nothing worth distilling");
-/// 4. otherwise `None` — every candidate was a gutted parse error, so the caller
-///    falls through to the Tier-2 bare-object scan instead of committing to a
-///    hollow failure.
-fn recover_distill_output(trimmed: &str) -> Option<SimardResult<DistillOutput>> {
-    let mut reported_failure: Option<SimardResult<DistillOutput>> = None;
-    let mut empty_ok: Option<DistillOutput> = None;
-    for envelope in candidate_runner_envelopes(trimmed) {
-        // A `success == false` run is authoritative: record it as a
-        // RecipeReportedFailure and keep scanning, but never let a gutted
-        // `success == true` view override it (and never silently drop it).
-        if !envelope.success {
-            if reported_failure.is_none() {
-                reported_failure = Some(envelope.into_distill_output());
-            }
-            continue;
-        }
-        match envelope.into_distill_output() {
-            // A populated recovery wins immediately: the intact view that
-            // survived the launch-banner contamination (#2517).
-            Ok(out) if !out.facts.is_empty() || !out.procedures.is_empty() => {
-                return Some(Ok(out));
-            }
-            // A genuinely empty "nothing to distill" answer — kept only as a
-            // fallback behind any populated recovery.
-            Ok(out) => {
-                if empty_ok.is_none() {
-                    empty_ok = Some(out);
-                }
-            }
-            // A gutted / unparseable candidate (e.g. the line-dropping view that
-            // deleted the escaped `output` line, leaving `output: null`) — try
-            // the next view rather than committing to its parse failure.
-            Err(_) => {}
-        }
-    }
-    // No populated recovery: prefer a reported failure (preserve the
-    // `success == false` contract), then an empty Ok, else `None` so the caller
-    // falls through to the Tier-2 bare-object scan.
-    reported_failure.or_else(|| empty_ok.map(Ok))
-}
-
-/// Collect every [`RecipeRunnerEnvelope`] recoverable from `trimmed` across the
-/// two cleaned `recipe_output` views, in view order, so a caller can pick the
-/// one that yields a populated [`DistillOutput`] (see [`recover_distill_output`]).
-///
-/// Unlike a first-match scan, ALL candidates are returned: the line-dropping
-/// [`strip_recipe_noise`](crate::recipe_output::strip_recipe_noise) view could
-/// gut a pretty-printed envelope's escaped `output` line to `null` (#2517; since
-/// #2570's structural-token guard that specific `"`-leading member line is
-/// preserved), and it still drops a compact envelope that shares a physical line
-/// with a leading banner token — so the line-preserving
-/// [`strip_ansi`](crate::recipe_output::strip_ansi) view's intact envelope must
-/// remain available and must not be shadowed.
-///
-/// Two cleaned views are tried, mirroring [`scan_for_facts_object`]:
-///
-/// 1. [`strip_recipe_noise`](crate::recipe_output::strip_recipe_noise) — strips
-///    ANSI escapes AND drops whole launcher/log/banner lines (recovers an
-///    envelope sitting on its own line after the banner lines).
-/// 2. [`strip_ansi`](crate::recipe_output::strip_ansi) — line-preserving
-///    (recovers an envelope that shares a physical line with a leading banner
-///    token, which view 1 would drop wholesale, and a pretty-printed envelope
-///    whose escaped `output` line view 1 would drop).
-///
-/// Within each view the string-aware
-/// [`balanced_objects`](crate::recipe_output::balanced_objects) scan is walked
-/// from the END, taking the LAST span that deserializes as a runner envelope, so
-/// a leading non-envelope log record (e.g. a `{"level":"info",…}` line the agent
-/// emitted before the envelope) cannot shadow the real envelope that trails it. A
-/// bare `{ "facts": [...] }` object lacks both required envelope fields, so it
-/// never matches here and correctly falls through to the Tier-2 bare-object path.
-fn candidate_runner_envelopes(trimmed: &str) -> Vec<RecipeRunnerEnvelope> {
-    let mut candidates = Vec::new();
-    for cleaned in [
-        crate::recipe_output::strip_recipe_noise(trimmed),
-        crate::recipe_output::strip_ansi(trimmed),
-    ] {
-        let view = cleaned.trim();
-        // Fast path within the cleaned view — it IS the envelope (banner lines
-        // dropped, nothing trailing).
-        if let Ok(envelope) = serde_json::from_str::<RecipeRunnerEnvelope>(view) {
-            candidates.push(envelope);
-            continue;
-        }
-        // Slow path — among every balanced top-level object (string-aware),
-        // scanned from the end, take the last that parses as a runner envelope.
-        for span in crate::recipe_output::balanced_objects(view)
-            .into_iter()
-            .rev()
-        {
-            if let Ok(envelope) = serde_json::from_str::<RecipeRunnerEnvelope>(span) {
-                candidates.push(envelope);
-                break;
-            }
-        }
-    }
-    candidates
-}
-
-/// Scan `text` for a balanced `{...}` substring that deserializes as a
-/// [`RecipeEnvelope`] (a bare `{ "facts": [...], "procedures": [...] }` object),
-/// tolerating leading/trailing prose. Returns `None` if none is found.
-///
-/// When several balanced objects are present the **last non-empty** one that
-/// parses wins: a leading banner/status object (e.g. a `NODE_OPTIONS` notice,
-/// or a thinking trace the agent emitted before its answer) no longer shadows
-/// the real facts object that trails it — this is the t=7517 / #2461
-/// parse-failure mode where a first-object scan locked onto the banner and the
-/// whole pass silently no-opped. Preferring the last *non-empty* object (and
-/// only falling back to an empty `{"facts":[]}` when none carry
-/// facts/procedures) keeps a legitimate "nothing worth distilling" answer while
-/// preventing an accidental trailing empty object from discarding earlier facts.
-///
-/// The scan is iterative (no recursion) so pathologically deep brace nesting
-/// terminates without a stack overflow; serde's own recursion limit bounds the
-/// per-candidate parse. Brace scanning is string-aware (it ignores `{`/`}`
-/// inside JSON string literals, respecting `\"` escapes) so a brace inside a
-/// fact's `content` cannot corrupt depth accounting.
-fn scan_for_facts_object(text: &str) -> Option<DistillOutput> {
-    // Try two cleaned views of the noisy step output, mirroring the shared
-    // `recipe_output::extract_json_payload` dual pass (issue #2484):
-    //
-    // 1. `strip_recipe_noise` strips ANSI escapes AND drops whole tracing/log
-    //    and runner-banner lines — this removes the `\x1b[2m<RFC3339 timestamp>`
-    //    log prefix that made `serde_json` reject the span (the t=7919 / #2461 /
-    //    #2484 distill parse-failure) and recovers a payload whose pretty body
-    //    has an interleaved tracing line.
-    // 2. `strip_ansi` is line-preserving — it recovers a payload that sits on
-    //    the SAME physical line as a leading timestamp/log prefix, which view 1
-    //    would otherwise drop wholesale.
-    //
-    // Both views are clean-path zero-copy (`Cow::Borrowed`) when stdout carries
-    // no `ESC` byte and no droppable line, so adopting the shared helper does
-    // not change behaviour on clean output. A non-empty facts object from
-    // either view wins; an empty `{"facts":[]}` "nothing to distill" answer is
-    // kept only as a fallback when neither view yields a populated object.
-    let mut empty_fallback: Option<DistillOutput> = None;
-    for cleaned in [
-        crate::recipe_output::strip_recipe_noise(text),
-        crate::recipe_output::strip_ansi(text),
-    ] {
-        if let Some(output) = scan_cleaned_for_facts(cleaned.trim()) {
-            if !output.facts.is_empty() || !output.procedures.is_empty() {
-                return Some(output);
-            }
-            if empty_fallback.is_none() {
-                empty_fallback = Some(output);
-            }
-        }
-    }
-    empty_fallback
 }
 
 /// Scan an already noise-stripped `trimmed` string for a `{ "facts": [...] }`
@@ -1458,8 +1276,8 @@ fn scan_for_facts_object(text: &str) -> Option<DistillOutput> {
 /// the last otherwise-non-empty object, then the last parseable empty object.
 /// Candidates are the balanced `{...}` substrings returned by
 /// [`crate::recipe_output::balanced_objects`] (string-aware, and resilient to an
-/// unmatched `{` in leading prose). The ANSI/log/banner stripping that produces
-/// `trimmed` lives in [`scan_for_facts_object`].
+/// unmatched `{` in leading prose). The empty-document guard and the caller
+/// contract live in [`parse_facts_document`].
 ///
 /// The grounded-capable tier exists because field-level leniency
 /// ([`de_lenient_string`]) lets a *source-less* facts object now parse as
@@ -1512,105 +1330,6 @@ fn scan_cleaned_for_facts(trimmed: &str) -> Option<DistillOutput> {
     nonempty_fallback.or(empty_fallback)
 }
 
-/// The `recipe-runner-rs` 0.3.6 `--output-format json` envelope. Only the
-/// fields the parser needs are modelled; unknown fields (`recipe_name`,
-/// `duration`, `context`, …) are ignored. Both `success` and `step_results`
-/// are REQUIRED so this type does not accidentally match a bare facts object.
-#[derive(serde::Deserialize)]
-struct RecipeRunnerEnvelope {
-    success: bool,
-    step_results: Vec<RecipeRunnerStepResult>,
-}
-
-/// One entry of `step_results[]`. `output` is a [`serde_json::Value`] because
-/// the runner emits it as a JSON *string* today but a future version could emit
-/// it as an object — the parser handles both.
-#[derive(serde::Deserialize)]
-struct RecipeRunnerStepResult {
-    #[serde(default)]
-    step_id: String,
-    #[serde(default)]
-    status: String,
-    #[serde(default)]
-    output: serde_json::Value,
-    #[serde(default)]
-    error: String,
-}
-
-impl RecipeRunnerEnvelope {
-    /// Extract the distill agent's facts/procedures from the envelope.
-    ///
-    /// `success == false` short-circuits to `Err` BEFORE any step output is
-    /// read — a failed run is never trusted, even if it somehow carries a
-    /// well-formed payload.
-    fn into_distill_output(self) -> SimardResult<DistillOutput> {
-        if !self.success {
-            return Err(SimardError::BridgeError(format!(
-                "distill: recipe-runner reported failure (success=false): {}",
-                truncate(self.first_error().trim(), 200)
-            )));
-        }
-        let step = self.select_distill_step().ok_or_else(|| {
-            SimardError::BridgeError(
-                "distill: recipe envelope had no completed `distill` step".to_string(),
-            )
-        })?;
-        extract_step_output(&step.output).ok_or_else(|| {
-            SimardError::BridgeError(format!(
-                "distill: `distill` step output did not contain a parseable \
-                 {{ \"facts\": [...] }} object; output: {}",
-                truncate(step_output_excerpt(&step.output).trim(), 200)
-            ))
-        })
-    }
-
-    /// Select the step to read facts from: the one with `step_id == "distill"`,
-    /// or — tolerating a future step rename — the last `completed` step.
-    fn select_distill_step(&self) -> Option<&RecipeRunnerStepResult> {
-        self.step_results
-            .iter()
-            .find(|s| s.step_id == "distill")
-            .or_else(|| {
-                self.step_results
-                    .iter()
-                    .rev()
-                    .find(|s| s.status == "completed")
-            })
-    }
-
-    /// First non-empty step error, for failure messages.
-    fn first_error(&self) -> String {
-        self.step_results
-            .iter()
-            .map(|s| s.error.as_str())
-            .find(|e| !e.trim().is_empty())
-            .unwrap_or("<no step error reported>")
-            .to_string()
-    }
-}
-
-/// Mine a [`DistillOutput`] from a step's `output` value. A JSON *string* is
-/// balanced-brace scanned (it may carry leading prose); a JSON *object*
-/// carrying `facts` is deserialized directly.
-fn extract_step_output(output: &serde_json::Value) -> Option<DistillOutput> {
-    match output {
-        serde_json::Value::String(s) => scan_for_facts_object(s),
-        serde_json::Value::Object(_) => serde_json::from_value::<RecipeEnvelope>(output.clone())
-            .ok()
-            .map(|e| e.into_output()),
-        _ => None,
-    }
-}
-
-/// A bounded, human-readable excerpt of a step `output` value for error
-/// messages (avoids quoting/escaping a `Value::String` twice).
-fn step_output_excerpt(output: &serde_json::Value) -> String {
-    match output {
-        serde_json::Value::String(s) => s.clone(),
-        other => other.to_string(),
-    }
-}
-
 #[derive(serde::Deserialize)]
 struct RecipeEnvelope {
     facts: Vec<RecipeFact>,
@@ -1626,9 +1345,9 @@ struct RecipeEnvelope {
 ///
 /// Without this, a single fact missing `source_episode_id` (or carrying a
 /// `null`/numeric value) made `serde` reject the **entire** `{ "facts": [...] }`
-/// envelope, so `scan_for_facts_object` found no parseable object and the whole
+/// envelope, so [`parse_facts_document`] found no parseable object and the whole
 /// batch was silently dropped with the recurring
-/// `` `distill` step output did not contain a parseable { "facts": [...] } `` error —
+/// `` facts document did not contain a parseable { "facts": [...] } `` error —
 /// burning an LLM call every cycle while the same batch deferred forever.
 ///
 /// Tolerating field-level noise lets the **well-formed** facts in a batch be
@@ -1854,7 +1573,7 @@ mod unit_tests {
     fn parse_recipe_output_accepts_plain_object() {
         let raw =
             r#"{"facts":[{"concept":"pr-pattern","content":"x","source_episode_id":"epi_1"}]}"#;
-        let facts = parse_recipe_output(raw).unwrap();
+        let facts = parse_facts(raw).unwrap();
         assert_eq!(facts.len(), 1);
         assert_eq!(facts[0].concept, "pr-pattern");
     }
@@ -1864,7 +1583,7 @@ mod unit_tests {
         let raw = r#"Sure, here is the JSON:
             {"facts":[{"concept":"bug-pattern","content":"y","source_episode_id":"epi_2"}]}
             That's all."#;
-        let facts = parse_recipe_output(raw).unwrap();
+        let facts = parse_facts(raw).unwrap();
         assert_eq!(facts.len(), 1);
         assert_eq!(facts[0].concept, "bug-pattern");
     }
@@ -1875,7 +1594,7 @@ mod unit_tests {
             {"concept":"made-up-label","content":"a","source_episode_id":"epi_1"},
             {"concept":"lesson-learned","content":"b","source_episode_id":"epi_2"}
         ]}"#;
-        let facts = parse_recipe_output(raw).unwrap();
+        let facts = parse_facts(raw).unwrap();
         assert_eq!(facts.len(), 1, "made-up-label must be filtered out");
         assert_eq!(facts[0].concept, "lesson-learned");
     }
@@ -1941,7 +1660,7 @@ mod unit_tests {
             {"concept":" bug_pattern ","content":"off by one","source_episode_id":"epi_2"},
             {"concept":"made-up-label","content":"nope","source_episode_id":"epi_3"}
         ]}"#;
-        let facts = parse_recipe_output(raw).unwrap();
+        let facts = parse_facts(raw).unwrap();
         assert_eq!(
             facts.len(),
             2,
@@ -1954,7 +1673,7 @@ mod unit_tests {
     #[test]
     fn parse_recipe_output_errors_when_no_object() {
         let raw = "no json here at all";
-        assert!(parse_recipe_output(raw).is_err());
+        assert!(parse_facts(raw).is_err());
     }
 
     // ── issue #2461: last-object-wins + string-aware extraction ──────────
@@ -1966,7 +1685,7 @@ mod unit_tests {
         // banner and the pass silently no-opped; "last object wins" recovers it.
         let raw = r#"{"recipe_name":"distill","status":"starting","note":"banner"}
             {"facts":[{"concept":"lesson-learned","content":"prefer last object","source_episode_id":"epi_3"}]}"#;
-        let facts = parse_recipe_output(raw).unwrap();
+        let facts = parse_facts(raw).unwrap();
         assert_eq!(facts.len(), 1);
         assert_eq!(facts[0].concept, "lesson-learned");
         assert_eq!(facts[0].content, "prefer last object");
@@ -1977,7 +1696,7 @@ mod unit_tests {
         // A fact whose content contains literal braces must not corrupt the
         // string-aware brace scanner.
         let raw = r#"thinking... {"facts":[{"concept":"bug-pattern","content":"handler for {req} leaks }","source_episode_id":"epi_4"}]}"#;
-        let facts = parse_recipe_output(raw).unwrap();
+        let facts = parse_facts(raw).unwrap();
         assert_eq!(facts.len(), 1);
         assert_eq!(facts[0].content, "handler for {req} leaks }");
     }
@@ -1987,7 +1706,7 @@ mod unit_tests {
         // A stray double-quote in prose BEFORE the JSON must not put the
         // scanner into string mode and swallow the object's `{` opener.
         let raw = "He said \"the answer is below:\n{\"facts\":[{\"concept\":\"pr-pattern\",\"content\":\"x\",\"source_episode_id\":\"epi_9\"}]}";
-        let facts = parse_recipe_output(raw).unwrap();
+        let facts = parse_facts(raw).unwrap();
         assert_eq!(facts.len(), 1);
         assert_eq!(facts[0].concept, "pr-pattern");
     }
@@ -2012,7 +1731,7 @@ mod unit_tests {
             r#"{"facts":[{"concept":"bug-pattern","content":"missing guard in handler","#,
             r#""source_episode_id":"epi_9900"}]}"#,
         );
-        let facts = parse_recipe_output(raw).expect("answer after an unmatched `{` must parse");
+        let facts = parse_facts(raw).expect("answer after an unmatched `{` must parse");
         assert_eq!(facts.len(), 1);
         assert_eq!(facts[0].concept, "bug-pattern");
         assert_eq!(facts[0].content, "missing guard in handler");
@@ -2031,10 +1750,10 @@ mod unit_tests {
             "\u{2139} NODE_OPTIONS=--max-old-space-size=8192 (saved preference)\n",
             "Run 'copilot update' to update\n",
         );
-        assert!(parse_recipe_output(raw).is_err());
+        assert!(parse_facts(raw).is_err());
         // And the empty / whitespace-only shapes likewise fail without panic.
-        assert!(parse_recipe_output("").is_err());
-        assert!(parse_recipe_output("   \n \t ").is_err());
+        assert!(parse_facts("").is_err());
+        assert!(parse_facts("   \n \t ").is_err());
     }
 
     // ── issue #2461: failure classification ─────────────────────────────
@@ -2048,28 +1767,26 @@ mod unit_tests {
                 SpawnFailure,
             ),
             (
+                "distill: failed to create facts output tempdir: permission denied",
+                SpawnFailure,
+            ),
+            (
                 "distill: recipe exited with exit status: 1: stderr= stdout=",
                 CopilotTerminalFailure,
             ),
-            // Production `--output-format json` parse failure (t=7517): the
-            // envelope parsed, the step ran, but its output was unparseable.
+            // Post-#2622/#2619 parse failures: the process exited 0 but the
+            // agent's facts document was missing, empty, or unparseable.
             (
-                "distill: `distill` step output did not contain a parseable { \"facts\": [...] } object; output: hi",
+                "distill: facts output file was not written by the agent (/tmp/x/facts.json): No such file or directory (os error 2)",
                 ParseFailure,
             ),
-            // Legacy bare-stdout parse failure (non-envelope `run()` / mocks).
             (
-                "distill: recipe run did not yield a parseable { \"facts\": [...] } object: hi",
+                "distill: facts document was empty; the agent produced no output",
                 ParseFailure,
             ),
-            // Envelope present but the run self-reported failure / no step.
             (
-                "distill: recipe-runner reported failure (success=false): boom",
-                RecipeReportedFailure,
-            ),
-            (
-                "distill: recipe envelope had no completed `distill` step",
-                RecipeReportedFailure,
+                "distill: facts document did not contain a parseable { \"facts\": [...] } object: hi",
+                ParseFailure,
             ),
             (
                 "distill: failed to serialize episodes payload: oops",
@@ -2135,15 +1852,13 @@ mod unit_tests {
     #[test]
     fn parse_failure_is_the_only_class_that_reached_parsing() {
         use DistillFailureClass::*;
-        // recipe_exited_ok: process exited 0 → parse-failure AND recipe-reported.
+        // recipe_exited_ok: process exited 0 → only parse-failure.
         assert!(ParseFailure.recipe_exited_ok());
-        assert!(RecipeReportedFailure.recipe_exited_ok());
         assert!(!CopilotTerminalFailure.recipe_exited_ok());
         assert!(!SpawnFailure.recipe_exited_ok());
         assert!(!SerializeFailure.recipe_exited_ok());
-        // reached_parsing: only parse-failure actually parsed step output.
+        // reached_parsing: only parse-failure actually reached the agent output.
         assert!(ParseFailure.reached_parsing());
-        assert!(!RecipeReportedFailure.reached_parsing());
         assert!(!CopilotTerminalFailure.reached_parsing());
     }
 
@@ -2198,37 +1913,14 @@ mod unit_tests {
     }
 
     #[test]
-    fn recipe_reported_failure_exited_ok_but_did_not_reach_parsing() {
-        // Envelope present (process exited 0) but the run self-reported failure
-        // or had no completed step: counts as a recipe attempt that exited 0,
-        // but it must NOT inflate the parse-rate denominator (no step output
-        // was parsed).
-        let payload = build_distill_success_context(
-            false,
-            Some(DistillFailureClass::RecipeReportedFailure),
-            40,
-            0,
-            1,
-            false,
-        );
-        let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
-        assert_eq!(v["recipe_exited_ok"], true, "envelope present → exit 0");
-        assert_eq!(
-            v["parse_attempted"], false,
-            "no step output reached parsing"
-        );
-        assert_eq!(v["parse_success"], false);
-        assert_eq!(v["failure_class"], "recipe-reported-failure");
-    }
-
-    #[test]
-    fn production_envelope_step_output_parse_failure_is_counted_in_parse_rate() {
-        // Regression for the production t=7517 path: the `--output-format json`
-        // step-output parse error MUST classify as parse-failure so it lands in
-        // the distill_parse_success_rate denominator (parse_attempted = true).
+    fn missing_facts_document_parse_failure_is_counted_in_parse_rate() {
+        // Regression for the issues #2622/#2619 path: a missing/empty/unparseable
+        // facts document (process exited 0) MUST classify as parse-failure so it
+        // lands in the distill_parse_success_rate denominator (parse_attempted =
+        // true).
         let err = SimardError::BridgeError(
-            "distill: `distill` step output did not contain a parseable \
-             { \"facts\": [...] } object; output: NODE_OPTIONS banner..."
+            "distill: facts document did not contain a parseable \
+             { \"facts\": [...] } object: launcher banner..."
                 .to_string(),
         );
         assert_eq!(
@@ -2258,7 +1950,7 @@ mod unit_tests {
             "\n",
             r#"{"facts":[]}"#
         );
-        let facts = parse_recipe_output(raw).unwrap();
+        let facts = parse_facts(raw).unwrap();
         assert_eq!(
             facts.len(),
             1,
@@ -2271,726 +1963,36 @@ mod unit_tests {
     fn scan_accepts_bare_empty_facts_as_nothing_to_distill() {
         // A lone `{"facts":[]}` is a legitimate "nothing worth distilling"
         // answer and must parse to zero facts (not an error).
-        let facts = parse_recipe_output(r#"{"facts":[]}"#).unwrap();
+        let facts = parse_facts(r#"{"facts":[]}"#).unwrap();
         assert!(facts.is_empty());
     }
-
-    // ── t=7919 / #2484: ANSI-coded tracing-log + banner noise in step output ──
-
-    #[test]
-    fn parse_recipe_output_recovers_from_ansi_log_noise() {
-        // #2484 live-evidence shape: the distill step output begins with the
-        // dimmed `\x1b[2m<RFC3339 timestamp>` tracing prefix, then the agent's
-        // facts object on the next line. The raw span carries `ESC` bytes so it
-        // is invalid JSON; the shared `strip_recipe_noise` adoption drops the
-        // ANSI-coloured log line and recovers the buried payload.
-        let esc = '\u{1b}';
-        let raw = format!(
-            "{esc}[2m2026-06-28T08:08:58.151133Z{esc}[0m {esc}[36m INFO{esc}[0m simard::distill: run\n\
-             {{\"facts\":[{{\"concept\":\"lesson-learned\",\
-             \"content\":\"shared extractor recovered me\",\"source_episode_id\":\"epi_8451\"}}]}}"
-        );
-        // The raw, un-stripped span must NOT parse (the silent-drop failure).
-        assert!(
-            serde_json::from_str::<serde_json::Value>(&raw).is_err(),
-            "raw ANSI/log-noised span must be unparseable JSON"
-        );
-        let facts = parse_recipe_output(&raw).expect("shared extractor must recover facts");
-        assert_eq!(facts.len(), 1);
-        assert_eq!(facts[0].concept, "lesson-learned");
-        assert_eq!(facts[0].content, "shared extractor recovered me");
-    }
-
-    #[test]
-    fn parse_recipe_output_recovers_from_runner_banner() {
-        // New capability over the former distill-private ANSI-only stripper:
-        // `strip_recipe_noise` ALSO drops the recipe-runner text-mode summary
-        // banner lines that can prefix the agent's payload, which the old
-        // ANSI-only path left in place (defeating the balanced-brace scan when
-        // a banner line itself carried stray braces).
-        let raw = "Recipe: distill-episodes SUCCESS (36.0s)\n\
-                   Steps: 1/1 completed\n\
-                   [completed] distill (36.0s)\n\
-                   {\"facts\":[{\"concept\":\"bug-pattern\",\
-                   \"content\":\"runner banner must be dropped\",\
-                   \"source_episode_id\":\"epi_9\"}]}";
-        let facts = parse_recipe_output(raw).expect("banner-prefixed payload must parse");
-        assert_eq!(facts.len(), 1);
-        assert_eq!(facts[0].concept, "bug-pattern");
-        assert_eq!(facts[0].content, "runner banner must be dropped");
-    }
-
-    #[test]
-    fn parse_recipe_output_recovers_facts_from_ansi_log_noise() {
-        // The t=7919 cycle: the distill step output carried ANSI-coded tracing
-        // log lines (the failing excerpt began `\x1b[2m2026-06-28T06:38:25…`)
-        // with the agent's facts object colourised inline. The raw ESC bytes
-        // interleaved with the JSON made `serde_json` reject the span, so the
-        // whole batch silently deferred. ANSI stripping recovers it.
-        let esc = '\u{1b}';
-        let raw = format!(
-            "{esc}[2m2026-06-28T06:38:25.928376Z{esc}[0m {esc}[36m DEBUG{esc}[0m thinking…\n\
-             {{\"facts\":[{{\"concept\":\"{esc}[33mbug-pattern{esc}[0m\",\
-             \"content\":\"ansi noise must be stripped\",\"source_episode_id\":\"epi_7\"}}]}}"
-        );
-        let facts = parse_recipe_output(&raw).expect("must recover facts past ANSI noise");
-        assert_eq!(facts.len(), 1);
-        assert_eq!(facts[0].concept, "bug-pattern");
-        assert_eq!(facts[0].content, "ansi noise must be stripped");
-    }
-
-    #[test]
-    fn parse_recipe_output_full_recovers_facts_from_ansi_coded_step_output() {
-        // Exact production t=7919 path: the `--output-format json` envelope's
-        // `distill` step `output` string is ANSI-coded tracing log noise
-        // (begins with the dimmed `\x1b[2m<timestamp>` prefix from the failing
-        // cycle) with the agent's facts object colourised inline. Before ANSI
-        // stripping this raised "step output did not contain a parseable
-        // { facts } object" and the 20-episode batch deferred for a full cycle;
-        // now the buried object is mined out of the step output and parsed.
-        let esc = '\u{1b}';
-        let step_output = format!(
-            "{esc}[2m2026-06-28T06:38:25.928376Z{esc}[0m {esc}[32m INFO{esc}[0m \
-             {esc}[2msimard::distill{esc}[0m: distilling 20 episodes\n\
-             {{{esc}[0m\"facts\":[{{\"concept\":\"{esc}[33mlesson-learned{esc}[0m\",\
-             \"content\":\"strip ansi before the facts scan\",\
-             \"source_episode_id\":\"epi_42\"}}]}}\n"
-        );
-        let envelope = serde_json::json!({
-            "recipe_name": "distill-episodes",
-            "success": true,
-            "step_results": [{
-                "step_id": "distill",
-                "status": "completed",
-                "output": step_output,
-                "error": ""
-            }]
-        })
-        .to_string();
-        let out = parse_recipe_output_full(&envelope).expect("ANSI-coded step output must parse");
-        assert_eq!(out.facts.len(), 1);
-        assert_eq!(out.facts[0].concept, "lesson-learned");
-        assert_eq!(out.facts[0].content, "strip ansi before the facts scan");
-        assert_eq!(out.facts[0].source_episode_id, "epi_42");
-    }
-
-    #[test]
-    fn parse_recipe_output_full_recovers_facts_from_copilot_launch_log_preamble() {
-        // Regression for issue #2496 (episode t=9271 live failure).
-        //
-        // The existing ANSI/banner tests above already cover dimmed
-        // `simard::distill` / `thinking` tracing prefixes and the
-        // recipe-runner text summary banner. This pins the distinct
-        // **Copilot CLI launch** noise shape the issue captured, which no
-        // other test exercises as a unit:
-        //
-        //   1. an ANSI-coloured `launching copilot binary=copilot` line,
-        //   2. an `\u{2139} NODE_OPTIONS=--max-old-space-size=…` line, and
-        //   3. a leading, ANSI-wrapped JSON *log record*
-        //      (`{"level":"info",…}`) — a complete brace-balanced object that
-        //      precedes the real facts object.
-        //
-        // Element 3 is the adversarial part: a first-object brace scan would
-        // lock onto the `{"level":…}` log record (which has no `facts` field
-        // and so fails the envelope parse) and never reach the trailing facts
-        // object. The current parser strips the ANSI/log noise and prefers the
-        // LAST non-empty facts object, so the buried payload is recovered.
-        // This is fed through the production Tier-1 `--output-format json`
-        // envelope path (`parse_recipe_output_full` -> `into_distill_output`
-        // -> `extract_step_output` -> `scan_for_facts_object`), which is where
-        // the `\`distill\` step output did not contain a parseable …` error in
-        // the issue originated.
-        let esc = '\u{1b}';
-        let step_output = format!(
-            "{esc}[2m2026-06-29T12:26:24.512Z{esc}[0m {esc}[32m INFO{esc}[0m launching copilot binary=copilot\n\
-             \u{2139} {esc}[2mNODE_OPTIONS=--max-old-space-size=8192{esc}[0m\n\
-             {esc}[36m{{\"level\":\"info\",\"msg\":\"session started\",\"cwd\":\"/repo\"}}{esc}[0m\n\
-             {{\"facts\":[{{\"concept\":\"bug-pattern\",\
-             \"content\":\"distill parser must tolerate ANSI + launch-log preamble\",\
-             \"source_episode_id\":\"epi_9271\"}}]}}\n"
-        );
-        // The raw step-output span carries ESC bytes and a leading non-facts
-        // object, so it must NOT parse as-is — the silent-drop failure mode.
-        assert!(
-            serde_json::from_str::<RecipeEnvelope>(step_output.trim()).is_err(),
-            "raw launch-log-noised step output must be unparseable as a facts envelope"
-        );
-        let envelope = serde_json::json!({
-            "recipe_name": "distill-episodes",
-            "success": true,
-            "step_results": [{
-                "step_id": "distill",
-                "status": "completed",
-                "output": step_output,
-                "error": ""
-            }]
-        })
-        .to_string();
-        let out = parse_recipe_output_full(&envelope)
-            .expect("issue #2496 launch-log-preamble payload must parse");
-        assert_eq!(out.facts.len(), 1, "exactly one fact recovered");
-        assert_eq!(out.facts[0].concept, "bug-pattern");
-        assert_eq!(
-            out.facts[0].content,
-            "distill parser must tolerate ANSI + launch-log preamble"
-        );
-        assert_eq!(out.facts[0].source_episode_id, "epi_9271");
-    }
 }
 
-/// Issue #2496: distill delegates launcher stripping to the **shared**
-/// `recipe_output` chokepoint (the same `is_noise_line` predicate the OODA
-/// brains use) and carries no parallel launcher cleaner. Complements the
-/// `parse_recipe_output_full_recovers_facts_from_copilot_launch_log_preamble`
-/// regression above (which uses an ISO-timestamped launcher line) by pinning the
-/// **bare**, non-timestamped launcher shapes that only the new
-/// `is_copilot_launcher_line` arm recognises.
-#[cfg(test)]
-mod issue_2496_distill_launcher_tests {
-    use super::*;
-
-    #[test]
-    fn distill_recovers_facts_behind_bare_launcher_preamble_via_shared_chokepoint() {
-        // A launcher preamble with NO ISO-8601 timestamp — the shape only the
-        // shared `is_copilot_launcher_line` arm drops. Distill recovers the
-        // trailing facts object through the same chokepoint the brains use.
-        let step_output = "\u{2139} NODE_OPTIONS=--max-old-space-size=32768 (saved preference). \
-             To change: /home/azureuser/.amplihack/config\n\
-             INFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot \
-             version=\"GitHub Copilot CLI 1.0.66-2.\"\n\
-             Run 'copilot update' to check for updates.\n\
-             {\"facts\":[{\"concept\":\"bug-pattern\",\
-             \"content\":\"shared chokepoint strips the launch preamble for distill too\",\
-             \"source_episode_id\":\"epi_2496\"}]}";
-        let envelope = serde_json::json!({
-            "recipe_name": "distill-episodes",
-            "success": true,
-            "step_results": [{
-                "step_id": "distill",
-                "status": "completed",
-                "output": step_output,
-                "error": ""
-            }]
-        })
-        .to_string();
-        let out = parse_recipe_output_full(&envelope)
-            .expect("issue #2496 bare-launcher-preamble payload must parse");
-        assert_eq!(out.facts.len(), 1, "exactly one fact recovered");
-        assert_eq!(out.facts[0].concept, "bug-pattern");
-        assert_eq!(out.facts[0].source_episode_id, "epi_2496");
-    }
-}
-
-/// Issue #2512: recover facts when the captured `recipe-runner-rs` stdout
-/// **begins with** the Copilot CLI launch banner *before* the JSON envelope.
-///
-/// The existing #2496 tests above pin the banner contaminating the **inner**
-/// `distill` step `output` string. This module pins the distinct, residual
-/// **outer-envelope** contamination: the copilot subprocess prints its launch
-/// preamble to the inherited stdout *before* recipe-runner-rs emits its
-/// `{ "recipe_name", "success", "step_results": … }` envelope, so the captured
-/// stdout starts with the banner and the fast Tier-1a `serde_json::from_str`
-/// rejects it. `recover_distill_output` (Tier 1b) recovers the envelope through
-/// the SAME shared `recipe_output` chokepoint the #2504 decide/orient fix uses.
-#[cfg(test)]
-mod issue_2512_outer_envelope_banner_tests {
-    use super::*;
-
-    /// The canonical production envelope, facts inlined.
-    fn envelope_with_facts() -> String {
-        serde_json::json!({
-            "recipe_name": "distill-episodes",
-            "success": true,
-            "step_results": [{
-                "step_id": "distill",
-                "status": "completed",
-                "output": r#"{"facts":[{"concept":"bug-pattern","content":"outer envelope banner must be stripped","source_episode_id":"epi_2512"}]}"#,
-                "error": ""
-            }]
-        })
-        .to_string()
-    }
-
-    #[test]
-    fn recovers_facts_when_bare_launch_banner_precedes_envelope() {
-        // The exact #2504 launch banner shapes (no ISO-8601 timestamp), prefixed
-        // to the captured stdout BEFORE the recipe-runner envelope `{`.
-        let raw = format!(
-            "\u{2139} NODE_OPTIONS=--max-old-space-size=32768 (saved preference). \
-             To change: /home/azureuser/.amplihack/config\n\
-             INFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot \
-             version=\"GitHub Copilot CLI 1.0.66-2.\"\n\
-             Run 'copilot update' to check for updates.\n\
-             {}",
-            envelope_with_facts()
-        );
-        // The raw stdout must NOT parse as an envelope directly (the silent-drop
-        // failure mode this issue fixes).
-        assert!(
-            serde_json::from_str::<RecipeRunnerEnvelope>(raw.trim()).is_err(),
-            "banner-prefixed stdout must be unparseable as a bare envelope"
-        );
-        let out = parse_recipe_output_full(&raw)
-            .expect("issue #2512 banner-prefixed envelope must parse");
-        assert_eq!(out.facts.len(), 1, "exactly one fact recovered");
-        assert_eq!(out.facts[0].concept, "bug-pattern");
-        assert_eq!(
-            out.facts[0].content,
-            "outer envelope banner must be stripped"
-        );
-        assert_eq!(out.facts[0].source_episode_id, "epi_2512");
-    }
-
-    #[test]
-    fn recovers_facts_when_ansi_log_line_precedes_envelope() {
-        // An ANSI-coloured tracing log line (dimmed `\x1b[2m<timestamp>` prefix)
-        // before the envelope — the line-dropping `strip_recipe_noise` view
-        // removes it and recovers the envelope on its own line.
-        let esc = '\u{1b}';
-        let raw = format!(
-            "{esc}[2m2026-06-30T18:00:00.000Z{esc}[0m {esc}[32m INFO{esc}[0m simard::distill: run\n{}",
-            envelope_with_facts()
-        );
-        let out = parse_recipe_output_full(&raw)
-            .expect("issue #2512 ANSI-log-prefixed envelope must parse");
-        assert_eq!(out.facts.len(), 1);
-        assert_eq!(out.facts[0].source_episode_id, "epi_2512");
-    }
-
-    #[test]
-    fn recovers_envelope_sharing_a_line_with_a_banner_token() {
-        // The banner token and the envelope share ONE physical line — the
-        // line-dropping view would discard the envelope wholesale, so the
-        // line-preserving `strip_ansi` view + balanced-object scan must recover
-        // it (the dual-view guarantee).
-        let raw = format!(
-            "INFO launching copilot binary=copilot {}",
-            envelope_with_facts()
-        );
-        let out = parse_recipe_output_full(&raw)
-            .expect("issue #2512 same-line banner+envelope must parse");
-        assert_eq!(out.facts.len(), 1);
-        assert_eq!(out.facts[0].source_episode_id, "epi_2512");
-    }
-
-    #[test]
-    fn leading_non_envelope_log_record_does_not_shadow_the_real_envelope() {
-        // A complete, brace-balanced `{"level":...}` log record precedes the
-        // envelope. It lacks `success`/`step_results`, so it must not be mistaken
-        // for the envelope; the end-first scan reaches the real envelope.
-        let raw = format!(
-            "{}\n{}",
-            r#"{"level":"info","msg":"session started","cwd":"/repo"}"#,
-            envelope_with_facts()
-        );
-        let out = parse_recipe_output_full(&raw)
-            .expect("issue #2512 leading log-record + envelope must parse");
-        assert_eq!(out.facts.len(), 1);
-        assert_eq!(out.facts[0].source_episode_id, "epi_2512");
-    }
-
-    #[test]
-    fn banner_prefixed_failed_envelope_reports_recipe_failure_not_silent_drop() {
-        // A banner-prefixed envelope with `success == false` must surface a
-        // RecipeReportedFailure (committed-to recovery), NOT silently fall
-        // through to a generic "did not yield a parseable" error.
-        let envelope = serde_json::json!({
-            "recipe_name": "distill-episodes",
-            "success": false,
-            "step_results": [{
-                "step_id": "distill",
-                "status": "failed",
-                "output": "",
-                "error": "agent timed out"
-            }]
-        })
-        .to_string();
-        let raw = format!(
-            "INFO launching copilot binary=copilot \
-             version=\"GitHub Copilot CLI 1.0.66-2.\"\n{envelope}"
-        );
-        let err = parse_recipe_output_full(&raw)
-            .expect_err("a success=false envelope must be an error, even banner-prefixed");
-        assert_eq!(
-            classify_distill_error(&err),
-            DistillFailureClass::RecipeReportedFailure,
-            "banner-prefixed failed run classifies as recipe-reported, not parse-failure"
-        );
-    }
-
-    #[test]
-    fn clean_envelope_with_no_banner_still_parses() {
-        // The fast Tier-1a path is unchanged for clean production stdout.
-        let out = parse_recipe_output_full(&envelope_with_facts())
-            .expect("clean envelope must still parse via the fast path");
-        assert_eq!(out.facts.len(), 1);
-        assert_eq!(out.facts[0].source_episode_id, "epi_2512");
-    }
-
-    #[test]
-    fn recovers_facts_from_compound_outer_and_inner_banner_contamination() {
-        // Worst case: the launch banner contaminates BOTH the outer stdout
-        // (before the envelope) AND the inner `distill` step output (before the
-        // facts). The inner banner is escaped inside the envelope's single-line
-        // `output`, so the whole compact envelope line itself *contains*
-        // `launching copilot binary=` — which makes the line-dropping
-        // `strip_recipe_noise` view discard the entire envelope. The
-        // line-preserving `strip_ansi` view must then recover the envelope
-        // (string-aware balanced scan), and the inner step-output scan strips the
-        // inner banner to reach the facts. This pins the dual-view interaction
-        // end-to-end.
-        let inner = "INFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot \
-             version=\"GitHub Copilot CLI 1.0.66-2.\"\n\
-             {\"facts\":[{\"concept\":\"lesson-learned\",\
-             \"content\":\"dual-view recovers compound banner contamination\",\
-             \"source_episode_id\":\"epi_compound\"}]}";
-        let envelope = serde_json::json!({
-            "recipe_name": "distill-episodes",
-            "success": true,
-            "step_results": [{
-                "step_id": "distill",
-                "status": "completed",
-                "output": inner,
-                "error": ""
-            }]
-        })
-        .to_string();
-        let raw = format!(
-            "\u{2139} NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: cfg\n\
-             Run 'copilot update' to check for updates.\n{envelope}"
-        );
-        let out = parse_recipe_output_full(&raw)
-            .expect("compound outer+inner banner contamination must still parse");
-        assert_eq!(out.facts.len(), 1);
-        assert_eq!(out.facts[0].concept, "lesson-learned");
-        assert_eq!(out.facts[0].source_episode_id, "epi_compound");
-    }
-}
-
-/// Issue #2517: recover facts AND procedures from the **full, high-fidelity**
-/// GitHub Copilot CLI `1.0.66-2` launch-banner capture — a multi-line banner
-/// wrapped in raw ANSI, prefixing a **pretty-printed** `recipe-runner-rs
-/// --output-format json` envelope whose `distill` step `output` string itself
-/// carries the agent subprocess's inner launch banner.
-///
-/// This pins the residual mis-route the #2512 tests missed. Those used a
-/// **compact** (single-line) envelope: when the inner banner contaminated the
-/// escaped `output`, the line-dropping [`strip_recipe_noise`] view dropped the
-/// ENTIRE one-line envelope, so recovery cleanly fell through to the
-/// line-preserving [`strip_ansi`] view. In production, however, recipe-runner-rs
-/// emits a **pretty-printed** envelope (see `REAL_RUNNER_ENVELOPE_VERBATIM`), so
-/// only the `"output": "…launching copilot binary=…"` line is dropped — leaving a
-/// structurally-valid but **gutted** envelope (`output` → `null`). The old
-/// first-match `recover_runner_envelope` committed to that gutted envelope,
-/// `extract_step_output` returned `None`, and the whole batch's facts AND
-/// procedures were silently swallowed with the recurring `` `distill` step output
-/// did not contain a parseable { "facts": [...] } `` error.
-///
-/// The fix ([`recover_distill_output`] + [`candidate_runner_envelopes`])
-/// evaluates BOTH cleaned views and commits to the candidate that actually
-/// yields a populated [`DistillOutput`], so the intact line-preserving view wins
-/// over the gutted line-dropping view.
-///
-/// Post-#2570: the structural-token guard now preserves that `"output": …` line,
-/// so the line-dropping view no longer guts THIS pretty shape on its own (see
-/// the renamed `line_dropping_view_preserves_pretty_envelope_output_after_2570_guard`);
-/// the two-view candidate selection stays as defence-in-depth for other shapes
-/// that view can still gut.
-#[cfg(test)]
-mod issue_2517_pretty_envelope_launch_banner_tests {
-    use super::*;
-
-    /// The distill agent's answer: two facts (allowed concepts, grounded) and
-    /// one fully-grounded procedure (non-empty name, >=1 steps, >=1 source ids).
-    const FACTS_AND_PROCEDURES_JSON: &str = r#"{"facts":[{"concept":"bug-pattern","content":"a pretty-printed runner envelope whose distill output line carries the launch banner is gutted by the line-dropping view","source_episode_id":"epi_2517"},{"concept":"lesson-learned","content":"evaluate both cleaned views and commit to the one that yields a populated DistillOutput","source_episode_id":"epi_2517"}],"procedures":[{"name":"distill-past-launch-banner","steps":["strip ansi","drop launcher lines","balanced-scan for the envelope"],"source_episode_ids":["epi_2517"]}]}"#;
-
-    /// The distill step `output` string exactly as recipe-runner captures it: the
-    /// agent subprocess prints its OWN `1.0.66-2` launch banner to stdout before
-    /// its JSON answer, so the banner prefixes the facts/procedures payload.
-    fn inner_step_output_with_banner() -> String {
-        format!(
-            "\u{2139}\u{fe0f} NODE_OPTIONS=--max-old-space-size=32768 (saved preference). \
-             To change: /home/azureuser/.amplihack/config\n\
-             INFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot \
-             version=\"GitHub Copilot CLI 1.0.66-2\"\n\
-             Run 'copilot update' to check for updates.\n\
-             {FACTS_AND_PROCEDURES_JSON}"
-        )
-    }
-
-    /// The full captured stdout: raw ANSI wrapping the multi-line outer launch
-    /// banner, then the PRETTY-printed runner envelope (mirroring the real
-    /// `--output-format json` shape) whose `distill` step `output` carries the
-    /// inner banner + facts + procedures.
-    fn raw_capture() -> String {
-        let esc = '\u{1b}';
-        let envelope = serde_json::to_string_pretty(&serde_json::json!({
-            "recipe_name": "distill-episodes",
-            "success": true,
-            "step_results": [{
-                "step_id": "distill",
-                "status": "completed",
-                "output": inner_step_output_with_banner(),
-                "error": "",
-                "duration": 12.34
-            }],
-            "duration": 12.5
-        }))
-        .expect("envelope must serialize");
-        format!(
-            "{esc}[2m{esc}[38;5;39m\u{2139}\u{fe0f} NODE_OPTIONS=--max-old-space-size=32768 \
-             (saved preference). To change: /home/azureuser/.amplihack/config{esc}[0m\n\
-             {esc}[2mINFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot \
-             version=\"GitHub Copilot CLI 1.0.66-2\"{esc}[0m\n\
-             {esc}[33mRun 'copilot update' to check for updates.{esc}[0m\n\
-             {envelope}"
-        )
-    }
-
-    /// HEADLINE REGRESSION: the full `1.0.66-2` launch banner (raw ANSI,
-    /// multi-line) preceding a pretty-printed envelope with an inner-banner
-    /// `output` must recover BOTH facts and procedures — not swallow them.
-    #[test]
-    fn full_1_0_66_2_launch_banner_with_ansi_and_envelope_recovers_facts_and_procedures() {
-        let raw = raw_capture();
-
-        // Precondition (proves the pre-fix drop path): the captured stdout does
-        // NOT parse as a bare recipe-runner envelope — the fast Tier-1a path
-        // fails, so Tier-1b recovery is the only route to the payload.
-        assert!(
-            serde_json::from_str::<RecipeRunnerEnvelope>(raw.trim()).is_err(),
-            "ANSI-banner-prefixed stdout must be unparseable as a bare envelope"
-        );
-
-        let out = parse_recipe_output_full(&raw)
-            .expect("issue #2517 pretty-envelope banner capture must parse into a DistillOutput");
-
-        assert!(
-            !out.facts.is_empty(),
-            "facts must be recovered, not swallowed by the gutted line-dropping view"
-        );
-        assert!(
-            !out.procedures.is_empty(),
-            "procedures must be recovered, not swallowed by the gutted line-dropping view"
-        );
-        assert_eq!(out.facts.len(), 2, "both allowed-concept facts recovered");
-        assert!(
-            out.facts.iter().all(|f| f.source_episode_id == "epi_2517"),
-            "fact provenance must survive the recovery"
-        );
-        assert_eq!(out.procedures.len(), 1, "the grounded procedure recovered");
-        assert_eq!(out.procedures[0].name, "distill-past-launch-banner");
-        assert_eq!(
-            out.procedures[0].source_episode_ids,
-            vec!["epi_2517".to_string()],
-            "procedure provenance must carry its source episode id"
-        );
-    }
-
-    /// The facts-only public wrapper must also recover the facts.
-    #[test]
-    fn facts_only_wrapper_recovers_facts_from_pretty_envelope() {
-        let facts = parse_recipe_output(&raw_capture())
-            .expect("issue #2517 facts-only wrapper must recover facts");
-        assert_eq!(facts.len(), 2, "parse_recipe_output must yield the facts");
-        assert!(facts.iter().any(|f| f.concept == "bug-pattern"));
-        assert!(facts.iter().any(|f| f.concept == "lesson-learned"));
-    }
-
-    /// Post-#2570 interaction pin (was `line_dropping_view_alone_guts_…`): the
-    /// line-dropping [`strip_recipe_noise`] view used to GUT this fixture — it
-    /// matched the pretty envelope's escaped `"output": …` line (which quotes
-    /// `launching copilot binary=`) as launcher noise and dropped it, leaving a
-    /// structurally valid envelope whose `output` was absent, so committing to
-    /// that view (the original #2517 bug) failed to yield facts. The #2570
-    /// structural-token guard now exempts that `"`-leading JSON payload line, so
-    /// the line-dropping view PRESERVES the `output` and recovers the facts on
-    /// its own. The #2517 "prefer the populated candidate" logic
-    /// ([`candidate_runner_envelopes`]) remains as defence-in-depth for a view
-    /// that could still be gutted (e.g. an envelope sharing a physical line with
-    /// a leading banner token); this test pins that #2570 has eliminated the
-    /// specific gutting trap for the real pretty-envelope shape.
-    #[test]
-    fn line_dropping_view_preserves_pretty_envelope_output_after_2570_guard() {
-        let raw = raw_capture();
-        let recovered_view = crate::recipe_output::strip_recipe_noise(raw.trim());
-        let envelope: RecipeRunnerEnvelope = serde_json::from_str(recovered_view.trim()).expect(
-            "the line-dropping view yields a structurally valid envelope; after the #2570 guard \
-             its escaped `output` JSON line is preserved rather than dropped",
-        );
-        let out = envelope.into_distill_output().expect(
-            "after the #2570 structural-token guard the line-dropping view preserves the \
-             `\"output\"` line, so the envelope yields facts on its own",
-        );
-        assert_eq!(
-            out.facts.len(),
-            2,
-            "both grounded facts are recovered by the line-dropping view post-#2570: {:?}",
-            out.facts
-        );
-        assert!(
-            out.facts.iter().all(|f| f.source_episode_id == "epi_2517"),
-            "fact provenance must survive the line-dropping recovery"
-        );
-    }
-
-    /// A pretty envelope WITHOUT the inner banner (clean `output`) is recovered
-    /// too — the line-dropping view keeps the clean `output` line, so it is not
-    /// gutted, and either view yields the payload.
-    #[test]
-    fn pretty_envelope_without_inner_banner_still_recovers() {
-        let esc = '\u{1b}';
-        let envelope = serde_json::to_string_pretty(&serde_json::json!({
-            "recipe_name": "distill-episodes",
-            "success": true,
-            "step_results": [{
-                "step_id": "distill",
-                "status": "completed",
-                "output": FACTS_AND_PROCEDURES_JSON,
-                "error": ""
-            }]
-        }))
-        .expect("envelope must serialize");
-        let raw = format!(
-            "{esc}[2m\u{2139}\u{fe0f} NODE_OPTIONS=x (saved preference).{esc}[0m\n{envelope}"
-        );
-        let out = parse_recipe_output_full(&raw)
-            .expect("clean-output pretty envelope behind a banner must recover");
-        assert_eq!(out.facts.len(), 2);
-        assert_eq!(out.procedures.len(), 1);
-    }
-
-    /// The `success == false` contract survives the pretty-envelope path: a
-    /// banner-prefixed failed run surfaces a `RecipeReportedFailure`, never a
-    /// silent drop and never a generic parse error.
-    #[test]
-    fn banner_prefixed_failed_pretty_envelope_reports_recipe_failure() {
-        let esc = '\u{1b}';
-        let envelope = serde_json::to_string_pretty(&serde_json::json!({
-            "recipe_name": "distill-episodes",
-            "success": false,
-            "step_results": [{
-                "step_id": "distill",
-                "status": "failed",
-                "output": "",
-                "error": "agent timed out"
-            }]
-        }))
-        .expect("envelope must serialize");
-        let raw = format!(
-            "{esc}[2m\u{2139}\u{fe0f} NODE_OPTIONS=--max-old-space-size=32768 (saved preference).\
-             {esc}[0m\n\
-             {esc}[2mINFO launching copilot binary=copilot version=\"GitHub Copilot CLI 1.0.66-2\"\
-             {esc}[0m\n{envelope}"
-        );
-        let err = parse_recipe_output_full(&raw)
-            .expect_err("a success=false pretty envelope must be an error, even banner-prefixed");
-        assert_eq!(
-            classify_distill_error(&err),
-            DistillFailureClass::RecipeReportedFailure,
-            "banner-prefixed failed run classifies as recipe-reported, not parse-failure"
-        );
-    }
-
-    /// A genuine "nothing worth distilling" answer (empty `facts`) behind BOTH an
-    /// inner and outer banner in a pretty envelope must be an empty `Ok`, never
-    /// an `Err` — so a legitimately empty pass does not burn a retry.
-    #[test]
-    fn banner_prefixed_pretty_envelope_with_nothing_to_distill_returns_empty_ok() {
-        let esc = '\u{1b}';
-        let inner = "INFO launching copilot binary=copilot version=\"GitHub Copilot CLI 1.0.66-2\"\n\
-                     {\"facts\":[]}";
-        let envelope = serde_json::to_string_pretty(&serde_json::json!({
-            "recipe_name": "distill-episodes",
-            "success": true,
-            "step_results": [{
-                "step_id": "distill",
-                "status": "completed",
-                "output": inner,
-                "error": ""
-            }]
-        }))
-        .expect("envelope must serialize");
-        let raw = format!(
-            "{esc}[2m\u{2139}\u{fe0f} NODE_OPTIONS=x (saved preference).{esc}[0m\n{envelope}"
-        );
-        let out = parse_recipe_output_full(&raw)
-            .expect("an empty 'nothing to distill' answer must be an empty Ok, not an Err");
-        assert!(
-            out.facts.is_empty() && out.procedures.is_empty(),
-            "the empty answer must yield an empty DistillOutput"
-        );
-    }
-}
-
-/// Episode t=9664 (live OODA consolidation, 2026-06-30, Copilot CLI 1.0.66-2):
-/// the distill bridge failed **recurrently** with the same
-/// `` `distill` step output did not contain a parseable { "facts": [...] } `` error
-/// (issue #2506) even though every ANSI/launch-log preamble shape was already stripped (the
-/// fix landed in #2479/#2484/#2490/#2504, and the deployed binary carried it).
-///
-/// The residual root cause was *field-level* strictness, not noise: the agent
-/// intermittently omits / nulls / scalar-types a single `facts[]` field
-/// (most often `source_episode_id`), which made `serde` reject the **whole**
-/// envelope so the entire batch was silently dropped and re-deferred every
-/// cycle. These tests pin the field-tolerant deserialization
-/// ([`de_lenient_string`]): one malformed fact no longer sinks its well-formed
-/// siblings, and an ungrounded recovered fact is still gated by
-/// [`assess_fact_reliability`] rather than promoted blindly.
+/// Episode t=9664 (live OODA consolidation): the distill agent intermittently
+/// omits / nulls / scalar-types a single `facts[]` field (most often
+/// `source_episode_id`), which made `serde` reject the **whole** envelope so the
+/// entire batch was silently dropped and re-deferred every cycle. These tests
+/// pin the field-tolerant deserialization ([`de_lenient_string`]) as it applies
+/// to the agent's **facts document** (issues #2622/#2619): one malformed fact no
+/// longer sinks its well-formed siblings, and an ungrounded recovered fact is
+/// still gated by [`assess_fact_reliability`] rather than promoted blindly.
 #[cfg(test)]
 mod issue_t9664_field_tolerance_tests {
     use super::*;
 
-    /// The exact production noise prefix captured for episode t=9664: an
-    /// ANSI-coloured ISO-timestamped `launching copilot binary=…` line followed
-    /// by the bare `\u{2139} NODE_OPTIONS=…` info marker, immediately preceding
-    /// the agent's real `{ "facts": [...] }` answer.
-    fn real_t9664_noise_prefix() -> String {
-        let e = '\u{1b}';
-        format!(
-            "{e}[2m2026-06-30T04:31:59.643823Z{e}[0m {e}[32m INFO{e}[0m launching copilot \
-             {e}[3mbinary{e}[0m{e}[2m={e}[0m/home/azureuser/.npm-global/bin/copilot \
-             {e}[3mversion{e}[0m{e}[2m={e}[0m\"GitHub Copilot CLI 1.0.66-2.\"\n\
-             \u{2139} NODE_OPTIONS=--max-old-space-size=8192\n"
-        )
-    }
-
-    fn distill_envelope(step_output: &str) -> String {
-        serde_json::json!({
-            "recipe_name": "distill-episodes",
-            "success": true,
-            "step_results": [{
-                "step_id": "distill",
-                "status": "completed",
-                "output": step_output,
-                "error": ""
-            }]
-        })
-        .to_string()
-    }
-
-    /// The headline regression: leading ANSI/launch-log noise ahead of a facts
-    /// payload in which one fact is **well-formed** and a sibling **omits
-    /// `source_episode_id`**. Before the fix the missing field made the whole
-    /// `{ "facts": [...] }` object unparseable and the entire batch was dropped;
-    /// now the payload parses and the well-formed fact is recovered.
+    /// The headline regression: a facts document in which one fact is
+    /// **well-formed** and a sibling **omits `source_episode_id`**. Before the
+    /// fix the missing field made the whole `{ "facts": [...] }` object
+    /// unparseable and the entire batch was dropped; now the document parses and
+    /// the well-formed fact is recovered.
     #[test]
     fn distill_recovers_wellformed_fact_when_sibling_omits_source_episode_id() {
-        let step_output = format!(
-            "{}{{\"facts\":[\
-               {{\"concept\":\"bug-pattern\",\"content\":\"distill parser must tolerate a fact missing source_episode_id\",\"source_episode_id\":\"epi_9664\"}},\
-               {{\"concept\":\"lesson-learned\",\"content\":\"a sibling fact omitted its source_episode_id\"}}\
-             ]}}",
-            real_t9664_noise_prefix()
-        );
-        // The raw step-output span carries ESC bytes and a field-incomplete
-        // fact, so it must NOT parse as-is — the silent-drop failure mode.
-        assert!(
-            serde_json::from_str::<RecipeEnvelope>(step_output.trim()).is_err(),
-            "raw noised + field-incomplete step output must be unparseable as-is"
-        );
-        let out = parse_recipe_output_full(&distill_envelope(&step_output))
-            .expect("t=9664 payload (noise + one field-incomplete fact) must parse");
+        let document = "{\"facts\":[\
+               {\"concept\":\"bug-pattern\",\"content\":\"distill parser must tolerate a fact missing source_episode_id\",\"source_episode_id\":\"epi_9664\"},\
+               {\"concept\":\"lesson-learned\",\"content\":\"a sibling fact omitted its source_episode_id\"}\
+             ]}";
+        let out = parse_facts_document(document)
+            .expect("t=9664 document (one field-incomplete fact) must parse");
         // Both facts are recovered by the parser (the reliability gate, applied
         // later in the pass, decides promotion vs. quarantine — see
         // `assess_fact_reliability`). The grounded one is intact.
@@ -3013,12 +2015,12 @@ mod issue_t9664_field_tolerance_tests {
     }
 
     /// A bare facts object whose only fact omits `source_episode_id` must parse
-    /// (Tier-2 path) instead of erroring — the minimal reproduction of the
-    /// schema-strictness gap, independent of any noise.
+    /// instead of erroring — the minimal reproduction of the schema-strictness
+    /// gap.
     #[test]
     fn parse_recipe_output_tolerates_fact_missing_source_episode_id() {
         let raw = r#"{"facts":[{"concept":"bug-pattern","content":"missing id field"}]}"#;
-        let facts = parse_recipe_output(raw).expect("a fact missing source_episode_id must parse");
+        let facts = parse_facts(raw).expect("a fact missing source_episode_id must parse");
         assert_eq!(facts.len(), 1);
         assert_eq!(facts[0].concept, "bug-pattern");
         assert!(facts[0].source_episode_id.is_empty());
@@ -3030,13 +2032,12 @@ mod issue_t9664_field_tolerance_tests {
     #[test]
     fn parse_recipe_output_tolerates_null_and_scalar_fields() {
         let null_field = r#"{"facts":[{"concept":"lesson-learned","content":"id was null","source_episode_id":null}]}"#;
-        let facts = parse_recipe_output(null_field).expect("null source_episode_id must parse");
+        let facts = parse_facts(null_field).expect("null source_episode_id must parse");
         assert_eq!(facts.len(), 1);
         assert!(facts[0].source_episode_id.is_empty());
 
         let numeric_field = r#"{"facts":[{"concept":"pr-pattern","content":"id was numeric","source_episode_id":9664}]}"#;
-        let facts =
-            parse_recipe_output(numeric_field).expect("numeric source_episode_id must parse");
+        let facts = parse_facts(numeric_field).expect("numeric source_episode_id must parse");
         assert_eq!(facts.len(), 1);
         assert_eq!(facts[0].source_episode_id, "9664");
     }
@@ -3069,8 +2070,7 @@ mod issue_t9664_field_tolerance_tests {
             "{\"facts\":[{\"concept\":\"bug-pattern\",\"content\":\"the attributed answer\",\"source_episode_id\":\"epi_1\"}]}\n",
             "{\"facts\":[{\"concept\":\"bug-pattern\",\"content\":\"a later source-less restatement\"}]}"
         );
-        let facts =
-            parse_recipe_output(step_output).expect("a grounded object must be recoverable");
+        let facts = parse_facts(step_output).expect("a grounded object must be recoverable");
         assert_eq!(
             facts.len(),
             1,
@@ -3087,7 +2087,7 @@ mod issue_t9664_field_tolerance_tests {
     #[test]
     fn non_scalar_field_values_collapse_to_empty() {
         let raw = r#"{"facts":[{"concept":"bug-pattern","content":["a","b"],"source_episode_id":{"x":1}}]}"#;
-        let facts = parse_recipe_output(raw).expect("non-scalar fields must not sink the envelope");
+        let facts = parse_facts(raw).expect("non-scalar fields must not sink the envelope");
         assert_eq!(facts.len(), 1);
         assert!(
             facts[0].content.is_empty(),
@@ -3105,118 +2105,145 @@ mod issue_t9664_field_tolerance_tests {
     }
 }
 
-/// Issue #2570: a **pretty-printed** inner facts JSON whose legitimate fact
-/// `"content"` line literally quotes the `launching copilot binary=` launcher
-/// substring must not have that line dropped by the shared
-/// `is_copilot_launcher_line` / `strip_recipe_noise` chokepoint.
+/// Issues #2622/#2619 — the distill result is read from a dedicated **facts
+/// file** the agent writes, never from recipe-runner stdout. These tests pin
+/// the two structural guarantees of that fix:
 ///
-/// Mechanism (pre-fix): `is_copilot_launcher_line` matched any physical line
-/// *containing* `launching copilot binary=`. When the distill agent emitted its
-/// `{ "facts": [...] }` object pretty-printed AND a fact's `content` value quoted
-/// that substring, the `strip_recipe_noise` view (tried first in
-/// [`scan_for_facts_object`]) dropped the whole `"content": …` line. The
-/// remaining object still parsed (`content` defaulted to `""` via
-/// [`de_lenient_string`]) and, because its `source_episode_id` was non-empty,
-/// [`scan_cleaned_for_facts`] returned it as a "grounded-capable" answer *before*
-/// the line-preserving `strip_ansi` view was tried — so the fact's real content
-/// was silently lost and the reliability hard gate then quarantined the
-/// now-empty fact. The fix guards `is_copilot_launcher_line` so a line beginning
-/// with a JSON structural token (`{`, `"`, `[`) is never classified as launcher
-/// noise, honouring the module's documented "a JSON payload line is never
-/// launcher noise" contract.
+/// 1. The copilot launcher banner / log lines on stdout can NEVER contaminate
+///    the parse — a valid facts file yields facts even when stdout is pure
+///    launcher noise (the exact live failure shape from daemon logs 02:45–02:47).
+/// 2. There is NO silent stdout fallback — a missing facts file is an explicit,
+///    retry-eligible parse failure even when stdout happens to carry a
+///    well-formed `{ "facts": [...] }` object.
 #[cfg(test)]
-mod issue_2570_pretty_fact_launcher_substring_tests {
+mod issue_2622_file_channel_tests {
     use super::*;
 
-    /// A single fact whose `content` quotes the launcher substring, emitted
-    /// pretty-printed inside the runner envelope's `distill` step `output`.
-    /// The content is >= 3 words and grounded, so if it survives it is a fully
-    /// promotable fact; if the `"content"` line is dropped it collapses to
-    /// empty and the reliability gate quarantines it.
-    fn pretty_inner_output() -> String {
-        // Hand-written pretty JSON so the `"content"` line begins (after
-        // indentation) with a `"` — the JSON structural token the fix guards on.
-        "{\n  \"facts\": [\n    {\n      \"concept\": \"lesson-learned\",\n      \
-         \"content\": \"the runner printed INFO launching copilot binary=/usr/bin/copilot \
-         before the answer\",\n      \"source_episode_id\": \"epi_2570\"\n    }\n  ]\n}"
-            .to_string()
+    /// The launcher banner captured live (daemon logs 02:45–02:47, Copilot CLI
+    /// 1.0.69-1) that was previously captured AS the distill step output and
+    /// scraped for facts — matching the banner, never the answer.
+    const LIVE_LAUNCHER_BANNER: &str = "2026-07-06T02:45:12.101010Z  INFO launching copilot \
+         binary=/home/azureuser/.npm-global/bin/copilot version=\"GitHub Copilot CLI 1.0.69-1.\"\n\
+         \u{2139} NODE_OPTIONS=--max-old-space-size=32768 (saved preference)\n\
+         Run 'copilot update' to update\n";
+
+    #[cfg(unix)]
+    fn output_with(stdout: &[u8], code: i32) -> std::process::Output {
+        use std::os::unix::process::ExitStatusExt;
+        std::process::Output {
+            status: std::process::ExitStatus::from_raw(code << 8),
+            stdout: stdout.to_vec(),
+            stderr: Vec::new(),
+        }
     }
 
-    fn envelope(inner: &str) -> String {
-        serde_json::json!({
-            "recipe_name": "distill-episodes",
-            "success": true,
-            "step_results": [{
-                "step_id": "distill",
-                "status": "completed",
-                "output": inner,
-                "error": ""
-            }]
-        })
-        .to_string()
-    }
-
-    /// The headline regression: the pretty-printed fact's full `content`
-    /// (including the launcher substring it quotes) must be preserved, not
-    /// line-dropped to an empty string.
+    /// The headline regression: the runner's stdout is nothing but the copilot
+    /// launcher banner, yet the agent wrote a clean facts envelope to the
+    /// dedicated file — the pass MUST succeed and yield the facts (no
+    /// parse-failure). This is the exact contamination shape from issues
+    /// #2622/#2619.
+    #[cfg(unix)]
     #[test]
-    fn pretty_printed_fact_content_quoting_launcher_substring_is_preserved() {
-        let out = parse_recipe_output_full(&envelope(&pretty_inner_output()))
-            .expect("issue #2570 pretty inner facts object must parse");
-        assert_eq!(
-            out.facts.len(),
-            1,
-            "exactly one fact recovered: {:?}",
-            out.facts
-        );
-        let fact = &out.facts[0];
-        assert_eq!(fact.concept, "lesson-learned");
-        assert_eq!(fact.source_episode_id, "epi_2570");
-        assert_eq!(
-            fact.content,
-            "the runner printed INFO launching copilot binary=/usr/bin/copilot before the answer",
-            "the fact content quoting the launcher substring must survive intact, not be \
-             line-dropped to empty"
-        );
-    }
+    fn launcher_banner_on_stdout_does_not_cause_parse_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let facts_path = dir.path().join("facts.json");
+        std::fs::write(
+            &facts_path,
+            r#"{"facts":[{"concept":"pr-pattern","content":"warm the shared cache before lbug pin bumps","source_episode_id":"epi_1"}],"procedures":[]}"#,
+        )
+        .unwrap();
 
-    /// The preserved fact must clear the reliability gate — proving the fix
-    /// actually restores fact-yield (not merely non-empty text). Grounded
-    /// (source in batch) + >= 3 words + known concept clears 0.5.
-    #[test]
-    fn preserved_fact_clears_the_reliability_gate() {
-        let out = parse_recipe_output_full(&envelope(&pretty_inner_output()))
-            .expect("issue #2570 pretty inner facts object must parse");
-        let fact = &out.facts[0];
-        let episode = CognitiveEpisode {
-            node_id: "epi_2570".to_string(),
-            content: "the source episode".to_string(),
-            source_label: "distill-test".to_string(),
-            temporal_index: 1,
-            compressed: false,
-        };
-        let score = assess_fact_reliability(fact, std::slice::from_ref(&episode), &out.facts);
-        assert!(
-            score >= DISTILL_RELIABILITY_THRESHOLD,
-            "preserved grounded fact must clear the promotion threshold, got {score}"
-        );
-    }
-
-    /// Compact (single-line) inner JSON quoting the same substring already
-    /// worked via the line-preserving `strip_ansi` view; pin it so the fix does
-    /// not regress the pre-existing recovery path.
-    #[test]
-    fn compact_fact_content_quoting_launcher_substring_still_recovers() {
-        let inner = "{\"facts\":[{\"concept\":\"bug-pattern\",\
-             \"content\":\"agent logged INFO launching copilot binary=/usr/bin/copilot here\",\
-             \"source_episode_id\":\"epi_2570c\"}]}";
-        let out = parse_recipe_output_full(&envelope(inner))
-            .expect("compact inner facts object must parse");
+        let output = output_with(LIVE_LAUNCHER_BANNER.as_bytes(), 0);
+        let document = harvest_facts_file(&output, &facts_path)
+            .expect("a launcher banner on stdout must NOT block reading the facts file");
+        let out = parse_facts_document(&document).expect("the clean facts file must parse");
         assert_eq!(out.facts.len(), 1);
+        assert_eq!(out.facts[0].concept, "pr-pattern");
+        assert_eq!(out.facts[0].source_episode_id, "epi_1");
+    }
+
+    /// No silent fallback: a missing facts file is an explicit `ParseFailure`
+    /// even when stdout carries a perfectly well-formed facts object — proving
+    /// stdout is never scraped as a fallback result channel.
+    #[cfg(unix)]
+    #[test]
+    fn missing_facts_file_is_parse_failure_never_stdout_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let facts_path = dir.path().join("facts.json"); // deliberately never written
+
+        let tempting_stdout =
+            br#"{"facts":[{"concept":"pr-pattern","content":"must be ignored","source_episode_id":"epi_9"}]}"#;
+        let output = output_with(tempting_stdout, 0);
+        let err = harvest_facts_file(&output, &facts_path)
+            .expect_err("a missing facts file must be an explicit error, never a stdout fallback");
         assert_eq!(
-            out.facts[0].content,
-            "agent logged INFO launching copilot binary=/usr/bin/copilot here"
+            classify_distill_error(&err),
+            DistillFailureClass::ParseFailure
         );
-        assert_eq!(out.facts[0].source_episode_id, "epi_2570c");
+    }
+
+    /// A non-zero recipe exit is surfaced as an explicit terminal failure that
+    /// carries the stdout/stderr context — never a silent success.
+    #[cfg(unix)]
+    #[test]
+    fn nonzero_exit_is_terminal_failure_with_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let facts_path = dir.path().join("facts.json");
+        let output = output_with(b"boom on stdout", 3);
+        let err = harvest_facts_file(&output, &facts_path)
+            .expect_err("a non-zero exit must surface an explicit error");
+        assert_eq!(
+            classify_distill_error(&err),
+            DistillFailureClass::CopilotTerminalFailure
+        );
+    }
+
+    /// A clean, exit-0 run whose facts file carries a valid envelope is read
+    /// verbatim from the file.
+    #[cfg(unix)]
+    #[test]
+    fn clean_run_reads_facts_verbatim_from_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let facts_path = dir.path().join("facts.json");
+        std::fs::write(&facts_path, r#"{"facts":[],"procedures":[]}"#).unwrap();
+        let output = output_with(b"", 0);
+        let document = harvest_facts_file(&output, &facts_path).expect("clean run must read file");
+        let out = parse_facts_document(&document).expect("an empty envelope is a valid success");
+        assert!(out.facts.is_empty() && out.procedures.is_empty());
+    }
+
+    /// An empty facts document (the agent created the file but wrote nothing) is
+    /// an explicit parse failure — never a hollow `Ok`.
+    #[test]
+    fn empty_facts_document_is_parse_failure() {
+        let err = parse_facts_document("   \n\t ")
+            .expect_err("an empty facts document must be an explicit error");
+        assert_eq!(
+            classify_distill_error(&err),
+            DistillFailureClass::ParseFailure
+        );
+    }
+
+    /// A launcher banner written INTO the file (no JSON object at all) still
+    /// fails explicitly — `parse_facts_document` does not scrape a banner for a
+    /// `{ "facts": [...] }` object.
+    #[test]
+    fn banner_only_document_is_parse_failure() {
+        let err = parse_facts_document(LIVE_LAUNCHER_BANNER)
+            .expect_err("a banner-only document has no facts object and must error");
+        assert_eq!(
+            classify_distill_error(&err),
+            DistillFailureClass::ParseFailure
+        );
+    }
+
+    /// The agent may wrap its answer in a Markdown code fence inside the file;
+    /// the facts must still be recovered (clean-channel format leniency).
+    #[test]
+    fn fenced_facts_document_still_parses() {
+        let fenced = "```json\n{\"facts\":[{\"concept\":\"bug-pattern\",\"content\":\"off-by-one in the ring buffer\",\"source_episode_id\":\"epi_7\"}],\"procedures\":[]}\n```";
+        let out = parse_facts_document(fenced).expect("a fenced facts document must still parse");
+        assert_eq!(out.facts.len(), 1);
+        assert_eq!(out.facts[0].source_episode_id, "epi_7");
     }
 }

--- a/src/memory_consolidation/distillation_fact_yield_bench.rs
+++ b/src/memory_consolidation/distillation_fact_yield_bench.rs
@@ -9,7 +9,7 @@
 //! corpus**. It exercises the deterministic portion of a distillation pass,
 //! everything downstream of the (non-deterministic) LLM recipe call:
 //!
-//! 1. `parse_recipe_output_full` — parses the recipe's JSON envelope and applies
+//! 1. `parse_facts_document` — parses the recipe's JSON envelope and applies
 //!    the concept filter ([`RecipeEnvelope::into_facts`]).
 //! 2. the ISAO reliability gate — [`assess_fact_reliability`] against
 //!    [`DISTILL_RELIABILITY_THRESHOLD`].
@@ -47,7 +47,7 @@
 //!
 //! * **baseline** — an in-test oracle that replicates the *legacy exact-match*
 //!   concept filter (`concept == "pr-pattern" | "bug-pattern" | "lesson-learned"`).
-//! * **improved** — the REAL production path (`parse_recipe_output_full`), which
+//! * **improved** — the REAL production path (`parse_facts_document`), which
 //!   now canonicalizes surface-form concept variants before the filter.
 //!
 //! It asserts the improved path promotes strictly more facts than the baseline
@@ -59,7 +59,7 @@
 use crate::memory_cognitive::CognitiveEpisode;
 use crate::memory_consolidation::distillation::{
     DISTILL_RELIABILITY_THRESHOLD, DistilledFact, KNOWN_DISTILL_CONCEPTS, assess_fact_reliability,
-    parse_recipe_output_full,
+    parse_facts_document,
 };
 
 /// Number of episodes in the fixed consolidation-input batch.
@@ -183,10 +183,10 @@ fn baseline_promoted(episodes: &[CognitiveEpisode]) -> Vec<DistilledFact> {
     gate_survivors(&filtered, episodes)
 }
 
-/// Improved path: the REAL production parse+filter (`parse_recipe_output_full`,
+/// Improved path: the REAL production parse+filter (`parse_facts_document`,
 /// which now canonicalizes concepts), then the same gate.
 fn improved_promoted(episodes: &[CognitiveEpisode]) -> Vec<DistilledFact> {
-    let output = parse_recipe_output_full(CORPUS_RECIPE_JSON)
+    let output = parse_facts_document(CORPUS_RECIPE_JSON)
         .expect("benchmark corpus must parse into a facts object");
     gate_survivors(&output.facts, episodes)
 }

--- a/src/memory_consolidation/distillation_tests.rs
+++ b/src/memory_consolidation/distillation_tests.rs
@@ -678,168 +678,49 @@ fn distillation_passes_source_episode_id_as_provenance() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Issue #2401 (RED): recipe-runner-rs JSON-envelope output capture
+// Issues #2622/#2619: distill facts-document parse (dedicated file channel)
 // ═══════════════════════════════════════════════════════════════════════════
 //
-// These tests pin the FIX for the latent distillation bug: in production the
-// daemon shells out to `recipe-runner-rs <recipe> -c episodes=<json>` and the
-// installed `recipe-runner 0.3.6` defaults to `--output-format text`, whose
-// stdout is only a human status banner:
+// Post-fix the distill agent WRITES its `{ "facts": [...], "procedures": [...] }`
+// envelope to a dedicated facts file and Simard reads THAT file — never the
+// recipe-runner stdout. `parse_facts_document` / `parse_facts` therefore parse
+// the agent's facts document (the file contents). The launcher-banner
+// contamination that motivated the retired stdout-scraping envelope path can no
+// longer reach the parser (see the hermetic `issue_2622_file_channel_tests` in
+// `distillation.rs` for the "banner on stdout, valid file ⇒ success" proof).
 //
-//     Recipe: distill-episodes (v1.0.0)
-//     Steps: 1
-//     Recipe 'distill-episodes': SUCCESS (18.0s)
-//       [completed] distill (18.0s)
-//
-// The agent's actual `{ "facts": [...], "procedures": [...] }` payload is NOT
-// on stdout in text mode, so `parse_recipe_output_full` always errors with
-// `recipe output did not contain a parseable { "facts": [...] } object` and the
-// pass silently no-ops every cycle — distillation has effectively NEVER
-// produced facts in prod.
-//
-// The fix is to invoke with `--output-format json` and teach the parser to dig
-// the agent's final-step output out of the runner's JSON envelope. The envelope
-// fixtures below are VERIFIED against the real installed `recipe-runner 0.3.6`
-// binary (captured via trivial `type: bash` probe recipes), so they pin the
-// parser to the binary's actual 0.3.6 output contract:
-//
-//     {
-//       "recipe_name": "distill-episodes",
-//       "success": true,
-//       "step_results": [
-//         { "step_id": "distill", "status": "completed",
-//           "output": "{\"facts\":[...],\"procedures\":[...]}",  // STRING
-//           "error": "", "duration": 18.04 }
-//       ],
-//       "duration": 18.05
-//     }
-//
-// ## Why these are RED before the fix
-//
-// `parse_recipe_output` / `parse_recipe_output_full` are currently PRIVATE
-// (`fn`, not `pub(crate)`), so the `use` import below fails to resolve — the
-// whole file fails to compile. That is the deterministic TDD red signal, the
-// same convention this file already uses for the rest of PR-B. The fix makes
-// both parsers `pub(crate)` and rewrites `parse_recipe_output_full` to extract
-// the distill step's `output` from the envelope (with a tolerant fallback that
-// keeps the existing bare-`{ "facts": ... }` / prose mock tests green).
-//
-// Even once they compile, the envelope-extraction asserts FAIL against the
-// pre-fix parser: the current balanced-brace scanner only recognises a bare
-// top-level `{ "facts": ... }` object, never the agent payload nested as an
-// ESCAPED STRING inside `step_results[].output`.
+// These tests pin the document parse contract: the facts schema, the concept
+// allow-list, provenance survival, prose/fence tolerance in the file, explicit
+// errors on empty/answerless documents, and bounded/robust error output.
 
-// `parse_recipe_output[_full]` must become `pub(crate)` for this module to use
-// them. Until the fix lands these are private `fn`s → unresolved-import (RED).
-use crate::memory_consolidation::distillation::{parse_recipe_output, parse_recipe_output_full};
+use crate::memory_consolidation::distillation::{parse_facts, parse_facts_document};
 
-/// Build a `recipe-runner 0.3.6` JSON envelope string with the given
-/// `success` flag and `step_results` array, matching the verified shape.
-fn runner_envelope(success: bool, steps: serde_json::Value) -> String {
-    serde_json::to_string_pretty(&serde_json::json!({
-        "recipe_name": "distill-episodes",
-        "success": success,
-        "step_results": steps,
-        "duration": 19.8,
-    }))
-    .expect("envelope fixture must serialize")
-}
+/// A representative facts document carrying BOTH facts and procedures.
+const FACTS_AND_PROCEDURES_DOCUMENT: &str = r#"{"facts":[{"concept":"pr-pattern","content":"CI flakes on lbug pin bumps until cache is warmed","source_episode_id":"e7"},{"concept":"lesson-learned","content":"Stale worktrees mask deploy drift","source_episode_id":"e12"}],"procedures":[{"name":"ci-fix:auto","steps":["re-run failed job","warm shared target cache","re-push"],"source_episode_ids":["e7","e9"]}]}"#;
 
-/// One `step_results[]` entry. `output` is a `serde_json::Value` so callers can
-/// supply either the real-shape STRING payload or (drift-tolerance) an object.
-fn step(step_id: &str, status: &str, output: serde_json::Value) -> serde_json::Value {
-    serde_json::json!({
-        "step_id": step_id,
-        "status": status,
-        "output": output,
-        "error": "",
-        "duration": 19.7,
-    })
-}
-
-/// A representative agent payload carrying BOTH facts and procedures, sanitized
-/// but structurally identical to a real distill run (see Example 1 in
-/// `docs/reference/distill-recipe-output-capture.md`).
-fn facts_and_procedures_payload() -> serde_json::Value {
-    serde_json::Value::String(
-        r#"{"facts":[{"concept":"pr-pattern","content":"CI flakes on lbug pin bumps until cache is warmed","source_episode_id":"e7"},{"concept":"lesson-learned","content":"Stale worktrees mask deploy drift","source_episode_id":"e12"}],"procedures":[{"name":"ci-fix:auto","steps":["re-run failed job","warm shared target cache","re-push --no-verify"],"source_episode_ids":["e7","e9"]}]}"#
-            .to_string(),
-    )
-}
-
-/// VERBATIM stdout captured from the installed `recipe-runner 0.3.6` binary
-/// running a single-step `type: bash` probe whose command echoes the facts
-/// JSON. Pins the parser to the binary's exact byte-level output contract,
-/// including the agent payload nested as an ESCAPED STRING in
-/// `step_results[].output`.
-const REAL_RUNNER_ENVELOPE_VERBATIM: &str = r#"{
-  "recipe_name": "probe",
-  "success": true,
-  "step_results": [
-    {
-      "step_id": "distill",
-      "status": "completed",
-      "output": "{\"facts\":[{\"concept\":\"pr-pattern\",\"content\":\"x\",\"source_episode_id\":\"epi_1\"}],\"procedures\":[]}",
-      "error": "",
-      "duration": 0.003756692
-    }
-  ],
-  "duration": 0.003760419
-}"#;
-
-/// The exact `--output-format text` banner the daemon captured in production —
-/// the input that triggered the silent no-op. It carries NO facts payload, so
-/// the parser MUST surface an explicit `Err` (never a hollow `Ok`).
-const TEXT_MODE_BANNER: &str = "Recipe: distill-episodes (v1.0.0)\n\
-Steps: 1\n\
-Recipe 'distill-episodes': SUCCESS (18.0s)\n\
-  [completed] distill (18.0s)";
-
-// ───────────────────────────────────────────────────────────────────────────
-// Tier 1 — runner-envelope extraction (the production path the fix introduces)
-// ───────────────────────────────────────────────────────────────────────────
-
-/// PRIMARY RED: a real, verbatim `recipe-runner 0.3.6` JSON envelope must parse
-/// into the agent's facts (the bug is that today it does not — the payload is
-/// nested as an escaped string in `step_results[].output`, which the pre-fix
-/// scanner never reaches).
+/// A clean facts document must parse into a `DistillOutput`.
 #[test]
-fn parser_extracts_facts_from_verbatim_real_envelope() {
-    let out = parse_recipe_output_full(REAL_RUNNER_ENVELOPE_VERBATIM)
-        .expect("verbatim recipe-runner 0.3.6 envelope must parse into a DistillOutput");
-    assert_eq!(out.facts.len(), 1, "one fact in the distill step output");
+fn document_parses_bare_facts_object() {
+    let out = parse_facts_document(
+        r#"{"facts":[{"concept":"pr-pattern","content":"bare","source_episode_id":"epi_1"}]}"#,
+    )
+    .expect("a clean facts document must parse");
+    assert_eq!(out.facts.len(), 1);
     assert_eq!(out.facts[0].concept, "pr-pattern");
     assert_eq!(out.facts[0].source_episode_id, "epi_1");
-    assert!(
-        out.procedures.is_empty(),
-        "the verbatim payload carries an empty procedures array"
-    );
+    assert!(out.procedures.is_empty());
 }
 
-/// PRIMARY RED: the distill step's `output` string carrying BOTH facts and
-/// procedures must yield both. This is the headline acceptance criterion —
-/// distillation must once again produce semantic facts AND procedural memory.
+/// The headline acceptance: a document with facts AND procedures yields both,
+/// with provenance intact — distillation produces semantic + procedural memory.
 #[test]
-fn parser_extracts_facts_and_procedures_from_distill_step_output() {
-    let raw = runner_envelope(
-        true,
-        serde_json::json!([step("distill", "completed", facts_and_procedures_payload())]),
-    );
-
-    let out = parse_recipe_output_full(&raw)
-        .expect("real-shaped runner envelope must parse into a DistillOutput");
-
-    assert_eq!(out.facts.len(), 2, "two valid facts in the distill output");
-    assert_eq!(
-        out.procedures.len(),
-        1,
-        "one valid procedure in the distill output"
-    );
-
+fn document_yields_facts_and_procedures() {
+    let out = parse_facts_document(FACTS_AND_PROCEDURES_DOCUMENT)
+        .expect("a facts+procedures document must parse");
+    assert_eq!(out.facts.len(), 2);
     let concepts: std::collections::HashSet<&str> =
         out.facts.iter().map(|f| f.concept.as_str()).collect();
-    assert!(concepts.contains("pr-pattern"));
-    assert!(concepts.contains("lesson-learned"));
+    assert!(concepts.contains("pr-pattern") && concepts.contains("lesson-learned"));
     let sources: std::collections::HashSet<&str> = out
         .facts
         .iter()
@@ -847,19 +728,12 @@ fn parser_extracts_facts_and_procedures_from_distill_step_output() {
         .collect();
     assert!(
         sources.contains("e7") && sources.contains("e12"),
-        "fact provenance (source_episode_id) must survive extraction; got {sources:?}"
+        "fact provenance must survive extraction; got {sources:?}"
     );
-
+    assert_eq!(out.procedures.len(), 1);
     let proc = &out.procedures[0];
     assert_eq!(proc.name, "ci-fix:auto");
-    assert_eq!(
-        proc.steps,
-        vec![
-            "re-run failed job".to_string(),
-            "warm shared target cache".to_string(),
-            "re-push --no-verify".to_string(),
-        ]
-    );
+    assert_eq!(proc.steps.len(), 3);
     assert_eq!(
         proc.source_episode_ids,
         vec!["e7".to_string(), "e9".to_string()],
@@ -867,204 +741,83 @@ fn parser_extracts_facts_and_procedures_from_distill_step_output() {
     );
 }
 
-/// Step selection: with multiple steps, the entry whose `step_id == "distill"`
-/// is the one read — NOT an earlier setup step whose output has no facts.
+/// Concept allow-list: labels outside the closed set are dropped.
 #[test]
-fn parser_selects_distill_step_among_multiple_steps() {
-    let distill_payload = serde_json::Value::String(
-        r#"{"facts":[{"concept":"lesson-learned","content":"second step wins","source_episode_id":"epi_9"}],"procedures":[]}"#
-            .to_string(),
-    );
-    let raw = runner_envelope(
-        true,
-        serde_json::json!([
-            step(
-                "prep",
-                "completed",
-                serde_json::json!("no facts here, just setup output")
-            ),
-            step("distill", "completed", distill_payload),
-        ]),
-    );
-
-    let out =
-        parse_recipe_output_full(&raw).expect("the `distill` step must be selected and parsed");
-    assert_eq!(out.facts.len(), 1);
-    assert_eq!(out.facts[0].source_episode_id, "epi_9");
-    assert_eq!(out.facts[0].concept, "lesson-learned");
-}
-
-/// Step-selection fallback: when no step is named `distill`, the LAST step with
-/// `status == "completed"` is used (tolerates a future step rename).
-#[test]
-fn parser_falls_back_to_last_completed_step_when_no_distill_id() {
-    let facts_payload = serde_json::Value::String(
-        r#"{"facts":[{"concept":"bug-pattern","content":"fallback selection works","source_episode_id":"epi_4"}]}"#
-            .to_string(),
-    );
-    let raw = runner_envelope(
-        true,
-        serde_json::json!([
-            step(
-                "orient",
-                "completed",
-                serde_json::json!("status preamble, no facts")
-            ),
-            step("decide", "completed", facts_payload),
-        ]),
-    );
-
-    let out = parse_recipe_output_full(&raw)
-        .expect("last completed step must be selected when no `distill` id is present");
-    assert_eq!(out.facts.len(), 1);
-    assert_eq!(out.facts[0].source_episode_id, "epi_4");
-    assert_eq!(out.facts[0].concept, "bug-pattern");
-}
-
-/// Concept allow-list still applies when extracting from the envelope: labels
-/// outside `pr-pattern | bug-pattern | lesson-learned` are dropped.
-#[test]
-fn parser_drops_unknown_concepts_inside_envelope() {
-    let payload = serde_json::Value::String(
-        r#"{"facts":[{"concept":"made-up-label","content":"a","source_episode_id":"epi_1"},{"concept":"lesson-learned","content":"b","source_episode_id":"epi_2"}]}"#
-            .to_string(),
-    );
-    let raw = runner_envelope(
-        true,
-        serde_json::json!([step("distill", "completed", payload)]),
-    );
-
-    let out = parse_recipe_output_full(&raw).expect("envelope must parse");
+fn document_drops_unknown_concepts() {
+    let out = parse_facts_document(
+        r#"{"facts":[{"concept":"made-up-label","content":"a","source_episode_id":"epi_1"},{"concept":"lesson-learned","content":"b","source_episode_id":"epi_2"}]}"#,
+    )
+    .expect("document must parse");
     assert_eq!(out.facts.len(), 1, "the made-up label must be filtered out");
     assert_eq!(out.facts[0].concept, "lesson-learned");
 }
 
-/// Drift tolerance: if a future runner emits `output` as an OBJECT instead of a
-/// JSON string, the facts must still be extracted (parser deserializes
-/// `output` as `serde_json::Value` and handles both shapes).
+/// The agent may add a little prose or a Markdown fence around its answer in the
+/// file; the facts are still recovered (clean-channel format leniency, NOT the
+/// launcher-banner stdout scraping this fix removed).
 #[test]
-fn parser_tolerates_output_as_json_object() {
-    let payload = serde_json::json!({
-        "facts": [{"concept": "pr-pattern", "content": "object output", "source_episode_id": "epi_5"}],
-        "procedures": []
-    });
-    let raw = runner_envelope(
-        true,
-        serde_json::json!([step("distill", "completed", payload)]),
-    );
-
-    let out =
-        parse_recipe_output_full(&raw).expect("an object-typed `output` must still yield facts");
-    assert_eq!(out.facts.len(), 1);
-    assert_eq!(out.facts[0].source_episode_id, "epi_5");
-}
-
-/// The facts-only wrapper (`parse_recipe_output`, the legacy `run` entry point)
-/// must read the envelope too, returning just the facts.
-#[test]
-fn facts_only_wrapper_reads_runner_envelope() {
-    let facts = parse_recipe_output(REAL_RUNNER_ENVELOPE_VERBATIM)
-        .expect("facts-only wrapper must also parse the envelope");
-    assert_eq!(facts.len(), 1);
-    assert_eq!(facts[0].concept, "pr-pattern");
-}
-
-// ───────────────────────────────────────────────────────────────────────────
-// Failure semantics — explicit Err, never silent degradation
-// ───────────────────────────────────────────────────────────────────────────
-
-/// A failure envelope (`success == false`, failed step, empty output) must
-/// surface an explicit `Err`. Captured verbatim shape from the real binary.
-#[test]
-fn parser_returns_err_on_failure_envelope() {
-    let raw = runner_envelope(
-        false,
-        serde_json::json!([{
-            "step_id": "distill",
-            "status": "failed",
-            "output": "",
-            "error": "Step 'distill' failed: bash step failed: Command failed (exit 3): boom",
-            "duration": 0.0037
-        }]),
-    );
-    assert!(
-        parse_recipe_output_full(&raw).is_err(),
-        "a failed run (success == false) must never yield Ok facts"
-    );
-}
-
-/// Defense-in-depth guard: even if a `success == false` envelope somehow
-/// carries a well-formed facts payload in its step output, the parser MUST NOT
-/// extract from it. `success == false` short-circuits to `Err` BEFORE the step
-/// output is mined — an implementer who reads the output before checking
-/// `success` fails this test.
-#[test]
-fn parser_does_not_extract_facts_from_failed_run() {
-    let raw = runner_envelope(
-        false,
-        serde_json::json!([step("distill", "failed", facts_and_procedures_payload())]),
-    );
-    assert!(
-        parse_recipe_output_full(&raw).is_err(),
-        "facts must never be trusted from a run whose success flag is false"
-    );
-}
-
-/// The exact production failure input — the `--output-format text` status
-/// banner — has no facts payload and MUST produce an explicit `Err` (this is
-/// the silent no-op the fix eliminates by switching to `--output-format json`).
-#[test]
-fn parser_errors_on_text_mode_status_banner() {
-    assert!(
-        parse_recipe_output_full(TEXT_MODE_BANNER).is_err(),
-        "the human-readable text banner carries no facts and must error explicitly"
-    );
-}
-
-// ───────────────────────────────────────────────────────────────────────────
-// Tolerant fallback — keep the legacy bare-object / prose contract green
-// ───────────────────────────────────────────────────────────────────────────
-
-/// Backward compatibility: a bare `{ "facts": [...] }` object (no runner
-/// envelope) must still parse, so the existing `DistillRecipeRunner` mock and
-/// in-module unit tests keep passing after the rewrite.
-#[test]
-fn parser_tolerant_fallback_accepts_bare_facts_object() {
-    let raw =
-        r#"{"facts":[{"concept":"pr-pattern","content":"bare","source_episode_id":"epi_1"}]}"#;
-    let out = parse_recipe_output_full(raw)
-        .expect("a bare facts object must still parse via the tolerant fallback");
-    assert_eq!(out.facts.len(), 1);
-    assert_eq!(out.facts[0].concept, "pr-pattern");
-}
-
-/// Backward compatibility: a bare facts object wrapped in prose must still be
-/// recovered by the tolerant balanced-brace fallback.
-#[test]
-fn parser_tolerant_fallback_extracts_facts_from_prose() {
-    let raw = "Sure, here is the JSON:\n\
+fn document_tolerates_prose_and_fence() {
+    let prose = "Here is the distilled output:\n\
         {\"facts\":[{\"concept\":\"bug-pattern\",\"content\":\"y\",\"source_episode_id\":\"epi_2\"}]}\n\
-        That's all.";
-    let out = parse_recipe_output_full(raw)
-        .expect("prose-wrapped bare facts must still parse via the tolerant fallback");
+        Done.";
+    let out = parse_facts_document(prose).expect("prose-wrapped document must parse");
     assert_eq!(out.facts.len(), 1);
     assert_eq!(out.facts[0].concept, "bug-pattern");
+
+    let fenced = "```json\n\
+        {\"facts\":[{\"concept\":\"pr-pattern\",\"content\":\"z\",\"source_episode_id\":\"epi_3\"}],\"procedures\":[]}\n\
+        ```";
+    let out = parse_facts_document(fenced).expect("fenced document must parse");
+    assert_eq!(out.facts.len(), 1);
+    assert_eq!(out.facts[0].source_episode_id, "epi_3");
 }
 
-// ───────────────────────────────────────────────────────────────────────────
-// Robustness — bounded error output, no panic/OOM on hostile input
-// ───────────────────────────────────────────────────────────────────────────
-
-/// Tier-3 errors must be bounded and must NOT echo the full captured payload
-/// (truncated excerpt only). A sentinel placed far past the truncation window
-/// must be absent from the error message — proof there is no payload leak.
+/// The facts-only wrapper reads the document too, returning just the facts.
 #[test]
-fn parser_error_does_not_leak_full_payload() {
+fn facts_only_wrapper_reads_document() {
+    let facts = parse_facts(FACTS_AND_PROCEDURES_DOCUMENT).expect("facts-only wrapper must parse");
+    assert_eq!(facts.len(), 2);
+}
+
+// ── Failure semantics — explicit Err, never silent degradation ──────────────
+
+/// An empty document (the agent created the file but wrote nothing) is an
+/// explicit `Err` — never a hollow `Ok`.
+#[test]
+fn empty_document_is_err() {
+    assert!(parse_facts_document("").is_err());
+    assert!(parse_facts_document("   \n\t ").is_err());
+}
+
+/// A document with no facts object (e.g. a launcher banner accidentally written
+/// to the file) errors explicitly — the parser never scrapes a banner for a
+/// `{ "facts": [...] }` object.
+#[test]
+fn answerless_document_is_err() {
+    let banner = "\u{2139} NODE_OPTIONS=--max-old-space-size=32768 (saved preference)\n\
+        launching copilot binary=/x version=\"GitHub Copilot CLI 1.0.69-1.\"\n";
+    assert!(parse_facts_document(banner).is_err());
+}
+
+/// A legitimate "nothing worth distilling" answer is a valid SUCCESS (zero
+/// facts), never a parse failure.
+#[test]
+fn empty_facts_envelope_is_success_not_failure() {
+    let out = parse_facts_document(r#"{"facts":[],"procedures":[]}"#)
+        .expect("an empty envelope is a valid success");
+    assert!(out.facts.is_empty() && out.procedures.is_empty());
+}
+
+// ── Robustness — bounded error output, no panic/OOM on hostile input ────────
+
+/// Error output must be bounded and must NOT echo the full document (truncated
+/// excerpt only): a sentinel far past the truncation window must be absent.
+#[test]
+fn document_error_does_not_leak_full_payload() {
     let sentinel = "SECRET_SENTINEL_AT_END";
     let raw = format!("{}{sentinel}", "x".repeat(50_000));
-
     let err =
-        parse_recipe_output_full(&raw).expect_err("a 50 KiB blob with no facts object must error");
+        parse_facts_document(&raw).expect_err("a 50 KiB blob with no facts object must error");
     let msg = err.to_string();
     assert!(
         !msg.contains(sentinel),
@@ -1078,22 +831,20 @@ fn parser_error_does_not_leak_full_payload() {
 }
 
 /// Pathologically deep brace nesting must terminate with an `Err` — no stack
-/// overflow, no hang. The balanced-brace scan must stay linear/iterative and
-/// any recursive JSON parse must hit serde's recursion limit and bail.
+/// overflow, no hang.
 #[test]
-fn parser_tolerates_deeply_nested_input_without_panic() {
+fn document_tolerates_deeply_nested_input_without_panic() {
     let depth = 50_000;
     let raw = format!("{}{}", "{".repeat(depth), "}".repeat(depth));
     assert!(
-        parse_recipe_output_full(&raw).is_err(),
+        parse_facts_document(&raw).is_err(),
         "deeply nested braces with no facts object must error without panicking"
     );
 }
 
-/// A large but VALID envelope (many facts) must extract every fact — the
-/// linear scan must handle size, not just trivially small inputs.
+/// A large but VALID document (many facts) must extract every fact.
 #[test]
-fn parser_handles_large_valid_envelope() {
+fn document_handles_large_valid_input() {
     let facts: Vec<serde_json::Value> = (0..1_000)
         .map(|i| {
             serde_json::json!({
@@ -1103,94 +854,14 @@ fn parser_handles_large_valid_envelope() {
             })
         })
         .collect();
-    let payload = serde_json::Value::String(
-        serde_json::to_string(&serde_json::json!({ "facts": facts, "procedures": [] })).unwrap(),
-    );
-    let raw = runner_envelope(
-        true,
-        serde_json::json!([step("distill", "completed", payload)]),
-    );
-
-    let out = parse_recipe_output_full(&raw).expect("a large valid envelope must parse all facts");
+    let raw =
+        serde_json::to_string(&serde_json::json!({ "facts": facts, "procedures": [] })).unwrap();
+    let out = parse_facts_document(&raw).expect("a large valid document must parse all facts");
     assert_eq!(
         out.facts.len(),
         1_000,
         "every fact in a large batch must survive"
     );
-}
-
-// ───────────────────────────────────────────────────────────────────────────
-// Production contract — VERBATIM real `recipe-runner 0.3.6` agent-step envelope
-// ───────────────────────────────────────────────────────────────────────────
-
-/// A real end-to-end capture from `recipe-runner-rs --output-format json` on
-/// the actual `distill-episodes.yaml` recipe (copilot agent, #2401
-/// verification). Two characteristics make this the decisive fixture that the
-/// synthetic ones above do NOT exercise:
-///
-/// 1. `step_results[].output` is a JSON *string* whose content is PROSE-PREFIXED
-///    — the agent emits an `ℹ NODE_OPTIONS=...` banner line BEFORE the
-///    `{ "facts": ... }` object. A plain `serde_json::from_str` on the output
-///    string fails here; only the balanced-brace scan recovers the object.
-/// 2. The envelope carries a top-level `context` field (the echoed inputs) that
-///    the parser must ignore.
-///
-/// If this passes, the exact shape the production daemon receives is parsed.
-const REAL_AGENT_ENVELOPE_WITH_PROSE: &str = r#"{
-  "recipe_name": "distill-episodes",
-  "success": true,
-  "step_results": [
-    {
-      "step_id": "distill",
-      "status": "completed",
-      "output": "ℹ NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: /home/azureuser/.amplihack/config\n{\n  \"facts\": [\n    {\n      \"concept\": \"bug-pattern\",\n      \"content\": \"Dependency/version bumps recurrently break CI via a cold shared target cache; warming the cache and re-pushing clears the failure.\",\n      \"source_episode_id\": \"epi_1\"\n    }\n  ],\n  \"procedures\": [\n    {\n      \"name\": \"ci-fix:auto\",\n      \"steps\": [\n        \"Re-run the failed CI job to confirm the failure is not transient.\",\n        \"Warm the shared target cache.\",\n        \"Re-push with --no-verify.\",\n        \"Confirm the pipeline goes green.\"\n      ],\n      \"source_episode_ids\": [\"epi_1\", \"epi_2\"]\n    }\n  ]\n}",
-      "error": "",
-      "duration": 14.017578161
-    }
-  ],
-  "context": {
-    "episodes": [
-      { "content": "CI failed on lbug pin bump.", "id": "epi_1", "source_label": "ci-runner", "temporal_index": 1 }
-    ]
-  },
-  "duration": 14.017590634
-}"#;
-
-/// PRIMARY ACCEPTANCE: the verbatim real prose-prefixed agent envelope must
-/// yield BOTH the fact and the procedure. This is the production-faithful proof
-/// that the #2401 fix restores semantic + procedural distillation.
-#[test]
-fn parser_extracts_facts_and_procedures_from_real_prose_prefixed_envelope() {
-    let out = parse_recipe_output_full(REAL_AGENT_ENVELOPE_WITH_PROSE)
-        .expect("the verbatim real prose-prefixed agent envelope must parse");
-
-    assert_eq!(out.facts.len(), 1, "one fact survives extraction");
-    assert_eq!(out.facts[0].concept, "bug-pattern");
-    assert_eq!(out.facts[0].source_episode_id, "epi_1");
-    assert!(
-        out.facts[0].content.contains("cold shared target cache"),
-        "fact content must survive the prose-prefix scan; got {:?}",
-        out.facts[0].content
-    );
-
-    assert_eq!(out.procedures.len(), 1, "one procedure survives extraction");
-    let proc = &out.procedures[0];
-    assert_eq!(proc.name, "ci-fix:auto");
-    assert_eq!(proc.steps.len(), 4, "all four procedure steps survive");
-    assert_eq!(
-        proc.source_episode_ids,
-        vec!["epi_1".to_string(), "epi_2".to_string()],
-        "procedure provenance must carry every source episode id"
-    );
-}
-
-/// The facts-only legacy wrapper must read the real prose-prefixed envelope too.
-#[test]
-fn facts_only_wrapper_reads_real_prose_prefixed_envelope() {
-    let facts = parse_recipe_output(REAL_AGENT_ENVELOPE_WITH_PROSE)
-        .expect("facts-only wrapper must parse the real envelope");
-    assert_eq!(facts.len(), 1);
-    assert_eq!(facts[0].concept, "bug-pattern");
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1576,8 +1247,8 @@ fn distilled_fact_confidence_is_computed_not_constant() {
 //   * A *transient* failure class (`ParseFailure`, `CopilotTerminalFailure`) is
 //     retried in-cycle up to `DISTILL_PARSE_RETRY_MAX` times; a recovered batch
 //     stores facts and marks ALL episodes within ONE pass.
-//   * A *structural* class (`SpawnFailure`, `SerializeFailure`,
-//     `RecipeReportedFailure`) escalates immediately — NO retry.
+//   * A *structural* class (`SpawnFailure`, `SerializeFailure`) escalates
+//     immediately — NO retry.
 //   * The retry-safety invariant holds across all in-cycle attempts: on final
 //     failure NO facts are stored and NO episodes are marked.
 //
@@ -1634,7 +1305,7 @@ impl DistillRecipeRunner for ScriptedRunner {
                 })
                 .collect()),
             Attempt::Parse => Err(SimardError::BridgeError(
-                "distill: `distill` step output did not contain a parseable { \"facts\": [...] } object; output: hi"
+                "distill: facts document did not contain a parseable { \"facts\": [...] } object: hi"
                     .to_string(),
             )),
             Attempt::Terminal => Err(SimardError::BridgeError(
@@ -1891,9 +1562,9 @@ fn surviving_parse_failure_writes_nothing_when_capture_disabled() {
 // Full-pass companion to the deterministic fact-yield benchmark
 // ───────────────────────────────────────────────────────────────────────────
 
-/// Runner that parses a fixed raw recipe-output envelope through the REAL
-/// production parse path (`parse_recipe_output_full`), so the concept
-/// canonicalization in `RecipeEnvelope::into_facts` is exercised end-to-end via
+/// Runner that parses a fixed raw facts document through the REAL production
+/// parse path (`parse_facts_document`), so the concept canonicalization in
+/// `RecipeEnvelope::into_facts` is exercised end-to-end via
 /// `distill_recent_episodes_with_runner` (parse → gate → dedup guard → store)
 /// rather than bypassed by a facts-returning stub.
 struct RawEnvelopeRunner {
@@ -1904,7 +1575,7 @@ struct RawEnvelopeRunner {
 impl DistillRecipeRunner for RawEnvelopeRunner {
     fn run(&self, _episodes: &[CognitiveEpisode]) -> SimardResult<Vec<DistilledFact>> {
         self.call_count.fetch_add(1, Ordering::SeqCst);
-        parse_recipe_output_full(self.raw).map(|o| o.facts)
+        parse_facts_document(self.raw).map(|o| o.facts)
     }
 }
 

--- a/src/memory_consolidation/raw_capture.rs
+++ b/src/memory_consolidation/raw_capture.rs
@@ -574,7 +574,6 @@ mod tests {
         for class in [
             "spawn-failure",
             "copilot-terminal-failure",
-            "recipe-reported-failure",
             "serialize-failure",
             "other",
         ] {


### PR DESCRIPTION
## Problem

Distillation failed **recurrently** with `class="parse-failure"` (confirmed live in daemon logs 02:45–02:47). Two defects compounded:

1. **Launcher noise captured as the result** — the copilot launcher banner (`… launching copilot binary=… version="GitHub Copilot CLI 1.0.69-1."`) landed in the distill step's captured `output`.
2. **Brittle stdout scraping** — the parser greped stdout for a `{ "facts": [...] }` object and matched the **banner**, never the answer.

Result: episode→fact yield was near zero because distillation could not parse its own output. This is exactly the brittle-parsing-of-agent-stdout antipattern the operator flagged (guideline **G3**).

## Fix — agentic file channel (fix the prompt + how output is returned, not the string parsing)

- The distill agent now **writes** its `{ "facts": [...], "procedures": [...] }` envelope to a **dedicated, per-invocation facts file**. Simard passes the absolute path via `-c facts_output_path=<tmp>`, the recipe interpolates it as `{{facts_output_path}}`, and Simard reads **that file** after the runner exits. **Stdout is never the result channel**, so launcher banners / log lines can no longer contaminate the parse.
- `harvest_facts_file` post-processes the finished process: non-zero exit → explicit terminal error (with context); exit 0 → read the file. A missing / empty / unparseable file is an explicit, **retry-eligible** `ParseFailure` — **no stdout fallback** (a silent fallback is a silent failure).
- **Retire the brittle stdout-scraping tiers**: `parse_recipe_output_full`, `RecipeRunnerEnvelope`/`RecipeRunnerStepResult`, `recover_distill_output`, `candidate_runner_envelopes`, `scan_for_facts_object`, `extract_step_output`, and the now-unused `RecipeReportedFailure` class. The clean-channel parser (`parse_facts_document` / `parse_facts`) reuses the facts **schema** (`RecipeEnvelope` + field-tolerant `de_lenient_string` + concept canonicalization) and tolerates only an LLM fence/prose *in the file* — not launcher-banner stdout.
- **G2**: no `amplihack-memory-lib` change — reading a clean file the agent wrote is orchestration, not a memory capability; `DistillOutput` stays a local Simard type. The shared `recipe_output::extract` helpers (8+ non-distill callers) are untouched.

Net **−1655 lines** in `distillation.rs` (brittle tiers removed).

## Validation

**Hermetic** (`issue_2622_file_channel_tests` in `distillation.rs`):
- `launcher_banner_on_stdout_does_not_cause_parse_failure` — banner on stdout + valid facts file ⇒ **SUCCESS** with facts (the exact live failure shape, now green).
- `missing_facts_file_is_parse_failure_never_stdout_fallback` — missing file ⇒ explicit `ParseFailure`, even when stdout carries a facts object.
- plus `nonzero_exit_is_terminal_failure_with_context`, empty/answerless/fenced document cases, and the rewritten document-parse suite in `distillation_tests.rs`.

**Live** `recipe-runner-rs 0.3.6` + copilot smoke run: the agent wrote a clean `facts.json` (2 grounded facts + 1 procedure, noise episode skipped) **even though** the runner's `step_results[].output` on stdout still carried the launcher banner + prose. The file channel read the clean file → healthy path yields facts (fail-rate → ~0).

## CI / constraints

- `cargo fmt`, `cargo clippy --all-targets --all-features --locked -D warnings`, the release test subset, and `mkdocs build --strict` all pass locally.
- default-workflow; off latest `origin/main`; pre-commit + pre-push hooks run (never `--no-verify`); no "Bridge"-named new symbols; no new stray prints; no silent fallbacks.

## Docs

- `docs/architecture/episode-distillation.md` and `docs/reference/distill-recipe-output-capture.md` rewritten for the file channel; the recipe prompt writes `{{facts_output_path}}`.

Closes #2622
Closes #2619