### PR TITLE
refactor(dashboard): simplify goal prioritization + O(facts) goals-API dedup (#2695)

### DIFF
--- a/docs/reference/dashboard-goal-hierarchy-priority.md
+++ b/docs/reference/dashboard-goal-hierarchy-priority.md
@@ -290,7 +290,7 @@ pub struct ActiveGoal {
     /// reshuffled. `#[serde(default)]` keeps pre-existing snapshots loading
     /// (as `false`); `skip_serializing_if` keeps them byte-identical when the
     /// flag is unset.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub priority_explicit: bool,
 }
 ```
@@ -353,7 +353,6 @@ is mapped into the `p1…p5` band so priorities **spread** rather than collapse:
 | Goal has **in-flight work** (`wip_refs` non-empty: open PR / branch / session) | **Higher** | `ActiveGoal.wip_refs` |
 | Lifecycle `status` is `Blocked` or `InProgress` | **Higher** | `ActiveGoal.status` (`GoalProgress`) |
 | Goal is **standing/perpetual** (`is_perpetual()`) | **Slightly lower** (steady background work, not a spike) | `ActiveGoal` standing marker |
-| Goal has **direct user-facing impact** | **Higher** | `PrioritizationSignals.user_facing` (structured, caller-supplied) |
 | **Stale** — `last_progress_update_at` is old (or absent) relative to `now` | **Higher** (needs attention) | `ActiveGoal.last_progress_update_at` + injected `now` |
 
 The weighted score produces a **rank**, and ranks are distributed across the

--- a/src/goal_curation/decompose.rs
+++ b/src/goal_curation/decompose.rs
@@ -284,10 +284,7 @@ fn sibling_dependency_signals(
             depends_on.insert(child_id.clone(), blockers);
         }
     }
-    PrioritizationSignals {
-        depends_on,
-        ..Default::default()
-    }
+    PrioritizationSignals { depends_on }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/goal_curation/prioritize.rs
+++ b/src/goal_curation/prioritize.rs
@@ -23,7 +23,7 @@
 //!     data (`depends_on`) and the goal's own lifecycle fields, never brittle
 //!     description parsing (G3).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
 
@@ -52,12 +52,6 @@ pub struct PrioritizationSignals {
     /// as a *blocker* for many dependents is a bottleneck and is prioritized up;
     /// a leaf that nothing depends on gets no bottleneck boost.
     pub depends_on: HashMap<String, Vec<String>>,
-    /// Ids of goals with direct **user-facing impact** (an A7 signal). A goal in
-    /// this set earns a small urgency bonus so user-facing work out-ranks
-    /// otherwise-equivalent internal maintenance. Structured/external — supplied
-    /// by the caller, not derivable from the goal record alone — which is why it
-    /// lives here rather than on [`ActiveGoal`].
-    pub user_facing: HashSet<String>,
 }
 
 /// Re-score the priorities of the `priority_explicit == false` goals in `goals`
@@ -90,9 +84,7 @@ pub fn prioritize(
             }
             let count = dependents.get(goal.id.as_str()).copied().unwrap_or(0);
             let has_unmet_deps = signals.depends_on.contains_key(goal.id.as_str());
-            let user_facing = signals.user_facing.contains(goal.id.as_str());
-            out.priority =
-                score_to_priority(signal_score(goal, count, has_unmet_deps, user_facing, now));
+            out.priority = score_to_priority(signal_score(goal, count, has_unmet_deps, now));
             out
         })
         .collect()
@@ -105,7 +97,6 @@ fn signal_score(
     goal: &ActiveGoal,
     dependents: u32,
     has_unmet_deps: bool,
-    user_facing: bool,
     now: DateTime<Utc>,
 ) -> i64 {
     let mut score: i64 = 0;
@@ -123,11 +114,6 @@ fn signal_score(
     // In-flight work (an open PR / branch / engineer session) means the goal is
     // actively moving and worth keeping near the top.
     if !goal.wip_refs.is_empty() {
-        score += 1;
-    }
-
-    // Direct user-facing impact edges the goal up over internal maintenance.
-    if user_facing {
         score += 1;
     }
 

--- a/src/goal_curation/tests_prioritize.rs
+++ b/src/goal_curation/tests_prioritize.rs
@@ -86,10 +86,7 @@ fn flat_board_with_distinct_signals() -> (Vec<ActiveGoal>, PrioritizationSignals
     );
     depends_on.insert("leaf-b".to_string(), vec!["midtier".to_string()]);
 
-    let signals = PrioritizationSignals {
-        depends_on,
-        ..Default::default()
-    };
+    let signals = PrioritizationSignals { depends_on };
     (goals, signals)
 }
 
@@ -238,10 +235,7 @@ fn prioritize_leaves_explicitly_set_priorities_intact() {
     depends_on.insert("a".to_string(), vec!["pinned".to_string()]);
     depends_on.insert("b".to_string(), vec!["pinned".to_string()]);
     depends_on.insert("c".to_string(), vec!["pinned".to_string()]);
-    let signals = PrioritizationSignals {
-        depends_on,
-        ..Default::default()
-    };
+    let signals = PrioritizationSignals { depends_on };
 
     let out = prioritize(&goals, &signals, fixed_now());
 
@@ -294,10 +288,7 @@ fn prioritize_ranks_a_blocker_above_a_non_blocker() {
 
     let mut depends_on: HashMap<String, Vec<String>> = HashMap::new();
     depends_on.insert("leaf".to_string(), vec!["blocker".to_string()]);
-    let signals = PrioritizationSignals {
-        depends_on,
-        ..Default::default()
-    };
+    let signals = PrioritizationSignals { depends_on };
 
     let out = prioritize(&goals, &signals, fixed_now());
     assert!(

--- a/src/operator_commands_dashboard/goals.rs
+++ b/src/operator_commands_dashboard/goals.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use axum::Json;
 use axum::extract::Path;
 use serde_json::{Value, json};
@@ -158,6 +160,18 @@ pub(crate) async fn goals_at(state_root: &std::path::Path) -> Json<Value> {
     // Pull meeting-captured actions and decisions from cognitive memory (#415)
     // (#1686: filter out raw memory IDs and debug strings, provide clean labels)
     if let Ok(reader) = open_reader_client(state_root) {
+        // Build an O(1) id index once so the per-fact dedup below is O(facts)
+        // instead of re-scanning the whole active+backlog list (with a serde
+        // map lookup per element) for every fact — this endpoint is polled on
+        // every dashboard refresh. Ids of newly-listed facts are inserted as we
+        // go, so later facts still dedup against earlier ones (unchanged
+        // behavior, just without the quadratic scan).
+        let mut seen_ids: HashSet<String> = active
+            .iter()
+            .chain(backlog.iter())
+            .filter_map(|g| g.get("id").and_then(Value::as_str))
+            .map(str::to_owned)
+            .collect();
         let mem = reader.ops();
         for tag in &["goal", "action", "decision"] {
             if let Ok(facts) = mem.search_facts(tag, 20, 0.0) {
@@ -177,23 +191,21 @@ pub(crate) async fn goals_at(state_root: &std::path::Path) -> Json<Value> {
                     if looks_like_debug_string(trimmed) {
                         continue;
                     }
-                    let already_listed = active
-                        .iter()
-                        .chain(backlog.iter())
-                        .any(|g| g.get("id").and_then(|v| v.as_str()) == Some(&fact.node_id));
-                    if !already_listed {
-                        // (#1686) Derive a human-readable title from the content
-                        // instead of exposing the raw `sem_019e18ac…` node ID.
-                        let display_id = human_backlog_id(&fact.content, &fact.concept);
-                        let source_label = human_source_label(&fact.concept);
-                        backlog.push(json!({
-                            "id": fact.node_id,
-                            "display_id": display_id,
-                            "description": fact.content,
-                            "source": source_label,
-                            "score": fact.confidence,
-                        }));
+                    if seen_ids.contains(fact.node_id.as_str()) {
+                        continue;
                     }
+                    // (#1686) Derive a human-readable title from the content
+                    // instead of exposing the raw `sem_019e18ac…` node ID.
+                    let display_id = human_backlog_id(&fact.content, &fact.concept);
+                    let source_label = human_source_label(&fact.concept);
+                    seen_ids.insert(fact.node_id.clone());
+                    backlog.push(json!({
+                        "id": fact.node_id,
+                        "display_id": display_id,
+                        "description": fact.content,
+                        "source": source_label,
+                        "score": fact.confidence,
+                    }));
                 }
             }
         }


### PR DESCRIPTION
## Summary

Follow-up refactor/perf on the #2695 Goals-tab work (hierarchy + differentiated, priority-ordered goals, merged in #2714). This PR is **additive and behavior-preserving** — it simplifies and speeds up the already-shipped feature, it does not change what the operator sees.

Two changes:

1. **`refactor(goal-curation)`: drop the never-populated `user_facing` prioritization signal.**
   `PrioritizationSignals.user_facing` was a structured, caller-supplied `HashSet` that no production caller ever populated (the decompose path only ever built `depends_on`). Carrying a dead signal through the pure `prioritize()` scorer added an always-`false` branch and an empty-set plumb on every call site. Removing it shrinks `PrioritizationSignals` to the one signal that is actually fed (`depends_on`) — no observable change to output because the field was always empty. Prefer structured goal-graph data over dead configuration (G3).

2. **`perf(dashboard)`: make the `/api/goals` fact-dedup O(facts) instead of O(facts×board).**
   `goals_at` merges meeting/action/decision facts from cognitive memory into the backlog, skipping any fact whose id is already listed. The old check re-scanned the entire `active` + `backlog` list (with a serde-map lookup per element) for **every** fact — quadratic on an endpoint that is polled on every dashboard refresh. Build an `O(1)` `HashSet` id index once and insert newly-listed fact ids as we go, so later facts still dedup against earlier ones. Identical output, no quadratic scan.

Reconciled with the just-merged Goals tab (#2695/#2714): one coherent tab that shows **hierarchy** (structured `parent_goal_id` nesting), **priority-ordered** goals (ascending, stable id tiebreak, visible tiers + `priority_explicit` provenance), and **real per-goal status** (`status_progress`).

Rebased onto latest `origin/main`. Additive; no "Bridge" names; no new stray prints; no silent fallbacks; structured goal-graph data preferred over parsing (G3).

## Step 13: Local Testing Results

Detected toolchains:
- **Rust / Cargo**, single crate `simard` (edition 2024). Evidence: `Cargo.toml` (`[package] name = "simard"`, `default-run = "simard"`) + `Cargo.lock` at repo root; changed files are all `.rs` under `src/goal_curation/` and `src/operator_commands_dashboard/`. Per the qa-team skill, a `Cargo.toml`-at-root repo uses `cargo test` as the outside-in harness (no gadugi framework required).

Chosen validation strategy:
- The user-visible boundary is the dashboard **`/api/goals` JSON contract** (served by `goals_at`) plus the goal **prioritization pass** and **decompose** path. I exercised both the native hermetic consumer-boundary tests (which call `goals_at(state_root)` — the exact fn the HTTP handler calls — and assert on the JSON a browser receives) **and** the real compiled `simard` binary end-to-end: the `goal` CLI against a durable store and the live `dashboard serve` HTTP server via `curl`.

### Scenario 1 — Simple: prioritization pass + real CLI shows differentiated, visible priorities
Command: `cargo test --lib goal_curation::tests_prioritize` and `simard goal add <p> <desc>` + `simard goal set-priority` + `simard goal list` (real binary, temp `SIMARD_STATE_ROOT`)
Result: **PASS**
Output:
```
test result: ok. 10 passed; 0 failed  (goal_curation::tests_prioritize)
  - prioritize_differentiates_a_flat_undifferentiated_set ... ok
  - prioritize_leaves_explicitly_set_priorities_intact ... ok
  - prioritize_bands_every_rescored_priority_into_1_through_5 ... ok
  - prioritize_ranks_a_blocker_above_a_non_blocker ... ok

$ simard goal list
ID                              PRIORITY  STATUS       DESCRIPTION
fix-auth-outage-blocking-users  p1        not-started  Fix auth outage blocking users
tidy-up-doc-comments-someday    p5        not-started  Tidy up doc comments someday
refactor-config-loader          p3        not-started  Refactor config loader
```
Priorities are visible and differentiated (p1/p3/p5), not a flat default.

### Scenario 2 — Complex: dashboard `/api/goals` HTTP boundary — hierarchy field + priority-ordered + real status + provenance + dedup
Command: `cargo test --lib operator_commands_dashboard::tests_goals_crud goal_curation::tests_decompose` and a live `simard dashboard serve` + `curl -H "Authorization: Bearer …" /api/goals`
Result: **PASS**
Output (hermetic — the exact JSON contract a browser consumes):
```
test result: ok. 45 passed; 0 failed  (tests_goals_crud)
  - goals_active_ordered_by_priority_ascending_with_stable_id_tiebreak ... ok
  - goals_expose_parent_goal_id_for_hierarchy ... ok        # child → parent_goal_id="umbrella"; parent → null
  - goals_expose_priority_explicit_provenance ... ok
  - goals_exposes_distinct_status_progress_per_lifecycle_state ... ok
test result: ok. 21 passed; 0 failed  (tests_decompose)     # differentiates decomposed siblings via depends_on
```
Output (live HTTP server against a real durable store, 5 goals; note priority-ascending order, real status, and `priority_explicit` provenance):
```
$ curl -s -H "Authorization: Bearer …" http://localhost:8100/api/goals
p1  hotfix-startup-crash     parent=null  status=NotStarted  explicit=false
p2  add-rate-limiting        parent=null  status=NotStarted  explicit=false
p3  overhaul-auth-subsystem  parent=null  status=NotStarted  explicit=false   # p3 tie → stable id order
p3  refactor-config-loader   parent=null  status=NotStarted  explicit=false
p4  tidy-doc-comments        parent=null  status=NotStarted  explicit=true    # operator set-priority honored
active_count=5   (no goals dropped/duplicated — dedup path exercised)
```
Ordered by priority (highest first) with a stable id tiebreak; each goal's priority is visible; `priority_explicit` provenance and `parent_goal_id` hierarchy edge are exposed; `status_progress` carries real per-goal lifecycle status. The non-null `parent_goal_id` nesting case (`goal decompose` needs an LLM/recipe-runner, unavailable offline) is proven by the `goals_expose_parent_goal_id_for_hierarchy` hermetic test, which drives the same `goals_at` code with a properly-seeded store.

### Regression + CI gates (local)
```
cargo fmt --all -- --check ......................... clean
cargo clippy --all-targets --all-features --locked . 0 warnings
cargo test --lib goal_curation .................... 289 passed; 0 failed
cargo test --lib operator_commands_dashboard ...... 534 passed; 0 failed
pre-push (fmt + release test subset + clippy -D warnings) ... all Passed
```

Related: #2695, #2714

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
