### PR TITLE
fix(dashboard): Goals tab renders each goal's real lifecycle status, not a blanket failed/blocked (#20)

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -161,6 +161,39 @@ Before (machine jargon) and after (plain English):
 |--------|-------|
 | ![Cluster card before](assets/dashboard-cluster-card-before.png) | ![Machines & Memory Sharing card after](assets/dashboard-cluster-card-after.png) |
 
+### Goals tab: lifecycle-status badges (#20)
+
+The **Goals** tab's active-goals table has a **Status** column that renders each
+goal's *real, live* lifecycle status as a distinctly-coloured **badge** —
+**Not started**, **In progress — N%**, **Blocked — &lt;reason&gt;**,
+**Completed**, **Proposed**, or **Paused**. Previously the tab printed the raw
+`status` string while the prominent coloured signal was the **Current Activity**
+chip (whose red `Failed` state made a mixed board of not-started / in-progress /
+blocked / completed goals all *look* failed). The two axes are now separated:
+the **Status** column is the authoritative lifecycle indicator, and the
+**Current Activity** column keeps its activity chip unchanged.
+
+| Lifecycle | Badge | Colour |
+|-----------|-------|--------|
+| `NotStarted` / `Proposed` | **Not started** / **Proposed** | grey `#8b949e` |
+| `InProgress { percent }` | **In progress — 42%** | accent `var(--accent)` |
+| `Blocked(reason)` | **Blocked — &lt;reason&gt;** | amber `#d29922` |
+| `Paused` | **Paused** | muted `#6e7681` |
+| `Completed` | **Completed** | green `#2ea043` |
+
+Blocked is amber `#d29922`, deliberately different from the activity chip's
+`Failed` red `#f85149`, so a lifecycle *block* (e.g. the OODA-safeguard
+`🔒 … needs human review` hold) is never mistaken for an activity *failure* —
+and the block reason is shown inline. The badge is driven by the additive
+`status_progress` field on `/api/goals` (the serialized `GoalProgress` enum),
+classified by enum key via `goalLifecycleKey` and coloured from the hard-coded
+`GOAL_STATUS_COLORS` allowlist, with the label produced by
+`humanizeGoalProgress` and escaped last. The view is **live** — `/api/goals`
+reloads the goal board on every request, so it reconciles with `simard goal
+list` by construction. See
+[Goals tab lifecycle-status badges](reference/dashboard-goal-lifecycle-status.md)
+for the full reference.
+
 ### Goals tab → Work Board: plain-English Task Memory & Recent Actions
 
 A live Playwright audit of the **Work Board** sub-section (in the **Goals** tab)
@@ -551,6 +584,7 @@ The `SIMARD_DASHBOARD_URL` environment variable is honored by `conftest.py` (def
 - [Memory architecture](memory.md)
 - [Run the OODA daemon](howto/run-ooda-daemon.md)
 - [Dashboard E2E tests](reference/dashboard-e2e-tests.md)
+- [Goals tab lifecycle-status badges](reference/dashboard-goal-lifecycle-status.md)
 - [Overview action-detail humanization](reference/dashboard-action-detail-humanization.md)
 - [Dashboard Feedback Widget](reference/dashboard-feedback-widget.md)
 - [How to report a bug or request a feature from the dashboard](howto/report-a-bug-or-request-a-feature.md)

--- a/docs/reference/dashboard-goal-lifecycle-status.md
+++ b/docs/reference/dashboard-goal-lifecycle-status.md
@@ -1,0 +1,258 @@
+---
+title: Goals tab lifecycle-status badges
+description: Reference for the Goals tab Status column — the per-goal lifecycle badge that renders each active goal's real, live status (Not started, In progress, Blocked + reason, Completed, Proposed, Paused) distinctly, driven by the additive status_progress field on /api/goals.
+last_updated: 2026-07-06
+owner: simard
+doc_type: reference
+related:
+  - ../dashboard.md
+  - ./goal-board-api.md
+  - ./dashboard-action-detail-humanization.md
+  - ../howto/unblock-stuck-ooda-goals.md
+---
+
+# Goals tab lifecycle-status badges
+
+Reference documentation for the **Status** column of the dashboard **Goals**
+tab. Each active goal now renders an authoritative, distinctly-coloured
+**lifecycle badge** that reflects that goal's *real, live* status —
+**Not started**, **In progress**, **Blocked** (with its block reason),
+**Completed**, **Proposed**, or **Paused** — instead of collapsing every goal
+into a single uniform "failed/blocked" appearance
+([#20](https://github.com/rysweet/Simard/issues/20)).
+
+## Why this exists
+
+The 20-slot active goal register is almost always in **mixed** states: some
+goals are `blocked` (for example the OODA-safeguard hold —
+`🔒 [OODA-SAFEGUARD] … 3 consecutive no-action cycles; needs human review`),
+many are `not-started`, several are `in-progress`, and several are `completed`.
+`simard goal list` reports those mixed states correctly.
+
+Previously the **Goals** tab did **not** reflect them: the prominent coloured
+signal in each row was the **Current Activity** *activity chip* (`Working`,
+`Skipped`, `Failed`, `Waiting`, `Spawned engineer`), and the Status column
+merely printed the raw `status` string. Operators read the activity chip — and
+its red `Failed` state — as the goal's lifecycle status, so the whole board
+looked as though every goal had failed or was blocked. That conflated two
+different axes:
+
+- **Lifecycle status** — where a goal sits in its life (not-started → in-progress
+  → completed, or blocked / paused). This is `GoalProgress`.
+- **Current activity** — what the daemon did on its *most recent* touch of the
+  goal (worked, skipped, spawned an engineer, …). This is the activity chip.
+
+The fix separates the two. The **Status** column is now the authoritative
+lifecycle indicator; the **Current Activity** column keeps the activity chip
+unchanged. A goal that is simply *not started* no longer looks *failed*, and a
+genuinely *blocked* goal shows **why**.
+
+## What the operator sees
+
+Active-goals table, **Status** column:
+
+| Goal lifecycle | Badge label | Badge colour |
+|----------------|-------------|--------------|
+| `NotStarted` | **Not started** | neutral grey `#8b949e` |
+| `Proposed` | **Proposed** | neutral grey `#8b949e` |
+| `InProgress { percent }` | **In progress — 42%** | accent `var(--accent)` |
+| `Blocked(reason)` | **Blocked — &lt;reason&gt;** | amber `#d29922` |
+| `Paused` | **Paused** | muted `#6e7681` |
+| `Completed` | **Completed** | green `#2ea043` |
+
+Key points:
+
+- **Blocked is amber `#d29922`, deliberately different from the activity chip's
+  `Failed` red `#f85149`.** A lifecycle *block* (needs human review) must not be
+  mistaken for an activity *failure*.
+- The **block reason is shown inline** — e.g.
+  `Blocked — 🔒 [OODA-SAFEGUARD] … 3 consecutive no-action cycles; needs human
+  review` — so the operator knows what to do without leaving the tab.
+- Every lifecycle status is **visually distinct**, so a board with mixed states
+  reads as mixed, matching `simard goal list`.
+
+### Before / after
+
+| Was (Status column) | Now (Status column) |
+|---------------------|---------------------|
+| `blocked: 🔒 [OODA-SAFEGUARD] … needs human review` (raw string, looked like every other row) | **Blocked — 🔒 [OODA-SAFEGUARD] … needs human review** (amber badge) |
+| `not-started` (raw string; row looked "failed" because the activity chip was red) | **Not started** (grey badge) |
+| `in-progress(42%)` (raw string) | **In progress — 42%** (accent badge) |
+| `completed` (raw string) | **Completed** (green badge) |
+
+## Live, not a stale snapshot
+
+The Goals tab reflects the **live** goal board. `/api/goals` rebuilds its view
+from the goal store on **every request** via
+`dashboard_goal_board_snapshot(state_root)` in
+[`goals.rs`](https://github.com/rysweet/Simard/blob/main/src/operator_commands_dashboard/goals.rs)
+— there is no cached one-time snapshot. Because both the dashboard and
+`simard goal list` read the same authoritative goal store, the two **agree by
+construction**: a goal that `simard goal list` reports as `blocked` renders as
+an amber **Blocked** badge in the tab, and so on.
+
+## API: the `status_progress` field
+
+The fix is **additive**. Each active-goal object returned by `/api/goals`
+carries a new `status_progress` field alongside the existing fields. It is the
+**serialized `GoalProgress` enum** (the same closed, trusted internal type used
+across the goal board), which is what carries the structured block reason and
+progress percent.
+
+```jsonc
+{
+  "active": [
+    {
+      "id": "audit-test-coverage",
+      "description": "Audit test coverage across crates",
+      "priority": 3,
+      "status": "not-started",                 // existing: GoalProgress Display string
+      "status_progress": "NotStarted",          // NEW: serialized GoalProgress enum
+      "assigned_to": null,
+      "repo": "rysweet/Simard",
+      "current_activity": null,
+      "status_chip": "Waiting",                 // existing: activity chip (unchanged)
+      "detail": "",
+      "detail_full": "",
+      "wip_refs": []
+    },
+    {
+      "id": "agent-kgpacks-rs-ws24",
+      "description": "…",
+      "priority": 1,
+      "status": "blocked: 🔒 [OODA-SAFEGUARD] … 3 consecutive no-action cycles; needs human review",
+      "status_progress": {                      // NEW: object form carries the reason
+        "Blocked": "🔒 [OODA-SAFEGUARD] … 3 consecutive no-action cycles; needs human review"
+      },
+      "status_chip": "Waiting",
+      "wip_refs": []
+    }
+  ],
+  "backlog": [ /* … unchanged … */ ],
+  "active_count": 20
+}
+```
+
+### `status_progress` serialization forms
+
+`status_progress` mirrors the `GoalProgress` enum exactly (see the
+[`GoalProgress` variants](goal-board-api.md#goalprogress-variants) table):
+
+| `GoalProgress` variant | `status_progress` JSON |
+|------------------------|------------------------|
+| `NotStarted` | `"NotStarted"` |
+| `Proposed` | `"Proposed"` |
+| `InProgress { percent }` | `{"InProgress":{"percent":42}}` |
+| `Blocked(reason)` | `{"Blocked":"<reason>"}` |
+| `Paused` | `"Paused"` |
+| `Completed` | `"Completed"` |
+
+### Compatibility
+
+- **Additive only.** The existing `status` (Display string), `status_chip`,
+  `detail`, `detail_full`, `current_activity`, and `wip_refs` fields are
+  **unchanged**. Existing consumers keep working; `status_progress` is new.
+- **No route, auth, or schema change.** `status_progress` rides the same
+  authenticated `GET /api/goals` request behind `require_auth`. Nothing new is
+  exposed — the block reason was already present in the `status` string.
+- **No persistence change.** `status_progress` is a **response-only
+  projection** of the in-memory `GoalProgress`; the on-disk goal store format,
+  the `GoalProgress` variants, and any migration path are untouched.
+
+## Rendering pipeline (front end)
+
+The Status column is rendered client-side in
+[`index_html`](https://github.com/rysweet/Simard/blob/main/src/operator_commands_dashboard/index_html/)
+from three cooperating pieces:
+
+1. **`humanizeGoalProgress(status_progress)`** *(existing, reused)* — turns the
+   serialized enum into a plain-text label: `"NotStarted"` → `Not started`,
+   `{"InProgress":{"percent":42}}` → `In progress — 42%`,
+   `{"Blocked":"<reason>"}` → `Blocked — <reason>`, `"Completed"` →
+   `Completed`, and so on. Returns **plain text only** (escape-last invariant).
+
+2. **`goalLifecycleKey(status_progress)`** *(the classifier)* — maps the
+   serialized enum to one canonical colour key —
+   `blocked` · `completed` · `in-progress` · `not-started` · `proposed` ·
+   `paused` — **by the enum variant name only**. It dispatches on the two serde
+   shapes that `GoalProgress` produces:
+
+   - **String forms** (`"NotStarted"`, `"Proposed"`, `"Paused"`, `"Completed"`,
+     and the legacy `"Done"`) are the variant name itself, so the classifier
+     keys **directly off the string**.
+   - **Object forms** (`{"Blocked":"<reason>"}`,
+     `{"InProgress":{"percent":42}}`) wrap the variant name as their sole key,
+     so the classifier reads **`Object.keys(status_progress)[0]`** — the variant
+     name — and never the wrapped payload.
+
+   In both cases the variant name is lower-cased/kebab-mapped to the colour key
+   (`Blocked`→`blocked`, `InProgress`→`in-progress`, `NotStarted`→`not-started`,
+   …). Any unrecognized value falls through to `not-started`. Because it keys on
+   the variant name only, it never inspects the block-reason text or the percent
+   value, so a hostile or unusual reason string cannot change which colour is
+   chosen (guideline **G3**: classify structured data by its enum, not by
+   parsing a Display string).
+
+3. **`GOAL_STATUS_COLORS`** *(the allowlist)* — a hard-coded map from colour key
+   to colour:
+
+   | Key | Colour |
+   |-----|--------|
+   | `blocked` | `#d29922` (amber) |
+   | `completed` | `#2ea043` (green) |
+   | `in-progress` | `var(--accent)` |
+   | `not-started` | `#8b949e` (grey) |
+   | `proposed` | `#8b949e` (grey) |
+   | `paused` | `#6e7681` (muted) |
+
+The Status cell renders a coloured badge whose **label** is
+`esc(humanizeGoalProgress(g.status_progress))` and whose **colour** is
+`GOAL_STATUS_COLORS[goalLifecycleKey(g.status_progress)]`. The fallback to the
+legacy `esc(g.status)` string triggers **only when `g.status_progress == null`**
+(field absent or explicitly null in older payloads) — a `== null` test, not a
+falsiness test. This mirrors `humanizeGoalProgress`, whose own guard is
+`if (status == null) return ''`: any present `status_progress` value (including
+an object form) is truthy and is always rendered through the humanizer +
+classifier path rather than falling back.
+
+The **Current Activity** column is unchanged: it still shows the activity chip
+(`Working` / `Skipped` / `Failed` / `Waiting` / `Spawned engineer`) plus any
+WIP references. The activity chip is **not** the page's status indicator.
+
+### Security invariants
+
+- **Output encoding, escape-last.** The badge label is
+  `esc(humanizeGoalProgress(...))` with `esc()` applied **last**, so an attacker
+  who controls a block reason cannot inject markup.
+- **Colour from the allowlist only.** Badge colour comes exclusively from the
+  hard-coded `GOAL_STATUS_COLORS` map keyed by `goalLifecycleKey`. Goal data is
+  **never** interpolated into a `style=` sink, so a reason string containing
+  `"` or `;` cannot break out of the badge's style or recolour it.
+- **Structured over brittle (G3).** Colour and layout decisions read the closed
+  `GoalProgress` enum key, not the free-form `status` Display string. The
+  percent is used for the label text only, never for badge geometry.
+
+## Tests
+
+Hermetic tests pin the behaviour end to end:
+
+- **API (`tests_goals_crud.rs`)** — given active goals with lifecycle
+  `{NotStarted, InProgress{percent}, Blocked(reason), Completed}`, `/api/goals`
+  exposes each goal's distinct `status_progress`, and the `Blocked` entry
+  carries its reason string. Existing `status_chip == "Working"` assertions stay
+  green (additive change).
+- **Rendering (`index_html/tests_tab_meta.rs`)** — `INDEX_HTML` contains
+  `humanizeGoalProgress(g.status_progress)`, defines `goalLifecycleKey(`, and
+  includes the amber blocked colour `#d29922` **distinct from** the activity
+  `Failed` red `#f85149` — proving the Status column renders per-status,
+  non-uniform lifecycle badges rather than one blanket "failed/blocked" look.
+- **Reconciliation** — a test asserts the rendered lifecycle statuses match the
+  underlying `GoalProgress` values, i.e. the dashboard view and the goal store
+  agree.
+
+## Related
+
+- [Dashboard](../dashboard.md) — the Goals tab in context
+- [Goal board API](goal-board-api.md) — `GoalProgress` variants and the goal store
+- [Overview action-detail humanization](dashboard-action-detail-humanization.md) — the sibling render-layer humanizer
+- [Unblock stuck OODA goals](../howto/unblock-stuck-ooda-goals.md) — clearing an OODA-safeguard block

--- a/docs/reference/goal-board-api.md
+++ b/docs/reference/goal-board-api.md
@@ -753,10 +753,12 @@ at `src/operator_commands_meeting/improvement_curation.rs:123`.
 
 | Variant | Fields | Meaning |
 |---------|--------|---------|
+| `Proposed` | — | Proposed but not yet accepted onto the active board |
 | `NotStarted` | — | Goal is queued; no engineer spawned yet |
 | `InProgress` | `percent: u32` | Engineer session is active; 0–100 |
-| `Completed` | — | Goal is done; will be archived at end of cycle |
 | `Blocked` | `reason: String` | Cannot proceed; requires operator attention |
+| `Paused` | — | Temporarily on hold — deliberately paused, not blocked |
+| `Completed` | — | Goal is done; will be archived at end of cycle |
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -308,6 +308,7 @@ nav:
     - Disk-Health API: reference/disk-health-api.md
     - Dashboard E2E Tests: reference/dashboard-e2e-tests.md
     - Dashboard Action-Detail Humanization: reference/dashboard-action-detail-humanization.md
+    - Dashboard Goal Lifecycle-Status Badges: reference/dashboard-goal-lifecycle-status.md
     - Dashboard Thinking Cycle History: reference/dashboard-thinking-cycle-history.md
     - Azlin Hosts Self-Membership: reference/azlin-hosts-self-membership.md
     - Azure DevOps ACL Self-Escalation Guard: reference/ado-acl-self-escalation-guard.md

--- a/src/operator_commands_dashboard/goals.rs
+++ b/src/operator_commands_dashboard/goals.rs
@@ -106,6 +106,15 @@ pub(crate) async fn goals_at(state_root: &std::path::Path) -> Json<Value> {
                 "description": g.description,
                 "priority": g.priority,
                 "status": g.status.to_string(),
+                // Issue #20: additively expose the SERIALIZED `GoalProgress`
+                // enum so the Goals tab can render a distinct, correctly-labeled
+                // lifecycle badge (and surface a block reason) per goal instead
+                // of dumping the free-form `status` string — which, paired with
+                // the red activity chip, made every goal read as "failed". The
+                // legacy `status` Display string above is left untouched
+                // (additive-only); consumers parse the enum by variant (G3),
+                // never the Display string.
+                "status_progress": &g.status,
                 "assigned_to": g.assigned_to,
                 "repo": g.repo,
                 "current_activity": g.current_activity,

--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -531,6 +531,30 @@ pub(crate) const PART_01: &str = r#"
       }
       return'';
     }
+    /* Issue #20: classify a serialized `GoalProgress` enum to a canonical
+       lifecycle KEY by VARIANT — never by parsing the free-form Display/reason
+       string (G3, agentic-over-brittle). The key indexes the GOAL_STATUS_COLORS
+       allowlist below so goal-supplied text is never interpolated into a style=
+       attribute. Accepts both the string variants ("NotStarted", "Completed",
+       …) and the struct/tuple variants ({"InProgress":{…}}, {"Blocked":"…"}). */
+    function goalLifecycleKey(status){
+      const M={Proposed:'proposed',NotStarted:'not-started',InProgress:'in-progress',Blocked:'blocked',Paused:'paused',Completed:'completed',Done:'completed'};
+      if(status==null)return'not-started';
+      if(typeof status==='string')return M[status]||'not-started';
+      if(typeof status==='object'){
+        if(Object.prototype.hasOwnProperty.call(status,'Blocked'))return'blocked';
+        if(Object.prototype.hasOwnProperty.call(status,'InProgress'))return'in-progress';
+        const k=Object.keys(status)[0];
+        if(k)return M[k]||'not-started';
+      }
+      return'not-started';
+    }
+    /* Hardcoded allowlist: one colour per lifecycle key. Blocked uses amber
+       (#d29922), DELIBERATELY different from the activity-Failed red (#f85149)
+       so a lifecycle-blocked goal is never mistaken for an activity failure
+       (issue #20). Completed=green, in-progress=accent, not-started/proposed=
+       grey, paused=muted. */
+    const GOAL_STATUS_COLORS={'not-started':'#8b949e','proposed':'#8b949e','in-progress':'var(--accent)','blocked':'#d29922','paused':'#6e7681','completed':'#2ea043'};
     function humanizeTaskMemory(content){
       const raw=(content==null)?'':String(content);
       const trimmed=raw.trim();

--- a/src/operator_commands_dashboard/index_html/part_03.rs
+++ b/src/operator_commands_dashboard/index_html/part_03.rs
@@ -9,6 +9,15 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
               const chipHtml='<span style="display:inline-block;padding:1px 8px;border-radius:10px;background:'+chipColor+';color:#fff;font-size:.7rem;font-weight:600;white-space:nowrap">'+esc(chip)+'</span>';
               const detailText=g.detail||'';
               const detailHtml=detailText?'<span style="font-size:.8rem;margin-left:6px">'+esc(detailText)+'</span>':'';
+              // Issue #20: render each goal's LIVE lifecycle status as a
+              // distinctly-colored badge driven by the additive serialized-enum
+              // g.status_progress (falling back to the legacy g.status string
+              // only if the field is absent). This replaces the old raw
+              // status-string cell that — paired with the red activity chip —
+              // made every goal read as failed/blocked.
+              const lifeColor=GOAL_STATUS_COLORS[goalLifecycleKey(g.status_progress)];
+              const lifeLabel=(g.status_progress!=null)?humanizeGoalProgress(g.status_progress):(g.status||'—');
+              const statusBadge='<span style="display:inline-block;padding:1px 8px;border-radius:10px;background:'+lifeColor+';color:#fff;font-size:.72rem;font-weight:600">'+esc(lifeLabel)+'</span>';
               const full=g.detail_full||'';
               const isFailed=(chip==='Failed');
               const expandHtml=(full&&full!==detailText)?'<details style="display:inline;margin-left:6px"'+(isFailed?' open':'')+' ><summary style="display:inline;cursor:pointer;color:'+(isFailed?'#f85149':'#8b949e')+';font-size:.7rem">'+(isFailed?'error details':'show full log')+'</summary><pre style="margin:.3rem 0 0;white-space:pre-wrap;font-size:.75rem;color:'+(isFailed?'#f85149':'#8b949e')+'">'+esc(full)+'</pre></details>':'';
@@ -26,7 +35,7 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
               <td style="text-align:center">${g.priority??'—'}</td>
               <td><code>${esc(g.id)}</code></td>
               <td>${esc(g.description)}</td>
-              <td>${esc(g.status)}</td>
+              <td>${statusBadge}</td>
               <td>${wipHtml}</td>
               <td>
                 <button class="btn" style="font-size:.7rem;padding:2px 6px" onclick="demoteGoal('${esc(g.id)}')">▼ Backlog</button>

--- a/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
@@ -981,3 +981,84 @@ fn rendered_html_wires_tab_alias_allowlist() {
         "the Engineers sub-section was never a standalone tab and must not have an alias"
     );
 }
+
+// ----- issue #20: Goals tab renders each goal's LIVE lifecycle status -----
+//
+// BUG: the active-goals Status column dumped the raw free-form `g.status`
+// string (`<td>${esc(g.status)}</td>`). Paired with the prominent red activity
+// chip in the Current Activity column, this made EVERY goal read as
+// "failed/blocked" even though the goals were in mixed states (not-started /
+// in-progress / blocked+reason / completed).
+//
+// FIX (frontend half): the Status cell renders a distinctly-colored lifecycle
+// badge driven by the additive serialized-enum `g.status_progress` field via
+// the existing `humanizeGoalProgress` (escape-last). A `goalLifecycleKey`
+// classifier maps the enum VARIANT (never the free-form reason text — G3,
+// agentic-over-brittle) to a canonical key that indexes a hardcoded
+// `GOAL_STATUS_COLORS` allowlist. Blocked uses amber (#d29922), DELIBERATELY
+// distinct from the activity-Failed red (#f85149), so a lifecycle-blocked goal
+// is never mistaken for an activity failure.
+//
+// This is the Rust half of the contract; the behavioral half is
+// tests/gadugi/dashboard-goals-lifecycle.sh.
+
+#[test]
+fn rendered_html_goals_status_column_uses_lifecycle_badge() {
+    // The Status cell must render the humanized lifecycle status from the
+    // additive serialized-enum field.
+    assert!(
+        INDEX_HTML.contains("humanizeGoalProgress(g.status_progress)"),
+        "the active-goals Status column must render humanizeGoalProgress(g.status_progress) \
+         so each goal shows its real lifecycle status, not a uniform failed/blocked dump"
+    );
+    // escape-last invariant: humanize the RAW enum, then esc() the result;
+    // never humanize already-escaped text.
+    assert!(
+        !INDEX_HTML.contains("humanizeGoalProgress(esc("),
+        "humanizeGoalProgress must run on the raw g.status_progress enum, never on \
+         already-escaped text (escape-last invariant)"
+    );
+    // The old uniform raw-status dump — the exact cell that made every goal
+    // look failed/blocked — must be gone.
+    assert!(
+        !INDEX_HTML.contains("<td>${esc(g.status)}</td>"),
+        "the Status column must no longer dump the raw free-form g.status string \
+         uniformly; it must render a per-status lifecycle badge"
+    );
+    // A genuinely-blocked goal must surface its reason via the humanizer's
+    // Blocked-object branch ('Blocked — <reason>').
+    assert!(
+        INDEX_HTML.contains("'Blocked — '+r"),
+        "humanizeGoalProgress must render a blocked goal's REASON ('Blocked — <reason>') \
+         so the Status column shows why a goal is blocked, not a bare 'failed'"
+    );
+}
+
+#[test]
+fn rendered_html_goals_status_classifier_and_color_allowlist() {
+    // A classifier keys the color allowlist off the enum VARIANT, not by
+    // parsing the free-form Display/reason string (G3: agentic-over-brittle).
+    assert!(
+        INDEX_HTML.contains("function goalLifecycleKey("),
+        "a goalLifecycleKey() classifier must map the serialized GoalProgress enum to a \
+         canonical lifecycle key by variant, not by parsing the Display string"
+    );
+    // A hardcoded color allowlist drives the badge color so goal data is never
+    // interpolated into a style= attribute.
+    assert!(
+        INDEX_HTML.contains("GOAL_STATUS_COLORS"),
+        "a hardcoded GOAL_STATUS_COLORS allowlist must drive the lifecycle badge color \
+         (goal data must never be interpolated into a style= attribute)"
+    );
+    // Blocked's amber must be present and DISTINCT from the activity-Failed red,
+    // so a lifecycle-blocked goal is not mistaken for an activity failure.
+    assert!(
+        INDEX_HTML.contains("#d29922"),
+        "the blocked lifecycle badge must use amber #d29922"
+    );
+    assert!(
+        !INDEX_HTML.contains("blocked:'#f85149'") && !INDEX_HTML.contains("Blocked:'#f85149'"),
+        "the blocked lifecycle badge must NOT reuse the activity-Failed red #f85149; \
+         it must be a distinct amber so blocked != failed"
+    );
+}

--- a/src/operator_commands_dashboard/tests_goals_crud.rs
+++ b/src/operator_commands_dashboard/tests_goals_crud.rs
@@ -1011,3 +1011,246 @@ async fn full_goal_lifecycle_crud_via_at_is_env_independent() {
         "no CRUD step may touch the ambient (decoy) SIMARD_STATE_ROOT"
     );
 }
+
+// ===========================================================================
+// Lifecycle status projection (issue #20)
+//
+// BUG: the dashboard "Goals" tab rendered EVERY active goal as failed/blocked
+// even though `simard goal list` (ground truth) shows the goals in MIXED
+// states — several `blocked` (with an OODA-safeguard "needs human review"
+// reason), many `not-started`, and several `completed`.
+//
+// FIX (backend half): `/api/goals` additively exposes a `status_progress`
+// field on each active goal — the *serialized `GoalProgress` enum* — so the
+// client can render a distinct, correctly-labeled lifecycle badge (and surface
+// the block reason) instead of dumping the free-form `status` string that,
+// paired with the red activity chip, read as "failed" for every goal. The
+// existing `status`, `status_chip`, `detail`, and `detail_full` fields are
+// UNCHANGED (additive-only).
+//
+// These are the Rust/backend half of the contract; the frontend rendering
+// half lives in `index_html/tests_tab_meta.rs`.
+// ===========================================================================
+
+/// The exact OODA-safeguard block reason from the confirmed diagnosis, used to
+/// prove a genuinely-blocked goal surfaces its reason (not a blanket "failed").
+const OODA_BLOCK_REASON: &str =
+    "🔒 [OODA-SAFEGUARD] agent-kgpacks-rs: 3 consecutive no-action cycles; needs human review";
+
+/// Build an active goal in an explicit lifecycle `status` with no
+/// `current_activity` (so the lifecycle status — not the activity chip — is the
+/// signal under test).
+fn goal_in_status(id: &str, status: GoalProgress) -> crate::goal_curation::ActiveGoal {
+    crate::goal_curation::ActiveGoal {
+        parent_goal_id: None,
+        repo: None,
+        id: id.to_string(),
+        description: format!("Goal {id}"),
+        priority: 2,
+        status,
+        assigned_to: Some("simard".to_string()),
+        current_activity: None,
+        wip_refs: vec![],
+        last_progress_update_at: None,
+    }
+}
+
+/// Seed a board whose active goals span the four distinct lifecycle states the
+/// Goals tab must render differently: not-started, in-progress, blocked (with a
+/// reason), and completed. Returns the `SharedMemoryGuard` (bind it).
+#[must_use]
+fn init_board_with_mixed_statuses(state: &HermeticState) -> SharedMemoryGuard {
+    let guard = SharedMemoryGuard::register(state);
+    save_goal_board(&GoalBoard::new(), guard.ops()).expect("init empty board");
+
+    let mut board = GoalBoard::new();
+    board
+        .active
+        .push(goal_in_status("goal-not-started", GoalProgress::NotStarted));
+    board.active.push(goal_in_status(
+        "goal-in-progress",
+        GoalProgress::InProgress { percent: 37 },
+    ));
+    board.active.push(goal_in_status(
+        "goal-blocked",
+        GoalProgress::Blocked(OODA_BLOCK_REASON.to_string()),
+    ));
+    board
+        .active
+        .push(goal_in_status("goal-completed", GoalProgress::Completed));
+
+    dashboard_save_goal_board(state.state_root(), &board).expect("seed mixed-status board");
+    guard
+}
+
+/// Find the active-goal JSON object with the given `id` in a `/api/goals`
+/// response, panicking with context if absent.
+fn active_by_id<'a>(active: &'a [serde_json::Value], id: &str) -> &'a serde_json::Value {
+    active
+        .iter()
+        .find(|g| g["id"] == id)
+        .unwrap_or_else(|| panic!("active goal {id:?} missing from /api/goals response"))
+}
+
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn goals_exposes_distinct_status_progress_per_lifecycle_state() {
+    let state = HermeticState::new();
+    let _mem = init_board_with_mixed_statuses(&state);
+
+    let result = goals_at(state.state_root()).await;
+    let active = result.0["active"].as_array().expect("active array");
+    assert_eq!(active.len(), 4, "all four seeded goals must be returned");
+
+    // Each goal exposes an additive `status_progress` = the SERIALIZED
+    // `GoalProgress` enum, distinctly per lifecycle state.
+    assert_eq!(
+        active_by_id(active, "goal-not-started")["status_progress"],
+        json!("NotStarted"),
+        "not-started goal must expose status_progress==\"NotStarted\", not a blocked/failed value"
+    );
+    assert_eq!(
+        active_by_id(active, "goal-in-progress")["status_progress"],
+        json!({ "InProgress": { "percent": 37 } }),
+        "in-progress goal must expose the InProgress percent variant"
+    );
+    assert_eq!(
+        active_by_id(active, "goal-blocked")["status_progress"],
+        json!({ "Blocked": OODA_BLOCK_REASON }),
+        "blocked goal must expose the Blocked variant carrying its reason"
+    );
+    assert_eq!(
+        active_by_id(active, "goal-completed")["status_progress"],
+        json!("Completed"),
+        "completed goal must expose status_progress==\"Completed\", not a blocked/failed value"
+    );
+
+    // The four values must be DISTINCT — the bug rendered everything the same
+    // (failed/blocked). Distinctness proves each real status is preserved.
+    let mut seen = std::collections::HashSet::new();
+    for g in active {
+        let sp = g["status_progress"].to_string();
+        assert!(
+            seen.insert(sp.clone()),
+            "status_progress values must be DISTINCT per lifecycle state; duplicate: {sp}"
+        );
+    }
+    assert_eq!(
+        seen.len(),
+        4,
+        "expected four distinct status_progress values, got {seen:?}"
+    );
+
+    // Direct regression guard: goals that are NOT blocked must not serialize as
+    // a Blocked variant (the exact symptom of the bug).
+    for id in ["goal-not-started", "goal-in-progress", "goal-completed"] {
+        assert!(
+            active_by_id(active, id)["status_progress"]
+                .get("Blocked")
+                .is_none(),
+            "non-blocked goal {id:?} must never carry a Blocked status_progress"
+        );
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn goals_blocked_status_progress_carries_reason() {
+    let state = HermeticState::new();
+    let _mem = init_board_with_mixed_statuses(&state);
+
+    let result = goals_at(state.state_root()).await;
+    let active = result.0["active"].as_array().expect("active array");
+    let blocked = active_by_id(active, "goal-blocked");
+
+    assert_eq!(
+        blocked["status_progress"]["Blocked"], OODA_BLOCK_REASON,
+        "a genuinely-blocked goal must surface its block REASON via status_progress"
+    );
+    // The reason text ("needs human review") must be present so the operator
+    // can act on it — not swallowed into a generic "failed/blocked".
+    assert!(
+        blocked["status_progress"]["Blocked"]
+            .as_str()
+            .unwrap_or("")
+            .contains("needs human review"),
+        "the block reason must retain the OODA-safeguard 'needs human review' text, got: {}",
+        blocked["status_progress"]
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn goals_status_progress_is_additive_not_replacing_existing_fields() {
+    let state = HermeticState::new();
+    let _mem = init_board_with_mixed_statuses(&state);
+
+    let result = goals_at(state.state_root()).await;
+    let active = result.0["active"].as_array().expect("active array");
+
+    // The change is additive: the pre-existing free-form `status` string and
+    // the `status_chip`/`detail_full` fields must still be present alongside
+    // the new `status_progress`.
+    for g in active {
+        assert!(
+            g["status"].as_str().is_some(),
+            "existing free-form `status` string must remain (additive change), goal: {}",
+            g["id"]
+        );
+        assert!(
+            g["status_chip"].as_str().is_some(),
+            "existing `status_chip` must remain (additive change), goal: {}",
+            g["id"]
+        );
+        assert!(
+            !g["status_progress"].is_null(),
+            "new `status_progress` must be populated, goal: {}",
+            g["id"]
+        );
+    }
+
+    // The blocked goal's legacy `status` Display string is unchanged
+    // ("blocked: <reason>"), proving we ADDED status_progress rather than
+    // rewriting the existing field.
+    let blocked = active_by_id(active, "goal-blocked");
+    assert!(
+        blocked["status"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("blocked"),
+        "legacy `status` string must stay the GoalProgress Display form, got: {}",
+        blocked["status"]
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn goals_status_progress_matches_live_goal_store() {
+    // R8 reconciliation: the dashboard's rendered lifecycle status for each
+    // goal must equal the goal store's actual `GoalProgress` (dashboard ⇄
+    // `simard goal list` agreement), read LIVE from the store.
+    let state = HermeticState::new();
+    let _mem = init_board_with_mixed_statuses(&state);
+
+    // Ground truth: re-read the persisted board (the same source of truth the
+    // CLI's `goal list` reports).
+    let store = dashboard_goal_board_snapshot(state.state_root()).expect("read back board");
+
+    let result = goals_at(state.state_root()).await;
+    let active = result.0["active"].as_array().expect("active array");
+    assert_eq!(
+        active.len(),
+        store.active.len(),
+        "dashboard active-goal count must match the goal store"
+    );
+
+    for stored in &store.active {
+        let rendered = active_by_id(active, &stored.id);
+        let expected = serde_json::to_value(&stored.status).expect("serialize GoalProgress");
+        assert_eq!(
+            rendered["status_progress"], expected,
+            "goal {:?}: dashboard status_progress must equal the store's live GoalProgress",
+            stored.id
+        );
+    }
+}

--- a/tests/gadugi/dashboard-goals-lifecycle.sh
+++ b/tests/gadugi/dashboard-goals-lifecycle.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# dashboard-goals-lifecycle.sh — outside-in qa-team check for the Goals tab
+# lifecycle-status fix (issue #20).
+#
+# BUG: the operator ran `simard goal list` (ground truth) and saw the 20 active
+# goals in MIXED states — several `blocked` (with an OODA-safeguard "needs human
+# review" reason), many `not-started`, and several `completed`. But the
+# dashboard "Goals" tab rendered EVERY goal as failed/blocked, because the
+# Status column dumped the raw free-form status string which — paired with the
+# prominent red activity chip in the Current Activity column — read as "failed"
+# for every row.
+#
+# FIX: `/api/goals` additively exposes a serialized `GoalProgress` enum
+# (`status_progress`) per active goal, and the Status column renders a
+# distinctly-colored lifecycle badge via `humanizeGoalProgress(g.status_progress)`
+# keyed off a `goalLifecycleKey()` variant classifier and a hardcoded
+# `GOAL_STATUS_COLORS` allowlist. Blocked uses amber (#d29922), deliberately
+# distinct from the activity-Failed red (#f85149), and a blocked goal surfaces
+# its reason ("Blocked — <reason>").
+#
+# This script boots the real dashboard binary, logs in with the dashkey, and
+# asserts — against the served HTML — that the lifecycle-badge machinery is
+# wired in and the old raw status-string dump is gone.
+set -euo pipefail
+
+PORT="${DASH_PORT:-8143}"
+DASHKEY_FILE="${HOME}/.simard/.dashkey"
+LOG="$(mktemp -t dash-goals-lifecycle.XXXXXX.log)"
+CJ="$(mktemp -t dash-goals-lifecycle-cookies.XXXXXX)"
+
+echo "[goals-lifecycle] building simard binary…"
+cargo build --quiet --bin simard
+BIN="${CARGO_TARGET_DIR:-target}/debug/simard"
+if [[ ! -x "$BIN" ]]; then
+  echo "[goals-lifecycle] FAIL: built binary not found at $BIN" >&2
+  exit 1
+fi
+
+echo "[goals-lifecycle] starting dashboard on :$PORT"
+"$BIN" dashboard serve --port="$PORT" >"$LOG" 2>&1 &
+DASH_PID=$!
+cleanup() { kill "$DASH_PID" 2>/dev/null || true; rm -f "$CJ"; }
+trap cleanup EXIT
+
+up=0
+for _ in $(seq 1 30); do
+  if curl -s -o /dev/null "http://localhost:$PORT/login"; then up=1; break; fi
+  sleep 1
+done
+if [[ "$up" -ne 1 ]]; then
+  echo "[goals-lifecycle] FAIL: dashboard did not come up on :$PORT" >&2
+  cat "$LOG" >&2
+  exit 1
+fi
+
+KEY="$(cat "$DASHKEY_FILE")"
+if ! curl -s -c "$CJ" -X POST -H 'Content-Type: application/json' \
+      -d "{\"code\":\"$KEY\"}" "http://localhost:$PORT/api/login" | grep -q '"ok":true'; then
+  echo "[goals-lifecycle] FAIL: login rejected" >&2
+  exit 1
+fi
+
+HTML="$(curl -s -b "$CJ" "http://localhost:$PORT/")"
+
+fail() { echo "[goals-lifecycle] FAIL: $1" >&2; exit 1; }
+
+# ── The Status column renders a lifecycle badge from the serialized enum ──────
+grep -qF 'humanizeGoalProgress(g.status_progress)' <<<"$HTML" \
+  || fail "the Status column must render humanizeGoalProgress(g.status_progress), \
+not a uniform raw status dump"
+# escape-last: humanize the RAW enum, never already-escaped text.
+grep -qF 'humanizeGoalProgress(esc(' <<<"$HTML" \
+  && fail "humanizeGoalProgress must run on the raw enum, not escaped text (escape-last)"
+# The old raw-status cell that made every goal look failed/blocked must be gone.
+grep -qF '<td>${esc(g.status)}</td>' <<<"$HTML" \
+  && fail "the Status column must no longer dump the raw free-form g.status string"
+
+# ── Variant classifier + hardcoded color allowlist (G3, no style injection) ──
+grep -qF 'function goalLifecycleKey(' <<<"$HTML" \
+  || fail "goalLifecycleKey() must classify the GoalProgress enum by variant"
+grep -qF 'GOAL_STATUS_COLORS' <<<"$HTML" \
+  || fail "a hardcoded GOAL_STATUS_COLORS allowlist must drive the badge color"
+
+# ── Blocked lifecycle badge is amber, DISTINCT from the activity-Failed red ──
+grep -qF '#d29922' <<<"$HTML" \
+  || fail "the blocked lifecycle badge must use amber #d29922"
+grep -qE "[Bb]locked:'#f85149'" <<<"$HTML" \
+  && fail "the blocked lifecycle badge must NOT reuse the activity-Failed red #f85149"
+
+# ── A blocked goal surfaces its REASON (not a bare 'failed') ─────────────────
+grep -qF "'Blocked — '+r" <<<"$HTML" \
+  || fail "a blocked goal must render its reason as 'Blocked — <reason>'"
+
+echo "[goals-lifecycle] PASS: Goals tab renders each goal's real lifecycle status"

--- a/tests/gadugi/dashboard-goals-lifecycle.yaml
+++ b/tests/gadugi/dashboard-goals-lifecycle.yaml
@@ -1,0 +1,52 @@
+name: "Dashboard Goals Tab Lifecycle Status (issue #20)"
+description: "Outside-in operator check that the Goals tab renders each goal's REAL lifecycle status instead of a uniform failed/blocked. `simard goal list` (ground truth) showed the 20 active goals in MIXED states — several `blocked` (with an OODA-safeguard 'needs human review' reason), many `not-started`, and several `completed` — but the tab dumped the raw status string which, paired with the red activity chip, read as 'failed' for every row. Boots the real dashboard binary, authenticates with the dashkey, and asserts the served HTML now renders a distinctly-colored lifecycle badge via humanizeGoalProgress(g.status_progress) keyed off a goalLifecycleKey() variant classifier and a hardcoded GOAL_STATUS_COLORS allowlist, that Blocked uses amber #d29922 (distinct from the activity-Failed red #f85149) and surfaces its reason ('Blocked — <reason>'), and that the old raw status dump is gone."
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 0
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Goals tab renders each goal's real lifecycle status"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/dashboard-goals-lifecycle.sh"
+    timeout: 300000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "dashboard"
+    - "usability"
+    - "goals"
+    - "self-serve-dashboard-improvement"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Problem

The Dashboard **Goals** tab rendered **every** active goal as failed/blocked. `simard goal list` (ground truth) shows the 20 active goals in **mixed** states — several `blocked` (with an OODA-safeguard *"needs human review"* reason), many `not-started`, and several `completed`.

**Root cause:** the active-goals **Status** column dumped the raw free-form `GoalProgress` `Display` string (`<td>${esc(g.status)}</td>`). Paired with the prominent **red activity chip** in the *Current Activity* column, this conflated two independent axes — **lifecycle status** vs. **current activity** — so a mixed board *looked* uniformly failed.

## Fix (additive, structured-over-brittle / G3)

**Backend — `src/operator_commands_dashboard/goals.rs`:**
- `/api/goals` additively exposes **`status_progress`** per active goal: the *serialized `GoalProgress` enum* (`"NotStarted"`, `{"InProgress":{"percent":N}}`, `{"Blocked":"<reason>"}`, `"Completed"`, `"Proposed"`, `"Paused"`).
- Existing `status` / `status_chip` / `detail` / `detail_full` / `current_activity` / `wip_refs` are **unchanged**.
- The snapshot is reloaded per request → the view is **live** and reconciles with `simard goal list` by construction.

**Frontend — `index_html/part_01.rs` + `part_03.rs`:**
- The **Status** column now renders a **distinctly-colored lifecycle badge**.
- `goalLifecycleKey()` classifies the enum **by variant** (never by parsing the Display/reason string).
- A hardcoded **`GOAL_STATUS_COLORS`** allowlist drives the color, so goal data is **never** interpolated into a `style=` sink.
- **Blocked = amber `#d29922`**, deliberately distinct from the activity-Failed red `#f85149`, and surfaces its reason via `humanizeGoalProgress` → **"Blocked — &lt;reason&gt;"**.
- Label is `esc(humanizeGoalProgress(g.status_progress))` (**escape-last**); falls back to the legacy `g.status` string only when `status_progress == null`.
- The **Current Activity** chip is unchanged.

| Lifecycle | Badge | Color |
|-----------|-------|-------|
| `NotStarted` / `Proposed` | Not started / Proposed | grey `#8b949e` |
| `InProgress { percent }` | In progress — N% | accent `var(--accent)` |
| `Blocked(reason)` | Blocked — &lt;reason&gt; | amber `#d29922` |
| `Paused` | Paused | muted `#6e7681` |
| `Completed` | Completed | green `#2ea043` |

## Tests (hermetic)

- **`tests_goals_crud.rs`** (4 new): goals spanning `{NotStarted, InProgress{percent}, Blocked(reason), Completed}` each expose a **distinct** `status_progress`; the blocked goal carries its reason; the change is additive; the projection **matches the live goal store**.
- **`index_html/tests_tab_meta.rs`** (2 new): the Status column wires `humanizeGoalProgress(g.status_progress)` behind the variant classifier + amber-distinct color allowlist; the old uniform raw dump is gone.
- **`tests/gadugi/dashboard-goals-lifecycle.{sh,yaml}`**: outside-in check against the served HTML.

## Docs

`docs/dashboard.md`, `docs/reference/goal-board-api.md`, and new `docs/reference/dashboard-goal-lifecycle-status.md`.

## Notes

- Additive-only; no `--no-verify`; pre-commit (fmt, clippy `-D warnings`, rust-only gate) green locally.
- Branch is at latest `origin/main`; coordinates with the concurrent `activitytab` / `dashprefetch` dashboard PRs (Status column vs. Activity chip are now cleanly separated).
- References the dashboard goal-board tracking id **#20** (not the unrelated GitHub issue #20).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>