### PR TITLE
feat(dashboard): make chat input a multi-line auto-growing textarea (#2690)

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -85,6 +85,12 @@ horizontal space. The transcript scrolls inside a flex-grown message area while
 the input row stays anchored at the bottom, and the panel grows with the browser
 window — no fixed small box.
 
+**Multi-line composer.** The message box is a multi-line text area: press
+**Enter** to send and **Shift+Enter** to add a newline. It starts at a single
+line, grows automatically as you type or paste additional lines (up to a capped
+height, then scrolls), and collapses back to one line after each message is
+sent. See [Dashboard Chat — multi-line message input](reference/dashboard-chat-multiline-input.md).
+
 **Streaming with graceful fallback.** Assistant replies appear **incrementally**,
 word-by-word, rather than all at once. A client that only understands the legacy
 single-message shape still works — it simply receives the reply as one complete

--- a/docs/reference/dashboard-chat-multiline-input.md
+++ b/docs/reference/dashboard-chat-multiline-input.md
@@ -1,0 +1,279 @@
+---
+title: Dashboard Chat — multi-line message input
+description: Reference for the multi-line, auto-growing chat composer on the operator dashboard Chat tab — keyboard model (Enter to send, Shift+Enter for a newline), auto-grow sizing, height reset on send, and the CSS/JS coupling that implements it.
+last_updated: 2026-07-06
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+related:
+  - ./dashboard-chat.md
+  - ./dashboard-e2e-tests.md
+  - ../dashboard.md
+---
+
+# Dashboard Chat — multi-line message input
+
+The **Chat** tab composer accepts **multi-line messages**. The input is a
+`<textarea>` that starts at a single-line height, **grows automatically** as you
+type additional lines, and caps at a maximum height beyond which it scrolls
+internally. `Enter` sends the message; `Shift+Enter` inserts a newline so you
+can compose paragraphs, paste multi-line snippets, or lay out a numbered list
+before sending.
+
+This reference documents the operator-facing behavior and the small frontend
+contract that implements it. For the chat feature as a whole — durable sessions,
+the REST session API, and the WebSocket streaming protocol — see the
+[Dashboard Chat reference](./dashboard-chat.md).
+
+**Frontend location:**
+
+- `src/operator_commands_dashboard/index_html/part_01.rs` — the `#chat-input`
+  `<textarea>` markup and `#chat-send` button.
+- `src/operator_commands_dashboard/index_html/part_00.rs` — the `#chat-input`
+  CSS (auto-grow sizing constraints).
+- `src/operator_commands_dashboard/index_html/part_04.rs` — `sendChat()`, the
+  `keydown` handler (send vs. newline), and the `input` auto-grow listener.
+
+---
+
+## Behavior
+
+### Keyboard model
+
+| Key | Action |
+|-----|--------|
+| `Enter` | **Send** the current message. Leading/trailing whitespace is trimmed; if the result is empty, nothing is sent. |
+| `Shift+Enter` | Insert a **newline** into the message without sending. The box grows to accommodate the new line (up to the max height). |
+| Typing / paste | The box **auto-grows** to fit the content as lines are added, and **shrinks** back as lines are removed. |
+
+`Enter`-to-send is the default so the common case (one-line messages) stays a
+single keystroke. `Shift+Enter` is the escape hatch for deliberate multi-line
+composition. The **Send** button remains available and is equivalent to
+pressing `Enter`.
+
+### Auto-grow and the height cap
+
+The composer starts at a **single-line minimum height (42px)** so the resting
+state is identical to the previous single-line input. As you add lines it grows
+to fit the content, up to a **maximum height (150px)**. Past that cap the
+textarea stops growing and scrolls internally (`overflow-y: auto`), so a very
+long draft never pushes the transcript off-screen or expands the panel without
+bound. Deleting lines shrinks the box back down toward the minimum.
+
+The box does **not** expose the native resize grabber (`resize: none`); sizing
+is driven entirely by content, not manual dragging.
+
+### Reset after sending
+
+After a message is sent (via `Enter` or the **Send** button) the textarea is
+cleared **and reset to its single-line minimum height**. An expanded, multi-line
+composer never lingers as an empty tall box after send — the next message starts
+fresh at one line.
+
+The reset runs **only on the successful-send path** — after the whitespace and
+WebSocket-connection guards, alongside `inp.value=''`. If a send is rejected
+(empty text, or no open socket) the draft and its current expanded height are
+intentionally preserved so you never lose an in-progress message.
+
+### Busy state
+
+While an assistant reply is streaming, the composer and **Send** button are
+**disabled** (`setChatBusy(true)`) and re-enabled when the reply completes
+(`done` frame). This is unchanged by the multi-line behavior — you cannot queue
+a second message mid-reply.
+
+### Whitespace-only guard
+
+A message consisting only of spaces or newlines is **not sent**. `sendChat()`
+trims the value and returns early when the trimmed result is empty, so an
+accidental `Enter` on a blank composer is a no-op.
+
+---
+
+## Frontend contract
+
+The multi-line composer is implemented with a CSS sizing envelope plus two small
+pieces of JavaScript. All content is still rendered through safe DOM sinks
+(`textContent` / `createTextNode`) — see [XSS safety](#xss-safety).
+
+> **Note on snippets:** the code blocks below are normalized for readability. The
+> embedded HTML in `index_html/` uses a condensed single-line style. Apply the
+> described changes **surgically** (e.g. only append `inp.style.height=''` after
+> `inp.value=''`, only swap `height:42px` for the min/max envelope) rather than
+> reformatting the existing lines.
+
+### 1. Markup — `part_01.rs`
+
+The composer is a `<textarea>` (not an `<input>`), which is what makes newlines
+and vertical growth possible:
+
+```html
+<div id="chat-input-row">
+  <textarea id="chat-input" placeholder="Type a message… (/close to end session)"></textarea>
+  <button id="chat-send" onclick="sendChat()">Send</button>
+</div>
+```
+
+The `id="chat-input"`, `id="chat-send"`, and placeholder text are a **stable
+contract** relied on by the end-to-end tests and must not change.
+
+### 2. Sizing CSS — `part_00.rs`
+
+The `#chat-input` rule constrains the auto-grow between a single-line floor and a
+capped ceiling, and scrolls past the cap:
+
+```css
+#chat-input{
+  flex:1;
+  padding:.5rem;
+  border:1px solid var(--border);
+  border-radius:6px;
+  background:var(--card);
+  color:var(--fg);
+  font-size:.9rem;
+  resize:none;
+  min-height:42px;      /* single-line resting height (was: height:42px) */
+  max-height:150px;     /* growth cap — MUST match the JS clamp below */
+  overflow-y:auto;      /* scroll once the cap is reached */
+  line-height:1.4;      /* comfortable spacing for multi-line drafts */
+}
+```
+
+The only CSS change is swapping the fixed `height:42px` for the
+`min-height`/`max-height`/`overflow-y` envelope above (plus `line-height` for
+readability). Because the fixed height was already interpreted border-box, the
+`min-height:42px` resting box is **pixel-identical** to the previous single-line
+input.
+
+> **`box-sizing` note:** the dashboard already applies a global
+> `*{margin:0;padding:0;box-sizing:border-box}` reset at the top of `part_00.rs`,
+> so `#chat-input` is **already** sized border-box — do **not** re-declare
+> `box-sizing` on the element. This global reset is what makes auto-grow stable:
+> the height the listener assigns is interpreted inclusive of padding, so the box
+> settles at the content height instead of gaining padding on every keystroke.
+
+### 3. Auto-grow listener — `part_04.rs`
+
+An `input` listener resizes the textarea to fit its content on every change. It
+measures by first collapsing to `auto`, then setting the height to the smaller
+of the content's `scrollHeight` and the cap:
+
+```js
+const chatInput = document.getElementById('chat-input');
+chatInput.addEventListener('input', () => {
+  chatInput.style.height = 'auto';                       // reset to measure true content height
+  chatInput.style.height = Math.min(chatInput.scrollHeight, 150) + 'px'; // clamp to the cap
+});
+```
+
+> **Coupling note:** the `150` clamp in the listener and `max-height:150px` in
+> the CSS are the same magic number and must be kept in sync. If one changes the
+> other must change too, or growth and scrolling will disagree.
+
+The listener computes a **numeric** height only. It never interpolates
+user-controlled strings into markup.
+
+### 4. Send + reset — `part_04.rs`
+
+`sendChat()` trims, guards against empty/disconnected states, sends over the
+WebSocket, clears the value, **and clears the inline height** so the box
+collapses back to the CSS `min-height`:
+
+```js
+function sendChat(){
+  const inp = document.getElementById('chat-input');
+  const txt = inp.value.trim();
+  if(!txt) return;                                   // whitespace-only guard
+  if(!ws || ws.readyState !== WebSocket.OPEN){
+    appendMsg('system','Not connected. Click Reconnect to establish a session.');
+    return;
+  }
+  appendMsg('user', txt);
+  ws.send(txt);
+  inp.value = '';
+  inp.style.height = '';                             // reset to single-line min-height after send
+  showTypingIndicator();
+  setChatBusy(true);
+}
+```
+
+### 5. Send-vs-newline keydown — `part_04.rs`
+
+The `keydown` handler distinguishes send from newline. `Enter` alone sends (and
+suppresses the default newline); `Enter` with `Shift` falls through to the
+browser's default, inserting a newline:
+
+```js
+document.getElementById('chat-input').addEventListener('keydown', e => {
+  if(e.key === 'Enter' && !e.shiftKey){ e.preventDefault(); sendChat(); }
+  // Shift+Enter: no preventDefault → the browser inserts a newline
+});
+```
+
+---
+
+## XSS safety
+
+Multi-line input does not change the dashboard's rendering model. User-authored
+message text — including multi-line and pasted content — is rendered exclusively
+through `document.createTextNode` / `textContent`, never `innerHTML`,
+`insertAdjacentHTML`, or `eval`. The auto-grow listener manipulates only the
+numeric `style.height`. Pasting markup such as
+`<img src=x onerror=alert(1)>` renders as **literal text** and is never
+executed. See [Dashboard Chat → XSS safety](./dashboard-chat.md#xss-safety).
+
+The backend independently bounds inbound WebSocket frame size (a compile-time
+cap in `chat.rs`); a large multi-line paste that exceeds the cap is refused, not
+persisted. Client-side sizing is a UX convenience and is never the sole size
+control.
+
+---
+
+## Examples
+
+### Compose a multi-line message
+
+1. Open the **Chat** tab and click into the composer.
+2. Type the first line, then press **Shift+Enter** to drop to a new line.
+   The box grows to two lines.
+3. Continue adding lines. Once the content exceeds ~150px tall the box stops
+   growing and scrolls internally.
+4. Press **Enter** (without Shift) to send. The whole multi-line message is sent
+   as one turn, and the composer resets to a single line.
+
+### Paste a code snippet, then send
+
+Paste a multi-line snippet into the composer — the box auto-grows to fit (up to
+the cap, then scrolls). Review it, edit if needed, and press **Enter** to send
+the entire block as a single message.
+
+---
+
+## Testing
+
+End-to-end coverage lives in
+[`tests/e2e-dashboard/specs/chat-lifecycle.spec.ts`](./dashboard-e2e-tests.md).
+That spec already asserts the composer placeholder, the not-connected warning,
+and `Enter`-to-send. The multi-line rows below **extend** it and must land
+together with the feature — they are the intended coverage, not all present
+today:
+
+| Scenario | Expectation |
+|----------|-------------|
+| `Enter` on a filled composer | Message is sent; transcript shows the `user` turn; composer clears and returns to single-line height. |
+| `Shift+Enter` | A newline is inserted; the message is **not** sent; the box grows. |
+| Repeated `Shift+Enter` past the cap | The box stops growing at the max height and scrolls internally. |
+| `Enter` on a whitespace-only composer | No message is sent (no-op). |
+| Busy state | Composer and **Send** are disabled while a reply streams and re-enabled on `done`. |
+| Multi-line paste containing markup | Rendered as literal text (no script execution). |
+
+The selectors `#chat-input`, `#chat-send`, and the composer placeholder are part
+of the test contract; keep them stable.
+
+---
+
+## Related reading
+
+- [Dashboard Chat — sessions, storage, and streaming protocol](./dashboard-chat.md)
+- [Dashboard guide → Chat tab](../dashboard.md#chat-tab-durable-resumable-sessions)
+- [Dashboard end-to-end tests](./dashboard-e2e-tests.md)

--- a/docs/reference/dashboard-chat.md
+++ b/docs/reference/dashboard-chat.md
@@ -7,6 +7,7 @@ owner: simard
 doc_type: reference
 related:
   - ./lightweight-chat-session.md
+  - ./dashboard-chat-multiline-input.md
   - ./meeting-backend-api.md
   - ./conversation-channel-api.md
   - ./agent-log-websocket.md
@@ -493,12 +494,26 @@ list (title + relative time). Clicking an item:
 
 A **New chat** control opens `GET /ws/chat` with no `session_id`.
 
+### Input & keyboard (multi-line composer)
+
+The composer is a **multi-line `<textarea>`** (`#chat-input`), not a single-line
+`<input>`. It starts at a single-line height, **auto-grows** as you add lines up
+to a capped maximum (then scrolls internally), and **resets to one line after a
+message is sent**. `Enter` sends; **`Shift+Enter` inserts a newline** for
+deliberate multi-line composition and pasted snippets. The whitespace-only
+guard, the streaming busy-disable, and the safe DOM sinks are all preserved.
+
+Full behavior, the CSS/JS sizing contract, and test coverage are documented in
+[Dashboard Chat — multi-line message input](./dashboard-chat-multiline-input.md).
+
 ### XSS safety
 
 All message content — streamed `chunk`s, replayed `restore` history, and
 sidebar titles — is rendered with `textContent` / `document.createTextNode`
 (or the shared `esc` helper), never `innerHTML`. Stored conversation text and
-model output are treated as untrusted and can never inject markup.
+model output are treated as untrusted and can never inject markup. This holds
+for **multi-line and pasted** input too: a message such as
+`<img src=x onerror=alert(1)>` renders as literal text.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -296,6 +296,7 @@ nav:
     - Signal Continuous Conversation: reference/signal-continuous-conversation.md
     - LightweightChatSession: reference/lightweight-chat-session.md
     - Dashboard Chat: reference/dashboard-chat.md
+    - Dashboard Chat — Multi-line Input: reference/dashboard-chat-multiline-input.md
     - Dashboard Feedback Widget: reference/dashboard-feedback-widget.md
     - Copilot Meeting Mode: reference/copilot-meeting-mode.md
     - Meeting Close Lifecycle: reference/meeting-close-lifecycle.md

--- a/src/operator_commands_dashboard/index_html/part_00.rs
+++ b/src/operator_commands_dashboard/index_html/part_00.rs
@@ -75,8 +75,9 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
     .typing-dots span:nth-child(3){animation-delay:.4s}
     @keyframes blink{0%,80%,100%{opacity:0}40%{opacity:1}}
     #chat-send:disabled{opacity:.5;cursor:not-allowed}
-    #chat-input-row{display:flex;gap:.5rem}
-    #chat-input{flex:1;padding:.5rem;border:1px solid var(--border);border-radius:6px;background:var(--card);color:var(--fg);font-size:.9rem;resize:none;height:42px}
+    #chat-input-row{display:flex;gap:.5rem;align-items:flex-end}
+    /* max-height here is coupled to the JS auto-grow clamp in part_04.rs (150) */
+    #chat-input{flex:1;padding:.5rem;border:1px solid var(--border);border-radius:6px;background:var(--card);color:var(--fg);font-size:.9rem;resize:none;min-height:42px;max-height:150px;overflow-y:auto;box-sizing:border-box;line-height:1.4}
     #chat-input:focus{outline:none;border-color:var(--accent)}
     #chat-send{padding:.5rem 1.2rem;border:none;border-radius:6px;background:var(--accent);color:#0d1117;font-weight:600;cursor:pointer}
     #chat-send:hover{opacity:.9}

--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -106,7 +106,7 @@ pub(crate) const PART_01: &str = r#"
         <div class="ws-status disconnected" id="ws-status">● Disconnected <button class="btn" onclick="initChat()" style="font-size:.75rem;padding:.1rem .4rem;margin-left:.5rem">Reconnect</button></div>
         <div id="chat-messages"></div>
         <div id="chat-input-row">
-          <textarea id="chat-input" placeholder="Type a message… (/close to end session)"></textarea>
+          <textarea id="chat-input" rows="1" placeholder="Type a message… (/close to end session)"></textarea>
           <button id="chat-send" onclick="sendChat()">Send</button>
         </div>
       </div>

--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -170,7 +170,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
         appendMsg('system','Not connected. Click Reconnect to establish a session.');
         return;
       }
-      appendMsg('user',txt); ws.send(txt); inp.value='';
+      appendMsg('user',txt); ws.send(txt); inp.value=''; inp.style.height='';
       showTypingIndicator(); setChatBusy(true);
     }
 
@@ -240,6 +240,10 @@ pub(crate) const PART_04: &str = r#"            let fmt;
     }
     document.getElementById('chat-input').addEventListener('keydown',e=>{
       if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();sendChat();}
+    });
+    /* Auto-grow the textarea up to 150px (coupled to max-height in part_00.rs), then scroll. */
+    document.getElementById('chat-input').addEventListener('input',e=>{
+      const inp=e.target; inp.style.height='auto'; inp.style.height=Math.min(inp.scrollHeight,150)+'px';
     });
 
 

--- a/tests/e2e-dashboard/specs/chat-multiline-input.spec.ts
+++ b/tests/e2e-dashboard/specs/chat-multiline-input.spec.ts
@@ -1,0 +1,264 @@
+import { test, expect } from '../fixtures/simard-dashboard';
+import { type Page } from '@playwright/test';
+
+/**
+ * Failing TDD e2e spec for the multi-line Dashboard Chat input (issue #2690).
+ *
+ * The dashboard chat box must become a genuine multi-line, auto-growing
+ * textarea instead of a fixed single-line-height input, while preserving the
+ * existing send semantics.
+ *
+ * Acceptance contract (from the design spec):
+ *   1. #chat-input is a <textarea> whose CSS grows between a min and a max
+ *      height, then scrolls (min-height:42px, max-height:150px,
+ *      overflow-y:auto, resize:none). The FIXED `height:42px` is gone.
+ *   2. Typing multiple lines auto-grows the box (JS `input` listener sets
+ *      height=auto then min(scrollHeight, 150)).
+ *   3. Growth is capped at max-height and the box becomes scrollable past it.
+ *   4. Shift+Enter inserts a newline and does NOT send.
+ *   5. Enter sends the trimmed message and the box collapses back to its
+ *      resting height (inline height cleared).
+ *   6. Multi-line content is transmitted intact (internal newlines preserved).
+ *   7. Whitespace-only input is not sent.
+ *   8. Busy state still disables the input and the send button.
+ *   9. Selectors (#chat-input, #chat-send) and the placeholder are unchanged.
+ *
+ * The CSS-envelope, auto-grow, cap-and-scroll, and box-collapse rows exercise
+ * not-yet-built CSS/JS and therefore FAIL until the frontend lands. The
+ * remaining rows guard behaviour that must NOT regress.
+ *
+ * The magic number 150 mirrors the CSS `max-height` and the JS clamp; keep it
+ * in sync with src/operator_commands_dashboard/index_html/{part_00,part_04}.rs.
+ *
+ * NOTE ON WS MOCKING: the dashboard has a stateful backend (persisted chat
+ * sessions can auto-populate the panel), so send-path tests (a) register the
+ * WebSocket mock *before* navigation — the only order that reliably intercepts
+ * the connection — and (b) assert on *relative* message counts rather than
+ * absolute ones.
+ */
+
+const MAX_HEIGHT_PX = 150;
+const MIN_HEIGHT_PX = 42;
+const WS_GLOB = '**/ws/chat*';
+
+/** Rendered pixel height of the textarea (border-box). */
+async function boxHeight(page: Page): Promise<number> {
+  return page.locator('#chat-input').evaluate(
+    (el) => el.getBoundingClientRect().height,
+  );
+}
+
+/** Echo each received message back as an assistant frame. */
+function echoHandler(ws: { onMessage: (cb: (m: unknown) => void) => void; send: (d: string) => void }) {
+  ws.onMessage((msg: unknown) => {
+    const text = typeof msg === 'string' ? msg : String(msg);
+    ws.send(JSON.stringify({ role: 'assistant', content: `echo:\n${text}` }));
+  });
+}
+
+/** Accept messages but never reply, so the busy state persists. */
+function silentHandler(ws: { onMessage: (cb: (m: unknown) => void) => void }) {
+  ws.onMessage(() => {
+    /* intentionally no reply */
+  });
+}
+
+/**
+ * Register the WS mock BEFORE navigating, open the chat tab, and connect.
+ * Registering the route before `goto` is the pattern that reliably intercepts
+ * the WebSocket the dashboard opens.
+ */
+async function openChatWithWs(
+  page: Page,
+  handler: Parameters<Page['routeWebSocket']>[1],
+): Promise<void> {
+  await page.routeWebSocket(WS_GLOB, handler);
+  await page.goto('/');
+  await page.locator('.tab[data-tab="chat"]').click();
+  await page.locator('#chat-messages').waitFor({ state: 'visible' });
+  await page.locator('#ws-status button').click();
+  await expect(page.locator('#ws-status')).toContainText('Connected', { timeout: 15_000 });
+}
+
+test.describe('Chat Multi-line Input @structural', () => {
+  test.beforeEach(async ({ chatPage, authenticatedPage }) => {
+    await authenticatedPage.goto('/');
+    await chatPage.openChatTab();
+  });
+
+  test('chat input is a textarea with the correct id and placeholder', async ({
+    chatPage,
+  }) => {
+    const tag = await chatPage.chatInput.evaluate((el) => el.tagName.toLowerCase());
+    expect(tag).toBe('textarea');
+    await expect(chatPage.chatInput).toHaveAttribute(
+      'placeholder',
+      'Type a message… (/close to end session)',
+    );
+    await expect(chatPage.sendButton).toBeVisible();
+  });
+
+  test('textarea uses a growable height envelope, not a fixed height', async ({
+    authenticatedPage,
+  }) => {
+    const style = await authenticatedPage.locator('#chat-input').evaluate((el) => {
+      const cs = getComputedStyle(el);
+      return {
+        minHeight: cs.minHeight,
+        maxHeight: cs.maxHeight,
+        overflowY: cs.overflowY,
+        resize: cs.resize,
+      };
+    });
+
+    // A fixed single-line height must NOT be enforced any more; instead the
+    // element grows between an explicit min and max.
+    expect(style.minHeight).toBe(`${MIN_HEIGHT_PX}px`);
+    expect(style.maxHeight).toBe(`${MAX_HEIGHT_PX}px`);
+    // Overflow must be auto so content past the cap scrolls.
+    expect(style.overflowY).toBe('auto');
+    // Manual resize handle stays disabled (JS controls height).
+    expect(style.resize).toBe('none');
+  });
+
+  test('typing multiple lines auto-grows the textarea', async ({ chatPage, authenticatedPage }) => {
+    const empty = await boxHeight(authenticatedPage);
+
+    await chatPage.chatInput.fill('single line');
+    const oneLine = await boxHeight(authenticatedPage);
+
+    await chatPage.chatInput.fill(
+      ['line one', 'line two', 'line three', 'line four', 'line five'].join('\n'),
+    );
+    const manyLines = await boxHeight(authenticatedPage);
+
+    // A single line is at the resting height.
+    expect(oneLine).toBeLessThanOrEqual(MIN_HEIGHT_PX + 12);
+    // Five lines must be visibly taller than one line.
+    expect(manyLines).toBeGreaterThan(oneLine + 20);
+    // ...but never taller than the cap.
+    expect(manyLines).toBeLessThanOrEqual(MAX_HEIGHT_PX + 2);
+    // Sanity: an empty box is also at the resting height.
+    expect(empty).toBeLessThanOrEqual(MIN_HEIGHT_PX + 12);
+  });
+
+  test('growth is capped at the max height and becomes scrollable', async ({
+    chatPage,
+    authenticatedPage,
+  }) => {
+    const lots = Array.from({ length: 30 }, (_, i) => `line ${i + 1}`).join('\n');
+    await chatPage.chatInput.fill(lots);
+
+    const height = await boxHeight(authenticatedPage);
+    expect(height).toBeLessThanOrEqual(MAX_HEIGHT_PX + 2);
+    expect(height).toBeGreaterThanOrEqual(MAX_HEIGHT_PX - 12);
+
+    const { scrollHeight, clientHeight } = await chatPage.chatInput.evaluate(
+      (el) => ({ scrollHeight: el.scrollHeight, clientHeight: el.clientHeight }),
+    );
+    // More content than fits => the box scrolls internally.
+    expect(scrollHeight).toBeGreaterThan(clientHeight);
+  });
+
+  test('Shift+Enter inserts a newline without sending', async ({ chatPage }) => {
+    const before = await chatPage.page.locator('.chat-msg').count();
+
+    await chatPage.chatInput.click();
+    await chatPage.chatInput.type('first line');
+    await chatPage.chatInput.press('Shift+Enter');
+    await chatPage.chatInput.type('second line');
+
+    const value = await chatPage.chatInput.inputValue();
+    expect(value).toBe('first line\nsecond line');
+
+    // Nothing was sent: no new chat bubble was appended.
+    expect(await chatPage.page.locator('.chat-msg').count()).toBe(before);
+    // Input still holds the draft.
+    await expect(chatPage.chatInput).not.toHaveValue('');
+  });
+});
+
+test.describe('Chat Multi-line Send @structural', () => {
+  test('Enter sends and the textarea collapses back to its resting height', async ({
+    chatPage,
+    authenticatedPage,
+  }) => {
+    await openChatWithWs(authenticatedPage, echoHandler);
+
+    // Build a tall multi-line draft, then confirm it grew.
+    await chatPage.chatInput.fill(
+      Array.from({ length: 8 }, (_, i) => `draft line ${i + 1}`).join('\n'),
+    );
+    const grown = await boxHeight(authenticatedPage);
+    expect(grown).toBeGreaterThan(MIN_HEIGHT_PX + 20);
+
+    await chatPage.chatInput.press('Enter');
+
+    // Draft cleared (message sent).
+    await expect(chatPage.chatInput).toHaveValue('');
+    // Inline height override is cleared so the box returns to CSS min-height.
+    const inlineHeight = await chatPage.chatInput.evaluate(
+      (el) => (el as HTMLTextAreaElement).style.height,
+    );
+    expect(inlineHeight).toBe('');
+    // Rendered height is back at the resting height.
+    const collapsed = await boxHeight(authenticatedPage);
+    expect(collapsed).toBeLessThanOrEqual(MIN_HEIGHT_PX + 12);
+  });
+
+  test('multi-line message is submitted with its newlines intact', async ({
+    chatPage,
+    authenticatedPage,
+  }) => {
+    await openChatWithWs(authenticatedPage, echoHandler);
+
+    await chatPage.chatInput.click();
+    await chatPage.chatInput.type('first line');
+    await chatPage.chatInput.press('Shift+Enter');
+    await chatPage.chatInput.type('second line');
+    await chatPage.chatInput.press('Enter');
+
+    // The echoed assistant bubble proves the multi-line payload was sent with
+    // both lines (and their newline) intact.
+    await chatPage.page
+      .locator('.chat-msg .role.assistant')
+      .first()
+      .waitFor({ state: 'visible', timeout: 5_000 });
+    const msgs = await chatPage.getMessages();
+
+    const assistant = msgs.find((m) => m.role === 'assistant');
+    expect(assistant).toBeDefined();
+    expect(assistant!.content).toContain('first line');
+    expect(assistant!.content).toContain('second line');
+
+    // The user's own bubble also preserves both lines.
+    const user = msgs.find((m) => m.role === 'user');
+    expect(user).toBeDefined();
+    expect(user!.content).toContain('first line');
+    expect(user!.content).toContain('second line');
+  });
+
+  test('whitespace-only input is not sent', async ({ chatPage, authenticatedPage }) => {
+    await openChatWithWs(authenticatedPage, echoHandler);
+
+    const before = await chatPage.page.locator('.chat-msg').count();
+    await chatPage.chatInput.fill('   \n  \n\t ');
+    await chatPage.sendButton.click();
+
+    // No bubble appended for whitespace-only content.
+    await chatPage.page.waitForTimeout(300);
+    expect(await chatPage.page.locator('.chat-msg').count()).toBe(before);
+  });
+
+  test('busy state disables the input and send button', async ({
+    chatPage,
+    authenticatedPage,
+  }) => {
+    await openChatWithWs(authenticatedPage, silentHandler);
+
+    await chatPage.sendMessage('are you there?');
+
+    await expect(chatPage.chatInput).toBeDisabled();
+    await expect(chatPage.sendButton).toBeDisabled();
+  });
+});


### PR DESCRIPTION
Closes #2690.

## What
Makes the Simard dashboard chat input a proper multi-line, auto-growing textarea. It was a fixed-height (42px) textarea that behaved like a single-line field.

## Changes
- **`part_00.rs` (CSS):** `height:42px` → `min-height:42px; max-height:150px; overflow-y:auto; box-sizing:border-box; line-height:1.4`. Input row uses `align-items:flex-end` so **Send** stays bottom-aligned as the box grows.
- **`part_01.rs` (HTML):** added `rows="1"` so the resting height honors `min-height:42px` (a bare `<textarea>` defaults to `rows=2` ≈56px).
- **`part_04.rs` (JS):** added an `input` listener that auto-grows the textarea up to 150px then scrolls, and resets the height after a successful send.

## Preserved behavior
- **Enter** sends, **Shift+Enter** inserts a newline (existing keydown handler untouched).
- Busy-disable (`setChatBusy`), the whitespace-only guard, and the XSS-safe text sinks (`createTextNode`/`textContent`) are all unchanged.
- WebSocket send path and all `#chat-input`/`#chat-send` ids + placeholder preserved (asserted by existing Playwright specs).

## Tests & docs
- New Playwright e2e spec `tests/e2e-dashboard/specs/chat-multiline-input.spec.ts` (TDD: red against the old frontend, green after the change).
- Reference docs added (`docs/reference/dashboard-chat-multiline-input.md`) and linked in nav.

Built via the dev-orchestrator workflow (design → security review → TDD → implement → verify). `cargo build`, `cargo fmt`, `cargo clippy -D warnings`, and the pre-push test gate all pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>