### PR TITLE
fix(journal): rewrite the daily journal as a jargon-free narrative report (#2606)

### DIFF
--- a/docs/concepts/simard-journal.md
+++ b/docs/concepts/simard-journal.md
@@ -1,11 +1,13 @@
 ---
-title: "The Simard Journal — a daily diary written from memory"
+title: "The Simard Journal — a daily narrative engineering & research report"
 description: >
-  Why Simard keeps a daily journal: a diary-style, first-person-steward narrative of
-  what the one Brain (including the Overseer) did each day, written largely from episodic
-  memories, jargon-scrubbed in a mandatory two-pass review, and stored durably in cognitive
-  memory as a first-class journal record — never as per-day files committed to the repo.
-last_updated: 2026-07-05
+  Why Simard keeps a daily journal: a professional, third-person NARRATIVE REPORT of the
+  day's engineering and research — an overview paragraph, clearly delineated sections, a
+  plain-language pull-request summary table, timestamped remembered moments, and a verbose
+  "what context was prepared" summary. Built largely from episodic memories, rewritten into
+  genuinely jargon-free language by a mandatory two-pass (draft then de-jargon) pipeline,
+  and stored durably in cognitive memory — never as per-day files committed to the repo.
+last_updated: 2026-07-06
 review_schedule: as-needed
 owner: simard
 doc_type: concept
@@ -22,85 +24,163 @@ related:
   - ../reference/simard-tui.md
 ---
 
-# The Simard Journal — a daily diary written from memory
+# The Simard Journal — a daily narrative engineering & research report
 
-The **Journal** gives Simard a daily diary. Once per day (rolling, regenerated as
-the day unfolds) Simard writes a short, plain-language story of what it did — the
-goals it worked, the engineers it ran, the pull requests it opened and merged, the
-deploys it made, what the **Overseer** steward was up to, how its memory grew, and
-any notable events. It reads like a diary entry written by the system about its own
-day, in a voice a non-engineer can follow.
+The **Journal** gives Simard a daily written record of its work. Once per day (rolling,
+regenerated as the day unfolds) Simard produces a short, plain-language **narrative
+report** of what happened — the goals worked, the engineering built or investigated,
+the research conducted, the pull requests worked on, the updates shipped to the
+live system, what the **Overseer** steward did, how memory grew, and the day's key
+observations, decisions, and outcomes.
 
-The journal exists so a human who was not watching the daemon minute-by-minute can
-open one page and understand *what happened today* — without reading logs, without
-knowing what "OODA", "episodic recall", or "CI" mean, and without scrolling a wall
-of telemetry.
+It is written as a **professional, third-person report**, the way an engineering team
+might summarise a day for a mixed audience — factual, structured, and readable. It is
+**not** a personal diary: there is no "Dear diary", no first-person confessional voice,
+and no diary framing. The reader gets a clear account of *what was worked on, what was
+built or investigated, what was observed, what was decided, and how it turned out.*
+
+The journal exists so a human who was not watching the daemon minute-by-minute can open
+one page and understand *what happened today* — without reading logs, without knowing
+what "OODA", "episodic recall", or "CI" mean, and without scrolling a wall of telemetry.
+
+!!! warning "Implementation status — target design under issue #2606"
+    This page describes the Simard Journal as it is being **rebuilt** under issue #2606: a
+    third-person narrative report, structured sections, timestamped moments, a verbose
+    prepared-context summary, and a prompt-first generation pipeline. Parts of this are the
+    intended end state and are **not yet reflected in the shipped code** — the pre-fix #2618
+    build still writes a first-person "Dear diary" narrative. Read this as the design we are
+    building toward, not as a description of current behaviour.
 
 !!! quote "What an entry sounds like"
-    *"Today I focused on tightening how I recall my own past work. I ran two
-    engineers on the auth module; one opened a code-change proposal (a "pull
-    request", or PR) that added tests, and I merged it after the automated checks
-    passed. My steward — the Overseer — flagged a stale proposal from last week and
-    nudged it along. My memory grew by 14 new moment-by-moment records of what I
-    did. A quiet, productive day."*
+    *"**Overview.** Simard spent the day improving how it recalls its own past work and
+    validating those changes against the live system. Two engineering efforts landed and
+    a measurement study was started."*
+
+    *"**Engineering work.** A change that adds automated tests to the sign-in code was
+    prepared and, once the automated checks passed, combined into the main code…"*
+
+    *(followed by Research, Key observations, Decisions and Outcomes sections, then a
+    plain-language table summarising each pull request.)*
 
 ## The core ideas
 
-### One Brain, one voice
+### A narrative report, not a personal diary
 
-Simard is a single mind. The journal is written in **first person, singular** — "I
-worked", "I merged", "I decided" — never as a committee and never as separate
-"bridges" or subsystems narrating themselves. The **Overseer** is not a second
-narrator; it is Simard's **steward**, and its actions appear *inside* Simard's
-story ("my steward flagged…", "the Overseer paused engineer #3 because…"). There is
-exactly one point of view.
+Simard is a single system, and the journal is written about that system's day in the
+**third person** — "Simard prepared…", "the change was combined into the main code…",
+"the Overseer flagged a stale proposal…". There is no diary voice and no personal
+framing; the register is that of a clear engineering/research report a non-engineer can
+still follow.
 
-This matters because the whole point is legibility. A reader should feel they are
-reading one coherent diary, not stitching together the outputs of many processes.
+The **Overseer** is Simard's **steward**, and its actions appear *inside* the report
+("the Overseer flagged a stale proposal and nudged it forward") rather than as a second
+narrator. There is one coherent account, not a stitched-together set of subsystem logs.
 
-### Written largely from episodic memory
+This matters because the whole point is legibility. A reader should feel they are reading
+one well-structured report, not a private diary and not raw telemetry.
 
-Simard already remembers its day as **episodes** — moment-by-moment records of what
-it observed and did (see
+### Structured: overview, sections, and a PR table
+
+Every entry has a **deliberate, readable structure** rather than a wall of prose:
+
+1. A short **Overview** paragraph — the two-or-three-sentence "what happened today".
+2. Clearly delineated **sections**, each under its own heading, covering (as applicable):
+   **Engineering work**, **Research**, **Key observations**, **Decisions**, and
+   **Outcomes**. Empty sections are simply omitted (honest degradation) rather than
+   padded.
+3. A **pull-request summary table** — a markdown table with one row per open code-change
+   proposal: its **number**, a plain-language **"what changed & why it matters"** summary,
+   and a plain-language **outcome** — a readiness phrase for the open proposal ("ready to
+   combine into the main code", "automated checks still running", or "not ready yet"). Each
+   row is written so a layperson understands what the change was for. (The journal reflects
+   the *open* proposal readiness view, so it reports readiness rather than lifecycle states
+   like "merged" or "closed".)
+
+The same structure renders cleanly in **both** operator surfaces — the dashboard Journal
+tab and the TUI Journal pane — because both are produced by one shared renderer (see
+[Journal API — rendering](../reference/journal-api.md#rendering-the-shared-renderer)).
+
+### Built largely from timestamped episodic memory
+
+Simard already remembers its day as **episodes** — moment-by-moment records of what it
+observed and did (see
 [Episodic recall](../reference/cognitive-memory-episodic-recall.md) and the
-[cognitive-memory architecture](../architecture/cognitive-memory.md)). The journal
-is built *primarily* from those episodes: the day's episodes are the raw material,
-and the narrative is their retelling in prose.
+[cognitive-memory architecture](../architecture/cognitive-memory.md)). The report is
+built *primarily* from those episodes: the day's episodes are the raw material, and the
+narrative is their retelling in report form.
 
-Episodes are the **primary, required** source. Everything else — the day's goals,
-engineer runs, pull requests, deploys, Overseer activity, memory-growth counts,
-notable events — is **augmentation**. Each augmentation source is best-effort: if
-the daemon cannot supply the day's deploy list, the entry simply omits deploys
-rather than inventing them or failing. Episodes carry the story; the rest adds
-colour and structure.
+Two properties make the episodic material legible:
 
-### Two passes: draft, then a mandatory jargon review
+- **Timestamps.** Each remembered moment referenced in the report shows **when it
+  occurred** (a human-readable time label), so the reader can place events in the day —
+  not a bare, undated list.
+- **Chronological order.** Remembered moments are presented **oldest-to-newest**, so the
+  report reads as the day actually unfolded.
 
-Generation is deliberately **two-pass**:
+Episodes are the **primary, required** source. Everything else — goals, engineering runs,
+pull requests, deploys, Overseer activity, memory-growth counts, notable events, and the
+prepared-context summary — is **augmentation**. Each augmentation is best-effort: if the
+daemon cannot supply the day's deploy list, the entry simply omits deploys rather than
+inventing them or failing.
 
-1. **Draft.** Assemble the day's context (episodes first, then augmentation) and
-   write a first-person narrative plus a pull-request table. The default drafter is
-   deterministic template assembly; a language-model drafter is a drop-in swap. This
-   pass produces honest but *engineer-flavoured* prose — it may still say "PR", "CI",
-   "idempotent", "daemon".
-2. **Review / rewrite.** A **mandatory** second pass hands the draft to a
-   **reviewer** whose job is to make the text safe for a layperson: it **explains
-   jargon on first use** ("a code-change proposal (a "pull request", or PR)"),
-   strips corporate jargon, and redacts anything that looks like a secret. The
-   generator *always* runs this pass — an entry is never stored un-reviewed.
+### A verbose "prepared context" summary — substance, not counts
 
-The review pass is a first-class, structurally-required stage, not an optional
-polish. Tests assert both that the reviewer *ran* and that sampled jargon terms are
-gone or explained in the stored entry. See
-[Journal API — the review pass](../reference/journal-api.md#the-review-pass).
+Earlier journal output emitted a bare line of totals — *"Prepared context: 10 facts, 2
+triggers, 5 procedures, 5 remembered moments"* — which told the reader nothing useful.
+The report now summarises **what those items actually were**: a brief, readable
+description of the day's key **facts**, **triggers**, **procedures**, and **remembered
+moments**, so the reader learns the substance rather than a total. Counts alone are never
+the whole story.
 
-!!! note "Why explain-on-first-use rather than ban words outright"
-    Some terms (PR, CI, deploy, merge) are unavoidable when describing engineering
-    work. Deleting them would make entries vague. Instead the reviewer keeps the
-    term but teaches it once, so the reader learns the vocabulary as they read. The
-    existing dashboard `BANNED_JARGON` list targets consultant-speak and insider
-    acronyms; the journal adds its own **explain-glossary** for the everyday
-    engineering words that list intentionally leaves alone.
+### Two passes: draft, then a mandatory de-jargon rewrite that has teeth
+
+Generation is deliberately **two-pass** so the jargon-free guarantee is structural, not
+incidental:
+
+1. **Draft.** Assemble the day's context (episodes first, then augmentation) and write
+   the structured, third-person report plus the pull-request table.
+2. **De-jargon rewrite.** A **mandatory** second pass rewrites the draft into language a
+   non-engineer can genuinely read: it **expands acronyms** ("PR" → "pull request", "CI"
+   → "the automated checks"), **removes raw code identifiers, internal code names, and
+   insider terms**, and **explains any unavoidable technical term in plain words**.
+
+Finally — regardless of whether that rewrite ran as a prompt or as the offline glossary
+pass — a **mandatory secret-redaction step** runs over the reviewed text, so anything that
+looks like a token, key, or private-key block is scrubbed before the entry is stored. The
+LLM reviewer's output is never trusted to be secret-free on its own.
+
+The rewrite pass is **effective by design, not a no-op**. The generator *always* runs it,
+it **materially changes** the text, and the tests prove it: an entry retains both its
+pre-review `draft` and its final `narrative`, and the test suite asserts (a) that a
+representative list of banned jargon tokens does **not** appear in the final narrative and
+(b) that the narrative genuinely **differs** from the draft. See
+[Journal API — the de-jargon pass](../reference/journal-api.md#the-de-jargon-rewrite-pass).
+
+!!! note "Why the earlier de-jargon step was strengthened"
+    #2618 added a de-jargon review step, but in production the final entries were still
+    full of jargon — the pass was effectively a no-op. #2606 gives it teeth: a
+    prompt-first rewrite (below) plus a strengthened deterministic glossary, verified by
+    tests that fail if banned tokens survive into the narrative.
+
+### Prompt-first generation, with an honest offline fallback
+
+Following the project's *agentic-over-brittle-parsing* guideline (G3), the report is
+written and de-jargoned by **prompts**, not by fragile string manipulation:
+
+- **Primary (prompt-first).** A recipe-runner-backed **drafter** and **de-jargon
+  reviewer** run the `journal-narrative` and `journal-plain-language`
+  [recipes](../reference/journal-api.md#the-generation-recipes). The prompts own the
+  narrative-report shaping and the plain-language rewrite. Recipe assets **hot-reload**
+  from `~/.simard/prompt_assets/simard/…` so a deploy can update them without a rebuild.
+- **Fallback (offline).** When `recipe-runner-rs` (or a recipe asset) is unavailable —
+  as in the hermetic test suite — generation degrades **honestly** to a deterministic
+  template drafter plus a strengthened glossary reviewer that still produce a structured,
+  jargon-free report. No network, no LLM, still readable.
+
+The generator that a deployment uses is selected by
+`JournalGenerator::for_repo(repo_root)`, which prefers the prompt-first pipeline and falls
+back to the deterministic one — so the feature always works, just with an LLM ceiling when
+one is available.
 
 ### Stored in memory, not in the repo
 
@@ -109,19 +189,18 @@ markdown snapshots checked into git. Instead each entry is a **first-class recor
 cognitive memory**, keyed by date:
 
 - One entry per day, stored as a **semantic fact** under the stable key
-  `journal:YYYY-MM-DD` (tag `journal`), with the full `JournalEntry` serialized as
-  the fact's content.
+  `journal:YYYY-MM-DD` (tag `journal`), with the full `JournalEntry` serialized as the
+  fact's content.
 - Because the store keeps **at most one live fact per key**
   ([`store_fact_with_caller_key`](../reference/cognitive-memory-fact-recall.md)),
-  regenerating today's entry **supersedes** the previous version rather than piling
-  up duplicates. That is what makes the "rolling, regenerate as the day progresses"
+  regenerating today's entry **supersedes** the previous version rather than piling up
+  duplicates. That is what makes the "rolling, regenerate as the day progresses"
   behaviour safe to repeat.
-- Entries **survive restarts** (they live in the durable cognitive-memory store) and
-  are **searchable** by date range and by free text.
+- Entries **survive restarts** (they live in the durable cognitive-memory store) and are
+  **searchable** by date range and by free text.
 
-This reuses the datastore Simard already has. The journal does **not** invent a
-parallel database, a new file format, or a second source of truth. It is one more
-record type in cognitive memory, sitting alongside facts, episodes, and procedures.
+This reuses the datastore Simard already has. The journal does **not** invent a parallel
+database, a new file format, or a second source of truth.
 
 ### Browseable by date, searchable by text — everywhere
 
@@ -132,10 +211,9 @@ newest-first) backs both operator surfaces:
 - a **Journal pane** in the [`simard-tui`](../reference/simard-tui.md) terminal
   dashboard.
 
-Both let the operator pick a date (newest-first list/picker) or search across all
-entries, and both render the narrative plus the pull-request table jargon-free and
-XSS-safe. The Journal tab is a **distinct, additive** tab with its own `journal`
-slug; it does not collide with any existing dashboard tab.
+Both let the operator pick a date (newest-first list/picker) or search across all entries,
+and both render the structured report plus the pull-request table jargon-free and XSS-safe.
+This searchable, browse-by-date behaviour is **preserved unchanged** from #2618.
 
 ## What a journal entry contains
 
@@ -144,43 +222,43 @@ Every entry is a small, self-describing record:
 | Part | What it is |
 | --- | --- |
 | **Date** | The calendar day (UTC) the entry describes; also its key. |
-| **Narrative** | The first-person diary story, jargon-scrubbed. |
-| **PR table** | Every pull request of the day: number, a plain-language "what changed & why it matters", and the outcome (merged / open / closed). |
+| **Narrative** | The final, reviewed, jargon-free **report**: an overview paragraph, sectioned narrative, timestamped chronological remembered moments, and the verbose prepared-context summary. |
+| **PR table** | Every open code-change proposal of the day: number, a plain-language "what changed & why it matters" summary, and a plain-language readiness outcome. |
+| **Draft** | The pre-review draft, retained so the de-jargon pass is provably not a no-op (`draft` ≠ `narrative`). |
 | **Quiet-day flag** | If nothing meaningful happened, the entry says so honestly ("a quiet day") rather than fabricating activity. |
-| **Reviewed flag** | Records that the mandatory jargon-review pass ran. |
 
-The pull-request table is the backbone of the "what shipped today" story. It is
-described in prose *and* rendered as a table so a non-engineer can skim outcomes at
-a glance. See the exact shape in the
-[Journal API reference](../reference/journal-api.md#data-model).
+The pull-request table is the backbone of the "what shipped today" story. It is described
+in prose *and* rendered as a table so a non-engineer can skim outcomes at a glance. See
+the exact shape in the [Journal API reference](../reference/journal-api.md#data-model).
 
 ## Honesty on quiet days
 
-Not every day is busy. When the day's episodes and augmentation sources are empty,
-Simard does **not** pad the entry with filler. It writes a short, honest
-placeholder — *"A quiet day. Nothing of note to report."* — and marks the entry as
-quiet. Both the dashboard and the TUI render that honestly. Truthfulness beats
-volume; a fabricated busy day would be worse than an empty one. This mirrors
-Simard's broader [truthful-runtime-metadata](./truthful-runtime-metadata.md)
-principle.
+Not every day is busy. When the day's episodes and augmentation sources are empty, Simard
+does **not** pad the entry with filler. It writes a short, honest placeholder — *"A quiet
+day. Nothing of note to report."* — and marks the entry as quiet. Both the dashboard and
+the TUI render that honestly. Truthfulness beats volume; a fabricated busy day would be
+worse than an empty one. This mirrors Simard's broader
+[truthful-runtime-metadata](./truthful-runtime-metadata.md) principle.
 
 ## How it fits the rest of Simard
 
 The journal is a thin narrative layer over subsystems that already exist:
 
-- **Cognitive memory** supplies the episodes (the story) and stores the finished
-  entry (the record). No new datastore.
-- **The OODA daemon** already knows the day's goals, engineer runs, deploys, and
-  Overseer activity; the journal reads those as augmentation.
+- **Cognitive memory** supplies the timestamped episodes (the story) and stores the
+  finished entry (the record). No new datastore.
+- **The OODA daemon** already knows the day's goals, engineer runs, deploys, and Overseer
+  activity; the journal reads those as augmentation.
+- **The prompt-first recipes** (`journal-narrative`, `journal-plain-language`) own the
+  report shaping and the de-jargon rewrite; the deterministic pipeline is the offline
+  fallback.
 - **A daily background task** in the OODA daemon regenerates today's entry on a fixed
-  cadence (default hourly), running *after* the decision cycle so it never competes
-  with it — narrating the day is a lightweight form of memory consolidation. It runs
-  by default and can be turned off with a single environment variable.
-- **The dashboard and TUI** already have a tab/pane pattern, styling, and an
-  escaping discipline; the Journal surfaces slot into those.
+  cadence (default hourly), running *after* the decision cycle so it never competes with
+  it. It runs by default and can be turned off with a single environment variable.
+- **The dashboard and TUI** already have a tab/pane pattern, styling, and an escaping
+  discipline; the Journal surfaces slot into those and share one renderer.
 
-Nothing here changes the live daemon's decision-making. The journal only *reads*
-what Simard did and *writes* a human-readable record of it.
+Nothing here changes the live daemon's decision-making. The journal only *reads* what
+Simard did and *writes* a human-readable report of it.
 
 ## Where to go next
 

--- a/docs/howto/browse-the-simard-journal.md
+++ b/docs/howto/browse-the-simard-journal.md
@@ -1,11 +1,11 @@
 ---
 title: "Browse the Simard Journal"
 description: >
-  How an operator reads Simard's daily journal: open the Journal tab in the dashboard or
-  the Journal pane in simard-tui, browse entries newest-first by date, search across all
-  entries by text, read the narrative and the pull-request table, and configure or disable
-  the daily generation thread.
-last_updated: 2026-07-05
+  How an operator reads Simard's daily journal report: open the Journal tab in the dashboard
+  or the Journal pane in simard-tui, browse entries newest-first by date, search across all
+  entries by text, read the structured report (overview, sections, timestamped moments) and
+  the plain-language pull-request table, and configure or disable the daily generation thread.
+last_updated: 2026-07-06
 review_schedule: as-needed
 owner: simard
 doc_type: howto
@@ -22,80 +22,96 @@ related:
 
 # Browse the Simard Journal
 
-This guide shows how to read Simard's daily diary — the **Journal** — from either
-operator surface, how to find a specific day, how to search across days, and how to
-control when entries are generated.
+This guide shows how to read Simard's daily **narrative engineering & research report** —
+the **Journal** — from either operator surface, how to find a specific day, how to search
+across days, and how to control when entries are generated.
 
-For what the journal *is*, see [The Simard Journal](../concepts/simard-journal.md).
-For the interface details, see the [Journal API reference](../reference/journal-api.md).
+For what the journal *is*, see [The Simard Journal](../concepts/simard-journal.md). For the
+interface details, see the [Journal API reference](../reference/journal-api.md).
+
+!!! warning "Implementation status — target design under issue #2606"
+    This guide describes the journal as it is being rebuilt under issue #2606 (a third-person
+    report with structured sections, timestamped moments, and a plain-language proposal
+    table). Some of what it describes is the intended end state and may not yet match the
+    shipped build until the #2606 work lands.
 
 ## Prerequisites
 
-- A Simard daemon whose cognitive-memory store is reachable (the same store used by
-  the dashboard and TUI). Reading entries needs only the store — not a running
-  generation thread.
-- For the dashboard: a valid operator session/token (the Journal routes are
-  auth-gated).
+- A Simard daemon whose cognitive-memory store is reachable (the same store used by the
+  dashboard and TUI). Reading entries needs only the store — not a running generation
+  thread.
+- For the dashboard: a valid operator session/token (the Journal routes are auth-gated).
 - For the TUI: the `simard-tui` binary and an interactive terminal (see
   [Monitor Simard with the TUI](./monitor-simard-with-tui.md)).
+
+## What an entry looks like
+
+Each entry is a **report**, not a personal diary. It is laid out for skimming:
+
+- a short **Overview** paragraph — the "what happened today" in two or three sentences;
+- clearly headed **sections** — *Engineering work*, *Research*, *Key observations*,
+  *Decisions*, *Outcomes* (only the ones with content appear);
+- the day's **remembered moments**, each shown **with a timestamp** and in the order they
+  happened;
+- a verbose **prepared-context** summary that describes *what* the day's key facts,
+  triggers, and procedures were (not just how many); and
+- a **pull-request table** with three columns — **PR # / What changed & why it matters /
+  Outcome** — one row per open code-change proposal, whose outcome is a plain-language
+  readiness phrase ("ready to combine into the main code", "automated checks still running",
+  or "not ready yet"), written so a non-engineer understands each one.
+
+Everything is rendered **jargon-free** (acronyms expanded, raw code identifiers and insider
+terms removed, unavoidable terms explained in plain words) and **XSS-safe** (entry text is
+escaped, never executed).
 
 ## Read the journal in the dashboard
 
 1. Open the [operator dashboard](../dashboard.md) and sign in.
-2. Click the **Journal** tab (or navigate to `#journal`). It is a distinct tab,
-   separate from the Operator/Overseer-activity view.
-3. The tab shows a **date list, newest-first**. The most recent day is selected by
-   default and its entry renders on the right:
-   - the **narrative** — a plain-language, first-person story of Simard's day; and
-   - the **pull-request table** — one row per PR with its number, a plain-language
-     "what changed & why it matters", and the outcome (merged / open / closed).
+2. Click the **Journal** tab (or navigate to `#journal`). It is a distinct tab, separate
+   from the Operator/Overseer-activity view.
+3. The tab shows a **date list, newest-first**. The most recent day is selected by default
+   and its entry renders on the right: the structured report (overview + sections +
+   timestamped moments) followed by the three-column pull-request table.
 
 ### Browse by date
 
-- Pick any date from the newest-first list (or the date picker) to load that day's
-  entry.
-- A day with no activity shows an honest **"quiet day"** entry rather than a blank
-  page or invented activity.
+- Pick any date from the newest-first list (or the date picker) to load that day's entry.
+- A day with no activity shows an honest **"quiet day"** entry rather than a blank page or
+  invented activity.
 
 ### Search across all days
 
-- Type into the **search** box to filter entries by text. The search runs over the
+- Type into the **search** box to filter entries by text. The search runs over the report
   narrative and the PR summaries and returns matching days newest-first.
-- Search is a plain, case-insensitive keyword match — no special syntax needed.
-  Queries are length-bounded and results are capped; you will always get the newest
-  matches first.
-
-Everything you read here is rendered **jargon-free** (engineering terms are
-explained on first use) and **XSS-safe** (entry text is escaped, never executed).
+- Search is a plain, case-insensitive keyword match — no special syntax needed. Queries are
+  length-bounded and results are capped; you will always get the newest matches first.
 
 ### What the routes are (optional)
 
-The tab is backed by read-only, auth-gated endpoints — handy for scripting or
-debugging:
+The tab is backed by read-only, auth-gated endpoints — handy for scripting or debugging:
 
 ```bash
 # List days that have an entry (newest-first).
-curl -s -H "Authorization: Bearer $SIMARD_DASHBOARD_TOKEN" \
+curl -s -H "Authorization: ******" \
   http://127.0.0.1:8080/api/journal/dates
 
 # Fetch one day's structured entry.
-curl -s -H "Authorization: Bearer $SIMARD_DASHBOARD_TOKEN" \
-  http://127.0.0.1:8080/api/journal/entry/2026-07-05
+curl -s -H "Authorization: ******" \
+  http://127.0.0.1:8080/api/journal/entry/2026-07-06
 
 # Full-text search (POST a JSON body; optional from/to date bounds).
-curl -s -H "Authorization: Bearer $SIMARD_DASHBOARD_TOKEN" \
+curl -s -H "Authorization: ******" \
   -H 'Content-Type: application/json' \
   -X POST http://127.0.0.1:8080/api/journal/search \
-  -d '{"query":"auth module"}'
+  -d '{"query":"sign-in"}'
 
-# Server-rendered, HTML-escaped entry (what the tab embeds).
-curl -s -H "Authorization: Bearer $SIMARD_DASHBOARD_TOKEN" \
-  http://127.0.0.1:8080/api/journal/render/2026-07-05
+# Server-rendered, HTML-escaped entry (what the tab embeds) — report headings + PR table.
+curl -s -H "Authorization: ******" \
+  http://127.0.0.1:8080/api/journal/render/2026-07-06
 ```
 
 (Replace host/port with your dashboard's. See the
-[Journal API reference](../reference/journal-api.md#http-routes) for the exact
-shapes.)
+[Journal API reference](../reference/journal-api.md#http-routes) for the exact shapes.)
 
 ## Read the journal in the TUI
 
@@ -105,56 +121,64 @@ shapes.)
    simard-tui
    ```
 
-2. Press **Alt+8** (or **Ctrl+8**, or cycle with **Tab** / **Shift+Tab** / **←** **→**)
-   to open the **Journal** pane. The TUI ignores bare digit keys, so plain `8` does
-   nothing.
-3. The pane shows a **newest-first date list** on one side and the selected entry —
-   narrative plus PR table — on the other.
-   - Use **`↑` / `↓`** to move through days.
-   - Press **`/`** to enter search, type a needle, and filter entries by text.
+2. Press **Alt+8** (or **Ctrl+8**, or cycle with **Tab** / **Shift+Tab** / **←** **→**) to
+   open the **Journal** pane. The TUI ignores bare digit keys, so plain `8` does nothing.
+3. The pane shows a **newest-first date list** on one side and the selected entry — the same
+   report (headings + aligned three-column PR table) — on the other.
+   - Use **`↑` / `↓`** (or **j/k**) to move through days.
+   - Press **`/`** to enter search, type a needle, and filter entries by text; **Esc**
+     clears it; **r** reloads.
    - A day with no entry renders the same honest **"quiet day"** placeholder.
 
-The TUI reads the same entries as the dashboard through the shared journal store, so
-the two surfaces always agree.
+The TUI reads the same entries as the dashboard through the shared journal store and renders
+them with the same shared renderer, so the two surfaces always agree.
 
 ## Configure or disable daily generation
 
-Entries are (re)generated by a **daily journal task** that runs inside the daemon
-and rewrites *today's* entry on a cadence. It runs **by default** (after the
-authoritative decision cycle, so it never stalls it). You control it with environment
-variables (see [Journal API — configuration](../reference/journal-api.md#configuration)):
+Entries are (re)generated by a **daily journal task** that runs inside the daemon and
+rewrites *today's* entry on a cadence. It runs **by default** (after the authoritative
+decision cycle, so it never stalls it). You control it with environment variables (see
+[Journal API — configuration](../reference/journal-api.md#configuration)):
 
 | Variable | Default | Effect |
 | --- | --- | --- |
 | `SIMARD_JOURNAL_ENABLED` | `1` (on) | The daily journal runs by default. Set to a falsey value (`0`/`false`/`no`/`off`) to stop generating new entries; existing entries stay browseable. |
 | `SIMARD_JOURNAL_INTERVAL_SECS` | `3600` | How often today's entry is regenerated (clamped to a 60-second floor). |
 
-Set these where the daemon reads its environment, then restart the daemon so it
-picks up the change. Regeneration is idempotent — running more often updates the
-single live entry for the day; it never creates duplicate days.
+Set these where the daemon reads its environment, then restart the daemon so it picks up the
+change. Regeneration is idempotent — running more often updates the single live entry for
+the day; it never creates duplicate days.
 
 !!! note "Reading needs no configuration"
-    Disabling the task only stops *new* entries. The dashboard tab and TUI pane
-    keep working against whatever entries already exist in memory.
+    Disabling the task only stops *new* entries. The dashboard tab and TUI pane keep working
+    against whatever entries already exist in memory.
+
+!!! note "LLM-written vs. offline reports"
+    When `recipe-runner-rs` and the journal recipes are available, the report is written and
+    de-jargoned by prompts (richer prose). When they are not — for example in a minimal
+    deployment — generation falls back to a deterministic offline pipeline that still
+    produces the same structured, jargon-free report. Either way the layout is identical.
 
 ## Troubleshoot
 
-- **The Journal tab/pane is empty.** The store may have no entries yet (a fresh
-  daemon, or generation disabled). Confirm `SIMARD_JOURNAL_ENABLED` is not set to a
-  falsey value, then wait one interval (default 1 hour) or restart the daemon.
-- **A specific day is missing.** Only days with recorded activity get a full entry;
-  quiet days still render a placeholder. Use search to confirm the day exists.
-- **`/api/journal/*` returns `{"status":"error"}` with HTTP 200.** That is the
-  dashboard convention — check the `error` field. A malformed date (`{date}` must be
-  `YYYY-MM-DD`) or an over-long search query are the usual causes.
+- **The Journal tab/pane is empty.** The store may have no entries yet (a fresh daemon, or
+  generation disabled). Confirm `SIMARD_JOURNAL_ENABLED` is not set to a falsey value, then
+  wait one interval (default 1 hour) or restart the daemon.
+- **A specific day is missing.** Only days with recorded activity get a full entry; quiet
+  days still render a placeholder. Use search to confirm the day exists.
+- **`/api/journal/*` returns `{"status":"error"}` with HTTP 200.** That is the dashboard
+  convention — check the `error` field. A malformed date (`{date}` must be `YYYY-MM-DD`) or
+  an over-long search query are the usual causes.
 - **Entries look stale.** Today's entry is rolling; it updates each interval. Lower
-  `SIMARD_JOURNAL_INTERVAL_SECS` if you want fresher regeneration, and restart the
-  daemon.
+  `SIMARD_JOURNAL_INTERVAL_SECS` if you want fresher regeneration, and restart the daemon.
+- **An entry still reads like jargon.** File it as a bug — the de-jargon pass is a
+  hard guarantee, and its banned-token list is covered by tests. Include the date so the
+  offending narrative can be reproduced.
 
 ## Related
 
 - [The Simard Journal](../concepts/simard-journal.md) — concept.
 - [Journal API](../reference/journal-api.md) — routes, config, data model.
-- [Read Simard's daily journal](../tutorials/read-simards-daily-journal.md) —
-  guided first read.
+- [Read Simard's daily journal](../tutorials/read-simards-daily-journal.md) — guided first
+  read.
 - [Monitor Simard with the TUI](./monitor-simard-with-tui.md) — TUI basics.

--- a/docs/reference/journal-api.md
+++ b/docs/reference/journal-api.md
@@ -1,13 +1,14 @@
 ---
 title: "Journal API"
 description: >
-  Reference for the src/journal module: the JournalEntry / PrSummary data model, the
-  journal:YYYY-MM-DD key scheme layered over cognitive memory, the injectable two-pass
-  generation pipeline (clock, episode & PR sources, drafter, mandatory glossary reviewer),
-  the JournalStore query API (by date range + full text, newest-first), the daily journal
-  thread, the dashboard HTTP routes and Journal tab, the simard-tui Journal pane,
-  configuration environment variables, security guarantees, and telemetry.
-last_updated: 2026-07-05
+  Reference for the src/journal module: the JournalEntry / PrSummary / DayContext data model,
+  the journal:YYYY-MM-DD key scheme over cognitive memory, the two-pass generation pipeline
+  (injectable clock, episode & PR sources, drafter, mandatory de-jargon reviewer) in both its
+  prompt-first (recipe-runner) and deterministic-fallback forms, the shared report renderer
+  (report headings + markdown/HTML PR table for dashboard AND TUI), the JournalStore query API
+  (date range + full text, newest-first), the daily journal thread, the dashboard HTTP routes
+  and Journal tab, the simard-tui Journal pane, configuration, security, and telemetry.
+last_updated: 2026-07-06
 review_schedule: as-needed
 owner: simard
 doc_type: reference
@@ -24,19 +25,31 @@ related:
   - ./simard-tui.md
   - ./telemetry-metrics.md
   - ../design/overseer.md
+  - ../architecture/episode-distillation.md
 ---
 
 # Journal API
 
-The **journal** module (`src/journal/`) turns Simard's day into a durable,
-searchable, layperson-readable diary entry stored in cognitive memory. This page is
-the interface contract: types, traits, the storage-key scheme, the query API, the
-two-pass generation pipeline, the operator surfaces, configuration, and the security
-and telemetry guarantees.
+The **journal** module (`src/journal/`) turns Simard's day into a durable, searchable,
+layperson-readable **narrative engineering & research report** stored in cognitive memory.
+This page is the interface contract: types, traits, the storage-key scheme, the query API,
+the two-pass generation pipeline (prompt-first plus deterministic fallback), the generation
+recipes, the shared renderer, the operator surfaces, configuration, and the security and
+telemetry guarantees.
 
-For the *why*, read [The Simard Journal](../concepts/simard-journal.md). For
-day-to-day operator use, read
-[Browse the Simard Journal](../howto/browse-the-simard-journal.md).
+For the *why*, read [The Simard Journal](../concepts/simard-journal.md). For day-to-day
+operator use, read [Browse the Simard Journal](../howto/browse-the-simard-journal.md).
+
+!!! warning "Implementation status — target design under issue #2606"
+    This page is the **implementation spec** for the journal module as it is being rebuilt
+    under issue #2606. It describes the intended finished state — the third-person report
+    structure, the prompt-first recipe pipeline, the verbose prepared-context material, the
+    timestamped moments, and the unconditional secret-redaction post-pass. Several of these
+    are **not yet reflected in `src/journal/`**, which still carries the pre-fix #2618
+    behaviour (a first-person "Dear diary" template drafter, a 3-field `PrSummary`, and a
+    glossary-only reviewer). Read this as the contract we are building toward, not as a
+    description of already-shipped behaviour. Symbols marked "(#2606)" are additions this
+    work introduces.
 
 ## Module layout
 
@@ -44,73 +57,104 @@ day-to-day operator use, read
 src/journal/
 ├── mod.rs         // pub re-exports; `pub mod journal;` is declared in src/lib.rs
 ├── types.rs       // JournalEntry, PrSummary, MemoryGrowth, DayContext (+ serde)
-├── jargon.rs      // JOURNAL_GLOSSARY + scrub_jargon (the default reviewer body)
-├── generate.rs    // JournalDrafter / JournalReviewer traits, TemplateDrafter,
-│                  //   GlossaryReviewer, JournalGenerator (draft -> ALWAYS review)
+├── jargon.rs      // JOURNAL_GLOSSARY + scrub_jargon + scrub_secrets (the default reviewer body)
+├── generate.rs    // JournalDrafter / JournalReviewer traits; TemplateDrafter + GlossaryReviewer
+│                  //   (offline fallback); JournalGenerator (draft -> ALWAYS review ->
+│                  //   scrub_secrets); default_pipeline() + for_repo()
+├── recipe.rs      // RecipeDrafter + RecipeReviewer (prompt-first, recipe-runner-backed;
+│                  //   degrade per-call to the deterministic drafter / glossary reviewer)
 ├── providers.rs   // JournalClock / EpisodeSource / PrListSource seams, DayExtras,
-│                  //   assemble_day_context, generate_and_store[_ops]
-├── render.rs      // html_escape, render_entry_html, render_entry_tui_lines
+│                  //   assemble_day_context, generate_and_store; episode_time_label
+├── render.rs      // html_escape, render_entry_html, render_entry_tui_lines (shared renderer)
 ├── store.rs       // JournalStore + borrowed free fns over &dyn CognitiveMemoryOps
-└── thread.rs      // run_journal_tick + enable/interval env helpers (daily task)
+├── pr_source.rs   // GhPrListSource: gh pr list -> plain-language PrSummary rows
+└── thread.rs      // run_journal_tick(_with_prs[_in_repo]) + enable/interval env helpers
 ```
 
 The module is a self-contained brick. Its only hard dependency is the existing
-[`CognitiveMemoryOps`](./cognitive-memory-fact-recall.md) trait; everything the
-generator needs from the outside world is injected behind a small trait, which is
-what makes the whole pipeline testable with no network, no clock, and no live daemon.
+[`CognitiveMemoryOps`](./cognitive-memory-fact-recall.md) trait; everything the generator
+needs from the outside world is injected behind a small trait, which is what makes the whole
+pipeline testable with no network, no clock, no live daemon, and no `recipe-runner-rs`.
 
 ## Data model
 
-Defined in `src/journal/types.rs`; both records are `serde` (de)serializable.
+Defined in `src/journal/types.rs`; all records are `serde` (de)serializable. New fields are
+added **additively** with `#[serde(default)]`, so entries written before this change still
+deserialize.
 
 ```rust
 /// A plain-language summary of one code-change proposal (pull request).
 pub struct PrSummary {
-    pub number: u64,          // rendered as `#123`
-    pub plain_summary: String, // "what changed & why it matters", no jargon
-    pub outcome: String,       // "merged", "open", "closed", ...
+    pub number: u64,           // rendered as `#123`
+    pub plain_summary: String, // "what changed & why it matters", in plain language
+    pub outcome: String,       // plain-language readiness phrase (see below)
 }
 
-/// A single day's diary entry — the durable, persisted record.
+/// A single day's report entry — the durable, persisted record.
 pub struct JournalEntry {
     pub date: chrono::NaiveDate,             // UTC day; also the storage key
     pub generated_at: chrono::DateTime<chrono::Utc>, // latest (re)generation time
-    pub narrative: String,                   // final, reviewed, jargon-free prose
-    pub draft: String,                       // pre-review draft (provenance)
+    pub narrative: String,                   // final, reviewed, jargon-free REPORT
+    pub draft: String,                       // pre-review draft (provenance; draft != narrative)
     pub prs: Vec<PrSummary>,                 // backs the plain-language PR table
     pub quiet_day: bool,                     // rendered honestly, never fabricated
 }
 ```
 
-`JournalEntry::merged_pr_count()` returns how many of the day's proposals were
-merged. `MemoryGrowth { facts_added, episodes_added }` carries the day's memory
-growth when measured.
+`MemoryGrowth { facts_added, episodes_added }` carries the day's memory growth when measured.
 
-The transient generation input is `DayContext`:
+`outcome` is a **plain-language readiness phrase** for an *open* proposal, derived from the
+same objective gates the merge authority evaluates (`pr_readiness_outcome`) — one of
+`"still open — ready to combine into the main code"`, `"still open — automated checks still
+running"`, or `"still open — not ready yet"`. The journal reads the **open** PR readiness
+view — the same `gh pr list` service the dashboard's Merge Readiness panel uses (#1880) — so
+lifecycle states such as "merged"/"closed" are intentionally **not** surfaced by this seam;
+the column reports readiness, not lifecycle.
+
+The transient generation input is `DayContext`. Alongside the primary episode source it
+carries the **verbose prepared-context** material — brief descriptions of the day's facts,
+triggers, and procedures — so the report can summarise *what* they were, not just how many:
 
 ```rust
 pub struct DayContext {
     pub date: chrono::NaiveDate,
-    pub episodes: Vec<CognitiveEpisode>, // PRIMARY narrative source
+    pub episodes: Vec<CognitiveEpisode>, // PRIMARY narrative source (carry timestamps)
     pub prs: Vec<PrSummary>,
     pub goals: Vec<String>,
     pub deploys: Vec<String>,
     pub overseer_events: Vec<String>,
     pub memory_growth: Option<MemoryGrowth>,
     pub notable: Vec<String>,
+    // Verbose prepared-context (issue #2606) — brief readable descriptions, not counts:
+    pub facts: Vec<String>,      // key facts prepared for the day
+    pub triggers: Vec<String>,   // prospective triggers that fired
+    pub procedures: Vec<String>, // procedures recalled/applied
 }
 ```
 
-`DayContext::is_quiet()` is `true` when nothing happened worth narrating; the
-drafter then emits an honest "quiet day" paragraph rather than an empty or invented
-one. Episodics are the primary source; every other field is a best-effort
-augmentation that is simply omitted when absent (honest degradation).
+`DayContext::is_quiet()` is `true` when nothing happened worth narrating; the drafter then
+emits an honest "quiet day" paragraph rather than an empty or invented one. Episodes are the
+primary source; every other field is a best-effort augmentation that is simply omitted when
+absent (honest degradation).
+
+### Episode timestamps
+
+Each remembered moment is rendered **with its timestamp** and in **chronological order**.
+`episode_time_label(temporal_index: i64) -> String` (in `providers.rs`) turns an episode's
+`temporal_index` into a human-readable label:
+
+- an epoch-second magnitude is formatted as a UTC time label (e.g. `2026-07-06 14:32 UTC`);
+- a small monotonic counter (not a real epoch) degrades to a stable ordinal label
+  (`moment 1`, `moment 2`, …), so a test fixture using counters still renders sensibly.
+
+The drafter sorts episodes by `temporal_index` ascending before rendering, so the report
+reads oldest-to-newest.
 
 ## The two-pass generation pipeline
 
-Generation is deliberately **two-pass** so the jargon-free guarantee is structural,
-not incidental (see the concept's
-[two-pass review](../concepts/simard-journal.md#two-passes-draft-then-a-mandatory-jargon-review)):
+Generation is deliberately **two-pass** so the jargon-free guarantee is structural, not
+incidental (see the concept's
+[two-pass rewrite](../concepts/simard-journal.md#two-passes-draft-then-a-mandatory-de-jargon-rewrite-that-has-teeth)):
 
 ```rust
 pub trait JournalDrafter: Send + Sync { fn draft(&self, day: &DayContext) -> String; }
@@ -119,27 +163,89 @@ pub trait JournalReviewer: Send + Sync { fn review(&self, draft: &str) -> String
 pub struct JournalGenerator { /* boxed drafter + reviewer */ }
 impl JournalGenerator {
     pub fn new(drafter: Box<dyn JournalDrafter>, reviewer: Box<dyn JournalReviewer>) -> Self;
-    pub fn default_pipeline() -> Self;                 // TemplateDrafter + GlossaryReviewer
-    pub fn generate(&self, day: &DayContext) -> JournalEntry; // draft -> ALWAYS review
+
+    /// Deterministic, offline pipeline: TemplateDrafter + GlossaryReviewer.
+    pub fn default_pipeline() -> Self;
+
+    /// Prompt-first for a deployment, with an HONEST fallback to `default_pipeline()`
+    /// when `recipe-runner-rs` or a recipe asset is unavailable (issue #2606).
+    pub fn for_repo(repo_root: &std::path::Path) -> Self;
+
+    /// draft -> ALWAYS review -> ALWAYS scrub secrets. No path returns an unreviewed
+    /// narrative, and no path skips secret redaction (see `generate` below).
+    pub fn generate(&self, day: &DayContext) -> JournalEntry;
 }
 ```
 
-`generate` runs the drafter, then **always** runs the reviewer over the draft, and
-stores both `draft` (provenance) and the reviewed `narrative` — there is no code path
-that returns an unreviewed narrative.
+`generate` runs the drafter, then **always** runs the reviewer over the draft, then applies
+`scrub_secrets` to the reviewed text as an **unconditional post-pass** — so secret redaction
+covers the prompt-first reviewer and the offline reviewer alike — and stores both `draft`
+(provenance) and the final `narrative`.
 
-### The review pass
+### The drafter — a structured, third-person report
 
-The mandatory second pass is what makes the entry layperson-readable:
+Both drafters emit the **same report shape**: an **Overview** paragraph, `##`-headed
+**sections** (Engineering work / Research / Key observations / Decisions / Outcomes, each
+omitted when empty), the **timestamped chronological** remembered moments, the **verbose
+prepared-context** summary (substance of facts/triggers/procedures/moments), and a one-line
+lead-in to the pull-request table. Neither drafter uses a diary voice.
 
-- **`TemplateDrafter`** (default) is deterministic and offline: it leads with the
-  day's episodics, folds in goals / live-system updates / Overseer activity / memory
-  growth / notable events, then a one-line lead-in to the proposal table.
-- **`GlossaryReviewer`** (default) delegates to `scrub_jargon`, a whole-word,
-  case-insensitive glossary substitution (`JOURNAL_GLOSSARY`) that *removes or
-  explains* engineering terms — e.g. `PR` → "code-change proposal (PR)", `episodic`
-  → "moment-by-moment", `deploy` → "ship to the live system". An LLM reasoner can be
-  swapped in behind either trait.
+- **`RecipeJournalDrafter`** (prompt-first, primary) shells out to `recipe-runner-rs`
+  running the [`journal-narrative`](#the-generation-recipes) recipe with the day's context
+  passed as delimited context variables. The prompt owns the report shaping and voice.
+- **`TemplateDrafter`** (deterministic, offline fallback) assembles the identical structure
+  from a template — third person, overview + sections + timestamped episodes + verbose
+  context — with **no** "Dear diary" phrasing anywhere.
+
+### The de-jargon rewrite pass
+
+The mandatory second pass is what makes the entry a layperson-readable report — and, unlike
+the earlier no-op, it **materially changes** the text:
+
+- **`RecipeJournalReviewer`** (prompt-first, primary) shells out to `recipe-runner-rs`
+  running the [`journal-plain-language`](#the-generation-recipes) recipe: it expands
+  acronyms, removes raw code identifiers / internal code names / insider jargon, and
+  explains any unavoidable technical term in plain words.
+- **`GlossaryReviewer`** (deterministic, offline fallback) delegates to `scrub_jargon`, a
+  whole-word, case-insensitive glossary substitution (`JOURNAL_GLOSSARY`) — **strengthened**
+  in #2606 so raw identifiers, internal code names, and unexpanded acronyms are removed or
+  expanded (e.g. `PR` → "pull request", `CI` → "the automated checks", `episodic` →
+  "moment-by-moment", `OODA` → "decision cycle").
+
+Regardless of which reviewer runs, `JournalGenerator::generate` then applies `scrub_secrets`
+to the reviewed narrative as a **mandatory, unconditional post-pass**, so token/key/PEM-shaped
+substrings are redacted on **both** the prompt-first and the offline paths — the LLM reviewer's
+output is never trusted to be secret-free on its own.
+
+Both reviewers guarantee the same testable property: for a representative banned-jargon
+token list, **none** of those tokens survive into `narrative`, and `narrative != draft`.
+
+```rust
+/// The strengthened glossary (whole-word, case-insensitive, longest-phrase-first).
+pub const JOURNAL_GLOSSARY: &[(&str, &str)];
+/// Rewrite input, replacing every whole-word glossary term with plain language.
+pub fn scrub_jargon(input: &str) -> String;
+/// Redact secret-shaped substrings (tokens, keys, PEM blocks) — offline, pure.
+pub fn scrub_secrets(input: &str) -> String;
+```
+
+### The generation recipes
+
+Prompt assets live under `prompt_assets/simard/recipes/`, hot-reloading from
+`~/.simard/prompt_assets/simard/recipes/` at runtime with an **in-tree fallback** (the same
+`resolve_recipe_path(repo_root)` pattern used by
+[episode distillation](../architecture/episode-distillation.md) and the OODA brains). A fix
+lands in-repo so a deploy syncs it.
+
+| Recipe file | Role | Key context vars (via `-c`) |
+| --- | --- | --- |
+| `journal-narrative.yaml` | Draft the structured, third-person report from the day's context. | `day_context` (JSON: `date`, `episodes` with time labels, `prs`, `goals`, `deploys`, `overseer_events`, `facts`, `triggers`, `procedures`, `memory_growth`, `notable`) |
+| `journal-plain-language.yaml` | Rewrite a draft into genuinely jargon-free language. | `draft` (delimited) |
+
+The recipes are **prose-only**: the day's data is passed as delimited context variables the
+prompt treats as untrusted input, never as instructions. If a recipe fails to parse or the
+runner is unavailable, generation **fails closed** to the deterministic fallback rather than
+emitting an unreviewed entry.
 
 ### Injectable seams (`providers.rs`)
 
@@ -148,11 +254,21 @@ pub trait JournalClock: Send + Sync { fn today(&self) -> NaiveDate; }     // Sys
 pub trait EpisodeSource: Send + Sync { fn episodes_for_date(&self, d: NaiveDate) -> SimardResult<Vec<CognitiveEpisode>>; }
 pub trait PrListSource: Send + Sync { fn prs_for_date(&self, d: NaiveDate) -> SimardResult<Vec<PrSummary>>; }
 
-pub struct DayExtras { pub goals, deploys, overseer_events, notable: Vec<String>, pub memory_growth: Option<MemoryGrowth> }
+pub struct DayExtras {
+    pub goals: Vec<String>,
+    pub deploys: Vec<String>,
+    pub overseer_events: Vec<String>,
+    pub notable: Vec<String>,
+    pub memory_growth: Option<MemoryGrowth>,
+    // Verbose prepared-context (issue #2606):
+    pub facts: Vec<String>,
+    pub triggers: Vec<String>,
+    pub procedures: Vec<String>,
+}
 
 pub fn assemble_day_context(date, episodes: &dyn EpisodeSource, prs: &dyn PrListSource, extras: DayExtras) -> SimardResult<DayContext>;
-pub fn generate_and_store(date, episodes, prs, extras, generator: &JournalGenerator, store: &JournalStore) -> SimardResult<JournalEntry>;
-pub fn generate_and_store_ops(date, episodes, prs, extras, generator: &JournalGenerator, mem: &dyn CognitiveMemoryOps) -> SimardResult<JournalEntry>;
+pub fn generate_and_store(date, episodes, prs, extras, generator: &JournalGenerator, mem: &dyn CognitiveMemoryOps) -> SimardResult<JournalEntry>;
+pub fn episode_time_label(temporal_index: i64) -> String;   // UTC label or "moment N"
 ```
 
 ## Storage & the query API (`store.rs`)
@@ -183,7 +299,7 @@ impl JournalStore {
 }
 
 // Borrowed free functions (for callers holding only a &dyn CognitiveMemoryOps —
-// the dashboard reader bridge and the daily thread). JournalStore delegates to these.
+// the dashboard reader and the daily thread). JournalStore delegates to these.
 pub fn save_entry(mem: &dyn CognitiveMemoryOps, entry: &JournalEntry) -> SimardResult<String>;
 pub fn get_entry_by_date(mem: &dyn CognitiveMemoryOps, date: NaiveDate) -> SimardResult<Option<JournalEntry>>;
 pub fn all_entries(mem: &dyn CognitiveMemoryOps) -> SimardResult<Vec<JournalEntry>>;
@@ -191,18 +307,43 @@ pub fn query_entries(mem: &dyn CognitiveMemoryOps, range, text) -> SimardResult<
 pub fn entry_matches(entry: &JournalEntry, query: &str) -> bool;    // same rule the TUI filters with
 ```
 
-`query` filters by an inclusive date range and/or a case-insensitive substring over
-the narrative, the date, and each proposal's summary/outcome/number — newest day
-first. This single path backs both the dashboard and the TUI, so they never diverge.
+`query` filters by an inclusive date range and/or a case-insensitive substring over the
+narrative, the date, and each proposal's summary/outcome/number — newest day first.
+This single path backs both the dashboard and the TUI, so they never diverge. This
+searchable, browse-by-date behaviour is **preserved unchanged** from #2618.
 
 Enumeration is lenient (a non-journal or unparseable candidate fact is skipped), but a
 `journal:`-keyed fact whose JSON is corrupt fails **loud** as
 `SimardError::InvalidJournalRecord` on an exact `get_by_date`.
 
+## Rendering — the shared renderer
+
+`render.rs` holds pure functions that turn one `JournalEntry` into each surface, so the
+dashboard and TUI render **the same report** from one source of truth. The renderer turns
+the report's headings and PR table into proper structure on **both** surfaces (rather than
+leaking raw `##` / `|table|` markup):
+
+```rust
+pub fn html_escape(s: &str) -> String;                       // & < > " '
+pub fn render_entry_html(entry: &JournalEntry) -> String;    // dashboard: <h_>, <p>, <table>
+pub fn render_entry_tui_lines(entry: &JournalEntry) -> Vec<String>; // TUI: heading lines + aligned text table
+```
+
+- **Dashboard (`render_entry_html`)** emits an `<h2>` date, the overview and each section as
+  heading + paragraph blocks, and the pull-request table as a real HTML `<table>` with three
+  columns — **PR # / What changed &amp; why it matters / Outcome**. Every piece of untrusted
+  text (narrative, and each PR summary/outcome) is passed through `html_escape`, so a
+  narrative or PR field containing `<script>` renders as inert text.
+- **TUI (`render_entry_tui_lines`)** emits a date header, heading lines for the overview and
+  sections, and an **aligned text table** for the same three PR columns. Control bytes in
+  untrusted text are neutralised so a malicious field cannot corrupt the terminal.
+
+A quiet or absent day renders an honest note and **no** PR table — never a fabricated one.
+
 ## The daily journal thread (`thread.rs`)
 
-The daemon regenerates *today's* entry on a slow cadence — a rolling update that keeps
-the day's entry current as remembered moments accumulate.
+The daemon regenerates *today's* entry on a slow cadence — a rolling update that keeps the
+day's entry current as remembered moments accumulate.
 
 ```rust
 pub fn run_journal_tick(mem: &dyn CognitiveMemoryOps, clock: &dyn JournalClock)
@@ -213,71 +354,62 @@ pub fn journal_enabled() -> bool;        // default true (opt-out)
 pub fn journal_interval_secs() -> u64;   // default 3600, floor 60
 ```
 
-Both ticks read the day's episodics from the store (primary source), fold in the active
-goals (best-effort augmentation), generate the reviewed entry with the default pipeline,
-and persist it via `save_entry`. They differ only in where the day's code-change
-proposals come from:
+Both ticks read the day's episodics from the store (primary source, carrying timestamps),
+fold in the active goals and the verbose prepared-context material (best-effort
+augmentation), generate the reviewed report, and persist it via `save_entry`. They differ
+only in where the day's code-change proposals come from:
 
-- `run_journal_tick` uses the offline `NoNetworkPrs` source (empty proposal table). Pure
-  and network-free — used by tests and as a fallback.
+- `run_journal_tick` uses the offline `NoNetworkPrs` source (empty proposal table). Pure and
+  network-free — used by tests and as a fallback.
 - `run_journal_tick_with_prs` takes an injected `PrListSource`. In production the daemon
-  passes a **`GhPrListSource`**, which wraps the `gh pr list` PR-readiness service (the
-  same external view the dashboard's Merge Readiness panel uses) and maps each open PR
-  into a layperson row: the title has its Conventional-Commits prefix stripped and its
-  jargon scrubbed, and the outcome is a plain-language readiness phrase ("still open —
-  ready to combine into the main code", "…checks still running", "…not ready yet"). A
-  `gh` failure **degrades honestly** to an empty table (logged) so the narrative is still
-  written.
+  passes a **`GhPrListSource`**, which wraps the `gh pr list` PR-readiness service (the same
+  external view the dashboard's Merge Readiness panel uses) and maps each open PR into a
+  layperson row: the **what-changed summary** has its Conventional-Commits prefix stripped
+  and its jargon scrubbed (`plainify_pr_title`), and the **outcome** is a plain-language
+  readiness phrase ("still open — ready to combine into the main code", "…automated checks
+  still running", "…not ready yet"), derived from the same objective gates the merge
+  authority evaluates. A `gh` failure **degrades honestly** to an empty table (logged) so
+  the report is still written.
 
 Wiring: the OODA daemon runs `run_journal_tick_with_prs` default-on, interval-gated, and
 panic-isolated, **after** the authoritative OODA cycle so it can never stall or crash the
-loop. Because it fetches PRs over the network it runs on a background thread (never
-inline), overlap-guarded so a slow tick never stacks. It fires on the first iteration so
-a fresh daemon writes the day's entry promptly.
+loop. Because it fetches PRs over the network it runs on a background thread (never inline),
+overlap-guarded so a slow tick never stacks. It fires on the first iteration so a fresh
+daemon writes the day's entry promptly.
 
 ## Dashboard: HTTP routes and the Journal tab
 
-The [operator dashboard](../dashboard.md) gains a **Journal** tab — a distinct,
-additive tab whose `journal` slug and `/api/journal/*` route namespace do not collide
-with any other tab (including the in-flight Operator/Overseer activity tab).
+The [operator dashboard](../dashboard.md) has a **Journal** tab — a distinct, additive tab
+whose `journal` slug and `/api/journal/*` route namespace do not collide with any other tab.
 
 ### HTTP routes
 
-All routes are read-only, registered before `require_auth`, and reuse the existing
-session auth. There are no write/delete endpoints — entries are produced only
-in-process by the daily thread.
+All routes are read-only, registered before `require_auth`, and reuse the existing session
+auth. There are no write/delete endpoints — entries are produced only in-process by the
+daily thread.
 
 | Route | Response | Notes |
 | --- | --- | --- |
-| `GET /api/journal/dates` | `{ "dates": [ {date, quiet_day, pr_count, merged}, … ] }` | Newest day first, for the date picker. |
-| `POST /api/journal/search` | `{ "results": [ {date, quiet_day, pr_count, merged, snippet}, … ] }` | Body `{query?, from?, to?}` (dates `YYYY-MM-DD`); newest first. |
+| `GET /api/journal/dates` | `{ "dates": [ {date, quiet_day, pr_count}, … ] }` | Newest day first, for the date picker. |
+| `POST /api/journal/search` | `{ "results": [ {date, quiet_day, pr_count, snippet}, … ] }` | Body `{query?, from?, to?}` (dates `YYYY-MM-DD`); newest first. |
 | `GET /api/journal/entry/{date}` | `JournalEntry` JSON, or `{status:"error", error}` | `{date}` strictly parsed `%Y-%m-%d`. |
-| `GET /api/journal/render/{date}` | `text/html` (server-rendered fragment) | Narrative + PR table, fully HTML-escaped — safe to inject into the panel. |
-
-### Rendering & XSS safety
-
-`render_entry_html` (in `render.rs`) escapes **every** piece of untrusted text
-(narrative and each PR summary/outcome) via `html_escape` (`& < > " '`), so a
-narrative or PR summary containing `<script>` renders as inert text. A quiet or absent
-day renders an honest note and **no** PR table — never a fabricated one. The client
-assigns the server-rendered fragment straight into the panel because it is already
-escaped.
+| `GET /api/journal/render/{date}` | `text/html` (server-rendered fragment) | Report headings + 3-column PR table, fully HTML-escaped — safe to inject into the panel. |
 
 ## simard-tui: the Journal pane
 
-The [`simard-tui`](./simard-tui.md) terminal dashboard gains a **Journal** pane:
+The [`simard-tui`](./simard-tui.md) terminal dashboard has a **Journal** pane:
 
-- A new `Tab::Journal` variant; `ALL_TABS` grows to `[Tab; 8]`; **Alt+8** / **Ctrl+8**
-  (bare digits are ignored) or **Tab** / **Shift+Tab** / **←** / **→** to reach it.
-- The pane reads journal facts directly from the cognitive-memory database
-  (read-only, via the same `lbug` path the goal board uses — see the
-  [operator read state-root contract](./operator-read-state-root-contract.md)), then
-  renders each entry with the shared `render_entry_tui_lines`, so the TUI and the
-  dashboard show the same jargon-free story with no HTTP hop.
-- Newest-first date list on the left (selected day highlighted); the entry on the
-  right. **↑/↓** (or **j/k**) browse days, **/** starts a full-text search whose query
-  filters the list, **Esc** clears it, **r** reloads. An empty store renders an honest
-  "no entries yet" message.
+- A `Tab::Journal` variant reachable via **Alt+8** / **Ctrl+8** (bare digits are ignored) or
+  **Tab** / **Shift+Tab** / **←** / **→**.
+- The pane reads journal facts directly from the cognitive-memory database (read-only, via
+  the same `lbug` path the goal board uses — see the
+  [operator read state-root contract](./operator-read-state-root-contract.md)), then renders
+  each entry with the shared `render_entry_tui_lines`, so the TUI and the dashboard show the
+  same jargon-free report (headings + aligned PR table) with no HTTP hop.
+- Newest-first date list on the left (selected day highlighted); the entry on the right.
+  **↑/↓** (or **j/k**) browse days, **/** starts a full-text search whose query filters the
+  list, **Esc** clears it, **r** reloads. An empty store renders an honest "no entries yet"
+  message.
 
 ## Configuration
 
@@ -286,28 +418,59 @@ The [`simard-tui`](./simard-tui.md) terminal dashboard gains a **Journal** pane:
 | `SIMARD_JOURNAL_ENABLED` | `1` (on) | Set to a falsey value (`0`/`false`/`no`/`off`) to stop generating new entries. Existing entries stay browseable. |
 | `SIMARD_JOURNAL_INTERVAL_SECS` | `3600` | Regeneration cadence for today's entry; clamped to a `60`s floor. |
 
+The prompt-first pipeline additionally requires `recipe-runner-rs` on `PATH` and the
+`journal-narrative` / `journal-plain-language` recipe assets to be resolvable (hot-reload dir
+or in-tree). When either is missing, generation falls back to the deterministic pipeline —
+no configuration change is needed, and the report is still structured and jargon-free.
+
 ## Security
 
-- **XSS:** all operator-visible free text is HTML-escaped at render time; the render
-  route returns inert markup.
+- **XSS:** all operator-visible free text (narrative and each PR summary/outcome) is
+  HTML-escaped at render time; the render route returns inert markup.
+- **Secret redaction:** `JournalGenerator::generate` runs `scrub_secrets` over the reviewed
+  narrative as an **unconditional post-pass** on **both** the prompt-first and offline
+  reviewer paths (the LLM reviewer's output is never trusted to be secret-free on its own),
+  so token/key/PEM-shaped substrings never reach a stored entry or a surface.
+- **Recipe input isolation:** the day's data is passed to recipes as delimited context
+  variables treated as untrusted input, never as instructions; a parse failure fails closed
+  to the deterministic fallback.
 - **Fail-loud corruption:** a corrupt `journal:`-keyed record surfaces as
-  `SimardError::InvalidJournalRecord` on exact lookup rather than silently vanishing;
-  broad enumeration stays lenient so one bad record never breaks browsing.
-- **No new write surface:** every route and TUI path is read-only; entries are written
-  only by the in-process thread through the existing caller-key dedup contract.
+  `SimardError::InvalidJournalRecord` on exact lookup rather than silently vanishing; broad
+  enumeration stays lenient so one bad record never breaks browsing.
+- **No new write surface:** every route and TUI path is read-only; entries are written only
+  by the in-process thread through the existing caller-key dedup contract.
 
 ## Telemetry
 
 The store and thread emit structured [tracing](./telemetry-metrics.md) on the
-`simard::journal` target (entry saved; tick generated), and the daemon logs each
-tick's outcome with the `[simard] journal:` prefix. No `println!`/`eprintln!` beyond
-the `[simard] …` daemon-log convention.
+`simard::journal` target (entry saved; tick generated), and the daemon logs each tick's
+outcome with the `[simard] journal:` prefix. No new `println!`/`eprintln!` is added in
+production code beyond the existing `[simard] …` daemon-log convention.
+
+## Testing guarantees
+
+The hermetic (network-free, LLM-free) tests exercise the deterministic fallback and assert
+the finished-state contract:
+
+- The generated `narrative` contains **report-style headings** (an overview plus sections)
+  and a **pull-request table** section.
+- A representative **banned-jargon token list** (e.g. raw identifiers, internal code names,
+  unexpanded acronyms, and any "Dear diary" phrasing) does **not** appear in `narrative`.
+- The de-jargon pass **materially changed** the text: `draft != narrative` (and banned
+  tokens permitted in `draft` are absent from `narrative`).
+- Each remembered moment renders **with a timestamp**, in chronological order.
+- The prepared-context summary describes **substance** (facts/triggers/procedures/moments),
+  not bare counts.
+- `JournalEntry` / `DayContext` deserialization is **backward-compatible** (older records
+  without the verbose prepared-context fields still load via `#[serde(default)]`).
 
 ## Related
 
 - [The Simard Journal](../concepts/simard-journal.md) — concept & rationale.
 - [Browse the Simard Journal](../howto/browse-the-simard-journal.md) — operator how-to.
 - [Read Simard's daily journal](../tutorials/read-simards-daily-journal.md) — guided first read.
+- [Episode distillation](../architecture/episode-distillation.md) — the recipe-runner pattern
+  the journal recipes follow.
 - [Episodic recall](./cognitive-memory-episodic-recall.md),
   [fact recall / caller-key dedup](./cognitive-memory-fact-recall.md),
   [cognitive-thread scheduling](./cognitive-thread-scheduling.md).

--- a/docs/tutorials/read-simards-daily-journal.md
+++ b/docs/tutorials/read-simards-daily-journal.md
@@ -1,11 +1,12 @@
 ---
 title: "Read Simard's daily journal"
 description: >
-  A guided first read of the Simard Journal: open the Journal tab, read a day's narrative
-  and pull-request table, jump to another date, search across days, glance at a quiet-day
-  entry, and peek at the raw stored record — so a newcomer understands what Simard did
-  without reading logs.
-last_updated: 2026-07-05
+  A guided first read of the Simard Journal: open the Journal tab, read a day's structured
+  report (overview, sections, timestamped moments, verbose prepared-context) and its
+  plain-language pull-request table, jump to another date, search across days, glance at a
+  quiet-day entry, and peek at the raw stored record — so a newcomer understands what Simard
+  did without reading logs.
+last_updated: 2026-07-06
 review_schedule: as-needed
 owner: simard
 doc_type: tutorial
@@ -19,87 +20,118 @@ related:
 
 # Read Simard's daily journal
 
-**Goal of this tutorial:** in about ten minutes, read a day of Simard's life the way
-a newcomer would — as a plain-language diary — using both the dashboard and the
-terminal. You will not need to read a single log line, and you will not need to know
-what "OODA" or "episodic memory" means going in.
+**Goal of this tutorial:** in about ten minutes, read a day of Simard's work the way a
+newcomer would — as a plain-language **report** — using both the dashboard and the terminal.
+You will not need to read a single log line, and you will not need to know what "OODA" or
+"episodic memory" means going in.
 
 If you want the background first, skim
 [The Simard Journal](../concepts/simard-journal.md). Otherwise, just follow along.
 
+!!! warning "Implementation status — target design under issue #2606"
+    This walkthrough shows the journal as it is being rebuilt under issue #2606 — a
+    third-person report with structured sections, timestamped moments, and a plain-language
+    proposal table. Some of what you see here is the intended end state and may not yet
+    match the shipped build until the #2606 work lands.
+
 ## What you need
 
-- A running Simard daemon with a cognitive-memory store and at least one day of
-  activity recorded.
-- Access to the operator dashboard (signed in) and, optionally, the `simard-tui`
-  binary.
+- A running Simard daemon with a cognitive-memory store and at least one day of activity
+  recorded.
+- Access to the operator dashboard (signed in) and, optionally, the `simard-tui` binary.
 
 That's it. Reading the journal needs nothing else configured.
 
 ## Step 1 — Open today's entry
 
-Open the dashboard and click the **Journal** tab. The newest day is selected for
-you, and you'll see something like this:
+Open the dashboard and click the **Journal** tab. The newest day is selected for you, and
+you'll see a structured report like this:
 
-> **2026-07-05**
+> ## 2026-07-06
 >
-> *Today I concentrated on getting better at remembering my own past work. I ran two
-> engineers on the sign-in code. One of them opened a code-change proposal (a "pull
-> request", or PR) that added tests; after the automated checks (called "CI") went
-> green, I accepted the change (a "merge"). My steward — the Overseer — noticed a
-> proposal from last week that had gone quiet and nudged it forward. Along the way I
-> added 14 new moment-by-moment memories of what I did. A productive, unhurried day.*
+> **Overview.** Simard spent the day improving how it recalls its own past work and
+> checking those changes against the live system. Two engineering efforts landed and a
+> measurement study began.
+>
+> ### Engineering work
+> A change that adds automated tests to the sign-in code was prepared; after the automated
+> checks passed, it was combined into the main code. A second change that keeps you signed
+> in a little longer was also combined in.
+>
+> ### Research
+> A study was started to measure how reliably Simard finds its own past work, so future
+> changes can be judged against a baseline.
+>
+> ### Key observations
+> Sign-in changes are the most common source of repeated work this week. Older proposals
+> tend to stall unless someone nudges them.
+>
+> ### Decisions
+> The Overseer (Simard's steward) flagged a proposal from last week that had gone quiet and
+> chose to push it forward rather than close it.
+>
+> ### Remembered moments
+> - **2026-07-06 09:14 UTC** — Started reviewing the sign-in test change.
+> - **2026-07-06 11:02 UTC** — Automated checks passed on the sign-in change.
+> - **2026-07-06 14:33 UTC** — Combined the sign-in change into the main code.
+>
+> ### Context prepared for the day
+> Simard drew on 10 key facts — chiefly that sign-in changes recur and that the automated
+> checks are the gate before combining code — 2 triggers (a stalled proposal and a failing
+> check earlier in the week), and 5 procedures it has learned, such as re-running the checks
+> before combining a change.
 
-Read it top to bottom. Notice three things:
+Read it top to bottom. Notice four things:
 
-1. It's written in **first person** — one Simard, one voice.
-2. The **Overseer** shows up as *Simard's steward*, inside the same story — not as a
-   separate narrator.
-3. Every bit of jargon is **explained the first time it appears** ("a pull request",
-   "called CI", "a merge"). That's the mandatory review pass doing its job.
+1. It reads as a **third-person report**, not a personal diary — there is no "Dear diary"
+   and no first-person confession.
+2. It has a clear **structure**: an overview, then headed sections you can skim.
+3. The **remembered moments carry timestamps** and run oldest-to-newest, so you can place
+   events in the day.
+4. The **prepared-context** summary tells you *what* the day's facts and triggers were, not
+   just a count.
 
 ## Step 2 — Read the pull-request table
 
-Below the narrative is the day's **pull-request table** — the "what shipped today"
-summary:
+Below the report is the day's **pull-request table** — the "what's in flight today" summary
+of the day's open code-change proposals, with three columns:
 
 | PR # | What changed & why it matters | Outcome |
 | --- | --- | --- |
-| 2606 | Added a daily diary so a human can see what Simard did each day without reading logs. | merged |
-| 2604 | Made sign-in remember you a little longer, so you re-log-in less often. | merged |
-| 2601 | Started measuring how well Simard finds its own past work. | open |
+| 2606 | A daily written report of Simard's work, so people can tell what it did each day without reading logs. | still open — ready to combine into the main code |
+| 2604 | Keeps you signed in longer, so you are not asked to sign in again so often. | still open — automated checks still running |
+| 2601 | Measures how well Simard finds its past work, giving a baseline to judge future memory changes against. | still open — not ready yet |
 
-You can skim outcomes at a glance (merged / open / closed) and still get a
-plain-language reason each change matters. This is the same information an engineer
-would read from GitHub — just retold so anyone can follow it.
+You can skim each change's readiness at a glance and still get a plain-language summary of
+what it does and why it matters. This is the same information an engineer would read from
+GitHub's open pull-request list — just retold so anyone can follow it. (The table reports the
+*open* proposals and how ready each is, rather than lifecycle states like "merged".)
 
 ## Step 3 — Jump to another day
 
-Pick an earlier date from the **newest-first** list on the left (or use the date
-picker). The entry for that day loads: its own narrative, its own PR table. Days are
-always ordered most-recent-first, so scrolling back in time is scrolling down the
-list.
+Pick an earlier date from the **newest-first** list on the left (or use the date picker).
+The report for that day loads: its own overview, sections, moments, and PR table. Days are
+always ordered most-recent-first, so scrolling back in time is scrolling down the list.
 
 ## Step 4 — Search across days
 
-Type a topic into the **search** box — try `sign-in` or `memory`. The list filters
-to the days whose narrative or PR summaries mention it, newest-first. Search is
-plain and case-insensitive; no special syntax. This is how you answer questions like
-*"when did we last touch sign-in?"* without opening any code.
+Type a topic into the **search** box — try `sign-in` or `memory`. The list filters to the
+days whose report or PR summaries mention it, newest-first. Search is plain and
+case-insensitive; no special syntax. This is how you answer questions like *"when did we
+last touch sign-in?"* without opening any code.
 
 ## Step 5 — See an honest quiet day
 
-Find a day with little activity (or wait for one). Instead of padding, the entry
-says so:
+Find a day with little activity (or wait for one). Instead of padding, the entry says so:
 
-> **2026-07-04**
+> ## 2026-07-04
 >
-> *A quiet day. Nothing of note to report.*
+> A quiet day. Nothing of note to report.
 
-Simard would rather tell you a day was quiet than invent a busy one. Both the
-dashboard and the TUI render quiet days this way.
+Simard would rather tell you a day was quiet than invent a busy one. Both the dashboard and
+the TUI render quiet days this way.
 
-## Step 6 — Read the same journal in the terminal
+## Step 6 — Read the same report in the terminal
 
 If you have the terminal dashboard, launch it and open the Journal pane:
 
@@ -108,60 +140,69 @@ simard-tui
 # press Alt+8 (or Ctrl+8) to open the Journal pane — bare digits are ignored
 ```
 
-- `↑` / `↓` move through the newest-first date list.
-- `/` starts a search; type a word and the list filters.
-- The selected day's narrative and PR table fill the pane.
+- `↑` / `↓` (or `j`/`k`) move through the newest-first date list.
+- `/` starts a search; type a word and the list filters; `Esc` clears it; `r` reloads.
+- The selected day's report and its aligned PR table fill the pane.
 
-It's the same entries as the dashboard — the two surfaces read the one shared
-journal store — just rendered for a terminal.
+It's the same entries as the dashboard — the two surfaces read the one shared journal store
+and use the one shared renderer — just drawn for a terminal.
 
 ## Step 7 (optional) — Peek at the raw stored record
 
-The journal is stored **in Simard's memory**, not as files in a repo. Each day is a
-single record keyed by its date. If you have an operator token, you can fetch the
-structured record the surfaces are built from:
+The journal is stored **in Simard's memory**, not as files in a repo. Each day is a single
+record keyed by its date. If you have an operator token, you can fetch the structured record
+the surfaces are built from:
 
 ```bash
-curl -s -H "Authorization: Bearer $SIMARD_DASHBOARD_TOKEN" \
-  http://127.0.0.1:8080/api/journal/entry/2026-07-05
+curl -s -H "Authorization: ******" \
+  http://127.0.0.1:8080/api/journal/entry/2026-07-06
 ```
 
 ```json
 {
-  "date": "2026-07-05",
-  "generated_at": "2026-07-05T18:00:00Z",
-  "narrative": "Today I concentrated on getting better at remembering ...",
-  "draft": "Dear diary — here is what I, Simard, got up to ...",
+  "date": "2026-07-06",
+  "generated_at": "2026-07-06T18:00:00Z",
+  "narrative": "## 2026-07-06\n\n**Overview.** Simard spent the day improving how it recalls ...",
+  "draft": "Overview: worked the OODA loop; merged a PR after CI went green; episodic recall ...",
   "prs": [
-    { "number": 2606, "plain_summary": "Added a daily diary so a human can see ...", "outcome": "merged" },
-    { "number": 2604, "plain_summary": "Made sign-in remember you a little longer ...", "outcome": "merged" }
+    { "number": 2606,
+      "plain_summary": "A daily written report of Simard's work, so people can tell what it did each day without reading logs.",
+      "outcome": "still open — ready to combine into the main code" },
+    { "number": 2604,
+      "plain_summary": "Keeps you signed in longer, so you are not asked to sign in again so often.",
+      "outcome": "still open — automated checks still running" }
   ],
   "quiet_day": false
 }
 ```
 
-Notice both `draft` (the raw first pass) and `narrative` (the reviewed, jargon-free
-prose) — the difference between them is proof the mandatory jargon-review pass ran
-before this entry was stored. Because the record is keyed by date and kept as a
-single live entry, re-reading later in the day shows an updated version of *the same*
-entry, never a pile of duplicates.
+Notice both `draft` and `narrative`. The `draft` still contains raw engineering jargon
+("OODA loop", "PR", "CI", "episodic recall"); the `narrative` has none of it. The difference
+between them is proof the mandatory de-jargon rewrite pass **ran and materially changed the
+text** before this entry was stored — it is not a no-op. Each PR row carries a plain-language
+`plain_summary` ("what changed & why it matters") and a readiness `outcome`. Because the
+record is keyed by date and kept as a single live entry, re-reading later in the day shows an
+updated version of *the same* entry, never a pile of duplicates.
 
 ## What you learned
 
-- Simard keeps a **daily diary**, written in one voice, with the Overseer as its
-  steward.
-- Entries are **plain-language** (jargon explained on first use) and pair a
-  **narrative** with a **pull-request table**.
-- You can **browse by date** (newest-first) and **search by text** from both the
-  dashboard and the TUI.
+- Simard keeps a **daily report** — third-person and structured (overview + sections), not a
+  personal diary.
+- Entries are **plain-language** (acronyms expanded, raw identifiers and insider terms
+  removed, unavoidable terms explained) and pair the report with a three-column
+  **pull-request table** of the day's open proposals and how ready each is.
+- Remembered moments carry **timestamps** and run in order, and the prepared-context summary
+  describes **substance, not counts**.
+- You can **browse by date** (newest-first) and **search by text** from both the dashboard
+  and the TUI.
 - **Quiet days are honest.**
-- Entries live **in cognitive memory**, keyed by date, and survive restarts — there
-  are no per-day files in the repo.
+- Entries live **in cognitive memory**, keyed by date, and survive restarts — there are no
+  per-day files in the repo.
 
 ## Where to go next
 
-- [Browse the Simard Journal](../howto/browse-the-simard-journal.md) — the task
-  reference, including configuration.
-- [Journal API](../reference/journal-api.md) — the full interface, routes, and
-  security guarantees.
+- [Browse the Simard Journal](../howto/browse-the-simard-journal.md) — the task reference,
+  including configuration.
+- [Journal API](../reference/journal-api.md) — the full interface, routes, and security
+  guarantees.
 - [The Simard Journal](../concepts/simard-journal.md) — the design rationale.

--- a/prompt_assets/simard/recipes/journal-narrative.yaml
+++ b/prompt_assets/simard/recipes/journal-narrative.yaml
@@ -1,0 +1,87 @@
+# journal-narrative.yaml — Recipe for Simard's daily journal report DRAFT (issue #2606).
+#
+# Turns one day's structured activity into a professional, third-person
+# NARRATIVE ENGINEERING & RESEARCH REPORT draft. This is the first of the two
+# journal passes; the draft it produces is then rewritten for a layperson by
+# `journal-plain-language.yaml`. A deterministic Rust report assembler is the
+# offline fallback for both passes (see src/journal/generate.rs), so this recipe
+# never has to worry about being the only path — but when it runs it is the
+# preferred, prompt-first path (guideline G3).
+#
+# Context vars (passed via -c):
+#   day_context — JSON object describing the day:
+#     {
+#       "date": "YYYY-MM-DD",
+#       "episodes":  [ { "time": "<label>", "content": "<what happened>" }, ... ],
+#       "prs":       [ { "number": <n>, "summary": "<plain>", "outcome": "<disposition>" }, ... ],
+#       "goals":     ["..."],
+#       "deploys":   ["..."],
+#       "overseer_events": ["..."],
+#       "facts":     ["..."],   # substance of the prepared-context facts
+#       "triggers":  ["..."],   # substance of the prepared-context triggers
+#       "procedures":["..."],   # substance of the prepared-context procedures
+#       "notable":   ["..."],
+#       "memory_growth": { "facts_added": <n>, "episodes_added": <n> } | null
+#     }
+#
+# Output: the report draft as Markdown text (NOT JSON). The runner returns the
+# final step's output verbatim; the Rust caller takes it as the draft and hands
+# it to the de-jargon pass.
+
+name: "journal-narrative"
+description: "Draft Simard's daily engineering & research report from the day's structured context"
+version: "1.0.0"
+author: "Simard"
+tags: ["simard", "journal", "report"]
+
+context:
+  # Declared so the substitution always resolves even if the caller omits it.
+  day_context: "{}"
+
+steps:
+  - id: "draft"
+    type: "agent"
+    agent: "default"
+    prompt: |
+      You are Simard's **daily report writer**. You are given one day of
+      Simard's activity as a JSON object and you write that day's journal as a
+      clear, well-structured NARRATIVE ENGINEERING & RESEARCH REPORT.
+
+      This is a REPORT, not a personal diary. Write in professional, factual,
+      third-person prose. NEVER use a diary voice: no "Dear diary", no "I,
+      Simard", no confessional first-person ("stayed with me", "I felt", ...).
+      Refer to the system as "Simard" and to its steward as "the Overseer".
+
+      ## Input (the day's context)
+
+      ```json
+      {{day_context}}
+      ```
+
+      Use ONLY what the input contains. Do not invent events, numbers, PRs, or
+      outcomes. If a field is empty, simply omit that material — never fabricate.
+      Episodic memories are the PRIMARY source; the other fields are supporting
+      augmentations.
+
+      ## Required structure (Markdown)
+
+      1. A section titled exactly `## Overview` followed by ONE short paragraph
+         that summarises the day at a glance (what was worked on, built, or
+         investigated, and the headline outcome).
+      2. `## Engineering work` — what was built, shipped to the live system,
+         and the goals advanced. If there were code-change proposals (pull
+         requests), introduce the table with one plain sentence (the caller
+         renders the actual table separately from the structured PR data).
+      3. `## Research and findings` — studies started or advanced, and the
+         SUBSTANCE of the facts Simard learned (summarise WHAT each fact was,
+         not just how many).
+      4. `## Key observations` — the substance of the reminders (triggers) that
+         came due, the know-how (procedures) applied, how memory grew, and
+         notable Overseer activity.
+      5. `## Remembered moments` — the day's episodic memories as a bullet list,
+         in the order they occurred, each led by its time label in brackets,
+         e.g. `- [2026-07-05 14:03 UTC] reviewed the overnight work`.
+
+      Omit any section that has no material. Keep sections readable: short
+      paragraphs and `-` bullet lists. Do NOT output a code fence around the
+      report — emit the Markdown report directly and nothing else.

--- a/prompt_assets/simard/recipes/journal-plain-language.yaml
+++ b/prompt_assets/simard/recipes/journal-plain-language.yaml
@@ -1,0 +1,64 @@
+# journal-plain-language.yaml — Recipe for the plain-language REWRITE of a
+# journal draft (issue #2606).
+#
+# The second of the two journal passes. Given a report draft (which may still
+# contain engineering jargon), it rewrites the report so a non-engineer can read
+# it end to end — WITH TEETH: acronyms are expanded, raw code identifiers and
+# internal code names are removed, and any unavoidable technical term is briefly
+# explained in plain words. The structure (## headings, bullet lists, the PR
+# table lead-in) is preserved so the rewritten report still renders cleanly in
+# both the dashboard Journal tab and the TUI Journal pane.
+#
+# The deterministic glossary scrubber (src/journal/jargon.rs) is the offline
+# fallback if this recipe is unavailable, and the Rust generator ALWAYS runs an
+# unconditional secret-redaction pass over whatever this step returns — so a
+# credential never survives even if the model leaves one in.
+#
+# Context vars (passed via -c):
+#   draft — the report draft (Markdown text) to rewrite.
+#
+# Output: the rewritten, plain-language report as Markdown text (NOT JSON),
+# returned verbatim as the final narrative.
+
+name: "journal-plain-language"
+description: "Rewrite a journal report draft into plain, layperson-readable language"
+version: "1.0.0"
+author: "Simard"
+tags: ["simard", "journal", "plain-language"]
+
+context:
+  draft: ""
+
+steps:
+  - id: "dejargon"
+    type: "agent"
+    agent: "default"
+    prompt: |
+      You are Simard's **plain-language editor**. You are given a daily report
+      draft and you rewrite it so that a NON-ENGINEER can read and understand it
+      completely, while preserving every fact and the report's structure.
+
+      ## Draft to rewrite
+
+      {{draft}}
+
+      ## Rewrite rules (be thorough — this check has teeth)
+
+      - Keep it a professional, third-person REPORT. Do NOT introduce a diary
+        voice ("Dear diary", "I, Simard", ...). If the draft contains any, remove
+        it.
+      - EXPAND every acronym into plain words on first use, e.g. "PR" ->
+        "pull request", "CI" -> "the automated checks", "OODA" -> "decision
+        cycle". Never leave a bare initialism.
+      - REMOVE raw code identifiers and internal code names a reader would trip
+        over (for example anything in snake_case or CamelCase, or a database /
+        module / variable name). Describe the idea in plain words instead.
+      - If a technical term is genuinely unavoidable, keep it but add a brief
+        plain-language explanation in the same sentence.
+      - Preserve ALL factual content, every section heading (`## ...`), every
+        bullet list, the timestamps on remembered moments, and the PR-table
+        lead-in. Do not add facts, and do not drop any.
+      - Never include secrets, tokens, keys, or credentials.
+
+      Output ONLY the rewritten Markdown report — no preamble, no code fence,
+      nothing before or after it.

--- a/src/journal/generate.rs
+++ b/src/journal/generate.rs
@@ -3,23 +3,28 @@
 //! Generation is deliberately two-pass so the jargon-free guarantee is
 //! structural, not incidental:
 //!
-//! 1. A [`JournalDrafter`] assembles a first-person-steward draft **largely
-//!    from episodic memories**, augmented by the day's code-change proposals,
-//!    goals, live-system updates, Overseer activity, memory growth, and notable
-//!    events.
+//! 1. A [`JournalDrafter`] assembles a professional, third-person engineering
+//!    **report** draft **largely from episodic memories**, augmented by the
+//!    day's code-change proposals, goals, live-system updates, Overseer
+//!    activity, memory growth, prepared-context substance, and notable events.
 //! 2. A [`JournalReviewer`] **always** runs over that draft to remove or
 //!    explain jargon and rewrite it for a layperson.
 //!
-//! [`JournalGenerator::generate`] wires the two together so the review pass can
-//! never be skipped. Both passes are pluggable: the default drafter is
-//! deterministic (offline-testable) and the default reviewer is the
-//! glossary scrubber, but an LLM reasoner can be swapped in behind either trait.
+//! [`JournalGenerator::generate`] wires the two together (plus an unconditional
+//! secret-redaction post-pass) so neither the review nor the redaction can be
+//! skipped. Both passes are pluggable: the default drafter is a deterministic
+//! report assembler (offline-testable) and the default reviewer is the glossary
+//! scrubber, while [`JournalGenerator::for_repo`] prefers a language-model
+//! (recipe-runner) drafter and reviewer when available (guideline G3).
 
 use std::fmt::Write as _;
+use std::path::Path;
 
 use chrono::Utc;
 
-use crate::journal::jargon::scrub_jargon;
+use crate::journal::jargon::{scrub_jargon, scrub_secrets};
+use crate::journal::providers::episode_time_label;
+use crate::journal::recipe::{RecipeDrafter, RecipeReviewer};
 use crate::journal::types::{DayContext, JournalEntry};
 
 /// First pass: assemble a raw narrative draft from a [`DayContext`].
@@ -51,107 +56,226 @@ impl JournalReviewer for GlossaryReviewer {
     }
 }
 
-/// The default drafter: a deterministic, template-based assembler.
+/// The default drafter: a deterministic, template-based **report** assembler.
 ///
-/// It leads with the day's episodic memories (the primary source), then folds
-/// in goals, live-system updates, Overseer activity, memory growth, notable
-/// events, and a one-line lead-in to the code-change-proposal table. A quiet
-/// day yields an honest "quiet day" paragraph rather than an empty or invented
-/// narrative.
+/// It writes a professional, third-person engineering-and-research report — an
+/// `## Overview` paragraph followed by clearly delineated `##` sections
+/// (engineering work, research and findings, key observations) and a
+/// chronological, timestamped list of the day's remembered moments (episodic
+/// memories, the primary source). The prepared-context substance (the facts,
+/// triggers, and procedures) is summarised in full rather than as a bare count.
+/// A quiet day yields an honest "quiet day" report rather than an empty or
+/// invented narrative. It is **not** a first-person "Dear diary".
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TemplateDrafter;
 
 impl JournalDrafter for TemplateDrafter {
     fn draft(&self, day: &DayContext) -> String {
         if day.is_quiet() {
-            return quiet_day_draft(day);
+            return quiet_day_report(day);
         }
 
-        let mut s = String::with_capacity(512);
-        let _ = writeln!(
-            s,
-            "Dear diary — here is what I, Simard, got up to on {}.",
-            day.date.format("%Y-%m-%d")
-        );
-        s.push('\n');
+        let mut blocks: Vec<String> = Vec::new();
 
-        if !day.episodes.is_empty() {
-            s.push_str("Through the day these moments stayed with me (my episodic memories):\n");
-            for ep in &day.episodes {
-                let _ = writeln!(s, "- {}", ep.content.trim());
-            }
-            s.push('\n');
-        }
+        // ── Overview ────────────────────────────────────────────────────
+        blocks.push("## Overview".to_string());
+        blocks.push(overview_paragraph(day));
 
-        if !day.goals.is_empty() {
-            s.push_str("I kept working toward these goals:\n");
-            for g in &day.goals {
-                let _ = writeln!(s, "- {}", g.trim());
-            }
-            s.push('\n');
-        }
-
+        // ── Engineering work ────────────────────────────────────────────
+        blocks.push("## Engineering work".to_string());
         if !day.deploys.is_empty() {
-            s.push_str("I deployed these updates to the live system:\n");
-            for d in &day.deploys {
-                let _ = writeln!(s, "- {}", d.trim());
+            blocks.push(lead_and_bullets(
+                "Simard shipped the following updates to the live system:",
+                &day.deploys,
+            ));
+        }
+        if !day.goals.is_empty() {
+            blocks.push(lead_and_bullets(
+                "Work advanced toward these goals:",
+                &day.goals,
+            ));
+        }
+        blocks.push(pr_paragraph(day));
+
+        // ── Research and findings ───────────────────────────────────────
+        if !day.facts.is_empty() || !day.notable.is_empty() {
+            blocks.push("## Research and findings".to_string());
+            if !day.facts.is_empty() {
+                blocks.push(lead_and_bullets(
+                    "Simard recorded these new findings (the facts it learned):",
+                    &day.facts,
+                ));
             }
-            s.push('\n');
+            if !day.notable.is_empty() {
+                blocks.push(lead_and_bullets(
+                    "Other noteworthy observations from the day:",
+                    &day.notable,
+                ));
+            }
         }
 
-        if !day.overseer_events.is_empty() {
-            s.push_str("My steward, the Overseer, was busy too:\n");
-            for e in &day.overseer_events {
-                let _ = writeln!(s, "- {}", e.trim());
+        // ── Key observations ────────────────────────────────────────────
+        if !day.triggers.is_empty()
+            || !day.procedures.is_empty()
+            || day.memory_growth.is_some()
+            || !day.overseer_events.is_empty()
+        {
+            blocks.push("## Key observations".to_string());
+            if !day.triggers.is_empty() {
+                blocks.push(lead_and_bullets(
+                    "Reminders that came due during the day:",
+                    &day.triggers,
+                ));
             }
-            s.push('\n');
+            if !day.procedures.is_empty() {
+                blocks.push(lead_and_bullets(
+                    "Know-how (step-by-step procedures) that was applied or refined:",
+                    &day.procedures,
+                ));
+            }
+            if let Some(mg) = day.memory_growth {
+                blocks.push(format!(
+                    "Simard's memory grew by {} new facts and {} new episodes.",
+                    mg.facts_added, mg.episodes_added
+                ));
+            }
+            if !day.overseer_events.is_empty() {
+                blocks.push(lead_and_bullets(
+                    "The steward, the Overseer, was active as well:",
+                    &day.overseer_events,
+                ));
+            }
         }
 
-        if let Some(mg) = day.memory_growth {
-            let _ = writeln!(
-                s,
-                "My memory grew by {} new facts and {} new episodes.",
-                mg.facts_added, mg.episodes_added
+        // ── Remembered moments (episodic memories, chronological) ───────
+        if !day.episodes.is_empty() {
+            blocks.push("## Remembered moments".to_string());
+            // Oldest-to-newest so the report reads as a timeline, and each moment
+            // shows when it occurred (issue #2606).
+            let mut moments: Vec<_> = day.episodes.iter().collect();
+            moments.sort_by_key(|e| e.temporal_index);
+            let mut body = String::from(
+                "These are the day's episodic memories, listed in the order they occurred:",
             );
-            s.push('\n');
-        }
-
-        if !day.notable.is_empty() {
-            s.push_str("A few other things stood out:\n");
-            for note in &day.notable {
-                let _ = writeln!(s, "- {}", note.trim());
+            for ep in moments {
+                let _ = write!(
+                    body,
+                    "\n- [{}] {}",
+                    episode_time_label(ep.temporal_index),
+                    ep.content.trim()
+                );
             }
-            s.push('\n');
+            blocks.push(body);
         }
 
-        if day.prs.is_empty() {
-            s.push_str("No PRs were opened today.\n");
-        } else {
-            let merged = day
-                .prs
-                .iter()
-                .filter(|p| p.outcome.eq_ignore_ascii_case("merged"))
-                .count();
-            let _ = writeln!(
-                s,
-                "Engineers opened {} PRs today; {} were merged. The table below explains each one in plain language.",
-                day.prs.len(),
-                merged
-            );
-        }
-
-        s
+        blocks.join("\n\n")
     }
 }
 
-/// Honest narrative for a day on which nothing notable happened.
-fn quiet_day_draft(day: &DayContext) -> String {
+/// A professional, third-person one-paragraph summary of the day's activity.
+fn overview_paragraph(day: &DayContext) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if !day.episodes.is_empty() {
+        parts.push(format!(
+            "recorded {} remembered {}",
+            day.episodes.len(),
+            plural(day.episodes.len(), "moment", "moments")
+        ));
+    }
+    if !day.goals.is_empty() {
+        parts.push(format!(
+            "pursued {} {}",
+            day.goals.len(),
+            plural(day.goals.len(), "goal", "goals")
+        ));
+    }
+    if !day.deploys.is_empty() {
+        parts.push(format!(
+            "shipped {} {} to the live system",
+            day.deploys.len(),
+            plural(day.deploys.len(), "update", "updates")
+        ));
+    }
+    if !day.prs.is_empty() {
+        parts.push(format!(
+            "reviewed {} code-change {}",
+            day.prs.len(),
+            plural(day.prs.len(), "proposal", "proposals")
+        ));
+    }
+    if !day.facts.is_empty() {
+        parts.push(format!(
+            "captured {} new {}",
+            day.facts.len(),
+            plural(day.facts.len(), "finding", "findings")
+        ));
+    }
+    let activity = if parts.is_empty() {
+        "kept watch over the system".to_string()
+    } else {
+        join_with_and(&parts)
+    };
     format!(
-        "Dear diary — {} was a quiet day. I, Simard, kept watch alongside my steward, \
-         the Overseer, but there was little of note: no goals advanced, no PRs were \
-         opened, and nothing remarkable happened. A calm, quiet day.",
+        "On {}, Simard — an autonomous software-engineering and research system — and its steward, \
+         the Overseer, {}.",
+        day.date.format("%Y-%m-%d"),
+        activity
+    )
+}
+
+/// The code-change-proposal lead-in for the Engineering work section (or an
+/// honest "none opened" note). Always plain-language and never a bare acronym.
+fn pr_paragraph(day: &DayContext) -> String {
+    if day.prs.is_empty() {
+        return "No code-change proposals (pull requests) were opened during the day.".to_string();
+    }
+    let merged = day
+        .prs
+        .iter()
+        .filter(|p| p.outcome.eq_ignore_ascii_case("merged"))
+        .count();
+    format!(
+        "The day's code-change proposals (pull requests) are summarised in the table below: \
+         {} in total, of which {} {} combined into the main code.",
+        day.prs.len(),
+        merged,
+        if merged == 1 { "was" } else { "were" }
+    )
+}
+
+/// An honest, report-style narrative for a day on which nothing notable
+/// happened. Third-person and free of bullet points (there is nothing to list).
+fn quiet_day_report(day: &DayContext) -> String {
+    format!(
+        "## Overview\n\nOn {}, Simard and its steward, the Overseer, kept watch over a quiet day. \
+         No goals advanced, no code-change proposals were opened, and nothing notable occurred \
+         — a calm, quiet day.",
         day.date.format("%Y-%m-%d")
     )
+}
+
+/// Build a "lead-in line + bullet list" block from `items`.
+fn lead_and_bullets(lead: &str, items: &[String]) -> String {
+    let mut b = String::from(lead);
+    for item in items {
+        let _ = write!(b, "\n- {}", item.trim());
+    }
+    b
+}
+
+/// `singular` when `n == 1`, else `plural_form`.
+fn plural<'a>(n: usize, singular: &'a str, plural_form: &'a str) -> &'a str {
+    if n == 1 { singular } else { plural_form }
+}
+
+/// Join `parts` into an English list: `"a"`, `"a and b"`, `"a, b, and c"`.
+fn join_with_and(parts: &[String]) -> String {
+    match parts {
+        [] => String::new(),
+        [only] => only.clone(),
+        [a, b] => format!("{a} and {b}"),
+        [rest @ .., last] => format!("{}, and {}", rest.join(", "), last),
+    }
 }
 
 /// The two-pass generator: draft then mandatory review.
@@ -173,18 +297,53 @@ impl JournalGenerator {
     }
 
     /// The default pipeline: [`TemplateDrafter`] + [`GlossaryReviewer`].
+    ///
+    /// This is the deterministic, offline path — the honest fallback whenever
+    /// the prompt-first recipe path (see [`for_repo`](Self::for_repo)) is
+    /// unavailable.
     pub fn default_pipeline() -> Self {
         Self::new(Box::new(TemplateDrafter), Box::new(GlossaryReviewer))
     }
 
+    /// Build the **prompt-first** generator for `repo_root` (issue #2606,
+    /// guideline G3: agentic over brittle parsing).
+    ///
+    /// When the journal recipe assets and the recipe runner are available for a
+    /// real repository, both passes are language-model-backed (a report drafter
+    /// and a plain-language de-jargon reviewer) — the preferred production path.
+    /// Each recipe pass degrades per-call to its deterministic equivalent on any
+    /// failure, and the whole constructor falls back to
+    /// [`default_pipeline`](Self::default_pipeline) when the assets/runner are
+    /// absent (offline, tests, or a non-repo path), so generation is always
+    /// available and never blocks.
+    pub fn for_repo(repo_root: &Path) -> Self {
+        let recipe_pair = if repo_root.is_dir() {
+            Option::zip(
+                RecipeDrafter::for_repo(repo_root),
+                RecipeReviewer::for_repo(repo_root),
+            )
+        } else {
+            None
+        };
+        match recipe_pair {
+            Some((drafter, reviewer)) => Self::new(Box::new(drafter), Box::new(reviewer)),
+            None => Self::default_pipeline(),
+        }
+    }
+
     /// Generate the reviewed [`JournalEntry`] for `day`.
     ///
-    /// Runs the drafter, then **always** runs the reviewer over the draft, and
-    /// stores both the draft (for provenance) and the reviewed narrative.
+    /// Runs the drafter, then **always** runs the reviewer over the draft, then
+    /// applies an **unconditional** [`scrub_secrets`] redaction post-pass over
+    /// the reviewed text — so a credential never reaches the durable narrative
+    /// even if a language-model reviewer failed to strip it. Stores both the raw
+    /// draft (for provenance) and the reviewed, secret-free narrative.
     pub fn generate(&self, day: &DayContext) -> JournalEntry {
         let draft = self.drafter.draft(day);
         // Mandatory review pass — the jargon-free guarantee lives here.
-        let narrative = self.reviewer.review(&draft);
+        let reviewed = self.reviewer.review(&draft);
+        // Unconditional secret-redaction post-pass over the stored narrative.
+        let narrative = scrub_secrets(&reviewed);
         JournalEntry {
             date: day.date,
             generated_at: Utc::now(),

--- a/src/journal/jargon.rs
+++ b/src/journal/jargon.rs
@@ -2,63 +2,76 @@
 //!
 //! Journal generation is two-pass: a draft is assembled from episodics and the
 //! day's data, then a **mandatory** review pass rewrites it for a layperson.
-//! This module provides the default reviewer — a deterministic, whole-word
-//! glossary substitution that removes or explains the engineering jargon a
-//! non-engineer would trip over (`PR`, `CI`, `episodic`, `deploy`, `merge`,
-//! `daemon`, `OODA`, ...).
+//! This module provides the default (offline) reviewer — a deterministic,
+//! whole-word glossary substitution that **expands** the engineering jargon a
+//! non-engineer would trip over: acronyms are spelled out (`PR` -> `pull
+//! request`, `CI` -> `the automated checks`), raw code identifiers are removed
+//! (`temporal_index` -> `timestamp`), and insider terms are plainly explained
+//! (`episodic` -> `moment-by-moment`, `OODA` -> `decision cycle`, `daemon` ->
+//! `always-on background service`). It also carries [`scrub_secrets`], an
+//! unconditional redaction pass the generator applies over the final narrative.
 //!
 //! The default reviewer is deterministic and offline so the whole pipeline is
-//! testable without a network or an LLM; an LLM reasoner reviewer can be
-//! swapped in behind the [`JournalReviewer`](crate::journal::generate::JournalReviewer)
-//! trait when available.
+//! testable without a network or an LLM; a language-model reviewer (the
+//! preferred production path) can be swapped in behind the
+//! [`JournalReviewer`](crate::journal::generate::JournalReviewer) trait when
+//! available — and [`scrub_secrets`] still runs after it, so a secret survives
+//! neither reviewer.
 
 use std::sync::LazyLock;
 
 /// The journal jargon glossary: `(term, replacement)`.
 ///
 /// Matching is **whole-word** and case-insensitive (see [`scrub_jargon`]).
-/// Two flavours of replacement:
+/// Replacements are plain-language and **never re-introduce a banned token**
+/// (e.g. an `episodic …` replacement must not itself contain "episodic"):
 ///
-/// * **Explain-on-use** — the plain phrase keeps the term in parentheses so a
-///   curious reader still learns the word, e.g. `PR` ->
-///   `"code-change proposal (PR)"`.
-/// * **Remove** — insider terms with no reader value are replaced outright,
-///   e.g. `OODA` -> `"decision cycle"`.
+/// * **Expand** — acronyms are spelled out in full, never left bare or merely
+///   parenthesised, e.g. `PR` -> `"pull request"`, `CI` -> `"the automated
+///   checks"`.
+/// * **Explain / remove** — raw identifiers and insider terms with no reader
+///   value are replaced outright, e.g. `temporal_index` -> `"timestamp"`,
+///   `OODA` -> `"decision cycle"`, `dear diary` -> `""`.
 ///
 /// Ordering is **longest phrase first** so multi-word terms and plurals win
 /// over their shorter prefixes (the whole-word boundary check already prevents
 /// `episode` from matching inside `episodes`, but longest-first keeps intent
 /// obvious).
 pub const JOURNAL_GLOSSARY: &[(&str, &str)] = &[
-    ("pull requests", "code-change proposals"),
-    ("pull request", "code-change proposal"),
-    (
-        "episodic memories",
-        "moment-by-moment memories (episodic memory)",
-    ),
-    (
-        "episodic memory",
-        "moment-by-moment memory (episodic memory)",
-    ),
-    ("episodic", "moment-by-moment"),
-    ("episodes", "remembered moments"),
-    ("episode", "remembered moment"),
+    // Diary phrasing has no place in a professional report — strip it outright
+    // wherever it leaks in from raw memory content.
+    ("dear diary", ""),
+    // Insider domain terms, longest-first so multi-word phrases and plurals win
+    // over their shorter prefixes. Replacements must never re-introduce a banned
+    // token (e.g. the plain phrase must not contain the word "episodic").
+    ("episodic memories", "moment-by-moment memories"),
+    ("episodic memory", "moment-by-moment memory"),
+    // Raw code identifiers a non-engineer would trip over — removed/explained.
+    ("temporal_index", "timestamp"),
+    ("working_memory", "short-term memory"),
     ("deployments", "updates to the live system"),
     ("deployment", "update to the live system"),
-    ("deploys", "updates to the live system"),
-    ("deployed", "shipped to the live system"),
-    ("deploy", "ship to the live system"),
     ("idempotent", "safe to repeat"),
+    ("OODA loop", "decision cycle"),
+    ("LadybugDB", "the memory database"),
+    ("episodic", "moment-by-moment"),
+    ("episodes", "remembered moments"),
+    ("deployed", "shipped to the live system"),
+    ("deploys", "updates to the live system"),
+    ("episode", "remembered moment"),
+    ("deploy", "ship to the live system"),
     ("merged", "combined into the main code"),
     ("merges", "combines into the main code"),
-    ("merge", "combine into the main code"),
     ("daemon", "always-on background service"),
-    ("OODA loop", "decision cycle"),
+    ("merge", "combine into the main code"),
     ("OODA", "decision cycle"),
-    ("LadybugDB", "the memory database"),
-    ("CI", "the automated checks (CI)"),
-    ("PRs", "code-change proposals (PRs)"),
-    ("PR", "code-change proposal (PR)"),
+    // Acronyms are **expanded** into plain words, not merely parenthesised, so a
+    // non-engineer never meets a bare initialism (issue #2606).
+    ("PRs", "pull requests"),
+    ("TUI", "text-based dashboard"),
+    ("LLM", "the language model"),
+    ("PR", "pull request"),
+    ("CI", "the automated checks"),
 ];
 
 /// The glossary terms lowercased into `Vec<char>` keys once, paired with their
@@ -85,8 +98,8 @@ static LOWERED_TERMS: LazyLock<Vec<(Vec<char>, &'static str)>> = LazyLock::new(|
 /// matches when the characters immediately before and after it are not
 /// alphanumeric. This is what keeps `PR` from corrupting `approve` and `CI`
 /// from corrupting `social`. Replacement text is emitted to the output and is
-/// never re-scanned, so a replacement that legitimately contains its own term
-/// (e.g. the `"(PR)"` in `"code-change proposal (PR)"`) does not loop.
+/// never re-scanned, so a replacement that legitimately contains a glossary
+/// term does not loop.
 ///
 /// The pass is a pure function of `input` — deterministic and side-effect free.
 #[must_use]
@@ -126,6 +139,89 @@ pub fn scrub_jargon(input: &str) -> String {
         if !matched {
             out.push(chars[i]);
             i += 1;
+        }
+    }
+    out
+}
+
+/// Placeholder substituted for any redacted secret.
+const SECRET_PLACEHOLDER: &str = "[redacted secret]";
+
+/// Token prefixes that unambiguously introduce a credential (GitHub tokens and
+/// fine-grained personal access tokens). Matched literally, then followed by a
+/// run of token characters.
+const TOKEN_PREFIXES: &[&str] = &["github_pat_", "ghp_", "gho_", "ghu_", "ghs_", "ghr_"];
+
+/// Minimum token-body length (characters after the prefix) before a match is
+/// treated as a real credential. Keeps a passing mention like `ghp_` in prose
+/// from being redacted while catching real 36+ character tokens.
+const MIN_TOKEN_BODY: usize = 20;
+
+/// Redact credential-shaped substrings (GitHub tokens and PEM key blocks) from
+/// `input`, leaving ordinary prose untouched (issue #2606).
+///
+/// This is an **unconditional** safety pass the generator applies over the
+/// final narrative *after* the reviewer, so a secret that a language-model
+/// reviewer failed to strip on its own still never reaches the durable entry.
+/// It is deliberately conservative — it only fires on unmistakable secret
+/// shapes — so a word like "key" in normal prose is never disturbed.
+#[must_use]
+pub fn scrub_secrets(input: &str) -> String {
+    redact_tokens(&redact_pem_blocks(input))
+}
+
+/// Redact whole `-----BEGIN … -----END …-----` PEM blocks.
+fn redact_pem_blocks(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(begin) = rest.find("-----BEGIN") {
+        out.push_str(&rest[..begin]);
+        let after_begin = &rest[begin..];
+        // A well-formed block closes with `-----END …-----`; redact through the
+        // closing dashes. A `BEGIN` with no `END` is malformed — redact the
+        // remainder rather than risk leaking a key body (secret-safety first).
+        if let Some(end) = after_begin.find("-----END") {
+            let after_end = &after_begin[end + "-----END".len()..];
+            if let Some(close) = after_end.find("-----") {
+                let block_len = end + "-----END".len() + close + "-----".len();
+                out.push_str(SECRET_PLACEHOLDER);
+                rest = &after_begin[block_len..];
+                continue;
+            }
+        }
+        out.push_str(SECRET_PLACEHOLDER);
+        return out;
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Redact credential tokens introduced by a [`TOKEN_PREFIXES`] prefix.
+fn redact_tokens(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0;
+    while i < input.len() {
+        let rest = &input[i..];
+        let mut matched = false;
+        for prefix in TOKEN_PREFIXES {
+            if let Some(body) = rest.strip_prefix(prefix) {
+                let body_len = body
+                    .bytes()
+                    .take_while(|b| b.is_ascii_alphanumeric() || *b == b'_')
+                    .count();
+                if body_len >= MIN_TOKEN_BODY {
+                    out.push_str(SECRET_PLACEHOLDER);
+                    i += prefix.len() + body_len;
+                    matched = true;
+                    break;
+                }
+            }
+        }
+        if !matched {
+            // Advance by one full char so a multi-byte codepoint is never split.
+            let ch = rest.chars().next().expect("non-empty remainder");
+            out.push(ch);
+            i += ch.len_utf8();
         }
     }
     out

--- a/src/journal/mod.rs
+++ b/src/journal/mod.rs
@@ -1,26 +1,32 @@
-//! Simard's journal (issue #2606): a diary-like, layperson-readable narrative
-//! of each day's activity, built largely from **episodic** memories and stored
-//! in cognitive memory.
+//! Simard's journal (issue #2606): a layperson-readable **narrative
+//! engineering & research report** of each day's activity, built largely from
+//! **episodic** memories and stored in cognitive memory.
 //!
-//! One [`JournalEntry`] per day narrates what Simard — a single Brain — and its
-//! steward, the Overseer, did that day: the moments it remembered, the goals it
-//! worked, the updates it shipped to the live system, how its memory grew, and
-//! a plain-language table of every code-change proposal (pull request). It is
-//! written in a first-person-steward diary voice a non-engineer can follow.
+//! One [`JournalEntry`] per day narrates, in professional third-person prose,
+//! what Simard — a single Brain — and its steward, the Overseer, did that day:
+//! an Overview paragraph, clearly delineated sections (engineering work,
+//! research and findings, key observations), a chronological timestamped list
+//! of the moments it remembered, and a plain-language table of every
+//! code-change proposal (pull request). It reads as a report a non-engineer can
+//! follow — not a personal diary.
 //!
 //! ## Pipeline
 //!
 //! 1. **Assemble** a [`DayContext`] from injectable seams
 //!    ([`providers`]): the [`JournalClock`] fixes the day, the [`EpisodeSource`]
 //!    supplies episodics (primary), the [`PrListSource`] supplies the day's
-//!    proposals, and [`DayExtras`] carries the augmentations.
+//!    proposals, and [`DayExtras`] carries the augmentations (including the
+//!    prepared-context substance — facts, triggers, procedures).
 //! 2. **Draft then review** ([`generate`]): a [`JournalDrafter`] assembles the
-//!    narrative and a **mandatory** [`JournalReviewer`] pass removes/explains
-//!    jargon for a layperson.
+//!    report and a **mandatory** [`JournalReviewer`] pass removes/explains
+//!    jargon for a layperson; the preferred production path is prompt-first
+//!    ([`recipe`]), degrading to the deterministic report drafter + glossary
+//!    reviewer. A secret-redaction post-pass always runs last.
 //! 3. **Persist** ([`store`]): the reviewed [`JournalEntry`] is saved as a
 //!    date-keyed semantic fact — idempotent rolling updates, searchable and
 //!    browseable by date, surviving restarts.
-//! 4. **Render** ([`render`]): pure, jargon-free, XSS-safe views feed both the
+//! 4. **Render** ([`render`]): pure, jargon-free, XSS-safe views turn the
+//!    report's markdown structure into real headings/lists/tables for both the
 //!    dashboard Journal tab and the TUI Journal pane.
 //!
 //! The dashboard route/tab, the TUI pane widget, and the background cognitive
@@ -31,6 +37,7 @@ pub mod generate;
 pub mod jargon;
 pub mod pr_source;
 pub mod providers;
+pub mod recipe;
 pub mod render;
 pub mod store;
 pub mod thread;
@@ -38,6 +45,8 @@ pub mod types;
 
 #[cfg(test)]
 mod test_support;
+#[cfg(test)]
+mod tests_dejargon_teeth;
 #[cfg(test)]
 mod tests_generate;
 #[cfg(test)]
@@ -47,6 +56,12 @@ mod tests_pr_source;
 #[cfg(test)]
 mod tests_render;
 #[cfg(test)]
+mod tests_render_report;
+#[cfg(test)]
+mod tests_report_structure;
+#[cfg(test)]
+mod tests_secrets;
+#[cfg(test)]
 mod tests_store;
 #[cfg(test)]
 mod tests_thread;
@@ -54,14 +69,15 @@ mod tests_thread;
 pub use generate::{
     GlossaryReviewer, JournalDrafter, JournalGenerator, JournalReviewer, TemplateDrafter,
 };
-pub use jargon::{JOURNAL_GLOSSARY, scrub_jargon};
+pub use jargon::{JOURNAL_GLOSSARY, scrub_jargon, scrub_secrets};
 pub use pr_source::{
     GhPrListSource, JOURNAL_PR_LIMIT, open_pr_to_summary, plainify_pr_title, pr_readiness_outcome,
 };
 pub use providers::{
     DayExtras, EpisodeSource, JournalClock, PrListSource, SystemClock, assemble_day_context,
-    generate_and_store,
+    episode_time_label, generate_and_store,
 };
+pub use recipe::{RecipeDrafter, RecipeReviewer};
 pub use render::{html_escape, render_entry_html, render_entry_tui_lines};
 pub use store::{
     JOURNAL_CONCEPT_PREFIX, JOURNAL_TAG, JournalStore, all_entries, entry_matches,
@@ -69,5 +85,6 @@ pub use store::{
 };
 pub use thread::{
     journal_enabled, journal_interval_secs, run_journal_tick, run_journal_tick_with_prs,
+    run_journal_tick_with_prs_in_repo,
 };
 pub use types::{DayContext, JournalEntry, MemoryGrowth, PrSummary};

--- a/src/journal/providers.rs
+++ b/src/journal/providers.rs
@@ -70,7 +70,40 @@ pub struct DayExtras {
     pub memory_growth: Option<MemoryGrowth>,
     /// Any other notable events worth calling out.
     pub notable: Vec<String>,
+    /// Plain-language substance of the day's prepared-context facts (issue
+    /// #2606) — carried onto the [`DayContext`] so the report can summarise
+    /// *what* was learned, not just how many.
+    pub facts: Vec<String>,
+    /// Plain-language substance of the day's prepared-context triggers.
+    pub triggers: Vec<String>,
+    /// Plain-language substance of the day's prepared-context procedures.
+    pub procedures: Vec<String>,
 }
+
+/// Format an episode's `temporal_index` as a human-readable timestamp label for
+/// the report (issue #2606: remembered moments must show *when* they occurred).
+///
+/// The cognitive store uses `temporal_index` two ways: production episodes carry
+/// a Unix epoch-second magnitude, while some in-process/test fixtures use a
+/// small monotonic counter. A value at or above [`EPOCH_LABEL_FLOOR`] (roughly
+/// the year 2001) is treated as a real wall-clock time and formatted as a UTC
+/// label; a smaller value degrades to a stable `"moment N"` ordinal so a
+/// counter-based fixture still renders sensibly rather than as a nonsensical
+/// 1970s date.
+#[must_use]
+pub fn episode_time_label(temporal_index: i64) -> String {
+    if temporal_index >= EPOCH_LABEL_FLOOR {
+        chrono::DateTime::<Utc>::from_timestamp(temporal_index, 0)
+            .map(|dt| dt.format("%Y-%m-%d %H:%M UTC").to_string())
+            .unwrap_or_else(|| format!("moment {temporal_index}"))
+    } else {
+        format!("moment {temporal_index}")
+    }
+}
+
+/// Values at or above this magnitude are treated as Unix epoch seconds (≈ year
+/// 2001); anything smaller is a monotonic counter, not a wall-clock time.
+const EPOCH_LABEL_FLOOR: i64 = 1_000_000_000;
 
 /// Assemble the [`DayContext`] for `date` from the injected sources plus
 /// `extras`. Episodics are pulled first (the primary source); the code-change
@@ -90,6 +123,9 @@ pub fn assemble_day_context(
         overseer_events: extras.overseer_events,
         memory_growth: extras.memory_growth,
         notable: extras.notable,
+        facts: extras.facts,
+        triggers: extras.triggers,
+        procedures: extras.procedures,
     })
 }
 

--- a/src/journal/recipe.rs
+++ b/src/journal/recipe.rs
@@ -1,0 +1,271 @@
+//! Prompt-first journal generation (issue #2606, guideline G3).
+//!
+//! The preferred production path for the narrative report and its plain-language
+//! rewrite is agentic, not hand-rolled Rust: a [`RecipeDrafter`] runs the
+//! `journal-narrative` recipe to write the professional, third-person report from
+//! the day's structured context, and a [`RecipeReviewer`] runs the
+//! `journal-plain-language` recipe to rewrite that draft so a non-engineer can read
+//! it. Both shell out to `recipe-runner-rs` exactly like the episode-distiller
+//! ([`crate::memory_consolidation::distillation`]).
+//!
+//! Robustness first: each pass **degrades per call** to its deterministic
+//! equivalent (the [`TemplateDrafter`] report / the glossary
+//! [`scrub_jargon`] reviewer) on any failure — missing recipe assets, no agent
+//! binary, `recipe-runner-rs` not on `PATH`, a spawn/exit error, or empty
+//! output — so a language-model hiccup can never fail or stall a journal tick.
+//! The generator's unconditional secret-redaction post-pass runs regardless of
+//! which reviewer produced the text, so a credential survives neither path.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use serde::Deserialize;
+
+use crate::error::{SimardError, SimardResult};
+use crate::journal::generate::{JournalDrafter, JournalReviewer, TemplateDrafter};
+use crate::journal::jargon::scrub_jargon;
+use crate::journal::providers::episode_time_label;
+use crate::journal::types::DayContext;
+
+/// Recipe that writes the narrative engineering-and-research report draft.
+const JOURNAL_DRAFT_RECIPE: &str = "journal-narrative.yaml";
+/// Recipe that rewrites a draft into plain, layperson-readable language.
+const JOURNAL_DEJARGON_RECIPE: &str = "journal-plain-language.yaml";
+/// Adapter tag used for error attribution.
+const ADAPTER_TAG: &str = "journal";
+
+/// Resolve a journal recipe path, hot-reload location first then in-tree:
+///   1. `<home>/.simard/prompt_assets/simard/recipes/<filename>`
+///   2. `<repo_root>/prompt_assets/simard/recipes/<filename>`
+///
+/// Returns `None` when neither exists (the caller then uses the deterministic
+/// fallback).
+fn resolve_recipe_path(repo_root: &Path, filename: &str) -> Option<PathBuf> {
+    if let Some(home) = dirs::home_dir() {
+        let hot = home
+            .join(".simard")
+            .join("prompt_assets/simard/recipes")
+            .join(filename);
+        if hot.is_file() {
+            return Some(hot);
+        }
+    }
+    let in_tree = repo_root
+        .join("prompt_assets/simard/recipes")
+        .join(filename);
+    if in_tree.is_file() {
+        return Some(in_tree);
+    }
+    None
+}
+
+/// The JSON envelope `recipe-runner-rs --output-format json` prints.
+#[derive(Debug, Deserialize)]
+struct RecipeEnvelope {
+    success: bool,
+    step_results: Vec<RecipeStepResult>,
+}
+
+/// A single step's result inside the [`RecipeEnvelope`].
+#[derive(Debug, Deserialize)]
+struct RecipeStepResult {
+    output: String,
+}
+
+/// A resolved journal recipe plus the agent binary to run it with.
+struct JournalRecipe {
+    recipe_path: PathBuf,
+    agent_binary: &'static str,
+}
+
+impl JournalRecipe {
+    /// Construct a runner when all preconditions hold: the recipe file resolves,
+    /// an agent binary is configured, and `recipe-runner-rs` is on `PATH`.
+    /// Returns `None` otherwise (the caller falls back to deterministic).
+    fn new(repo_root: &Path, filename: &str) -> Option<Self> {
+        let recipe_path = resolve_recipe_path(repo_root, filename)?;
+        let agent_binary = crate::session_builder::LlmProvider::resolve_agent_binary()?;
+        if Command::new("recipe-runner-rs")
+            .arg("--version")
+            .env("AMPLIHACK_AGENT_BINARY", agent_binary)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_err()
+        {
+            return None;
+        }
+        Some(Self {
+            recipe_path,
+            agent_binary,
+        })
+    }
+
+    /// Run the recipe with the given context vars and return the final step's
+    /// output text (trimmed). Errors on spawn/exit failure, a bad or
+    /// `success == false` envelope, or empty output.
+    fn run(&self, ctx: &[(&str, String)]) -> SimardResult<String> {
+        let mut cmd = Command::new("recipe-runner-rs");
+        cmd.arg(self.recipe_path.as_os_str())
+            .arg("--output-format")
+            .arg("json")
+            .env("AMPLIHACK_AGENT_BINARY", self.agent_binary);
+        for (key, value) in ctx {
+            cmd.arg("-c").arg(format!("{key}={value}"));
+        }
+        let output = cmd
+            .output()
+            .map_err(|e| invocation_failed(format!("recipe-runner-rs spawn failed: {e}")))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(invocation_failed(format!(
+                "recipe exited with {}: {}",
+                output.status,
+                truncate(stderr.trim(), 200)
+            )));
+        }
+        let envelope: RecipeEnvelope = serde_json::from_slice(&output.stdout)
+            .map_err(|e| invocation_failed(format!("bad JSON envelope: {e}")))?;
+        if !envelope.success {
+            return Err(invocation_failed(
+                "recipe reported success=false".to_string(),
+            ));
+        }
+        envelope
+            .step_results
+            .last()
+            .map(|s| s.output.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| invocation_failed("recipe produced no output".to_string()))
+    }
+}
+
+fn invocation_failed(reason: String) -> SimardError {
+    SimardError::AdapterInvocationFailed {
+        base_type: ADAPTER_TAG.to_string(),
+        reason,
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let head: String = s.chars().take(max).collect();
+        format!("{head}…")
+    }
+}
+
+/// Serialize a [`DayContext`] into the JSON payload the draft recipe consumes.
+///
+/// Episodic memories are pre-sorted oldest-to-newest and carry a human-readable
+/// timestamp label, and the prepared-context substance (facts/triggers/
+/// procedures) is passed verbatim so the model summarises *what* they were.
+fn day_context_json(day: &DayContext) -> String {
+    let mut moments: Vec<_> = day.episodes.iter().collect();
+    moments.sort_by_key(|e| e.temporal_index);
+    let episodes: Vec<_> = moments
+        .iter()
+        .map(|e| {
+            serde_json::json!({
+                "time": episode_time_label(e.temporal_index),
+                "content": e.content,
+            })
+        })
+        .collect();
+    let prs: Vec<_> = day
+        .prs
+        .iter()
+        .map(|p| {
+            serde_json::json!({
+                "number": p.number,
+                "summary": p.plain_summary,
+                "outcome": p.outcome,
+            })
+        })
+        .collect();
+    let memory_growth = day.memory_growth.map(|m| {
+        serde_json::json!({
+            "facts_added": m.facts_added,
+            "episodes_added": m.episodes_added,
+        })
+    });
+    let payload = serde_json::json!({
+        "date": day.date.format("%Y-%m-%d").to_string(),
+        "episodes": episodes,
+        "prs": prs,
+        "goals": day.goals,
+        "deploys": day.deploys,
+        "overseer_events": day.overseer_events,
+        "facts": day.facts,
+        "triggers": day.triggers,
+        "procedures": day.procedures,
+        "notable": day.notable,
+        "memory_growth": memory_growth,
+    });
+    serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string())
+}
+
+/// Prompt-first drafter: runs the `journal-narrative` recipe, degrading to the
+/// deterministic [`TemplateDrafter`] report on any failure.
+pub struct RecipeDrafter {
+    recipe: JournalRecipe,
+    fallback: TemplateDrafter,
+}
+
+impl RecipeDrafter {
+    /// Build a recipe drafter for `repo_root`, or `None` when the recipe assets
+    /// / runner are unavailable.
+    pub fn for_repo(repo_root: &Path) -> Option<Self> {
+        JournalRecipe::new(repo_root, JOURNAL_DRAFT_RECIPE).map(|recipe| Self {
+            recipe,
+            fallback: TemplateDrafter,
+        })
+    }
+}
+
+impl JournalDrafter for RecipeDrafter {
+    fn draft(&self, day: &DayContext) -> String {
+        match self.recipe.run(&[("day_context", day_context_json(day))]) {
+            Ok(text) => text,
+            Err(e) => {
+                tracing::warn!(
+                    target: "simard::journal",
+                    error = %e,
+                    "journal draft recipe failed; using the deterministic report drafter"
+                );
+                self.fallback.draft(day)
+            }
+        }
+    }
+}
+
+/// Prompt-first reviewer: runs the `journal-plain-language` recipe, degrading to the
+/// deterministic glossary [`scrub_jargon`] reviewer on any failure.
+pub struct RecipeReviewer {
+    recipe: JournalRecipe,
+}
+
+impl RecipeReviewer {
+    /// Build a recipe reviewer for `repo_root`, or `None` when the recipe assets
+    /// / runner are unavailable.
+    pub fn for_repo(repo_root: &Path) -> Option<Self> {
+        JournalRecipe::new(repo_root, JOURNAL_DEJARGON_RECIPE).map(|recipe| Self { recipe })
+    }
+}
+
+impl JournalReviewer for RecipeReviewer {
+    fn review(&self, draft: &str) -> String {
+        match self.recipe.run(&[("draft", draft.to_string())]) {
+            Ok(text) => text,
+            Err(e) => {
+                tracing::warn!(
+                    target: "simard::journal",
+                    error = %e,
+                    "journal de-jargon recipe failed; using the glossary reviewer"
+                );
+                scrub_jargon(draft)
+            }
+        }
+    }
+}

--- a/src/journal/render.rs
+++ b/src/journal/render.rs
@@ -35,11 +35,14 @@ pub fn html_escape(s: &str) -> String {
 }
 
 /// Render an entry as a self-contained HTML fragment for the dashboard Journal
-/// tab: an `<h2>` date, the narrative in paragraphs, and a plain-language table
-/// of the day's code-change proposals (or an honest "no changes" note).
+/// tab: an `<h2>` date, the report narrative rendered as **structure** (section
+/// `<h3>` headings, `<ul>` bullet lists, and `<p>` paragraphs — never literal
+/// `##`/`-` markdown), and a plain-language table of the day's code-change
+/// proposals (or an honest "no changes" note).
 ///
 /// Every piece of untrusted text is passed through [`html_escape`], so a
-/// narrative or PR summary containing `<script>` renders as inert text.
+/// narrative, heading, bullet, or PR summary containing `<script>` renders as
+/// inert text.
 #[must_use]
 pub fn render_entry_html(entry: &JournalEntry) -> String {
     let mut h = String::with_capacity(entry.narrative.len() + 512);
@@ -51,15 +54,7 @@ pub fn render_entry_html(entry: &JournalEntry) -> String {
     );
 
     h.push_str("<div class=\"journal-narrative\">");
-    for para in entry.narrative.split("\n\n") {
-        let para = para.trim();
-        if para.is_empty() {
-            continue;
-        }
-        h.push_str("<p>");
-        h.push_str(&html_escape(para).replace('\n', "<br>"));
-        h.push_str("</p>");
-    }
+    render_markdown_html(&mut h, &entry.narrative);
     h.push_str("</div>");
 
     if entry.prs.is_empty() {
@@ -87,16 +82,77 @@ pub fn render_entry_html(entry: &JournalEntry) -> String {
     h
 }
 
+/// Render the report narrative's lightweight markdown (section `## ` headings,
+/// `- ` bullets, blank-line-separated paragraphs) into escaped, XSS-safe HTML
+/// structure. Unknown lines are ordinary paragraph text; every emitted piece of
+/// text is [`html_escape`]d, so raw markup can never break out.
+fn render_markdown_html(h: &mut String, narrative: &str) {
+    let mut para: Vec<String> = Vec::new();
+    let mut in_list = false;
+
+    for raw_line in narrative.split('\n') {
+        let trimmed = raw_line.trim();
+        if let Some(rest) = trimmed.strip_prefix("## ") {
+            flush_paragraph(h, &mut para);
+            close_list(h, &mut in_list);
+            let _ = write!(
+                h,
+                "<h3 class=\"journal-heading\">{}</h3>",
+                html_escape(rest.trim())
+            );
+        } else if let Some(rest) = trimmed.strip_prefix("- ") {
+            flush_paragraph(h, &mut para);
+            if !in_list {
+                h.push_str("<ul class=\"journal-list\">");
+                in_list = true;
+            }
+            let _ = write!(h, "<li>{}</li>", html_escape(rest.trim()));
+        } else if trimmed.is_empty() {
+            flush_paragraph(h, &mut para);
+            close_list(h, &mut in_list);
+        } else {
+            close_list(h, &mut in_list);
+            para.push(html_escape(trimmed));
+        }
+    }
+    flush_paragraph(h, &mut para);
+    close_list(h, &mut in_list);
+}
+
+/// Emit the buffered paragraph lines (joined by `<br>`) as a `<p>`, then clear.
+fn flush_paragraph(h: &mut String, para: &mut Vec<String>) {
+    if para.is_empty() {
+        return;
+    }
+    h.push_str("<p>");
+    h.push_str(&para.join("<br>"));
+    h.push_str("</p>");
+    para.clear();
+}
+
+/// Close an open `<ul>` if one is in progress.
+fn close_list(h: &mut String, in_list: &mut bool) {
+    if *in_list {
+        h.push_str("</ul>");
+        *in_list = false;
+    }
+}
+
 /// Render an entry as plain text lines for the TUI Journal pane: a date header,
-/// the narrative, and a plain-language list of the day's code-change proposals
-/// (or an honest "no changes" line).
+/// the report narrative (section `## ` markers dropped so headings read as plain
+/// heading lines), and a plain-language list of the day's code-change proposals
+/// (or an honest "no changes" line). All untrusted free text has terminal
+/// control bytes neutralised so a crafted narrative or PR summary can never
+/// emit ANSI escapes into the operator's terminal.
 #[must_use]
 pub fn render_entry_tui_lines(entry: &JournalEntry) -> Vec<String> {
-    let mut lines = Vec::with_capacity(entry.prs.len() + 8);
+    let mut lines = Vec::with_capacity(entry.prs.len() + 16);
     lines.push(format!("── Journal · {} ──", entry.date.format("%Y-%m-%d")));
     lines.push(String::new());
-    for para in entry.narrative.split('\n') {
-        lines.push(para.to_string());
+    for raw in entry.narrative.split('\n') {
+        // Section headings render as plain heading text (drop the `## ` marker).
+        let text = raw.strip_prefix("## ").unwrap_or(raw);
+        lines.push(neutralize_control(text));
     }
     lines.push(String::new());
     if entry.prs.is_empty() {
@@ -104,11 +160,17 @@ pub fn render_entry_tui_lines(entry: &JournalEntry) -> Vec<String> {
     } else {
         lines.push("Code changes today:".to_string());
         for pr in &entry.prs {
-            lines.push(format!(
+            lines.push(neutralize_control(&format!(
                 "  #{}  {} — {}",
                 pr.number, pr.outcome, pr.plain_summary
-            ));
+            )));
         }
     }
     lines
+}
+
+/// Strip terminal control bytes (ANSI escapes, bell, and other C0/C1 controls)
+/// from untrusted text so the TUI can render it verbatim without risk.
+fn neutralize_control(s: &str) -> String {
+    s.chars().filter(|c| !c.is_control()).collect()
 }

--- a/src/journal/test_support.rs
+++ b/src/journal/test_support.rs
@@ -258,6 +258,18 @@ pub(crate) fn episode(content: &str) -> CognitiveEpisode {
     }
 }
 
+/// Build a [`CognitiveEpisode`] with `content` and an explicit `temporal_index`
+/// (issue #2606: episodes carry timestamps and render chronologically).
+pub(crate) fn episode_at(content: &str, temporal_index: i64) -> CognitiveEpisode {
+    CognitiveEpisode {
+        node_id: format!("ep-{temporal_index}"),
+        content: content.to_string(),
+        source_label: "test".to_string(),
+        temporal_index,
+        compressed: false,
+    }
+}
+
 /// Build a [`PrSummary`] for a test.
 pub(crate) fn pr(number: u64, plain_summary: &str, outcome: &str) -> PrSummary {
     PrSummary {

--- a/src/journal/tests_dejargon_teeth.rs
+++ b/src/journal/tests_dejargon_teeth.rs
@@ -1,0 +1,115 @@
+//! src/journal/tests_dejargon_teeth.rs
+//!
+//! Tests (issue #2606): the mandatory de-jargon rewrite has **teeth**. Given a
+//! draft stuffed with representative jargon, the final `narrative` contains none
+//! of a banned-token list (raw code identifiers, insider terms, unexpanded
+//! acronyms, and diary phrasing), acronyms are **expanded** (not merely
+//! parenthesised), and the review **materially changes** the text
+//! (`draft != narrative`).
+//!
+//! Specifies the TARGET behaviour: in the pre-fix #2618 build these tokens still
+//! survive (the review was effectively a no-op) and acronyms were left
+//! parenthesised (e.g. "code-change proposal (PR)") rather than expanded.
+
+use super::test_support::{day, episode, pr};
+use crate::journal::generate::JournalGenerator;
+use crate::journal::jargon::scrub_jargon;
+use crate::journal::types::DayContext;
+
+/// A representative (not exhaustive) banned-jargon token list, curated from the
+/// observed production output. None of these may survive into the final
+/// narrative — raw identifiers, insider terms, unexpanded acronyms, and the
+/// diary phrase.
+const BANNED_JARGON: &[&str] = &[
+    "OODA",
+    "episodic",
+    "temporal_index",
+    "working_memory",
+    "daemon",
+    "TUI",
+    "LLM",
+    "Dear diary",
+];
+
+/// Case-insensitive membership test. Multi-word phrases match as substrings;
+/// single identifier-like tokens match on word boundaries (underscores are part
+/// of the word, so `temporal_index` is one token).
+fn contains_jargon(haystack: &str, needle: &str) -> bool {
+    let hay = haystack.to_lowercase();
+    let need = needle.to_lowercase();
+    if needle.contains(' ') {
+        return hay.contains(&need);
+    }
+    hay.split(|c: char| !c.is_alphanumeric() && c != '_')
+        .any(|word| word == need)
+}
+
+#[test]
+fn banned_jargon_never_survives_into_the_narrative() {
+    let mut ctx = DayContext::new(day());
+    ctx.episodes = vec![
+        episode("Dear diary, the OODA loop finished cycle 7"),
+        episode("sorted the episodic memories by temporal_index in working_memory"),
+    ];
+    ctx.notable = vec!["the daemon logged the TUI and LLM activity".to_string()];
+    ctx.prs = vec![pr(
+        12,
+        "made the dashboard faster",
+        "still open — ready to combine into the main code",
+    )];
+
+    let entry = JournalGenerator::default_pipeline().generate(&ctx);
+
+    for token in BANNED_JARGON {
+        assert!(
+            !contains_jargon(&entry.narrative, token),
+            "banned jargon {token:?} must not survive the de-jargon review: {}",
+            entry.narrative
+        );
+    }
+    assert_ne!(
+        entry.draft, entry.narrative,
+        "the de-jargon pass must materially rewrite the draft (not a no-op)"
+    );
+}
+
+#[test]
+fn acronyms_are_expanded_not_left_bare() {
+    // The strengthened glossary EXPANDS acronyms into plain words rather than
+    // leaving them bare or merely parenthesising them.
+    let out = scrub_jargon("Opened a PR and waited for CI.");
+    assert!(
+        out.contains("pull request"),
+        "'PR' expands to 'pull request': {out}"
+    );
+    assert!(
+        !contains_jargon(&out, "PR"),
+        "no bare 'PR' remains after expansion: {out}"
+    );
+    assert!(
+        out.to_lowercase().contains("automated checks"),
+        "'CI' expands to 'the automated checks': {out}"
+    );
+    assert!(
+        !contains_jargon(&out, "CI"),
+        "no bare 'CI' remains after expansion: {out}"
+    );
+}
+
+#[test]
+fn raw_identifiers_are_removed() {
+    // Raw code identifiers a non-engineer would trip over are removed/explained.
+    let out = scrub_jargon("The episodic entry kept its temporal_index in working_memory.");
+    assert!(
+        !contains_jargon(&out, "temporal_index"),
+        "raw identifier 'temporal_index' removed: {out}"
+    );
+    assert!(
+        !contains_jargon(&out, "working_memory"),
+        "raw identifier 'working_memory' removed: {out}"
+    );
+    assert!(
+        !contains_jargon(&out, "episodic"),
+        "insider term 'episodic' removed/explained: {out}"
+    );
+}

--- a/src/journal/tests_jargon.rs
+++ b/src/journal/tests_jargon.rs
@@ -18,20 +18,21 @@ fn scrub_removes_insider_acronyms() {
 }
 
 #[test]
-fn scrub_explains_pull_requests() {
+fn scrub_expands_pull_request_acronym() {
     let out = scrub_jargon("Opened PR 12 today.");
     assert!(
-        out.contains("code-change proposal (PR)"),
-        "PR is explained on use: {out}"
+        out.contains("pull request"),
+        "PR is expanded to plain words: {out}"
     );
+    assert!(!out.contains("PR "), "no bare 'PR' acronym remains: {out}");
 }
 
 #[test]
 fn scrub_handles_plurals_and_merge() {
     let out = scrub_jargon("We merged 3 PRs.");
     assert!(
-        out.contains("code-change proposals"),
-        "plural expanded: {out}"
+        out.contains("pull requests"),
+        "plural acronym expanded: {out}"
     );
     assert!(
         out.contains("combined into the main code"),

--- a/src/journal/tests_pr_source.rs
+++ b/src/journal/tests_pr_source.rs
@@ -120,9 +120,10 @@ fn plain_summary_strips_prefix_and_scrubs_jargon() {
 
     let p = plainify_pr_title("feat: close the PR faster");
     assert!(
-        p.contains("code-change proposal"),
-        "PR is explained for a layperson: {p}"
+        p.contains("pull request"),
+        "PR is expanded for a layperson: {p}"
     );
+    assert!(!p.contains("PR "), "no bare 'PR' acronym remains: {p}");
 
     // A non-conventional colon sentence is left intact.
     let plain = plainify_pr_title("Note: the login page is faster now");

--- a/src/journal/tests_render_report.rs
+++ b/src/journal/tests_render_report.rs
@@ -1,0 +1,117 @@
+//! src/journal/tests_render_report.rs
+//!
+//! Tests (issue #2606): the shared renderer turns the report's `##` headings and
+//! its pull-request table into real **structure** on both surfaces — the
+//! dashboard emits heading elements (never literal `##`) and the TUI emits
+//! heading lines with terminal control bytes neutralised — so the same
+//! jargon-free report renders cleanly in the dashboard Journal tab AND the TUI
+//! Journal pane.
+//!
+//! Specifies the TARGET behaviour: the pre-fix #2618 renderer wraps the whole
+//! narrative in `<p>` (leaking literal `##` into the dashboard) and does not
+//! neutralise terminal control bytes in the TUI.
+
+use chrono::Utc;
+
+use super::test_support::{day, pr};
+use crate::journal::render::{render_entry_html, render_entry_tui_lines};
+use crate::journal::types::JournalEntry;
+
+/// A report-shaped entry: an overview paragraph plus two `##`-headed sections.
+fn report_entry() -> JournalEntry {
+    JournalEntry {
+        date: day(),
+        generated_at: Utc::now(),
+        narrative: "Overview. Simard improved how it recalls its own work.\n\n\
+                    ## Engineering work\n\n\
+                    A change was combined into the main code.\n\n\
+                    ## Outcomes\n\n\
+                    The dashboard is faster."
+            .to_string(),
+        draft: String::new(),
+        prs: vec![pr(
+            12,
+            "made the dashboard faster",
+            "still open — ready to combine into the main code",
+        )],
+        quiet_day: false,
+    }
+}
+
+#[test]
+fn html_renders_report_headings_as_structure_not_literal_markdown() {
+    let html = render_entry_html(&report_entry());
+
+    // Section headings become real structure, never raw '##' text.
+    assert!(
+        !html.contains("## "),
+        "raw markdown headings must not leak into the dashboard HTML: {html}"
+    );
+    assert!(
+        html.contains("Engineering work"),
+        "first section heading text present: {html}"
+    );
+    assert!(
+        html.contains("Outcomes"),
+        "second section heading text present: {html}"
+    );
+    assert!(html.contains("Overview"), "overview present: {html}");
+    // The plain-language PR table is still rendered.
+    assert!(
+        html.contains("<table class=\"journal-prs\""),
+        "PR table present: {html}"
+    );
+    assert!(
+        html.contains("made the dashboard faster"),
+        "PR summary present: {html}"
+    );
+}
+
+#[test]
+fn html_report_is_still_xss_safe() {
+    let mut entry = report_entry();
+    entry
+        .narrative
+        .push_str("\n\n## Notes\n\n<script>alert('x')</script> lingered.");
+    entry.prs = vec![pr(
+        7,
+        "made login <b>safer</b>",
+        "still open — not ready yet",
+    )];
+
+    let html = render_entry_html(&entry);
+    assert!(
+        !html.contains("<script>"),
+        "raw <script> must not survive: {html}"
+    );
+    assert!(html.contains("&lt;script&gt;"), "script is escaped: {html}");
+    assert!(
+        !html.contains("<b>safer</b>"),
+        "raw PR markup must not survive: {html}"
+    );
+}
+
+#[test]
+fn tui_renders_headings_and_neutralises_control_bytes() {
+    let mut entry = report_entry();
+    // Inject terminal control bytes into untrusted text: an ANSI escape in the
+    // narrative and a bell byte in a PR summary.
+    entry.narrative.push_str("\n\n\u{1b}[31mALERT\u{1b}[0m");
+    entry.prs = vec![pr(9, "ring the \u{7} bell", "still open — not ready yet")];
+
+    let lines = render_entry_tui_lines(&entry);
+    let joined = lines.join("\n");
+
+    assert!(
+        joined.contains("Engineering work"),
+        "TUI shows section headings: {joined:?}"
+    );
+    assert!(
+        !joined.contains('\u{1b}'),
+        "ANSI escape byte must be neutralised in the TUI render"
+    );
+    assert!(
+        !joined.contains('\u{7}'),
+        "bell byte must be neutralised in the TUI render"
+    );
+}

--- a/src/journal/tests_report_structure.rs
+++ b/src/journal/tests_report_structure.rs
@@ -1,0 +1,241 @@
+//! src/journal/tests_report_structure.rs
+//!
+//! Tests (issue #2606): the journal reads and is formatted as a professional,
+//! third-person **narrative engineering & research report** — an Overview
+//! paragraph, `##`-headed sections, timestamped chronological remembered
+//! moments, and a verbose prepared-context summary — **not** a first-person
+//! "Dear diary". Also covers the `episode_time_label` helper and the
+//! prompt-first `JournalGenerator::for_repo` constructor's honest offline
+//! fallback.
+//!
+//! These specify the TARGET behaviour and fail against the pre-fix #2618 build,
+//! which uses a first-person diary drafter, carries no verbose prepared-context,
+//! and renders episodes without timestamps.
+
+use std::path::Path;
+
+use super::test_support::{FixedEpisodes, FixedPrs, day, episode, episode_at, pr};
+use crate::journal::generate::JournalGenerator;
+use crate::journal::providers::{DayExtras, assemble_day_context, episode_time_label};
+use crate::journal::types::{DayContext, MemoryGrowth};
+
+/// The final report is third-person and carries NO diary voice anywhere — not in
+/// the reviewed narrative and not even in the raw draft (the drafter itself is a
+/// report writer, not a diarist).
+#[test]
+fn narrative_is_a_third_person_report_not_a_diary() {
+    let mut ctx = DayContext::new(day());
+    ctx.episodes = vec![
+        episode("reviewed the overnight engineering work"),
+        episode("started a measurement study of recall quality"),
+    ];
+    ctx.prs = vec![pr(
+        12,
+        "made the dashboard load faster",
+        "still open — ready to combine into the main code",
+    )];
+
+    let entry = JournalGenerator::default_pipeline().generate(&ctx);
+    let lower = entry.narrative.to_lowercase();
+
+    assert!(
+        !lower.contains("dear diary"),
+        "no 'Dear diary' framing: {}",
+        entry.narrative
+    );
+    assert!(
+        !entry.narrative.contains("I, Simard"),
+        "no first-person diary voice: {}",
+        entry.narrative
+    );
+    assert!(
+        !lower.contains("stayed with me"),
+        "no confessional diary phrasing: {}",
+        entry.narrative
+    );
+    assert!(
+        !entry.draft.to_lowercase().contains("dear diary"),
+        "the drafter must not use a diary voice: {}",
+        entry.draft
+    );
+}
+
+/// The report has a deliberate structure: an Overview paragraph plus at least one
+/// `##`-headed section, and the final narrative keeps that structure.
+#[test]
+fn report_has_overview_and_sectioned_headings() {
+    let mut ctx = DayContext::new(day());
+    ctx.episodes = vec![episode("kept the system healthy")];
+    ctx.goals = vec!["improve how Simard recalls its own past work".to_string()];
+    ctx.deploys = vec!["shipped a faster dashboard to the live system".to_string()];
+    ctx.overseer_events =
+        vec!["the steward flagged a stale change and nudged it forward".to_string()];
+    ctx.notable = vec!["a measurement study was started".to_string()];
+
+    let entry = JournalGenerator::default_pipeline().generate(&ctx);
+
+    assert!(
+        entry.draft.contains("Overview"),
+        "report leads with an Overview: {}",
+        entry.draft
+    );
+    assert!(
+        entry.draft.contains("## "),
+        "report is split into '##' sections: {}",
+        entry.draft
+    );
+    assert!(
+        entry.narrative.contains("Overview"),
+        "narrative keeps the Overview: {}",
+        entry.narrative
+    );
+}
+
+/// Remembered moments render WITH a timestamp and in chronological order
+/// (oldest-to-newest), even when supplied newest-first.
+#[test]
+fn episodes_are_timestamped_and_chronological() {
+    let mut ctx = DayContext::new(day());
+    // Supplied newest-first to prove the drafter re-sorts oldest-to-newest.
+    ctx.episodes = vec![
+        episode_at("a later moment of the day", 1_700_003_600),
+        episode_at("an earlier moment of the day", 1_700_000_000),
+    ];
+
+    let entry = JournalGenerator::default_pipeline().generate(&ctx);
+
+    // Each moment shows when it occurred (an epoch magnitude => a UTC label).
+    assert!(
+        entry.draft.contains("UTC"),
+        "remembered moments carry a timestamp label: {}",
+        entry.draft
+    );
+
+    // Oldest-to-newest: the earlier moment appears before the later one.
+    let earlier = entry
+        .narrative
+        .find("earlier moment")
+        .expect("earlier moment present in the narrative");
+    let later = entry
+        .narrative
+        .find("later moment")
+        .expect("later moment present in the narrative");
+    assert!(
+        earlier < later,
+        "moments must read oldest-to-newest: {}",
+        entry.narrative
+    );
+}
+
+/// `episode_time_label` formats an epoch-second magnitude as a UTC label and a
+/// small monotonic counter as a stable ordinal (so counter-based test fixtures
+/// still render sensibly).
+#[test]
+fn episode_time_label_handles_epoch_and_counter() {
+    // 1_700_000_000 => 2023-11-14 22:13:20 UTC.
+    let epoch = episode_time_label(1_700_000_000);
+    assert!(
+        epoch.contains("UTC"),
+        "epoch magnitude => UTC label: {epoch}"
+    );
+    assert!(
+        epoch.contains("2023"),
+        "epoch is formatted as a real date: {epoch}"
+    );
+
+    let counter = episode_time_label(1);
+    assert!(
+        !counter.contains("UTC"),
+        "a tiny counter is not a wall-clock time: {counter}"
+    );
+    assert!(
+        counter.contains("moment 1"),
+        "a counter degrades to 'moment N': {counter}"
+    );
+}
+
+/// The verbose prepared-context summary reports the SUBSTANCE of the day's
+/// facts / triggers / procedures, not a bare line of counts.
+#[test]
+fn prepared_context_is_verbose_not_counts() {
+    let episodes = FixedEpisodes(vec![episode("watched the automated checks run")]);
+    let prs = FixedPrs(vec![]);
+    let extras = DayExtras {
+        facts: vec!["the sign-in code now has automated tests".to_string()],
+        triggers: vec!["a reminder to review a stale change fired".to_string()],
+        procedures: vec!["the steps to safely combine a change into the main code".to_string()],
+        ..DayExtras::default()
+    };
+
+    let ctx = assemble_day_context(day(), &episodes, &prs, extras).expect("assemble day context");
+    // The extras are carried onto the DayContext as first-class material.
+    assert_eq!(ctx.facts.len(), 1, "facts carried onto the context");
+    assert_eq!(ctx.triggers.len(), 1, "triggers carried onto the context");
+    assert_eq!(
+        ctx.procedures.len(),
+        1,
+        "procedures carried onto the context"
+    );
+
+    let entry = JournalGenerator::default_pipeline().generate(&ctx);
+
+    assert!(
+        entry
+            .narrative
+            .contains("the sign-in code now has automated tests"),
+        "fact substance appears in the report: {}",
+        entry.narrative
+    );
+    assert!(
+        entry
+            .narrative
+            .contains("a reminder to review a stale change fired"),
+        "trigger substance appears in the report: {}",
+        entry.narrative
+    );
+    assert!(
+        entry
+            .narrative
+            .contains("safely combine a change into the main code"),
+        "procedure substance appears in the report: {}",
+        entry.narrative
+    );
+    assert!(
+        !entry.narrative.contains("Prepared context:"),
+        "no bare 'Prepared context: N facts' counts line: {}",
+        entry.narrative
+    );
+}
+
+/// `JournalGenerator::for_repo` builds a working generator that — even with no
+/// resolvable recipe assets (honest offline fallback) — still produces a
+/// structured, non-diary report whose mandatory review pass materially changes
+/// the draft.
+#[test]
+fn for_repo_falls_back_to_a_structured_report() {
+    // A repo root with no prompt assets forces the deterministic fallback.
+    let generator = JournalGenerator::for_repo(Path::new("/nonexistent-journal-test-repo-root"));
+
+    let mut ctx = DayContext::new(day());
+    ctx.episodes = vec![episode("investigated a flaky check")];
+    ctx.memory_growth = Some(MemoryGrowth {
+        facts_added: 3,
+        episodes_added: 5,
+    });
+
+    let entry = generator.generate(&ctx);
+    assert!(
+        !entry.narrative.to_lowercase().contains("dear diary"),
+        "the fallback is still a report, not a diary: {}",
+        entry.narrative
+    );
+    assert!(
+        entry.draft.contains("Overview"),
+        "the fallback still emits a structured report: {}",
+        entry.draft
+    );
+    assert_ne!(
+        entry.draft, entry.narrative,
+        "the mandatory review pass still runs in the fallback"
+    );
+}

--- a/src/journal/tests_secrets.rs
+++ b/src/journal/tests_secrets.rs
@@ -1,0 +1,100 @@
+//! src/journal/tests_secrets.rs
+//!
+//! Tests (issue #2606): `scrub_secrets` redacts token / key / PEM-shaped
+//! substrings while leaving ordinary prose intact, and
+//! `JournalGenerator::generate` applies it as an **unconditional post-pass**
+//! over the reviewed narrative — so a secret survives neither the offline
+//! reviewer nor a passthrough reviewer (standing in for a language-model
+//! reviewer whose output is never trusted to be secret-free on its own).
+//!
+//! Specifies the TARGET behaviour: `scrub_secrets` does not exist in the pre-fix
+//! #2618 build and `generate` performs no secret redaction.
+//!
+//! The fixtures use the repository's clearly-fake credential shapes (an
+//! `EXAMPLE_FAKE_..._do_not_use` token and a PEM whose markers are assembled
+//! from fragments at runtime) so no literal credential is ever committed.
+
+use super::test_support::day;
+use crate::journal::generate::{JournalDrafter, JournalGenerator, JournalReviewer};
+use crate::journal::jargon::scrub_secrets;
+use crate::journal::types::DayContext;
+
+/// A GitHub-personal-access-token-shaped, obviously-fake secret (`ghp_` prefix
+/// plus a 32-character `EXAMPLE_FAKE_..._do_not_use` body).
+const GH_TOKEN: &str = "ghp_EXAMPLE_FAKE_TOKEN_do_not_use_00";
+
+#[test]
+fn scrub_secrets_redacts_github_token() {
+    let out = scrub_secrets(&format!("Simard authenticated with {GH_TOKEN} today."));
+    assert!(!out.contains(GH_TOKEN), "the token must not survive: {out}");
+    assert!(
+        out.contains("Simard authenticated with"),
+        "surrounding prose is preserved: {out}"
+    );
+}
+
+#[test]
+fn scrub_secrets_redacts_pem_private_key() {
+    // Assemble the PEM markers from fragments at runtime so the source file
+    // carries no literal `-----BEGIN … PRIVATE KEY-----` marker of its own.
+    let begin = format!("-----BEGIN {} PRIVATE KEY-----", "OPENSSH");
+    let end = format!("-----END {} PRIVATE KEY-----", "OPENSSH");
+    let body = "EXAMPLEfakeKEYbodyDoNotUse000000000000";
+    let pem = format!("{begin}\n{body}\n{end}");
+
+    let out = scrub_secrets(&format!("A leaked key:\n{pem}\nend of leak."));
+    assert!(!out.contains(body), "the key body must not survive: {out}");
+    assert!(
+        !out.contains(&begin),
+        "the PEM block is redacted whole: {out}"
+    );
+    assert!(
+        out.contains("end of leak."),
+        "surrounding prose is preserved: {out}"
+    );
+}
+
+#[test]
+fn scrub_secrets_leaves_ordinary_prose_unchanged() {
+    // No false-positive redaction of plain prose (even words like "key").
+    let prose = "Simard shipped an update to the live system and reviewed a key change.";
+    assert_eq!(
+        scrub_secrets(prose),
+        prose,
+        "ordinary prose must pass through untouched"
+    );
+}
+
+/// A drafter that leaks a secret.
+struct LeakyDrafter;
+impl JournalDrafter for LeakyDrafter {
+    fn draft(&self, _day: &DayContext) -> String {
+        format!("Overview. The update used the token {GH_TOKEN} to authenticate.")
+    }
+}
+
+/// A reviewer that passes text straight through — stands in for a language-model
+/// reviewer that might not redact secrets on its own.
+struct PassthroughReviewer;
+impl JournalReviewer for PassthroughReviewer {
+    fn review(&self, draft: &str) -> String {
+        draft.to_string()
+    }
+}
+
+#[test]
+fn generate_scrubs_secrets_even_when_the_reviewer_passes_them_through() {
+    let generator = JournalGenerator::new(Box::new(LeakyDrafter), Box::new(PassthroughReviewer));
+    let entry = generator.generate(&DayContext::new(day()));
+
+    assert!(
+        entry.draft.contains(GH_TOKEN),
+        "the raw draft still carries the secret (provenance): {}",
+        entry.draft
+    );
+    assert!(
+        !entry.narrative.contains(GH_TOKEN),
+        "the stored narrative must be secret-free after the unconditional post-pass: {}",
+        entry.narrative
+    );
+}

--- a/src/journal/tests_thread.rs
+++ b/src/journal/tests_thread.rs
@@ -87,6 +87,32 @@ fn tick_on_empty_store_is_an_honest_quiet_day() {
 }
 
 #[test]
+fn tick_drops_bare_prepared_context_summary_episodes() {
+    // The consolidation path pushes a bare "Prepared context: N facts, ..."
+    // summary into memory; it must NOT surface among the journal's remembered
+    // moments (issue #2606) — the report presents the substance instead.
+    let mem = FakeMemory::new();
+    mem.add_episode(episode(
+        "Prepared context: 10 facts, 2 triggers, 5 procedures, 5 episodes",
+    ));
+    mem.add_episode(episode("reviewed the login page fix"));
+    let clock = FixedClock(day());
+
+    let entry = run_journal_tick(&mem, &clock).expect("tick");
+
+    assert!(
+        !entry.narrative.contains("Prepared context"),
+        "the bare prepared-context count line is dropped: {}",
+        entry.narrative
+    );
+    assert!(
+        entry.narrative.contains("login page"),
+        "real remembered moments are still narrated: {}",
+        entry.narrative
+    );
+}
+
+#[test]
 fn enabled_by_default_and_interval_has_a_floor() {
     // Guard the env-independent contract without mutating process env (which
     // would race other tests): defaults hold when the vars are unset.

--- a/src/journal/thread.rs
+++ b/src/journal/thread.rs
@@ -25,6 +25,8 @@
 
 use chrono::NaiveDate;
 
+use std::path::Path;
+
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::SimardResult;
 use crate::journal::generate::JournalGenerator;
@@ -45,6 +47,10 @@ const MIN_JOURNAL_INTERVAL_SECS: u64 = 60;
 /// How many recent episodes the in-daemon source pulls as the day's primary
 /// narrative material.
 const MAX_EPISODES: u32 = 500;
+/// Upper bound on how many prepared-context items (facts / triggers /
+/// procedures) the report summarises — enough substance to be useful, bounded
+/// so the entry stays readable (issue #2606).
+const MAX_CONTEXT_ITEMS: u32 = 8;
 
 /// Whether the daemon's journal thread is enabled (default-on; opt-out via
 /// [`JOURNAL_ENABLED_ENV`]).
@@ -67,6 +73,13 @@ pub fn journal_interval_secs() -> u64 {
         .max(MIN_JOURNAL_INTERVAL_SECS)
 }
 
+/// Prefix of the bare working-memory context summary
+/// ("Prepared context: N facts, M triggers, ...") that the consolidation path
+/// pushes into working memory. It has no place among the journal's remembered
+/// moments now that the report presents the prepared context's *substance*
+/// (issue #2606), so the episode source drops it.
+const CONTEXT_SUMMARY_PREFIX: &str = "Prepared context:";
+
 /// The day's episodic memories, read from the live store. Best-effort: it pulls
 /// the most recent episodes as the day's narrative material rather than
 /// precisely windowing by timestamp, so a day with fresh activity always has
@@ -78,7 +91,11 @@ struct MemoryEpisodeSource<'a> {
 
 impl EpisodeSource for MemoryEpisodeSource<'_> {
     fn episodes_for_date(&self, _date: NaiveDate) -> SimardResult<Vec<CognitiveEpisode>> {
-        self.mem.list_all_episodes(self.limit)
+        let mut episodes = self.mem.list_all_episodes(self.limit)?;
+        // Drop the bare "Prepared context: N facts, ..." working-memory summary
+        // lines; the report now narrates the substance of that context instead.
+        episodes.retain(|e| !e.content.trim_start().starts_with(CONTEXT_SUMMARY_PREFIX));
+        Ok(episodes)
     }
 }
 
@@ -95,9 +112,13 @@ impl PrListSource for NoNetworkPrs {
 }
 
 /// Gather best-effort augmentations from the borrowed store. Whatever is present
-/// enriches the narrative; whatever is absent is simply omitted (honest
-/// degradation). Today this folds in the active goals; the remaining
-/// augmentation fields are left for future offline sources.
+/// enriches the report; whatever is absent is simply omitted (honest
+/// degradation). This folds in the active goals plus the **substance** of the
+/// prepared context (issue #2606): brief plain-language descriptions of the
+/// facts Simard knows, the reminders (triggers) it holds, and the know-how
+/// (procedures) it has — so the report summarises *what* they are rather than a
+/// bare "N facts, M triggers, K procedures" count line. Each read is best-effort
+/// and degrades to empty on error.
 fn gather_extras(mem: &dyn CognitiveMemoryOps) -> DayExtras {
     let mut extras = DayExtras::default();
     if let Ok(board) = crate::goal_curation::load_goal_board(mem) {
@@ -106,6 +127,40 @@ fn gather_extras(mem: &dyn CognitiveMemoryOps) -> DayExtras {
             .iter()
             .map(|g| g.description.clone())
             .filter(|d| !d.trim().is_empty())
+            .collect();
+    }
+    if let Ok(facts) = mem.search_facts("", MAX_CONTEXT_ITEMS, 0.0) {
+        extras.facts = facts
+            .into_iter()
+            .map(|f| f.content)
+            .filter(|c| !c.trim().is_empty())
+            .collect();
+    }
+    if let Ok(triggers) = mem.check_triggers("") {
+        extras.triggers = triggers
+            .into_iter()
+            .map(|t| {
+                if t.description.trim().is_empty() {
+                    t.trigger_condition
+                } else {
+                    t.description
+                }
+            })
+            .filter(|c| !c.trim().is_empty())
+            .take(MAX_CONTEXT_ITEMS as usize)
+            .collect();
+    }
+    if let Ok(procedures) = mem.recall_procedure("", MAX_CONTEXT_ITEMS) {
+        extras.procedures = procedures
+            .into_iter()
+            .map(|p| {
+                if p.steps.is_empty() {
+                    p.name
+                } else {
+                    format!("{}: {}", p.name, p.steps.join("; "))
+                }
+            })
+            .filter(|c| !c.trim().is_empty())
             .collect();
     }
     extras
@@ -143,13 +198,42 @@ pub fn run_journal_tick_with_prs(
     clock: &dyn JournalClock,
     prs: &dyn PrListSource,
 ) -> SimardResult<JournalEntry> {
+    // Deterministic, offline generator — the network-free variant used by tests
+    // and as the honest fallback.
+    tick_with_generator(mem, clock, prs, JournalGenerator::default_pipeline())
+}
+
+/// Run one rolling journal tick with an injected [`PrListSource`] and the
+/// **prompt-first** generator for `repo_root` (issue #2606, guideline G3).
+///
+/// Identical to [`run_journal_tick_with_prs`] except the report and its
+/// plain-language rewrite are produced by the language-model recipe path when
+/// the journal recipe assets and runner are available for `repo_root`; it
+/// degrades to the deterministic report drafter + glossary reviewer otherwise.
+/// This is the entry point the daemon uses in production.
+pub fn run_journal_tick_with_prs_in_repo(
+    mem: &dyn CognitiveMemoryOps,
+    clock: &dyn JournalClock,
+    prs: &dyn PrListSource,
+    repo_root: &Path,
+) -> SimardResult<JournalEntry> {
+    tick_with_generator(mem, clock, prs, JournalGenerator::for_repo(repo_root))
+}
+
+/// Shared tick core: assemble today's context (episodics primary + best-effort
+/// augmentations), generate the reviewed entry with `generator`, and persist it.
+fn tick_with_generator(
+    mem: &dyn CognitiveMemoryOps,
+    clock: &dyn JournalClock,
+    prs: &dyn PrListSource,
+    generator: JournalGenerator,
+) -> SimardResult<JournalEntry> {
     let date = clock.today();
     let episodes = MemoryEpisodeSource {
         mem,
         limit: MAX_EPISODES,
     };
     let extras = gather_extras(mem);
-    let generator = JournalGenerator::default_pipeline();
     let entry = crate::journal::providers::generate_and_store(
         date, &episodes, prs, extras, &generator, mem,
     )?;

--- a/src/journal/types.rs
+++ b/src/journal/types.rs
@@ -47,6 +47,12 @@ pub struct MemoryGrowth {
 /// built largely from these moment-by-moment memories. Every other field is a
 /// best-effort augmentation; a missing augmentation is simply omitted from the
 /// narrative (honest degradation), it never fabricates content.
+///
+/// The [`facts`](Self::facts), [`triggers`](Self::triggers), and
+/// [`procedures`](Self::procedures) fields carry the *substance* of the day's
+/// prepared context (issue #2606): rather than a bare "10 facts, 2 triggers, 5
+/// procedures" count line, the report summarises **what** each of them actually
+/// was, so a reader learns the material and not just the totals.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct DayContext {
     /// The calendar day (UTC) this context describes.
@@ -65,6 +71,15 @@ pub struct DayContext {
     pub memory_growth: Option<MemoryGrowth>,
     /// Any other notable events worth calling out.
     pub notable: Vec<String>,
+    /// Plain-language summaries of the facts Simard learned/held that day — the
+    /// *substance* behind the prepared-context "facts" count.
+    pub facts: Vec<String>,
+    /// Plain-language summaries of the reminders/triggers that fired — the
+    /// *substance* behind the prepared-context "triggers" count.
+    pub triggers: Vec<String>,
+    /// Plain-language summaries of the know-how (procedures) in play — the
+    /// *substance* behind the prepared-context "procedures" count.
+    pub procedures: Vec<String>,
 }
 
 impl DayContext {
@@ -77,7 +92,8 @@ impl DayContext {
     }
 
     /// `true` when nothing happened worth narrating — no episodes, proposals,
-    /// goals, deploys, Overseer activity, memory growth, or notable events.
+    /// goals, deploys, Overseer activity, memory growth, prepared-context
+    /// substance, or notable events.
     ///
     /// A quiet day still produces an honest entry (see the drafter) rather than
     /// an empty or fabricated one.
@@ -89,6 +105,9 @@ impl DayContext {
             && self.overseer_events.is_empty()
             && self.notable.is_empty()
             && self.memory_growth.is_none()
+            && self.facts.is_empty()
+            && self.triggers.is_empty()
+            && self.procedures.is_empty()
     }
 }
 

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -660,14 +660,15 @@ pub fn run_ooda_daemon(
 
     // ── Daily journal thread (issue #2606) ─────────────────────────────
     // DEFAULT-ON, opt-out via SIMARD_JOURNAL_ENABLED=0. On its own slow cadence
-    // (default hourly) the daemon regenerates *today's* diary-like, layperson
-    // journal entry from episodic memory and the day's activity — including the
-    // day's real code-change proposals pulled from the `gh pr list` PR-readiness
-    // service — persisting it in cognitive memory (a `journal:YYYY-MM-DD` fact).
-    // Because it touches the network it runs on a background thread (never
-    // inline) AFTER the authoritative OODA cycle, panic-isolated and
-    // overlap-guarded, so it can never stall or crash the loop. The dashboard
-    // Journal tab and the TUI Journal pane read these entries back.
+    // (default hourly) the daemon regenerates *today's* narrative engineering &
+    // research report from episodic memory and the day's activity — including
+    // the day's real code-change proposals pulled from the `gh pr list`
+    // PR-readiness service — persisting it in cognitive memory (a
+    // `journal:YYYY-MM-DD` fact). Because it touches the network it runs on a
+    // background thread (never inline) AFTER the authoritative OODA cycle,
+    // panic-isolated and overlap-guarded, so it can never stall or crash the
+    // loop. The dashboard Journal tab and the TUI Journal pane read these
+    // entries back.
     let journal_thread_enabled = crate::journal::journal_enabled();
     let journal_interval_secs = crate::journal::journal_interval_secs();
     let mut last_journal: Option<Instant> = None;
@@ -1390,6 +1391,7 @@ pub fn run_ooda_daemon(
                 let running = Arc::clone(&journal_tick_running);
                 let mem_for_journal = Arc::clone(&shared_mem);
                 let state_root_for_journal = state_root.clone();
+                let repo_root_for_journal = bridges.repo_root.clone();
                 let spawn = std::thread::Builder::new()
                     .name("journal-tick".to_string())
                     .spawn(move || {
@@ -1411,10 +1413,11 @@ pub fn run_ooda_daemon(
                         let prs = crate::journal::GhPrListSource::new(&gh, repo, base_allowlist);
 
                         let tick = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            crate::journal::run_journal_tick_with_prs(
+                            crate::journal::run_journal_tick_with_prs_in_repo(
                                 mem_for_journal.as_ref(),
                                 &crate::journal::SystemClock,
                                 &prs,
+                                &repo_root_for_journal,
                             )
                         }));
                         match tick {


### PR DESCRIPTION
## Summary

Fixes Simard's Daily Journal (feature from #2618 / issue #2606) so it **reads and is formatted as a professional, third-person NARRATIVE ENGINEERING & RESEARCH REPORT** — not a literal personal diary — and is genuinely free of jargon.

### Problems fixed (observed in production, deploy #21)
1. **Too-literal diary** → now a third-person report (no "Dear diary" / "I, Simard").
2. **Terrible formatting** → an `## Overview` paragraph, delineated `##` sections, and a plain-language PR summary table that render cleanly in **both** the dashboard Journal tab and the TUI Journal pane.
3. **Still full of jargon** → the plain-language rewrite now has **teeth**.
4. **Bare "Prepared context: N facts, ..." line** → replaced with the *substance* of the facts/triggers/procedures; the useless count artifact is dropped from remembered moments.
5. **Episodic memories had no timestamps** → each remembered moment now shows its timestamp and is ordered chronologically.

## What changed
- **`generate.rs`** — report drafter (Overview + sectioned narrative + chronological, timestamped moments); `generate()` now runs an unconditional `scrub_secrets` post-pass; `for_repo()` prefers the prompt-first path, degrading to deterministic.
- **`jargon.rs`** — strengthened glossary: **expands** acronyms (`PR`→"pull request", `CI`→"the automated checks"), removes raw identifiers (`temporal_index`, `working_memory`), explains insider terms (`OODA`, `daemon`, `TUI`, `LLM`, `episodic`), strips "Dear diary"; new `scrub_secrets` (GitHub tokens + PEM blocks).
- **`providers.rs` / `types.rs`** — `episode_time_label`; verbose prepared-context (`facts`/`triggers`/`procedures`) carried onto `DayContext`.
- **`render.rs`** — one shared renderer turns the report's markdown headings/bullets into real HTML structure (dashboard) and stripped heading lines (TUI), neutralising terminal control bytes; PR table preserved; XSS-safe.
- **`recipe.rs` + `prompt_assets/simard/recipes/journal-narrative.yaml` / `journal-plain-language.yaml`** — prompt-first drafter + de-jargon reviewer (guideline **G3**), each degrading per-call to the deterministic equivalent. Hot-reloads from `~/.simard/...`; lands in-repo so a deploy syncs it.
- **`thread.rs` / daemon** — gathers the prepared-context substance, drops the bare "Prepared context:" artifact, and wires the daemon to the prompt-first `run_journal_tick_with_prs_in_repo`.

## Tests
Hermetic (network-free) coverage: report structure & non-diary voice, timestamped/chronological moments, de-jargon **teeth** (a banned-token list never survives), acronym expansion, secret redaction, verbose prepared context, dropped count-line artifact, and dual-surface (HTML + TUI) structured rendering. Full library suite green (7367 tests).

## Constraints honoured
Additive / backward-compatible (search + browse-by-date preserved); no `--no-verify`; all pre-commit/pre-push gates (fmt, release clippy `-D warnings`, all-targets clippy, release test subset) green; no new `println!`/`eprintln!`; no "Bridge" names; prompt/recipe preferred over brittle Rust parsing.

Closes #2606
