### PR TITLE
chore(deps): bump amplihack-agent-eval → clean agent-result channel (amplihack-rs #856)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "amplihack-agent-eval"
 version = "0.11.1"
-source = "git+https://github.com/rysweet/amplihack-rs.git?rev=2a93441d1837f9f853d5dddc56cc1088353a8872#2a93441d1837f9f853d5dddc56cc1088353a8872"
+source = "git+https://github.com/rysweet/amplihack-rs.git?rev=14dc30b10e87764120c6f2bae7f3630522c29e5d#14dc30b10e87764120c6f2bae7f3630522c29e5d"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "d
 # `git ls-remote`); the delta is workflow/recipe/CI-tooling fixes only, with the
 # `amplihack-agent-eval` crate surface (GymRunner/GymConfig/GymScenarioResult)
 # and the reverted workspace version 0.11.1 unchanged.
-amplihack-agent-eval = { git = "https://github.com/rysweet/amplihack-rs.git", rev = "2a93441d1837f9f853d5dddc56cc1088353a8872" }
+amplihack-agent-eval = { git = "https://github.com/rysweet/amplihack-rs.git", rev = "14dc30b10e87764120c6f2bae7f3630522c29e5d" }
 # De-fork phase 2b (issue #2307): the native cognitive-memory fork is gone, but
 # `lbug` is still a direct dependency of the standalone `simard-tui` binary
 # (`src/bin/simard_tui/goals.rs`), which opens a LadybugDB read-only to render

--- a/tests/issue_2626_amplihack_pin_bump.rs
+++ b/tests/issue_2626_amplihack_pin_bump.rs
@@ -41,7 +41,7 @@ use std::path::PathBuf;
 // ── Target / stale pin constants (verified against upstream `main`) ──────────
 
 /// amplihack-rs `main` HEAD carrying the `amplihack-agent-eval` crate to adopt.
-const AGENT_EVAL_TARGET_REV: &str = "2a93441d1837f9f853d5dddc56cc1088353a8872";
+const AGENT_EVAL_TARGET_REV: &str = "14dc30b10e87764120c6f2bae7f3630522c29e5d";
 /// amplihack-memory-lib `main` commit carrying the `amplihack-memory` crate:
 /// PR #120's squash-merge (the first-class `creative_idea` prospective memory
 /// type — CreativeIdeaStatus lifecycle + typed MemoryLink/MemoryLinkKind — which


### PR DESCRIPTION
Bumps the pinned amplihack-rs rev to pick up the first-class clean agent-result channel merged in rysweet/amplihack-rs#856. This is the durable substrate that lets Simard's recipe-output consumers stop scraping noisy stdout (the extract_json_payload/extract_verdict brittle-parsing antipattern).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>