### PR TITLE
fix(distill): tolerate trailing comma in agent JSON so one bad token no longer drops the whole batch (#2658)

### DIFF
--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -1270,6 +1270,32 @@ pub(crate) fn parse_facts_document(document: &str) -> SimardResult<DistillOutput
     )))
 }
 
+/// Parse a bare `{ "facts": [...] }` object, tolerating a single **trailing
+/// comma** malformation as a last resort (issue #2658).
+///
+/// Strict `serde_json` is attempted first, so the clean path is byte-identical
+/// and unchanged. Only when that fails is a retry attempted on the
+/// [`strip_json_trailing_commas`](crate::recipe_output::strip_json_trailing_commas)
+/// view — a provable no-op on valid JSON — so one cosmetic trailing comma
+/// before a `}`/`]` (the single most common LLM-JSON defect) can no longer
+/// reject the whole facts object and silently drop the entire batch (the
+/// residual 100% distill parse-failure shape). A genuinely malformed object
+/// (not just a trailing comma) leaves the stripped view unchanged, so it still
+/// fails and precision is never weakened.
+fn parse_facts_envelope_lenient(text: &str) -> Option<RecipeEnvelope> {
+    if let Ok(parsed) = serde_json::from_str::<RecipeEnvelope>(text) {
+        return Some(parsed);
+    }
+    // The stripper borrows the input unchanged when it holds no trailing comma,
+    // so a `Borrowed` result means the strict parse above already saw these
+    // exact bytes and failed — there is nothing new to try. Only an `Owned`
+    // (actually-stripped) view can parse where the strict attempt could not.
+    match crate::recipe_output::strip_json_trailing_commas(text) {
+        std::borrow::Cow::Owned(stripped) => serde_json::from_str::<RecipeEnvelope>(&stripped).ok(),
+        std::borrow::Cow::Borrowed(_) => None,
+    }
+}
+
 /// Scan an already noise-stripped `trimmed` string for a `{ "facts": [...] }`
 /// object, preferring (in order) the LAST balanced object candidate that carries
 /// a **grounded-capable** fact — one with a non-empty `source_episode_id` — then
@@ -1288,7 +1314,7 @@ pub(crate) fn parse_facts_document(document: &str) -> SimardResult<DistillOutput
 /// while still recovering a source-less answer when that is all the output holds.
 fn scan_cleaned_for_facts(trimmed: &str) -> Option<DistillOutput> {
     // Fast path — the text IS the JSON object.
-    if let Ok(parsed) = serde_json::from_str::<RecipeEnvelope>(trimmed) {
+    if let Some(parsed) = parse_facts_envelope_lenient(trimmed) {
         return Some(parsed.into_output());
     }
     // Slow path — among every balanced `{...}` substring (string-aware, so a
@@ -1309,7 +1335,7 @@ fn scan_cleaned_for_facts(trimmed: &str) -> Option<DistillOutput> {
         .into_iter()
         .rev()
     {
-        if let Ok(parsed) = serde_json::from_str::<RecipeEnvelope>(span) {
+        if let Some(parsed) = parse_facts_envelope_lenient(span) {
             let output = parsed.into_output();
             if output
                 .facts
@@ -1674,6 +1700,93 @@ mod unit_tests {
     fn parse_recipe_output_errors_when_no_object() {
         let raw = "no json here at all";
         assert!(parse_facts(raw).is_err());
+    }
+
+    // ── issue #2658: trailing-comma tolerance (residual 100% parse-failure) ──
+    //
+    // A single trailing comma before a `}`/`]` is the most common real-world
+    // LLM JSON defect. Before this fix strict `serde_json` rejected the WHOLE
+    // facts object, the batch was deferred every cycle, and
+    // `distill_parse_success_rate` collapsed toward 0 (the overseer's "100%
+    // parse-failure"). These pin that one cosmetic comma no longer drops the
+    // batch, while never corrupting string content or repairing genuinely
+    // malformed JSON.
+
+    #[test]
+    fn parse_recovers_bare_trailing_comma_facts_object() {
+        // Trailing comma after the last fact object AND after the `facts` array.
+        let raw = r#"{"facts":[{"concept":"pr-pattern","content":"warm the cache before pin bumps","source_episode_id":"epi_1"},],}"#;
+        assert!(
+            serde_json::from_str::<serde_json::Value>(raw).is_err(),
+            "precondition: the trailing-comma object must be strict-invalid JSON"
+        );
+        let facts =
+            parse_facts(raw).expect("a trailing-comma facts object must recover >= 1 fact (#2658)");
+        assert_eq!(facts.len(), 1, "the single well-formed fact is salvaged");
+        assert_eq!(facts[0].concept, "pr-pattern");
+        assert_eq!(facts[0].source_episode_id, "epi_1");
+    }
+
+    #[test]
+    fn parse_recovers_trailing_comma_with_procedures() {
+        // The pretty-printed shape an agent emits into its facts file, with
+        // trailing commas after the fact, the facts array, a procedure step,
+        // and the top-level object.
+        let raw = "{\n  \"facts\": [\n    {\"concept\": \"lesson-learned\", \"content\": \"one bad token must not drop the batch\", \"source_episode_id\": \"epi_7\"},\n  ],\n  \"procedures\": [\n    {\"name\": \"ci-fix\", \"steps\": [\"re-run\",], \"source_episode_ids\": [\"epi_7\"]},\n  ],\n}";
+        let out = parse_facts_document(raw)
+            .expect("a trailing-comma facts+procedures document must recover (#2658)");
+        assert_eq!(out.facts.len(), 1);
+        assert_eq!(out.facts[0].source_episode_id, "epi_7");
+        assert_eq!(out.procedures.len(), 1);
+        assert_eq!(out.procedures[0].steps, vec!["re-run".to_string()]);
+    }
+
+    #[test]
+    fn parse_recovers_trailing_comma_object_wrapped_in_prose() {
+        // The slow (balanced-brace) path must also tolerate a trailing comma —
+        // a little leading/trailing prose around the malformed object.
+        let raw = r#"Sure, here it is:
+            {"facts":[{"concept":"bug-pattern","content":"z","source_episode_id":"epi_3"},]}
+            done."#;
+        let facts = parse_facts(raw)
+            .expect("a prose-wrapped trailing-comma object must recover via the slow path (#2658)");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].concept, "bug-pattern");
+    }
+
+    #[test]
+    fn parse_trailing_comma_recovery_never_corrupts_string_content() {
+        // `content` ends with "…, " and the object still has a real structural
+        // trailing comma before `]` — only the structural comma may be removed.
+        let raw = r#"{"facts":[{"concept":"pr-pattern","content":"rebase, squash, then merge,","source_episode_id":"epi_4"},]}"#;
+        let facts = parse_facts(raw)
+            .expect("structural trailing comma removed, string content preserved (#2658)");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(
+            facts[0].content, "rebase, squash, then merge,",
+            "the comma-laden content (incl. its trailing comma) must survive verbatim"
+        );
+    }
+
+    #[test]
+    fn parse_still_fails_on_genuinely_malformed_non_trailing_comma() {
+        // An ELIDED array element `,,` is not a lone trailing comma: leniency
+        // must never widen to accept broken JSON, so precision is unchanged.
+        let raw = r#"{"facts":[{"concept":"pr-pattern","content":"a","source_episode_id":"e1"},,{"concept":"bug-pattern","content":"b","source_episode_id":"e2"}]}"#;
+        assert!(
+            parse_facts(raw).is_err(),
+            "an elided array element is not a trailing comma and must still fail (#2658)"
+        );
+    }
+
+    #[test]
+    fn parse_wellformed_object_unaffected_by_trailing_comma_recovery() {
+        // Clean-path invariant: a well-formed object is parsed by the strict
+        // path; the trailing-comma retry is never reached.
+        let raw = r#"{"facts":[{"concept":"lesson-learned","content":"clean","source_episode_id":"epi_9"}]}"#;
+        let facts = parse_facts(raw).expect("well-formed object parses");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].source_episode_id, "epi_9");
     }
 
     // ── issue #2461: last-object-wins + string-aware extraction ──────────

--- a/src/memory_consolidation/distillation_fact_yield_bench.rs
+++ b/src/memory_consolidation/distillation_fact_yield_bench.rs
@@ -334,3 +334,79 @@ fn fact_yield_benchmark_recovers_only_surface_variants_not_offspec() {
         );
     }
 }
+
+/// Deterministic **before/after parse-recovery benchmark** for issue #2658.
+///
+/// A single trailing comma in the distiller agent's JSON (the most common LLM
+/// JSON defect) made strict `serde_json` reject the WHOLE facts object, so the
+/// batch was deferred every cycle and `distill_parse_success_rate` collapsed
+/// toward 0 (the overseer's "residual 100% parse-failure"). Over a batch of
+/// trailing-comma documents reproducing that shape, the strict baseline fails
+/// EVERY one (parse-failure-rate = 1.000) while the shipped tolerant parser
+/// (`parse_facts_document`, the real production path) recovers EVERY one
+/// (parse-failure-rate = 0.000).
+///
+/// This is the deterministic, in-process analog of the live
+/// `distill_parse_success_rate` self-metric, which
+/// `record_parse_outcome("distill", parsed.is_ok())` drives from the same
+/// `parse_facts_document` return value on every real pass — so a production
+/// distill pass over trailing-comma output moves that metric off the floor by
+/// the exact mechanism proven here.
+#[test]
+fn distill_parse_failure_rate_benchmark_before_1000_after_0000() {
+    // A batch of realistic trailing-comma distill facts documents (bare and
+    // pretty-printed) that each carry one well-formed, grounded fact.
+    let doc = |ep: &str, pretty: bool| -> String {
+        if pretty {
+            format!(
+                "{{\n  \"facts\": [\n    {{\"concept\": \"lesson-learned\", \"content\": \"c\", \"source_episode_id\": \"{ep}\"}},\n  ],\n}}"
+            )
+        } else {
+            format!(
+                "{{\"facts\":[{{\"concept\":\"pr-pattern\",\"content\":\"c\",\"source_episode_id\":\"{ep}\"}},],}}"
+            )
+        }
+    };
+    let batch: Vec<String> = vec![
+        doc("epi_1", false),
+        doc("epi_2", true),
+        doc("epi_3", false),
+        doc("epi_4", true),
+        doc("epi_5", false),
+    ];
+    let n = batch.len() as f64;
+
+    // BEFORE — the strict baseline (what the pre-#2658 parser effectively did:
+    // reject the whole facts object on any trailing comma). Every one fails.
+    let before_failures = batch
+        .iter()
+        .filter(|raw| serde_json::from_str::<serde_json::Value>(raw).is_err())
+        .count();
+    let before_failure_rate = before_failures as f64 / n;
+
+    // AFTER — the shipped tolerant parser on the real production entry point.
+    let after_failures = batch
+        .iter()
+        .filter(|raw| {
+            parse_facts_document(raw)
+                .map(|o| o.facts.is_empty())
+                .unwrap_or(true)
+        })
+        .count();
+    let after_failure_rate = after_failures as f64 / n;
+
+    println!(
+        "[distill-parse-recovery-bench #2658] batch={} before_failure_rate={before_failure_rate:.3} \
+         after_failure_rate={after_failure_rate:.3}",
+        batch.len()
+    );
+
+    assert_eq!(
+        before_failure_rate, 1.000,
+        "baseline strict parse must fail EVERY trailing-comma document (the residual 100% shape)"
+    );
+    assert_eq!(
+        after_failure_rate, 0.000,
+        "the tolerant parser must recover EVERY trailing-comma document (fact-yield restored)"
+    );
+}

--- a/src/recipe_output/extract.rs
+++ b/src/recipe_output/extract.rs
@@ -298,6 +298,111 @@ pub fn last_balanced_object(s: &str) -> Option<&str> {
     balanced_objects(s).pop()
 }
 
+/// Strip JSON **trailing commas** — a `,` immediately preceding a closing `}`
+/// or `]` (ignoring intervening ASCII whitespace) — as a last-resort recovery
+/// view for otherwise-well-formed LLM JSON (issue #2658).
+///
+/// A trailing comma before `}`/`]` is the single most common real-world LLM
+/// JSON defect and is **never valid JSON**, so this stripper is a *provable
+/// no-op on valid input*: it returns [`Cow::Borrowed`] byte-for-byte unchanged
+/// whenever no trailing comma is present (the zero-allocation clean path).
+/// A caller therefore retries a strict-parse failure on this view without any
+/// risk of altering behaviour on well-formed output.
+///
+/// String-literal aware: a comma inside a JSON string (respecting `\"`
+/// escapes) is never touched, so a comma in a fact's `content` is preserved
+/// verbatim. Only the offending comma bytes are removed and every removed byte
+/// is ASCII, so the result is always valid UTF-8.
+///
+/// Note this targets *only* the single-trailing-comma shape. A genuinely
+/// malformed object (e.g. an elided element `[1,,2]`, an unquoted key, a
+/// missing value) is left still-malformed so the caller's strict parse still
+/// rejects it — leniency never widens to accept broken JSON.
+pub fn strip_json_trailing_commas(s: &str) -> Cow<'_, str> {
+    let bytes = s.as_bytes();
+    // Cheap detection pass first so clean JSON borrows unchanged (zero-alloc).
+    if !has_trailing_comma(bytes) {
+        return Cow::Borrowed(s);
+    }
+    // Rebuild, dropping only the trailing commas. Only ASCII comma bytes are
+    // ever skipped, so the surviving bytes remain valid UTF-8.
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_string {
+            out.push(c);
+            if escaped {
+                escaped = false;
+            } else if c == b'\\' {
+                escaped = true;
+            } else if c == b'"' {
+                in_string = false;
+            }
+        } else if c == b'"' {
+            in_string = true;
+            out.push(c);
+        } else if c == b',' && next_nonspace_is_close(bytes, i + 1) {
+            // Trailing comma — drop it (do not copy).
+        } else {
+            out.push(c);
+        }
+        i += 1;
+    }
+    match String::from_utf8(out) {
+        Ok(stripped) => Cow::Owned(stripped),
+        // Unreachable in practice (only ASCII commas are dropped), but never
+        // panic on recovery input — fall back to the original text.
+        Err(_) => Cow::Borrowed(s),
+    }
+}
+
+/// Does `bytes` contain at least one string-aware trailing comma?
+///
+/// Mirrors the scan in [`strip_json_trailing_commas`] but only detects, so the
+/// common clean case can borrow the input without allocating.
+fn has_trailing_comma(bytes: &[u8]) -> bool {
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if c == b'\\' {
+                escaped = true;
+            } else if c == b'"' {
+                in_string = false;
+            }
+        } else if c == b'"' {
+            in_string = true;
+        } else if c == b',' && next_nonspace_is_close(bytes, i + 1) {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+/// Is the first non-ASCII-whitespace byte at or after `i` a closing `}`/`]`?
+///
+/// Only JSON insignificant whitespace (space, tab, LF, CR, form-feed) is
+/// skipped; any other byte (including `"` opening the next key/element) means
+/// the comma is a legitimate separator and must be kept.
+fn next_nonspace_is_close(bytes: &[u8], mut i: usize) -> bool {
+    while i < bytes.len() {
+        match bytes[i] {
+            b' ' | b'\t' | b'\n' | b'\r' | 0x0c => i += 1,
+            b'}' | b']' => return true,
+            _ => return false,
+        }
+    }
+    false
+}
+
 /// Extract a JSON object from noisy recipe stdout as an owned `String`.
 ///
 /// Tries two cleaned views and returns the last balanced `{…}` from the first
@@ -606,6 +711,101 @@ mod tests {
         let m = extract_verdict(raw, &["reject", "accept"]).unwrap();
         assert_eq!(m.keyword, "accept");
         assert_eq!(m.rationale, "After review I accept the claim.");
+    }
+
+    // ---- strip_json_trailing_commas (issue #2658) ------------------------
+
+    #[test]
+    fn strip_trailing_commas_valid_json_is_borrowed_zero_copy() {
+        // The clean path must not allocate and must be byte-identical: a
+        // provable no-op on valid JSON, so a strict-parse retry on this view
+        // can never change behaviour on well-formed output.
+        let s = r#"{"facts":[{"concept":"pr-pattern","content":"a"}],"procedures":[]}"#;
+        let out = strip_json_trailing_commas(s);
+        assert!(
+            matches!(out, Cow::Borrowed(_)),
+            "valid JSON must borrow unchanged (zero-alloc)"
+        );
+        assert_eq!(out, s);
+    }
+
+    #[test]
+    fn strip_trailing_commas_before_brace_and_bracket() {
+        // Trailing comma before `}` and before `]` are both removed, yielding
+        // parseable JSON.
+        let malformed = r#"{"facts":[{"concept":"pr-pattern","content":"a",},],}"#;
+        let fixed = strip_json_trailing_commas(malformed);
+        assert!(matches!(fixed, Cow::Owned(_)), "a change must allocate");
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&fixed).is_ok(),
+            "stripped output must be valid JSON: {fixed}"
+        );
+        assert_eq!(
+            fixed,
+            r#"{"facts":[{"concept":"pr-pattern","content":"a"}]}"#
+        );
+    }
+
+    #[test]
+    fn strip_trailing_commas_tolerates_whitespace_before_close() {
+        // Whitespace (incl. newlines) between the comma and the closer is
+        // skipped — the pretty-printed shape an LLM actually emits.
+        let malformed = "{\n  \"facts\": [\n    {\"concept\": \"a\"},\n  ],\n}";
+        let fixed = strip_json_trailing_commas(malformed);
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&fixed).is_ok(),
+            "pretty-printed trailing commas must be recovered: {fixed}"
+        );
+    }
+
+    #[test]
+    fn strip_trailing_commas_never_corrupts_comma_in_string_content() {
+        // A `,}` or `,]` sequence INSIDE a JSON string is content, not a
+        // trailing comma, and must survive verbatim (including when the string
+        // ends immediately after it).
+        let s = r#"{"content":"first, second,","tag":"x"}"#;
+        let out = strip_json_trailing_commas(s);
+        assert!(
+            matches!(out, Cow::Borrowed(_)),
+            "string-internal commas are not trailing commas — must borrow"
+        );
+        assert_eq!(out, s);
+
+        // Even a literal `, ]` inside string content is preserved.
+        let s2 = r#"{"content":"a, ] b, } c"}"#;
+        assert_eq!(strip_json_trailing_commas(s2), s2);
+    }
+
+    #[test]
+    fn strip_trailing_commas_respects_escaped_quote_in_string() {
+        // An escaped quote must not prematurely end the string, so a `,]`
+        // after it (still inside the string) is not stripped.
+        let s = r#"{"content":"he said \"go,\" then left,","k":1}"#;
+        let out = strip_json_trailing_commas(s);
+        assert!(matches!(out, Cow::Borrowed(_)));
+        assert_eq!(out, s);
+    }
+
+    #[test]
+    fn strip_trailing_commas_leaves_genuinely_malformed_still_malformed() {
+        // An elided element `,,` is NOT a single trailing comma: leniency must
+        // not repair it into valid JSON.
+        let malformed = r#"{"facts":[1,,2]}"#;
+        let out = strip_json_trailing_commas(malformed);
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&out).is_err(),
+            "a doubly-malformed array must remain malformed: {out}"
+        );
+    }
+
+    #[test]
+    fn strip_trailing_commas_preserves_multibyte_utf8() {
+        // Non-ASCII content around a stripped comma must round-trip intact.
+        let malformed = r#"{"content":"café — δοκιμή","k":1,}"#;
+        let fixed = strip_json_trailing_commas(malformed);
+        let v: serde_json::Value =
+            serde_json::from_str(&fixed).expect("multibyte content must stay valid after strip");
+        assert_eq!(v["content"], "café — δοκιμή");
     }
 }
 

--- a/src/recipe_output/mod.rs
+++ b/src/recipe_output/mod.rs
@@ -11,7 +11,7 @@ pub mod extract;
 
 pub use extract::{
     VerdictMatch, balanced_objects, extract_json_payload, extract_verdict, last_balanced_object,
-    strip_ansi, strip_recipe_noise,
+    strip_ansi, strip_json_trailing_commas, strip_recipe_noise,
 };
 
 /// Record the outcome of a recipe-output parse for one phase.

--- a/tests/qa-scenarios/distill-trailing-comma-parse.yaml
+++ b/tests/qa-scenarios/distill-trailing-comma-parse.yaml
@@ -1,0 +1,89 @@
+name: distill-trailing-comma-parse
+app_type: cli
+description: |
+  Verify episode→fact distillation tolerates a trailing comma in the distiller
+  agent's `{ "facts": [...] }` JSON (issue #2658 — the residual "100%
+  parse-failure" shape after the launcher-banner / ANSI fixes). A trailing comma
+  before a `}` or `]` is the single most common real-world LLM JSON defect; the
+  balanced-brace scan still finds the span, but strict `serde_json` rejected the
+  WHOLE object, so the batch was silently deferred every cycle and
+  `distill_parse_success_rate` collapsed toward 0. A new string-aware,
+  last-resort `strip_json_trailing_commas` recovery view (a provable no-op on
+  valid JSON) is retried only after the strict parse fails, so one cosmetic comma
+  no longer drops the batch — WITHOUT weakening precision (a comma inside a
+  fact's string content is preserved, and a genuinely malformed object still
+  fails). Proven by the hermetic in-process unit tests + the deterministic
+  before/after parse-recovery benchmark this scenario drives (no network, no live
+  host mutation). The CLI runner rejects any non-zero exit, so a failing test
+  fails the scenario.
+agents:
+  - name: simard-cli
+    type: cli
+    command: cargo
+steps:
+  # Stripper primitive: a trailing comma before `}`/`]` (incl. pretty-printed
+  # whitespace) is removed to valid JSON, while a comma inside string content and
+  # a genuinely-malformed (elided-element) object are left untouched. Zero-alloc
+  # borrow on valid JSON proves the clean path is byte-identical. First
+  # invocation may compile the test binary.
+  - action: run
+    params:
+      command: "cargo test --locked --lib recipe_output::extract::tests::strip_trailing_commas"
+    timeout: 600000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Production path: a bare trailing-comma facts object recovers >= 1 fact
+  # instead of dropping the whole batch (the headline #2658 acceptance).
+  - action: run
+    params:
+      command: "cargo test --locked --lib memory_consolidation::distillation::unit_tests::parse_recovers_bare_trailing_comma_facts_object"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Precision guard: a comma inside a fact's `content` string is never corrupted,
+  # and a genuinely malformed (elided `,,`) object still fails — leniency never
+  # widens to accept broken JSON.
+  - action: run
+    params:
+      command: "cargo test --locked --lib -- memory_consolidation::distillation::unit_tests::parse_trailing_comma_recovery_never_corrupts_string_content memory_consolidation::distillation::unit_tests::parse_still_fails_on_genuinely_malformed_non_trailing_comma"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Deterministic before/after parse-recovery benchmark: over a batch that
+  # reproduces the residual 100% shape, the strict baseline fails EVERY one
+  # (failure-rate 1.000) and the shipped tolerant parser recovers EVERY one
+  # (failure-rate 0.000) — the in-process analog of the live
+  # `distill_parse_success_rate` self-metric moving off the floor.
+  - action: run
+    params:
+      command: "cargo test --locked --lib memory_consolidation::distillation_fact_yield_bench::distill_parse_failure_rate_benchmark_before_1000_after_0000 -- --nocapture"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "before_failure_rate=1.000 after_failure_rate=0.000"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000


### PR DESCRIPTION
## Verdict: READY TO MERGE

All six merge-ready criteria are satisfied with concrete evidence (below): a
qa-team scenario validated + run, an internal-only doc justification, a
three-cycle quality audit ending clean, a **100% green CI run** (linked
per-check), a populated evidence-bearing description, and a focused 5-file
diff with no unrelated edits. The change is a bounded, precision-safe,
issue-prescribed fix for #2658. **Recommendation: merge.**

## Summary

Fixes #2658. Episode distillation still reported a **residual 100% parse-failure
rate** on some cycles after the launcher-banner / ANSI fixes. The residual shape
is a **trailing comma** in the distiller agent's JSON: a `,` before a `}`/`]` —
the single most common real-world LLM JSON defect. The balanced-brace scan still
finds the `{ "facts": [...] }` span (a trailing comma does not unbalance braces),
but strict `serde_json::from_str` rejects the **entire** object, so the pass
returns `None`/`Err`, the batch is silently deferred every cycle, and
`distill_parse_success_rate` collapses toward 0 (the overseer's "100%").

## Fix

Add a string-aware, last-resort `strip_json_trailing_commas` recovery view to the
shared `recipe_output::extract` module, and retry the distill facts-object parse
on it **only after** the strict parse fails (`parse_facts_envelope_lenient`, wired
into both parse sites of `scan_cleaned_for_facts` — the fast path and the
balanced-brace slow path). This is exactly the fix prescribed in issue #2658.

Key safety properties (precision is never weakened):

- **Provable no-op on valid JSON.** A trailing comma before `}`/`]` is never
  valid JSON, so the stripper returns `Cow::Borrowed` byte-for-byte unchanged on
  clean input (zero-allocation). The strict path is reached first and is
  byte-identical, so behaviour on well-formed output cannot change.
- **String-content safe.** A comma inside a fact's `content` (respecting `\"`
  escapes and multibyte UTF-8) is never touched.
- **Malformed stays malformed.** Only a lone trailing comma is repaired; a
  genuinely malformed object (e.g. an elided `,,` element) still fails, so the
  reliability/allow-list gates are unaffected. The repair is a defensive
  *last resort* after strict parse — not a replacement for the structured-output
  contract.

## Where the fix lands

Entirely in **`rysweet/Simard`** (`src/recipe_output/extract.rs`,
`src/memory_consolidation/distillation.rs`). The parse/repair path lives in
Simard's own `recipe_output::extract` + distillation modules, **not** in
`amplihack-memory-lib`, so no upstream landing or `amplihack-memory` `rev=`
pin-bump is required.

---

## Merge-ready evidence

### Criterion 1 — qa-team scenario (validated + run)
- New scenario: `tests/qa-scenarios/distill-trailing-comma-parse.yaml`.
- `gadugi-test validate -f … --strict` → `✓ Scenario "distill-trailing-comma-parse" is valid` (1 valid, 0 invalid).
- `gadugi-test run -s distill-trailing-comma-parse` → `✓ Passed: 1  ✗ Failed: 0  ✓ All tests passed!`
  (drives the stripper unit tests, bare-object recovery, precision guards, and the before/after benchmark).

### Criterion 2 — docs (internal-only, justified)
No user-facing CLI/output surface changes. The only new public item is
`recipe_output::extract::strip_json_trailing_commas`, an internal crate-level
parsing primitive re-exported alongside the existing `strip_ansi` /
`strip_recipe_noise` helpers, fully documented by doc comments on the new fn and
the `parse_facts_envelope_lenient` retry helper. No end-user docs apply.

### Criterion 3 — quality-audit (3 SEEK→VALIDATE→FIX cycles, clean final)
- **Cycle 1 — stripper primitive:** empty input, comma-at-EOF (no closer →
  correctly *not* stripped), `\\`/`\"` escape handling, multibyte UTF-8 passthrough. 0 findings.
- **Cycle 2 — integration/precision:** double-parse only on failure; no
  false-positive recoveries (only structural trailing commas, never valid JSON);
  recovered facts still flow through the concept allow-list + reliability gate;
  "last-object-wins" tier logic unchanged. 0 findings.
- **Cycle 3 — robustness/security:** O(n) single-pass (no DoS; the 50k-nested-brace
  guard test still passes); panic-safe UTF-8 rebuild; the no-op-on-valid-JSON
  guarantee holds even with the superset whitespace set. 0 findings. **Final cycle clean**
  (zero critical/high; zero medium correctness/security).

### Criterion 4 — CI 100% green
**Green CI run:** https://github.com/rysweet/Simard/actions/runs/28790251495 (conclusion: **success**). Every required check passed:

| Check | Status | Run |
| --- | --- | --- |
| pre-commit (fmt + clippy --release + `cargo test --all-features --locked`) | ✅ pass (10m45s) | [job](https://github.com/rysweet/Simard/actions/runs/28790251495/job/85366789245) |
| cargo-audit | ✅ pass | [job](https://github.com/rysweet/Simard/actions/runs/28790251495/job/85366789222) |
| cargo-deny | ✅ pass | [job](https://github.com/rysweet/Simard/actions/runs/28790251495/job/85366789191) |
| cargo-vet | ✅ pass | [job](https://github.com/rysweet/Simard/actions/runs/28790251495/job/85366789210) |
| npm-audit | ✅ pass | [job](https://github.com/rysweet/Simard/actions/runs/28790251495/job/85366789169) |
| install-real | ✅ pass | [job](https://github.com/rysweet/Simard/actions/runs/28790251495/job/85368834735) |
| e2e-dashboard | ✅ pass | [job](https://github.com/rysweet/Simard/actions/runs/28790251495/job/85368834769) |
| coverage | ✅ pass | [job](https://github.com/rysweet/Simard/actions/runs/28790251572/job/85366789415) |
| GitGuardian Security Checks | ✅ pass | — |

`gh pr view` rollup: **`mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`**, 16/16 checks SUCCESS, 0 pending, 0 failing.

### Criterion 5 — diff focused (no unrelated edits)
5 files, all on-issue: `recipe_output/extract.rs` (+stripper, +7 tests),
`recipe_output/mod.rs` (re-export), `memory_consolidation/distillation.rs`
(+retry helper, 2 wiring sites, +6 tests), `distillation_fact_yield_bench.rs`
(+before/after benchmark), and the new qa-scenario. No unrelated edits.

### Criterion 6 — verdict
**READY TO MERGE** (stated at the top). Rationale: criteria 1–5 are each satisfied
with concrete, linked evidence; CI is 100% green on run
[28790251495](https://github.com/rysweet/Simard/actions/runs/28790251495); the
change is bounded, precision-safe, and matches the fix the issue prescribes.

---

## Issue acceptance criteria (#2658)
- [x] Trailing-comma facts object (bare + pretty/prose-wrapped) recovers ≥ 1 fact.
- [x] A comma inside a fact's string content is never corrupted.
- [x] A genuinely malformed object (not just a trailing comma) still fails.
- [x] Deterministic before/after parse-recovery benchmark recorded
      (`before_failure_rate=1.000 → after_failure_rate=0.000`).
- [x] `distill_parse_success_rate` drives toward 1.0 — the tolerant
      `parse_facts_document` return value that `record_parse_outcome("distill", …)`
      trends is now `Ok` for trailing-comma output. The deterministic benchmark is
      the in-process analog of that live self-metric; a live LLM distill pass over
      trailing-comma output moves the trended metric off the floor by the exact
      mechanism proven here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
