### PR TITLE
fix(dashboard): multi-line chat input + preserve newlines in agent output

### DIFF
--- a/src/operator_commands_dashboard/index_html/part_00.rs
+++ b/src/operator_commands_dashboard/index_html/part_00.rs
@@ -51,6 +51,7 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
     #chat-messages{background:#010409;border:1px solid var(--border);border-radius:6px;padding:.6rem;flex:1;min-height:0;overflow-y:auto;font-size:.9rem;margin-bottom:.5rem}
     .chat-msg{margin-bottom:.5rem} .chat-msg .role{font-weight:700;margin-right:.5rem}
     .chat-msg .role.user{color:var(--accent)} .chat-msg .role.system{color:var(--yellow)} .chat-msg .role.assistant{color:var(--green)}
+    .chat-msg .content{white-space:pre-wrap;word-break:break-word}
     .chat-typing{padding:.25rem 0;color:#8b949e}
     #tab-chat.active{display:flex;flex-direction:column;height:calc(100vh - 106px);padding:.4rem 1.25rem .6rem}
     #tab-chat .page-h1{margin-bottom:.1rem}
@@ -75,8 +76,8 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
     .typing-dots span:nth-child(3){animation-delay:.4s}
     @keyframes blink{0%,80%,100%{opacity:0}40%{opacity:1}}
     #chat-send:disabled{opacity:.5;cursor:not-allowed}
-    #chat-input-row{display:flex;gap:.5rem}
-    #chat-input{flex:1;padding:.5rem;border:1px solid var(--border);border-radius:6px;background:var(--card);color:var(--fg);font-size:.9rem;resize:none;height:42px}
+    #chat-input-row{display:flex;gap:.5rem;align-items:flex-end}
+    #chat-input{flex:1;padding:.5rem;border:1px solid var(--border);border-radius:6px;background:var(--card);color:var(--fg);font-size:.9rem;font-family:inherit;line-height:1.4;resize:vertical;min-height:66px;max-height:220px;overflow-y:auto}
     #chat-input:focus{outline:none;border-color:var(--accent)}
     #chat-send{padding:.5rem 1.2rem;border:none;border-radius:6px;background:var(--accent);color:#0d1117;font-weight:600;cursor:pointer}
     #chat-send:hover{opacity:.9}

--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -106,7 +106,7 @@ pub(crate) const PART_01: &str = r#"
         <div class="ws-status disconnected" id="ws-status">● Disconnected <button class="btn" onclick="initChat()" style="font-size:.75rem;padding:.1rem .4rem;margin-left:.5rem">Reconnect</button></div>
         <div id="chat-messages"></div>
         <div id="chat-input-row">
-          <textarea id="chat-input" placeholder="Type a message… (/close to end session)"></textarea>
+          <textarea id="chat-input" rows="3" placeholder="Type a message… (Enter to send, Shift+Enter for a new line, /close to end session)"></textarea>
           <button id="chat-send" onclick="sendChat()">Send</button>
         </div>
       </div>

--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -170,7 +170,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
         appendMsg('system','Not connected. Click Reconnect to establish a session.');
         return;
       }
-      appendMsg('user',txt); ws.send(txt); inp.value='';
+      appendMsg('user',txt); ws.send(txt); inp.value=''; inp.style.height='';
       showTypingIndicator(); setChatBusy(true);
     }
 
@@ -184,6 +184,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
         roleSpan.textContent='assistant:';
         div.appendChild(roleSpan);
         streamSpan=document.createElement('span');
+        streamSpan.className='content';
         div.appendChild(streamSpan);
         el.appendChild(div);
         streamText='';
@@ -233,12 +234,21 @@ pub(crate) const PART_04: &str = r#"            let fmt;
       const roleSpan=document.createElement('span');
       roleSpan.className='role '+role;
       roleSpan.textContent=role+':';
+      const contentSpan=document.createElement('span');
+      contentSpan.className='content';
+      contentSpan.textContent=content;
       div.appendChild(roleSpan);
-      div.appendChild(document.createTextNode(' '+content));
+      div.appendChild(contentSpan);
       el.appendChild(div);
       el.scrollTop=el.scrollHeight;
     }
-    document.getElementById('chat-input').addEventListener('keydown',e=>{
+    const chatInputEl=document.getElementById('chat-input');
+    function autoGrowChatInput(){
+      chatInputEl.style.height='auto';
+      chatInputEl.style.height=Math.min(chatInputEl.scrollHeight,220)+'px';
+    }
+    chatInputEl.addEventListener('input',autoGrowChatInput);
+    chatInputEl.addEventListener('keydown',e=>{
       if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();sendChat();}
     });
 


### PR DESCRIPTION
## Problem

Two operator-reported issues with the dashboard **Chat** tab:

1. The chat input was a fixed `height:42px`, `resize:none` textarea — it behaved like a single-line field, making longer messages awkward to compose.
2. Agent/assistant replies rendered with their newlines collapsed — carriage returns were being swallowed because message text was inserted as a bare text node with default HTML whitespace handling.

## Changes

**Multi-line input** (`part_00.rs` CSS, `part_01.rs` HTML, `part_04.rs` JS)
- `#chat-input` is now `rows="3"`, `resize:vertical`, `min-height:66px`, `max-height:220px`, with `line-height` and `font-family:inherit`.
- Auto-grows as you type (up to 220px), and resets height after send.
- Enter still sends; **Shift+Enter** inserts a newline (behavior unchanged, now discoverable via placeholder).
- `#chat-input-row` uses `align-items:flex-end` so the Send button stays anchored to the bottom of the taller box.

**Preserve newlines in output** (`part_00.rs` CSS, `part_04.rs` JS)
- Added `.chat-msg .content{white-space:pre-wrap;word-break:break-word}`.
- `appendMsg` now wraps content in a `.content` span (via `textContent`, so no HTML injection).
- The streaming span (`appendChunk`/`finalizeStream`) also carries the `.content` class, so both streamed and finalized replies preserve carriage returns and spacing — rendering as blocktext.

## Testing

- `cargo test --lib operator_commands_dashboard::index_html` — 45 passed.
- `cargo fmt`, `cargo clippy --release` and full pre-push clippy `--all-targets --all-features --locked` passed.
- Content is still inserted via `textContent`, preserving the existing XSS-safe rendering.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>