### PR TITLE
fix(journal): consume clean narrative result-channel so first section is not polluted by launcher/tool output

### DIFF
--- a/docs/concepts/simard-journal.md
+++ b/docs/concepts/simard-journal.md
@@ -13,6 +13,7 @@ owner: simard
 doc_type: concept
 related:
   - ../reference/journal-api.md
+  - ../reference/journal-narrative-result-channel.md
   - ../howto/browse-the-simard-journal.md
   - ../tutorials/read-simards-daily-journal.md
   - ../architecture/cognitive-memory.md

--- a/docs/howto/verify-the-journal-clean-narrative.md
+++ b/docs/howto/verify-the-journal-clean-narrative.md
@@ -1,0 +1,121 @@
+---
+title: Verify the journal's clean narrative
+description: Step-by-step how-to for confirming that the daily-journal narrative is captured from the agent's clean result-file channel, not from recipe-runner stdout — regenerating the day's journal, fetching the authenticated GET /api/journal/render/<date>, and proving the first paragraph is real prose free of the copilot launcher banner and the agent's tool-call trace.
+last_updated: 2026-07-07
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../reference/journal-narrative-result-channel.md
+  - ../reference/journal-api.md
+  - ../howto/browse-the-simard-journal.md
+  - ../howto/verify-the-distillation-semantic-handoff.md
+  - ../concepts/copilot-launcher-preamble-stripping.md
+---
+
+# Verify the journal's clean narrative
+
+Use this how-to to confirm that the daily journal is captured the **clean** way:
+each agent pass (the narrative **draft** and its plain-language **rewrite**)
+writes its finished report to a dedicated result **file** that Simard reads, and
+Simard never scrapes `recipe-runner-rs` stdout. The property you are verifying is
+that the launcher banner and the agent's own tool-call trace can **no longer**
+appear in the stored narrative — because stdout is never read as the result.
+
+For the mechanism, see the
+[Journal narrative result channel](../reference/journal-narrative-result-channel.md).
+
+## Before you start
+
+- The OODA daemon must be **running** and serving the dashboard on
+  `http://127.0.0.1:8080` (adjust host/port to your deployment).
+- You need the dashboard login code from `~/.simard/.dashkey`.
+- Confirm the hot-reload recipes carry the file-channel contract (a stale asset
+  is the one footgun this fix guards against, loudly):
+
+  ```console
+  $ grep -l narrative_output ~/.simard/prompt_assets/simard/recipes/journal-narrative.yaml
+  $ grep -l plain_output     ~/.simard/prompt_assets/simard/recipes/journal-plain-language.yaml
+  ```
+
+  Both must print their path. A missing marker means the deployed recipe predates
+  the fix; re-run `scripts/redeploy-local.sh` so the current recipes reach
+  `~/.simard/prompt_assets/`.
+
+## 1. Regenerate today's journal
+
+The journal is rolling and regenerated as the day unfolds; wait for the next
+journal thread tick, or force a regeneration for today's date so the entry is
+produced by the current (result-file) code path. Then note the date you want to
+inspect, e.g. `2026-07-07`.
+
+## 2. Authenticate and fetch the rendered entry
+
+Log in with the dashkey (form-urlencoded `code=<dashkey>`), keep the returned
+`simard_session` cookie, and fetch the server-rendered entry:
+
+```bash
+DATE=2026-07-07
+KEY="$(cat ~/.simard/.dashkey)"
+
+# POST the login code; save the simard_session cookie.
+curl -s -c /tmp/simard.cookies \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode "code=${KEY}" \
+  http://127.0.0.1:8080/api/login >/dev/null
+
+# Fetch the rendered journal HTML with the session cookie.
+curl -s -b /tmp/simard.cookies \
+  "http://127.0.0.1:8080/api/journal/render/${DATE}" > /tmp/journal.html
+```
+
+## 3. Assert the first paragraph is clean prose
+
+The first `<p>` of `journal-narrative` must be the real report opening (for
+example, "On July 7, 2026, Simard operated in a largely self-directed decision
+cycle…") and must contain **none** of the launcher/tool-trace markers. Grep for
+each contaminant — every one of these must return **no match**:
+
+```bash
+! grep -F 'nested amplihack session' /tmp/journal.html \
+  && ! grep -F 'launching copilot binary' /tmp/journal.html \
+  && ! grep -F 'NODE_OPTIONS=' /tmp/journal.html \
+  && ! grep -F 'Read draft.ctx' /tmp/journal.html \
+  && ! grep -F 'lines read' /tmp/journal.html \
+  && ! grep -F '●' /tmp/journal.html \
+  && ! grep -F '│' /tmp/journal.html \
+  && ! grep -F '└' /tmp/journal.html \
+  && echo "CLEAN: no launcher/tool-trace markers in the rendered journal"
+```
+
+To eyeball the opening paragraph directly:
+
+```bash
+grep -o '<p class="journal-narrative[^>]*">[^<]*' /tmp/journal.html | head -1
+```
+
+It should begin with prose, not with `2026-…T…Z  WARN` or a `●` glyph.
+
+## What you just proved
+
+- The narrative was captured from the agent's **result file**, not stdout — the
+  copilot launcher banner (`WARN nested amplihack session`, `INFO launching
+  copilot`, `ℹ NODE_OPTIONS=…`) and the agent's tool-call trace (`● Read
+  draft.ctx`, `│`, `└ N lines read`) never entered the stored text.
+- If the agent had failed to write its result file, the pass would have degraded
+  **loudly** to the honest offline drafter/reviewer — never to a stored stdout
+  dump. See the
+  [failure semantics](../reference/journal-narrative-result-channel.md#failure-semantics).
+
+## If markers still appear
+
+- **Stale hot-reload recipe.** Re-check the `grep -l` marker test in
+  [Before you start](#before-you-start); re-run `scripts/redeploy-local.sh` and
+  regenerate.
+- **Old binary still deployed.** Confirm the running daemon includes this fix
+  (`src/journal/recipe.rs` reads `harvest_narrative_file`, not a `RecipeEnvelope`
+  from stdout) and redeploy if not.
+- **Degraded-but-clean.** If the operator log shows an
+  `AdapterInvocationFailed` for the journal adapter, the pass used the honest
+  offline path — the text is clean but deterministic; investigate the recorded
+  Overseer diagnosis rather than the render.

--- a/docs/reference/journal-api.md
+++ b/docs/reference/journal-api.md
@@ -27,6 +27,7 @@ related:
   - ../design/overseer.md
   - ../architecture/episode-distillation.md
   - ./recipe-context-file-transport.md
+  - ./journal-narrative-result-channel.md
   - ../concepts/journal-recipe-spawn-e2big.md
   - ../howto/diagnose-journal-e2big-spawn-failures.md
 ---

--- a/docs/reference/journal-narrative-result-channel.md
+++ b/docs/reference/journal-narrative-result-channel.md
@@ -1,0 +1,454 @@
+---
+title: Journal narrative result channel
+description: How Simard's daily-journal narrative and plain-language passes capture the agent's clean report — the dedicated result-file channel (narrative_output / plain_output), the shared harvest_narrative_file reader, the contract-marker recipe guard (recipe_declares_result_file / select_recipe), the loud failure taxonomy that degrades to the honest offline path, and the recipe-asset sync that keeps the hot-reload path current. The launcher banner and the agent's own tool-call trace can never enter the stored narrative because stdout is no longer read as the result.
+last_updated: 2026-07-07
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+status: shipped
+related:
+  - ./journal-api.md
+  - ./goal-decompose-result-channel.md
+  - ./distill-recipe-output-capture.md
+  - ./recipe-context-file-transport.md
+  - ../concepts/simard-journal.md
+  - ../concepts/journal-report-tone-contract.md
+  - ../concepts/copilot-launcher-preamble-stripping.md
+  - ../howto/verify-the-journal-clean-narrative.md
+  - ../howto/browse-the-simard-journal.md
+  - ../design/eliminate-deterministic-fallbacks.md
+---
+
+# Journal narrative result channel
+
+> **Status — clean-result-channel capture for the journal narrative.**
+> Both journal agent passes — the narrative **draft** and its plain-language
+> **rewrite** — capture the agent's report from a **dedicated result file** the
+> agent writes, not from `recipe-runner-rs` stdout. Present tense below
+> describes the shipped behavior. Locations:
+> reader + invocation `src/journal/recipe.rs`
+> (`JournalRecipe::run`, `harvest_narrative_file`, `recipe_declares_result_file`,
+> `select_recipe`); tests `src/journal/tests_clean_result_channel.rs`
+> (registered in `src/journal/mod.rs`); recipes
+> `prompt_assets/simard/recipes/journal-narrative.yaml` (drafter,
+> `narrative_output`) and
+> `prompt_assets/simard/recipes/journal-plain-language.yaml` (reviewer,
+> `plain_output`); asset sync `scripts/redeploy-local.sh`.
+
+The [journal generation pipeline](./journal-api.md) turns one day of Simard's
+activity into a durable, layperson-readable **narrative engineering & research
+report** in two agentic passes: a **drafter** runs the `journal-narrative`
+recipe to write the professional third-person report from the day's structured
+context, and a **reviewer** runs the `journal-plain-language` recipe to rewrite
+that draft so a non-engineer can read it. This page documents the
+**output-capture contract** between Simard and those two agents: how each pass's
+finished report is captured, what happens on failure, and how the recipe assets
+reach the running daemon.
+
+This page is the transport-layer companion to the [Journal API](./journal-api.md);
+it changes **only** how each agent's report reaches Simard, not what the pipeline
+does with it. The good narrative body, the mandatory
+[plain-language reviewer pass](./journal-api.md#the-two-pass-generation-pipeline), and the
+unconditional `scrub_secrets` / de-jargon post-passes in
+`src/journal/generate.rs` are preserved **exactly**.
+
+It is the journal-side sibling of the goal-decompose
+[result channel](./goal-decompose-result-channel.md) and the distillation
+[clean result channel](./distill-recipe-output-capture.md): the same
+brittle-parsing-of-agent-stdout antipattern, closed the same structural way. The
+journal reader is **modeled on** — not a byte-for-byte copy of —
+`harvest_subgoals_file`: it keeps the file-channel shape, the
+"non-zero exit surfaces stderr **and** stdout" diagnostic, and the same **1 MiB
+size cap** and **empty / whitespace-only rejection**, but it captures **prose**
+(Markdown), not a JSON envelope — so there is no deserialize step and no
+`parse_*` companion, just a trimmed, non-empty string.
+
+---
+
+## The bug this closes
+
+Before this fix, `JournalRecipe::run` invoked `recipe-runner-rs --output-format
+json`, deserialized a `RecipeEnvelope` from **stdout**, and took
+`step_results.last().output` as the narrative. That captured stdout included
+everything the copilot launcher and the agent print **around** the answer:
+
+```text
+2026-07-07T01:03:03.969016Z  WARN nested amplihack session detected — launching anyway session_id="session-18bfdc2635821690" depth=2
+2026-07-07T01:03:04.604657Z  INFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot version="GitHub Copilot CLI 1.0.69-2."
+ℹ NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: /home/azureuser/.amplihack/config
+● Read draft.ctx  │ /tmp/simard-journal-ctx-XXXX/draft.ctx  └ 153 lines read
+```
+
+The rewriter step's output began with the **launcher banner** (`WARN nested
+amplihack session`, `INFO launching copilot`, `ℹ NODE_OPTIONS=…`) and the
+agent's **own tool-call trace** (`● Read draft.ctx`, the `│` continuation, and
+`└ 153 lines read`). Because that noise was captured as the step output, it
+landed verbatim as the **leading paragraph** of the stored narrative. The rest
+of the journal read well — the journaltone contract had landed — but the live
+`GET /api/journal/render/<date>` returned this garbage as the first `<p>` of
+`journal-narrative`, only reaching the real prose ("On July 7, 2026, Simard
+operated in a largely self-directed decision cycle…") **after** it.
+
+This is the exact
+[raw-stdout-scrape antipattern](../concepts/copilot-launcher-preamble-stripping.md)
+already retired for distillation ([#2679](https://github.com/rysweet/Simard/issues/2679))
+and goal-decompose ([#2708](https://github.com/rysweet/Simard/issues/2708)). The
+fix is **not** to strip `WARN` / `INFO` / `ℹ` / `●` / `│` / `└` lines with a
+regex — that is the same brittle parsing wearing a different hat, and it rots
+the moment the launcher changes a prefix. The fix removes stdout from the result
+path entirely: each agent **writes** its finished report to a private,
+per-invocation file, and Simard reads **that file**. A launcher banner or a
+tool-call trace on stdout can no longer contaminate the narrative, because
+stdout is never read as the result.
+
+---
+
+## Invocation
+
+`JournalRecipe::run` shells out to `recipe-runner-rs` with an argv-vector (no
+shell), one invocation per pass. The day-context / draft **input** still rides
+the shared [`ContextFile`](./recipe-context-file-transport.md) channel exactly
+as before (the E2BIG hardening from
+[#2640 / #2692](../concepts/journal-recipe-spawn-e2big.md) is unchanged); the
+new piece is the dedicated **output** file:
+
+```text
+recipe-runner-rs <recipe_path>
+    -c <input_key>_path=<abs ContextFile path>   # day_context (drafter) | draft (reviewer)
+    -c <output_key>=<abs result-file path>        # narrative_output | plain_output
+```
+
+with `AMPLIHACK_AGENT_BINARY` in the environment. Note the retired
+`--output-format json` flag is **gone** — the result no longer comes from a
+stdout envelope.
+
+- Each pass owns an `output_key` threaded into `JournalRecipe::new`:
+  the drafter (`journal-narrative.yaml`) uses **`narrative_output`**; the
+  reviewer (`journal-plain-language.yaml`) uses **`plain_output`**. The same
+  `run` body serves both, so **both** recipes are fixed — the reviewer is the
+  live contaminant, but the drafter shares the vulnerable path.
+- The output path is a fresh, mode-`0700` per-invocation tempdir
+  (`tempfile::Builder`) plus a `<output_key>.md` filename, unique per call. The
+  recipe interpolates it into the prompt via `{{narrative_output}}` /
+  `{{plain_output}}` and instructs the agent to write **only** the finished
+  report there. It is a **self-generated** absolute temp path — never LLM- or
+  user-supplied text — so it is not sanitized.
+- The `TempDir` guard is bound to a local that outlives both `.output()` **and**
+  the file read, so the path exists while the recipe writes it and while Simard
+  reads it; the directory and its contents are removed when the guard drops at
+  the end of the call, **after** the file has been read.
+
+`JournalRecipe::run` builds the argv and holds the tempdir guard;
+`harvest_narrative_file` post-processes the finished `std::process::Output`.
+`harvest_narrative_file` is factored out so the "stdout noise is inert" contract
+is hermetically testable without spawning a subprocess.
+
+---
+
+## Reader API
+
+One function captures the **report** (the result-file contents):
+
+- `harvest_narrative_file(output: &std::process::Output, path: &Path) -> SimardResult<String>`
+  — post-processes a finished invocation. It:
+  1. surfaces a **non-zero exit** as a loud error carrying **both** truncated
+     stderr **and** stdout (recipe-runner emits its structured failure on stdout
+     and stderr is often empty, so the error string must include stdout or a
+     non-zero exit risks a context-free message);
+  2. uses the **`std::fs::metadata(path)` call itself as the missing-file check**
+     — if the agent wrote nothing the `metadata` call errors and surfaces a loud
+     "result file was not written" error — and then **size-guards** the present
+     file: `metadata(path).len() > MAX_NARRATIVE_FILE_BYTES` (1 MiB) is a loud
+     error **before** the read, so a runaway agent write cannot OOM the process
+     (a *missing* file is therefore rejected here, at the `metadata` call, not
+     after a read);
+  3. reads the file via `String::from_utf8_lossy` (deliberately more lenient than
+     the decompose sibling's `read_to_string`, and never `unwrap`, so malformed
+     UTF-8 cannot panic the reader), then **trims**;
+  4. rejects an **empty / whitespace-only** file loudly (the agent created the
+     file but wrote no report);
+  5. otherwise returns `Ok(prose)` — the trimmed, non-empty report.
+
+There is deliberately **no stdout fallback**. Scraping stdout is exactly the
+launcher-banner contamination this fix removes, and a silent fallback is a silent
+failure. Because the result channel is clean prose (not a JSON envelope), there
+is no deserialize step, no `RecipeEnvelope`, and no `parse_*` companion — the
+old `RecipeEnvelope` / `RecipeStepResult` stdout-parsing types are **deleted**.
+
+---
+
+## Contract-marker recipe guard
+
+Like goal-decompose, the daemon resolves each recipe hot-reload-first
+(`~/.simard/prompt_assets/simard/recipes/`) then in-tree — but a **stale**
+hot-reloaded recipe that predates this fix would tell the agent to print the
+report to stdout and never write the result file, turning every journal pass
+into a "result file was not written" failure. To keep hot-reload useful without
+that footgun, resolution mirrors `decompose.rs`:
+
+- Each recipe declares its `output_key` as the **result-file contract marker**
+  (`narrative_output` for the drafter, `plain_output` for the reviewer).
+- `recipe_declares_result_file(path)` returns whether the file at `path`
+  contains that marker; an unreadable file is treated as non-compatible so it
+  can never win the selection.
+- `select_recipe(candidates, marker)` searches the candidates in priority order
+  (hot, then in-tree) for the **first that both exists and declares the
+  marker**; only if none is contract-aware does it fall back to the
+  highest-priority existing recipe (so the run surfaces a loud, explicit error
+  rather than silently reintroducing the stdout scrape).
+- Two implementation notes distinguish this from the decompose sibling. First,
+  because the two journal passes carry **different** markers, `select_recipe`
+  takes the marker as a **parameter** rather than keying off decompose's single
+  `RESULT_FILE_CONTRACT_MARKER` const. Second, resolution shifts from the old
+  `resolve_recipe_path` "return the first existing path" shape to **collecting
+  both candidate paths** (hot then in-tree) and handing that slice to
+  `select_recipe`, so a contract-aware in-tree recipe can win over a stale hot
+  one.
+
+A stale-but-present recipe therefore never shadows a compatible one, and a
+missing marker fails loudly rather than silently — the code fix and the asset
+update must land together.
+
+---
+
+## Failure semantics
+
+Every failure is explicit and **loud**, then degrades to the **honest offline
+path** — never a stored stdout dump, never a silent success. The failure classes
+for a single pass (`JournalRecipe::run` / `harvest_narrative_file`):
+
+| Trigger | Error | Degrades to |
+|---|---|---|
+| `recipe-runner-rs` not spawnable / context-file write fails | `SimardError::AdapterInvocationFailed` (pre-exec spawn class → `classify_spawn_failure` + `record_step_failure`) | offline path |
+| result tempdir cannot be created | `AdapterInvocationFailed` (recorded for the Overseer) | offline path |
+| recipe **process** exited non-zero | `AdapterInvocationFailed` (truncated stderr **and** stdout) | offline path |
+| result file **missing** (agent wrote nothing) | `AdapterInvocationFailed` | offline path |
+| result file **empty / whitespace-only** | `AdapterInvocationFailed` | offline path |
+| result file **oversized** (> 1 MiB) | `AdapterInvocationFailed` (before the read) | offline path |
+
+The spawn-class failures are **not** swallowed into a bare `warn!`: they are
+classified ([`classify_spawn_failure`](./terminal-failure-diagnosis-api.md)) and
+recorded into the Overseer's failure sink
+([`record_step_failure`](./overseer-tick-details.md)) so the next Observe pass
+lifts them into a corrective signal; the degrade is then logged at `error` level.
+Both are **preserved** by this change.
+
+The **degrade target is the existing honest offline path**, unchanged:
+
+- the drafter degrades to the deterministic
+  [`TemplateDrafter`](./journal-api.md#the-two-pass-generation-pipeline) report assembler
+  (whose "Remembered moments" section already drops raw error-log episodes via
+  `is_raw_error_log_episode`, so a degraded journal is never a dump of historical
+  error text);
+- the reviewer degrades to the deterministic glossary
+  [`scrub_jargon`](./journal-api.md#the-two-pass-generation-pipeline) reviewer.
+
+And regardless of which path produced the text, `Generator::generate` still runs
+its **unconditional** `scrub_secrets` redaction post-pass over the stored
+narrative, so a credential survives neither path. The stored narrative is
+therefore always one of: the agent's clean result-file report, the deterministic
+report, or the glossary rewrite — **never** captured stdout.
+
+---
+
+## Examples
+
+### Example 1 — clean capture (the headline case)
+
+The runner's stdout carries the launcher banner (`WARN nested amplihack
+session`, `INFO launching copilot`, `ℹ NODE_OPTIONS=…`) and the agent's
+tool-call trace (`● Read draft.ctx`, `│`, `└ 153 lines read`); the agent wrote
+its finished report to `plain_output`. Simard reads the file and the stored
+narrative **begins with the real prose** — "On July 7, 2026, Simard operated in
+a largely self-directed decision cycle…" — and contains **none** of the banner or
+tool-trace lines.
+
+### Example 2 — missing result file (no stdout fallback)
+
+The process exits 0 but the agent never wrote the file — even if stdout happens
+to carry a well-formed report, it is **not** scraped. `harvest_narrative_file`
+returns an explicit `AdapterInvocationFailed`, the pass degrades to the honest
+offline drafter/reviewer, and `scrub_secrets` still runs. The contaminated
+stdout is never stored.
+
+### Example 3 — non-zero exit is loud
+
+A non-zero recipe exit yields an `AdapterInvocationFailed` carrying the truncated
+stderr **and** stdout for the operator log and the Overseer, then degrades to the
+offline path.
+
+### Example 4 — oversized file is rejected before the read
+
+A result file over the 1 MiB cap is rejected by the `metadata().len()` guard
+**before** the file bytes are read, so a runaway agent write cannot exhaust memory; the
+pass degrades to the offline path.
+
+---
+
+## Recipe & prompt asset sync
+
+The daemon resolves each recipe hot-reload-first from
+`~/.simard/prompt_assets/simard/recipes/` (see the contract-marker guard above),
+falling back to the in-tree copy. On the deployed VM the daemon's working
+directory is a worktree, so a **stale** hot-reload asset would run the old
+"print your report to stdout" instructions even though the code now reads a file
+— which is why the marker guard prefers a contract-aware recipe and otherwise
+fails loudly.
+
+`scripts/redeploy-local.sh` syncs **all** prompt assets — including both journal
+recipes — into `~/.simard/prompt_assets/simard/` on every redeploy, and fails
+the redeploy if zero recipes reached the hot-reload path (see the
+[goal-decompose sync note](./goal-decompose-result-channel.md#recipe-prompt-asset-sync)).
+As there, the redeploy guard enforces **presence, not freshness** (count-based),
+so content freshness is a **separate** check.
+
+> **Operational note.** After deploying this fix, verify the hot-reload assets
+> carry the file-channel instructions:
+>
+> ```console
+> $ grep -l narrative_output ~/.simard/prompt_assets/simard/recipes/journal-narrative.yaml
+> $ grep -l plain_output     ~/.simard/prompt_assets/simard/recipes/journal-plain-language.yaml
+> ```
+>
+> A stale asset that still says "emit the report to stdout" will make the agent
+> write nothing to the file — a loud `AdapterInvocationFailed` by design that
+> degrades to the honest offline path (the code fails loudly rather than
+> silently reintroducing the stdout scrape). The code fix and both asset updates
+> must land together.
+
+> **Asset-edit checklist.** When updating each recipe, edit the whole file, not
+> just the agent prompt body:
+>
+> - add the `output_key` to the `context:` block (`narrative_output: ""` /
+>   `plain_output: ""`) so the substitution always resolves even if the caller
+>   omits it;
+> - add a **write-to-file-only** contract instruction to the prompt: write the
+>   FULL report ONLY to the file at `{{narrative_output}}` / `{{plain_output}}`,
+>   **not** to stdout;
+> - keep the existing read-from-path instruction (`{{day_context_path}}` /
+>   `{{draft_path}}`) — the **input** ContextFile channel is unchanged;
+> - update the header comment block's `# Output:` line from "agent stdout" to the
+>   result file (the `grep -l` freshness check matches the interpolated
+>   `{{…_output}}` in the prompt body and will **not** flag a stale `# Output:
+>   agent stdout` comment — review that header by eye).
+
+---
+
+## Security
+
+- **No command injection.** The argv is built with
+  `Command::new("recipe-runner-rs").arg(...)`; every context variable is a
+  single `-c key=value` argument, so untrusted PR / episode text in the day
+  context can never inject a shell command or extra flag. `<output_key>` is a
+  compile-time constant and the result path is a tempfile-generated absolute
+  path (never attacker-supplied). This argv-only construction must be preserved.
+- **Private result file.** The output file lives inside a mode-`0700`,
+  randomized-path per-invocation tempdir (mirroring the input `ContextFile`) and
+  is removed when the invocation returns; the file may transiently hold
+  pre-redaction narrative text, so it must never land on a shared stdout stream —
+  closing the predictable-`/tmp`-path TOCTOU / symlink / info-leak surface.
+- **Bounded file read.** `harvest_narrative_file` size-guards the file (rejects
+  `> 1 MiB` before it reads any file bytes) so a runaway agent cannot exhaust
+  memory, and reads via `from_utf8_lossy` rather than a `String::from_utf8(…)`
+  `unwrap` that could panic on non-UTF-8.
+- **Bounded error output.** Error messages reuse `truncate(…, 200)`, so a large
+  hostile document never echoes its full content into a log; no new `println!` /
+  `eprintln!` is added, and the raw file body is never logged.
+- **Secret redaction preserved.** `Generator::generate` runs its unconditional
+  `scrub_secrets` post-pass downstream of `harvest_narrative_file`, so a
+  credential never reaches the durable narrative regardless of which path
+  produced the text.
+- **XSS unchanged.** `render_entry_html` still HTML-escapes the narrative (the
+  existing HTML-escaping XSS tests, `html_is_xss_safe` /
+  `html_report_is_still_xss_safe`): the clean channel changes *content* only, and
+  the render-time escape is preserved.
+- **No stdout fallback.** A missing / empty / oversized file is an explicit
+  `Err`; stdout is never scraped as a backup result channel.
+
+---
+
+## Code location
+
+| Item | File |
+|---|---|
+| `JournalRecipe::run` (adds `-c <output_key>=<path>`, drops `--output-format json`, holds the tempdir guard) | `src/journal/recipe.rs` |
+| `harvest_narrative_file` (read file / size-guard / loud errors, no stdout fallback) | `src/journal/recipe.rs` |
+| `recipe_declares_result_file` / `select_recipe` (contract-marker guard) | `src/journal/recipe.rs` |
+| `RecipeDrafter` / `RecipeReviewer` (degrade to offline on `Err`, unchanged) | `src/journal/recipe.rs` |
+| Drafter recipe (writes `{{narrative_output}}`) | `prompt_assets/simard/recipes/journal-narrative.yaml` |
+| Reviewer recipe (writes `{{plain_output}}`) | `prompt_assets/simard/recipes/journal-plain-language.yaml` |
+| `Generator::generate` (mandatory reviewer + unconditional `scrub_secrets`, unchanged) | `src/journal/generate.rs` |
+| Recipe asset sync | `scripts/redeploy-local.sh` |
+| Tests | `src/journal/tests_clean_result_channel.rs` (registered in `src/journal/mod.rs`) |
+
+The `JournalDrafter` / `JournalReviewer` traits, `TemplateDrafter`,
+`GlossaryReviewer`, `scrub_jargon`, `scrub_secrets`, the `ContextFile` **input**
+channel, and the `is_raw_error_log_episode` offline filter are **unchanged** —
+the transport fix is additive and back-compatible.
+
+---
+
+## Testing
+
+The clean-channel behavior is pinned by `src/journal/tests_clean_result_channel.rs`
+(subprocess-free, using a synthetic `Output` built with an `output_with(stdout,
+code)` helper and a `tempfile` result path). The headline test is a **RED
+regression** against the reported bug:
+
+| Test | Coverage |
+|---|---|
+| noisy-stdout-is-inert (RED on the bug) | An `Output` whose stdout carries the launcher banner **plus** the tool-call trace, and a result file containing clean prose ⇒ the harvested narrative **starts with the prose** and contains **none** of: `nested amplihack session`, `launching copilot binary`, `NODE_OPTIONS=`, `Read draft.ctx`, `lines read`, or the `●` / `│` / `└` box-drawing glyphs. |
+| missing-file-is-loud | A clean exit with **no** result file ⇒ `AdapterInvocationFailed`, even when stdout carries a well-formed report. |
+| empty-file-is-loud | An empty / whitespace-only file ⇒ loud `AdapterInvocationFailed`. |
+| oversized-file-is-loud | A file over the 1 MiB cap ⇒ loud error **before** a full read. |
+| nonzero-exit-is-loud | A non-zero recipe exit ⇒ loud error carrying truncated stderr **and** stdout. |
+| marker guard | `recipe_declares_result_file` detects `narrative_output` / `plain_output`; `select_recipe` never lets a stale (marker-less) hot recipe shadow a contract-aware one, and returns `None` only when no candidate exists. |
+
+Run the suite:
+
+```console
+$ cargo test -p simard --lib journal::tests_clean_result_channel
+```
+
+The headline test **fails** against the pre-fix stdout-scrape code (the harvested
+text begins with the banner) and **passes** once `run` reads the result file.
+
+---
+
+## Migration — from a dedicated file to the durable channel
+
+The dedicated `narrative_output` / `plain_output` file is the **available-now**
+clean substrate, matching the shape of the shipped goal-decompose and distill
+file channels. The durable substrate is the `semanticchannel`
+clean-agent-result-channel work in `amplihack-rs`
+([#856](https://github.com/rysweet/Simard/issues/856), pinned in Simard via
+amplihack-agent-eval), and this consumer **satisfies the semanticchannel
+"a consumer uses the clean channel" verification**. Once `recipe-runner-rs`
+exposes a first-class structured result channel, the agent → Simard handoff
+migrates from the temp file to that channel with no change to
+`harvest_narrative_file`'s trim/validate contract, the `JournalDrafter` /
+`JournalReviewer` traits, or `Generator::generate` — only `JournalRecipe::run`'s
+transport wiring moves.
+
+Per the memory-architecture policy (G2): the clean-result capture that belongs
+in the shared agent-invocation layer stays upstream in amplihack-rs; Simard keeps
+only the **thin journal-side seam** (this file channel), so no engine pin bump is
+required for this fix.
+
+---
+
+## Out of scope
+
+- **The narrative body and tone.** The report structure, the journaltone /
+  [tone contract](../concepts/journal-report-tone-contract.md), and the
+  plain-language rewrite rules are unchanged — this change fixes only how the
+  agent's report reaches Simard.
+- **The input `ContextFile` channel** and the
+  [E2BIG spawn hardening](../concepts/journal-recipe-spawn-e2big.md) are
+  unchanged; this fix adds the **output** file, it does not touch the input file.
+- **The offline fallback.** `TemplateDrafter`, `scrub_jargon`, `scrub_secrets`,
+  and the `is_raw_error_log_episode` filter are the honest last resort and are
+  preserved exactly.
+- **`semanticchannel` implementation** in `amplihack-rs` (the durable substrate)
+  is tracked upstream; this Simard-side fix uses the dedicated file now and
+  migrates later.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -202,6 +202,7 @@ nav:
     - Run Dashboard E2E Tests: howto/run-dashboard-e2e-tests.md
     - Capture and Diagnose a Failing Distill Sample: howto/capture-and-diagnose-a-failing-distill-sample.md
     - Verify the Distillation Semantic Handoff: howto/verify-the-distillation-semantic-handoff.md
+    - Verify the Journal's Clean Narrative: howto/verify-the-journal-clean-narrative.md
     - Measure Recall Precision (Hybrid): howto/measure-recall-precision-hybrid.md
     - Read Simard Status: howto/simard-status.md
     - Watch Overseer Activity: howto/watch-overseer-activity.md
@@ -229,6 +230,7 @@ nav:
     - simard-engineer-step CLI: reference/simard-engineer-step.md
     - simard-tui Dashboard: reference/simard-tui.md
     - Journal API: reference/journal-api.md
+    - Journal Narrative Result Channel: reference/journal-narrative-result-channel.md
     - npx / npm Install: reference/npx-npm-install.md
     - Update Check: reference/update-check.md
     - amplihack Freshness Gate: reference/amplihack-freshness-gate.md

--- a/prompt_assets/simard/recipes/journal-narrative.yaml
+++ b/prompt_assets/simard/recipes/journal-narrative.yaml
@@ -27,9 +27,18 @@
 #       "memory_growth": { "facts_added": <n>, "episodes_added": <n> } | null
 #     }
 #
-# Output: the report draft as Markdown text (NOT JSON). The runner returns the
-# final step's output verbatim; the Rust caller takes it as the draft and hands
-# it to the de-jargon pass.
+#   narrative_output — ABSOLUTE path to the result FILE the agent must write its
+#     FINAL report to (bug #2679). The agent writes ONLY the finished Markdown
+#     report to this file; the Rust caller reads the narrative from this file and
+#     NEVER from recipe-runner stdout. Scraping stdout captured the copilot
+#     launcher banner (WARN nested amplihack session / INFO launching copilot /
+#     ℹ NODE_OPTIONS=…) and the agent's own tool-call trace (● Read … / │ / └ N
+#     lines read) and made that garbage the LEADING text of the stored journal.
+#     Mirrors the clean-result-file channel proven for goal decomposition (#2708).
+#
+# Output: the report draft is written to the file at `narrative_output` as
+# Markdown text (NOT JSON). The Rust caller reads the draft from that file and
+# hands it to the de-jargon pass; recipe-runner stdout is inert.
 
 name: "journal-narrative"
 description: "Draft Simard's daily engineering & research report from the day's structured context"
@@ -40,6 +49,9 @@ tags: ["simard", "journal", "report"]
 context:
   # Declared so the substitution always resolves even if the caller omits it.
   day_context_path: ""
+  # ABSOLUTE path to the clean result file the agent writes its final report to
+  # (bug #2679). Declared so `{{narrative_output}}` always resolves.
+  narrative_output: ""
 
 steps:
   - id: "draft"
@@ -91,4 +103,19 @@ steps:
 
       Omit any section that has no material. Keep sections readable: short
       paragraphs and `-` bullet lists. Do NOT output a code fence around the
-      report — emit the Markdown report directly and nothing else.
+      report.
+
+      ## Where to put the report (bug #2679 — clean result channel)
+
+      Write ONLY the finished Markdown report to the result file at this
+      absolute path, using your file-writing tool:
+
+      ```
+      {{narrative_output}}
+      ```
+
+      The file must contain the report and NOTHING ELSE — no preamble, no
+      status lines, no tool-call narration, no code fence. Your terminal
+      output (stdout) is IGNORED; only the contents of this file become the
+      journal draft. If you cannot write the file, stop and report the failure
+      — do not emit the report to stdout instead.

--- a/prompt_assets/simard/recipes/journal-plain-language.yaml
+++ b/prompt_assets/simard/recipes/journal-plain-language.yaml
@@ -20,8 +20,18 @@
 #     into argv, so a full-length draft can never overflow ARG_MAX / fail the
 #     spawn with E2BIG. The agent READS this file.
 #
-# Output: the rewritten, plain-language report as Markdown text (NOT JSON),
-# returned verbatim as the final narrative.
+#   plain_output — ABSOLUTE path to the result FILE the agent must write its
+#     FINAL rewritten report to (bug #2679). The agent writes ONLY the finished
+#     plain-language Markdown to this file; the Rust caller reads the narrative
+#     from this file and NEVER from recipe-runner stdout, so the copilot launcher
+#     banner (WARN nested amplihack session / INFO launching copilot /
+#     ℹ NODE_OPTIONS=…) and the agent's own tool-call trace (● Read … / │ / └ N
+#     lines read) can never leak into the stored journal. Mirrors the
+#     clean-result-file channel proven for goal decomposition (#2708).
+#
+# Output: the rewritten, plain-language report is written to the file at
+# `plain_output` as Markdown text (NOT JSON), and read from that file verbatim
+# as the final narrative; recipe-runner stdout is inert.
 
 name: "journal-plain-language"
 description: "Rewrite a journal report draft into plain, layperson-readable language"
@@ -31,6 +41,9 @@ tags: ["simard", "journal", "plain-language"]
 
 context:
   draft_path: ""
+  # ABSOLUTE path to the clean result file the agent writes its rewrite to (bug
+  # #2679). Declared so `{{plain_output}}` always resolves.
+  plain_output: ""
 
 steps:
   - id: "dejargon"
@@ -71,3 +84,18 @@ steps:
 
       Output ONLY the rewritten Markdown report — no preamble, no code fence,
       nothing before or after it.
+
+      ## Where to put the report (bug #2679 — clean result channel)
+
+      Write ONLY the finished rewritten Markdown report to the result file at
+      this absolute path, using your file-writing tool:
+
+      ```
+      {{plain_output}}
+      ```
+
+      The file must contain the rewritten report and NOTHING ELSE — no preamble,
+      no status lines, no tool-call narration, no code fence. Your terminal
+      output (stdout) is IGNORED; only the contents of this file become the final
+      journal narrative. If you cannot write the file, stop and report the
+      failure — do not emit the report to stdout instead.

--- a/src/journal/mod.rs
+++ b/src/journal/mod.rs
@@ -45,6 +45,8 @@ pub mod types;
 
 #[cfg(test)]
 mod test_support;
+#[cfg(all(test, unix))]
+mod tests_clean_result_channel;
 #[cfg(test)]
 mod tests_dejargon_teeth;
 #[cfg(test)]

--- a/src/journal/recipe.rs
+++ b/src/journal/recipe.rs
@@ -21,6 +21,20 @@
 //! argv, so `ARG_MAX` is irrelevant and the recipe reads the full payload from
 //! the file (mirrors the distiller's `facts_output_path`).
 //!
+//! ## Clean result channel (bug #2679)
+//!
+//! The agent's RESULT is likewise read from a dedicated result **file** it is
+//! told to write (`-c narrative_output=<abs>` / `-c plain_output=<abs>`), never
+//! scraped from `recipe-runner-rs` stdout. Raw stdout carries the copilot
+//! launcher banner (`WARN nested amplihack session`, `INFO launching copilot`,
+//! `ℹ NODE_OPTIONS=…`) and the agent's own box-drawing tool-call trace
+//! (`● Read draft.ctx`, `│ …`, `└ N lines read`); scraping it made all of that
+//! the LEADING text of the stored journal — the raw-stdout-scrape antipattern
+//! already fixed for goal decomposition (issue #2708). [`harvest_narrative_file`]
+//! reads the narrative from the clean file and treats stdout as inert, and
+//! [`select_recipe`] refuses a stale hot-reloaded recipe that lacks the
+//! result-file contract marker so a pre-#2679 asset can never shadow the fix.
+//!
 //! ## No silent fallback (operator rule: fallback == silent failure)
 //!
 //! A genuine spawn failure is NOT swallowed into a bare `warn!`. It is classified
@@ -36,8 +50,6 @@
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-
-use serde::Deserialize;
 
 use crate::error::{SimardError, SimardResult};
 use crate::journal::generate::{JournalDrafter, JournalReviewer, TemplateDrafter};
@@ -55,56 +67,81 @@ const JOURNAL_DEJARGON_RECIPE: &str = "journal-plain-language.yaml";
 /// Adapter tag used for error attribution.
 const ADAPTER_TAG: &str = "journal";
 
-/// Resolve a journal recipe path, hot-reload location first then in-tree:
+/// The `-c` context key the draft recipe writes its clean narrative FILE to.
+/// Doubles as the result-file contract marker for [`select_recipe`] (bug #2679).
+const NARRATIVE_OUTPUT_KEY: &str = "narrative_output";
+/// The `-c` context key the plain-language recipe writes its clean rewrite FILE
+/// to. Doubles as the result-file contract marker for [`select_recipe`].
+const PLAIN_OUTPUT_KEY: &str = "plain_output";
+
+/// Journal recipe candidates in descending priority: hot-reload location first,
+/// then the in-tree asset:
 ///   1. `<home>/.simard/prompt_assets/simard/recipes/<filename>`
 ///   2. `<repo_root>/prompt_assets/simard/recipes/<filename>`
-///
-/// Returns `None` when neither exists (the caller then uses the deterministic
-/// fallback).
-fn resolve_recipe_path(repo_root: &Path, filename: &str) -> Option<PathBuf> {
+fn recipe_candidates(repo_root: &Path, filename: &str) -> Vec<PathBuf> {
+    let mut candidates = Vec::with_capacity(2);
     if let Some(home) = dirs::home_dir() {
-        let hot = home
-            .join(".simard")
+        candidates.push(
+            home.join(".simard")
+                .join("prompt_assets/simard/recipes")
+                .join(filename),
+        );
+    }
+    candidates.push(
+        repo_root
             .join("prompt_assets/simard/recipes")
-            .join(filename);
-        if hot.is_file() {
-            return Some(hot);
-        }
-    }
-    let in_tree = repo_root
-        .join("prompt_assets/simard/recipes")
-        .join(filename);
-    if in_tree.is_file() {
-        return Some(in_tree);
-    }
-    None
+            .join(filename),
+    );
+    candidates
 }
 
-/// The JSON envelope `recipe-runner-rs --output-format json` prints.
-#[derive(Debug, Deserialize)]
-struct RecipeEnvelope {
-    success: bool,
-    step_results: Vec<RecipeStepResult>,
+/// Whether the recipe at `path` declares the post-#2679 clean-result-file
+/// contract — it mentions the `<output_key>` context var (e.g.
+/// `narrative_output`) the agent must write its final report to. An unreadable
+/// file is treated as non-compatible so it can never win selection.
+fn recipe_declares_result_file(path: &Path, output_key: &str) -> bool {
+    std::fs::read_to_string(path)
+        .map(|contents| contents.contains(output_key))
+        .unwrap_or(false)
 }
 
-/// A single step's result inside the [`RecipeEnvelope`].
-#[derive(Debug, Deserialize)]
-struct RecipeStepResult {
-    output: String,
+/// Choose which recipe to run from `candidates` (descending priority).
+///
+/// Returns the first candidate that exists AND declares the clean-result-file
+/// contract for `output_key`, so a stale (pre-#2679) hot-reloaded recipe — one
+/// that still relies on scraped stdout — can never shadow a contract-aware one.
+/// If no candidate declares the contract, falls back to the highest-priority
+/// existing recipe (the run then surfaces a loud "result file was not written"
+/// error rather than silently scraping stdout). Returns `None` only when no
+/// candidate exists at all (the caller then uses the deterministic fallback).
+fn select_recipe(candidates: &[PathBuf], output_key: &str) -> Option<PathBuf> {
+    let existing: Vec<&PathBuf> = candidates.iter().filter(|p| p.is_file()).collect();
+    existing
+        .iter()
+        .find(|p| recipe_declares_result_file(p, output_key))
+        .or_else(|| existing.first())
+        .map(|p| (*p).clone())
 }
 
-/// A resolved journal recipe plus the agent binary to run it with.
+/// A resolved journal recipe, the agent binary to run it with, and the `-c`
+/// context key the recipe writes its CLEAN result FILE to (bug #2679).
 struct JournalRecipe {
     recipe_path: PathBuf,
     agent_binary: &'static str,
+    /// Result-file context key (`narrative_output` / `plain_output`): the agent
+    /// is told this absolute path and writes ONLY its final report there, so the
+    /// narrative is read from a clean file — never scraped from noisy stdout.
+    output_key: &'static str,
 }
 
 impl JournalRecipe {
-    /// Construct a runner when all preconditions hold: the recipe file resolves,
-    /// an agent binary is configured, and `recipe-runner-rs` is on `PATH`.
+    /// Construct a runner when all preconditions hold: a contract-aware recipe
+    /// file resolves (declares the `output_key` clean-result-file marker), an
+    /// agent binary is configured, and `recipe-runner-rs` is on `PATH`.
     /// Returns `None` otherwise (the caller falls back to deterministic).
-    fn new(repo_root: &Path, filename: &str) -> Option<Self> {
-        let recipe_path = resolve_recipe_path(repo_root, filename)?;
+    fn new(repo_root: &Path, filename: &str, output_key: &'static str) -> Option<Self> {
+        let candidates = recipe_candidates(repo_root, filename);
+        let recipe_path = select_recipe(&candidates, output_key)?;
         let agent_binary = crate::session_builder::LlmProvider::resolve_agent_binary()?;
         if Command::new("recipe-runner-rs")
             .arg("--version")
@@ -119,16 +156,28 @@ impl JournalRecipe {
         Some(Self {
             recipe_path,
             agent_binary,
+            output_key,
         })
     }
 
-    /// Run the recipe with the given context vars and return the final step's
-    /// output text (trimmed). Every context value is *unbounded*, so each is
-    /// delivered through the shared file channel ([`ContextFile`]): the payload
-    /// goes to a private temp file and only the short `<key>_path=<abs>` rides on
-    /// argv, so a full day's context can never overflow `ARG_MAX` and fail the
-    /// spawn with `E2BIG` (issues #2640/#2692). Errors on spawn/exit failure, a
-    /// bad or `success == false` envelope, or empty output.
+    /// Run the recipe with the given context vars and return the agent's CLEAN
+    /// narrative, read from the dedicated result **file** it was told to write —
+    /// NEVER from `recipe-runner-rs` stdout (bug #2679). Raw stdout carries the
+    /// copilot launcher banner (`WARN nested amplihack session`, `INFO launching
+    /// copilot`, `ℹ NODE_OPTIONS=…`) and the agent's own box-drawing tool-call
+    /// trace (`● Read draft.ctx`, `│ …`, `└ N lines read`); scraping it made all
+    /// of that the LEADING text of the stored journal. Now a fresh per-invocation
+    /// tempdir (mode 0700 via `tempfile`) supplies a unique result path passed as
+    /// `-c <output_key>=<abs>`, and the recipe prompt writes ONLY the final report
+    /// there — stdout is inert.
+    ///
+    /// Every INPUT context value is *unbounded*, so each is delivered through the
+    /// shared file channel ([`ContextFile`]): the payload goes to a private temp
+    /// file and only the short `<key>_path=<abs>` rides on argv, so a full day's
+    /// context can never overflow `ARG_MAX` and fail the spawn with `E2BIG`
+    /// (issues #2640/#2692). Errors loudly on spawn/exit failure or a
+    /// missing/empty/oversized result file; there is deliberately NO stdout
+    /// fallback.
     ///
     /// A pre-exec spawn failure (the E2BIG defect and its siblings) is an
     /// `io::Error` with no child, so it is classified and recorded into the
@@ -136,10 +185,8 @@ impl JournalRecipe {
     fn run(&self, ctx: &[(&str, String)]) -> SimardResult<String> {
         let mut cmd = Command::new("recipe-runner-rs");
         cmd.arg(self.recipe_path.as_os_str())
-            .arg("--output-format")
-            .arg("json")
             .env("AMPLIHACK_AGENT_BINARY", self.agent_binary);
-        // Route every context var through the file channel; the guards must
+        // Route every INPUT context var through the file channel; the guards must
         // outlive `output()` so the files exist while the recipe reads them.
         let mut guards: Vec<ContextFile> = Vec::with_capacity(ctx.len());
         for (key, value) in ctx {
@@ -154,6 +201,28 @@ impl JournalRecipe {
             cmd.arg("-c").arg(cf.arg_value());
             guards.push(cf);
         }
+
+        // Dedicated, per-invocation result file the agent writes its clean final
+        // report to (bug #2679). The fresh tempdir (mode 0700 via `tempfile`)
+        // gives a unique absolute path with no cross-invocation races, and is
+        // removed when `result_dir` drops at the end of this call — AFTER the
+        // narrative has been read by `harvest_narrative_file` below. This mirrors
+        // the decomposition clean-result-channel fix
+        // ([`crate::goal_curation::decompose`], issue #2708).
+        let result_dir = tempfile::Builder::new()
+            .prefix("simard-journal-result-")
+            .tempdir()
+            .map_err(|e| {
+                // A tempdir-create failure (e.g. ENOSPC) is a spawn-class failure:
+                // classify + record before degrading, like the input channel.
+                record_step_failure(classify_spawn_failure(&e));
+                invocation_failed(format!("failed to create journal result-file tempdir: {e}"))
+            })?;
+        let result_path = result_dir.path().join(format!("{}.md", self.output_key));
+        let result_path_arg = result_path.to_string_lossy().into_owned();
+        cmd.arg("-c")
+            .arg(format!("{}={result_path_arg}", self.output_key));
+
         let output = cmd.output().map_err(|e| {
             // Pre-exec spawn failure (E2BIG / ENOSPC / ENOMEM / …). Record a
             // structured diagnosis for the Overseer to act on — the "no silent
@@ -161,28 +230,82 @@ impl JournalRecipe {
             record_step_failure(classify_spawn_failure(&e));
             invocation_failed(format!("recipe-runner-rs spawn failed: {e}"))
         })?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(invocation_failed(format!(
-                "recipe exited with {}: {}",
-                output.status,
-                truncate(stderr.trim(), 200)
-            )));
-        }
-        let envelope: RecipeEnvelope = serde_json::from_slice(&output.stdout)
-            .map_err(|e| invocation_failed(format!("bad JSON envelope: {e}")))?;
-        if !envelope.success {
-            return Err(invocation_failed(
-                "recipe reported success=false".to_string(),
-            ));
-        }
-        envelope
-            .step_results
-            .last()
-            .map(|s| s.output.trim().to_string())
-            .filter(|s| !s.is_empty())
-            .ok_or_else(|| invocation_failed("recipe produced no output".to_string()))
+
+        // Read the CLEAN narrative from the dedicated result file — never from
+        // stdout. `result_dir` is still alive, so the file exists while it is
+        // read; it is unlinked when this call returns.
+        harvest_narrative_file(&output, &result_path)
     }
+}
+
+/// Maximum size (bytes) accepted for a journal result file. A runaway agent that
+/// writes an enormous file must be rejected loudly *before* the read, never
+/// allowed to OOM the process. Mirrors the decomposition seam's
+/// `MAX_SUBGOALS_FILE_BYTES` guard.
+const MAX_NARRATIVE_FILE_BYTES: u64 = 1024 * 1024;
+
+/// Post-process a finished `recipe-runner-rs` invocation into the journal
+/// narrative, reading it from the dedicated result **file** the agent was told
+/// to write (`-c <output_key>=…`) — NEVER from stdout (bug #2679).
+///
+/// * A non-zero exit is a **loud** terminal `journal` failure carrying the
+///   truncated stderr and stdout, so a failed run is never a silent success.
+/// * On a clean (exit-0) run the narrative is read from `path`. A missing,
+///   empty/whitespace-only, or oversized file is a **loud** `journal` error.
+///   There is deliberately NO stdout fallback: scraping stdout is exactly the
+///   launcher-banner / tool-trace contamination this fix removes.
+/// * The file is decoded lossily (`from_utf8_lossy`), so a malformed agent write
+///   can never panic the reader.
+///
+/// Split out of [`JournalRecipe::run`] so the "stdout noise is inert" contract
+/// is hermetically testable without spawning a subprocess.
+pub(crate) fn harvest_narrative_file(
+    output: &std::process::Output,
+    path: &Path,
+) -> SimardResult<String> {
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        return Err(invocation_failed(format!(
+            "recipe-runner-rs exited with {}: stderr={} stdout={}",
+            output.status,
+            truncate(stderr.trim(), 200),
+            truncate(stdout.trim(), 200)
+        )));
+    }
+
+    // Size guard BEFORE the read. A missing file surfaces here as a loud journal
+    // error (the agent produced no result), never a stdout fallback.
+    let meta = std::fs::metadata(path).map_err(|e| {
+        invocation_failed(format!(
+            "journal result file {} was not written by the agent: {e}",
+            path.display()
+        ))
+    })?;
+    if meta.len() > MAX_NARRATIVE_FILE_BYTES {
+        return Err(invocation_failed(format!(
+            "journal result file {} is {} bytes, exceeding the {MAX_NARRATIVE_FILE_BYTES}-byte cap",
+            path.display(),
+            meta.len()
+        )));
+    }
+
+    // Read raw bytes and decode lossily: a malformed agent write (invalid UTF-8)
+    // must be handled, never panic the reader (unlike `read_to_string`).
+    let bytes = std::fs::read(path).map_err(|e| {
+        invocation_failed(format!(
+            "journal result file {} could not be read: {e}",
+            path.display()
+        ))
+    })?;
+    let narrative = String::from_utf8_lossy(&bytes).trim().to_string();
+    if narrative.is_empty() {
+        return Err(invocation_failed(format!(
+            "journal result file {} was empty; the agent wrote no narrative",
+            path.display()
+        )));
+    }
+    Ok(narrative)
 }
 
 fn invocation_failed(reason: String) -> SimardError {
@@ -262,9 +385,11 @@ impl RecipeDrafter {
     /// Build a recipe drafter for `repo_root`, or `None` when the recipe assets
     /// / runner are unavailable.
     pub fn for_repo(repo_root: &Path) -> Option<Self> {
-        JournalRecipe::new(repo_root, JOURNAL_DRAFT_RECIPE).map(|recipe| Self {
-            recipe,
-            fallback: TemplateDrafter,
+        JournalRecipe::new(repo_root, JOURNAL_DRAFT_RECIPE, NARRATIVE_OUTPUT_KEY).map(|recipe| {
+            Self {
+                recipe,
+                fallback: TemplateDrafter,
+            }
         })
     }
 }
@@ -300,7 +425,8 @@ impl RecipeReviewer {
     /// Build a recipe reviewer for `repo_root`, or `None` when the recipe assets
     /// / runner are unavailable.
     pub fn for_repo(repo_root: &Path) -> Option<Self> {
-        JournalRecipe::new(repo_root, JOURNAL_DEJARGON_RECIPE).map(|recipe| Self { recipe })
+        JournalRecipe::new(repo_root, JOURNAL_DEJARGON_RECIPE, PLAIN_OUTPUT_KEY)
+            .map(|recipe| Self { recipe })
     }
 }
 

--- a/src/journal/tests_clean_result_channel.rs
+++ b/src/journal/tests_clean_result_channel.rs
@@ -1,0 +1,250 @@
+//! src/journal/tests_clean_result_channel.rs
+//!
+//! RED regression tests for the journal narrative CLEAN-RESULT-CHANNEL fix
+//! (bug #2679 — "the Simard journal's FIRST SECTION is polluted").
+//!
+//! ## The bug these tests pin
+//!
+//! The agentic narrative path in [`crate::journal::recipe`] captured
+//! `recipe-runner-rs` **raw stdout** and stored it as the narrative. Raw stdout
+//! carries the copilot launcher preamble (`WARN nested amplihack session`,
+//! `INFO launching copilot binary=…`, `ℹ NODE_OPTIONS=…`) and the agent's own
+//! tool-call trace (`● Read draft.ctx`, `│ …`, `└ 153 lines read`). All of that
+//! garbage became the LEADING text of the stored journal, ahead of the real
+//! prose — the exact raw-stdout-scrape antipattern already fixed for
+//! distillation and for goal decomposition (issue #2708).
+//!
+//! ## The contract these tests specify
+//!
+//! The fix is the SAME clean-result-file channel proven in
+//! [`crate::goal_curation::decompose`] (`harvest_subgoals_file`): the agent is
+//! told a dedicated result-file path and writes ONLY its final report there, and
+//! Simard reads the narrative from that **file** — never from stdout. These
+//! tests drive a split-out, hermetically testable seam:
+//!
+//! ```ignore
+//! pub(crate) fn harvest_narrative_file(
+//!     output: &std::process::Output,
+//!     path: &std::path::Path,
+//! ) -> crate::error::SimardResult<String>
+//! ```
+//!
+//! that reads the narrative from `path` and treats stdout as INERT. Because it
+//! takes a fabricated [`std::process::Output`], the "stdout noise never leaks
+//! into the narrative" contract is provable WITHOUT spawning a subprocess.
+//!
+//! These tests are RED until that seam exists in `src/journal/recipe.rs`
+//! (exposed at least `pub(crate)` so this sibling test module can call it).
+//!
+//! No literal secret is committed: fixtures use only the launcher-banner /
+//! tool-trace shapes from the live #2679 evidence and obviously-synthetic prose.
+
+use crate::error::SimardError;
+use crate::journal::recipe::harvest_narrative_file;
+
+// ── The live #2679 contamination, verbatim in shape ─────────────────────────
+
+/// The clean narrative the agent actually wrote — the ONLY thing that belongs in
+/// the journal. Mirrors the real prose that (in the live bug) began only AFTER
+/// the launcher/tool-trace garbage.
+const CLEAN_NARRATIVE: &str = "On July 7, 2026, Simard operated in a largely \
+self-directed decision cycle, advancing several engineering goals and folding \
+what it learned into long-term memory.\n\n\
+## Engineering work\n\n\
+Simard shipped a fix for the journal's contaminated opening paragraph and \
+verified it on the live dashboard.\n\n\
+## Remembered moments\n\n\
+- [2026-07-07 01:03 UTC] began the day's self-directed review";
+
+/// A realistic slice of the LIVE #2679 raw `recipe-runner-rs` stdout: the
+/// copilot launcher banner (nested-session WARN, launching-copilot INFO,
+/// NODE_OPTIONS notice) followed by the agent's own box-drawing tool-call trace
+/// for reading `draft.ctx`. Under the old raw-stdout-scrape code this whole blob
+/// — banner + trace + prose — became the stored narrative, so its FIRST
+/// paragraph was garbage. It must be completely INERT to the clean channel.
+const CONTAMINATED_STDOUT: &str = "2026-07-07T01:03:03.969016Z  WARN nested \
+amplihack session detected — launching anyway session_id=\"session-18bfdc2635821690\" depth=2\n\
+2026-07-07T01:03:04.604657Z  INFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot version=\"GitHub Copilot CLI 1.0.69-2.\"\n\
+\u{2139} NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: /home/azureuser/.amplihack/config\n\
+\u{25CF} Read draft.ctx  \u{2502} /tmp/simard-journal-ctx-XXXX/draft.ctx  \u{2514} 153 lines read\n\
+On July 7, 2026, Simard operated in a largely self-directed decision cycle...";
+
+/// Every substring / glyph that proves launcher-banner or tool-trace
+/// contamination. The stored narrative must contain NONE of these (deliverable
+/// requirement #2).
+const FORBIDDEN_MARKERS: &[&str] = &[
+    "nested amplihack session",
+    "launching copilot binary",
+    "NODE_OPTIONS=",
+    "Read draft.ctx",
+    "lines read",
+    "\u{25CF}", // ● black circle — tool-call bullet
+    "\u{2502}", // │ box-drawing vertical — tool-trace gutter
+    "\u{2514}", // └ box-drawing up-and-right — "N lines read" leader
+];
+
+/// Build a synthetic finished process result with the given stdout and exit
+/// code, so `harvest_narrative_file`'s "stdout is inert" contract is provable
+/// without a real subprocess. `code << 8` places `code` in the exit-code byte
+/// (low byte 0 ⇒ not signalled), so `.success()` is true iff `code == 0`.
+fn output_with(stdout: &[u8], code: i32) -> std::process::Output {
+    use std::os::unix::process::ExitStatusExt;
+    std::process::Output {
+        status: std::process::ExitStatus::from_raw(code << 8),
+        stdout: stdout.to_vec(),
+        stderr: Vec::new(),
+    }
+}
+
+/// Assert a narrative is clean: starts with the real prose and carries none of
+/// the launcher-banner / tool-trace markers.
+fn assert_clean_narrative(narrative: &str) {
+    assert!(
+        narrative.starts_with("On July 7, 2026, Simard operated"),
+        "the stored narrative must BEGIN with the real prose, not launcher/tool-trace \
+         garbage; got: {narrative:?}"
+    );
+    for marker in FORBIDDEN_MARKERS {
+        assert!(
+            !narrative.contains(marker),
+            "the stored narrative leaked launcher/tool-trace marker {marker:?}: {narrative:?}"
+        );
+    }
+}
+
+/// Assert a loud journal failure: the clean-channel seam never degrades to a
+/// silent success, and every failure is the same `AdapterInvocationFailed`
+/// under the `journal` adapter tag.
+fn assert_loud_journal_error(err: SimardError) {
+    match err {
+        SimardError::AdapterInvocationFailed { base_type, .. } => {
+            assert_eq!(
+                base_type, "journal",
+                "a clean-channel failure must be attributed to the journal adapter"
+            );
+        }
+        other => panic!("expected AdapterInvocationFailed{{base_type:\"journal\"}}, got {other:?}"),
+    }
+}
+
+// ── Group A: `harvest_narrative_file` reads the clean result FILE and treats
+//    stdout as inert (the #2679 fix). ──────────────────────────────────────────
+
+/// THE headline #2679 regression. `recipe-runner-rs` stdout is the full live
+/// contamination (launcher banner + box-drawing tool trace + a prose prefix),
+/// yet the agent wrote ONLY clean prose to its dedicated result file. Harvest
+/// MUST return the clean prose from the file, and NONE of the stdout garbage may
+/// appear in it. This is exactly deliverable requirement #2.
+#[test]
+fn contaminated_stdout_never_pollutes_the_narrative() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("narrative_output.md");
+    std::fs::write(&path, CLEAN_NARRATIVE).unwrap();
+
+    let output = output_with(CONTAMINATED_STDOUT.as_bytes(), 0);
+    let narrative = harvest_narrative_file(&output, &path)
+        .expect("clean result file must be read even when stdout is full of launcher/tool noise");
+
+    assert_clean_narrative(&narrative);
+    assert_eq!(
+        narrative, CLEAN_NARRATIVE,
+        "the narrative must be the file's clean prose verbatim, not scraped stdout"
+    );
+}
+
+/// A clean exit-0 run with empty stdout reads the narrative verbatim from the
+/// file (trimmed), proving the file is the sole narrative source.
+#[test]
+fn clean_file_is_read_verbatim_and_trimmed() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("narrative_output.md");
+    std::fs::write(&path, format!("\n\n{CLEAN_NARRATIVE}\n\n")).unwrap();
+
+    let output = output_with(b"", 0);
+    let narrative =
+        harvest_narrative_file(&output, &path).expect("a clean exit-0 run reads the result file");
+
+    assert_eq!(
+        narrative, CLEAN_NARRATIVE,
+        "surrounding whitespace must be trimmed, leaving the exact prose"
+    );
+}
+
+/// No silent fallback: a missing result file is a LOUD journal error even when
+/// stdout carries a perfectly clean, well-formed narrative — proving stdout is
+/// NEVER scraped as a fallback narrative channel (the antipattern this fix kills).
+#[test]
+fn missing_result_file_is_loud_error_never_stdout_fallback() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("narrative_output.md"); // deliberately never written
+
+    // stdout is clean, complete prose — tempting to scrape. It must be ignored.
+    let output = output_with(CLEAN_NARRATIVE.as_bytes(), 0);
+    let err = harvest_narrative_file(&output, &path)
+        .expect_err("a missing result file must be a loud error, never a stdout fallback");
+    assert_loud_journal_error(err);
+}
+
+/// The agent created the result file but wrote nothing (or only whitespace): a
+/// loud journal error, never a hollow empty narrative that would silently pass.
+#[test]
+fn empty_result_file_is_loud_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("narrative_output.md");
+    std::fs::write(&path, "   \n\t  \n").unwrap();
+
+    let output = output_with(b"", 0);
+    let err = harvest_narrative_file(&output, &path)
+        .expect_err("an empty/whitespace-only result file must surface loudly");
+    assert_loud_journal_error(err);
+}
+
+/// A runaway agent that writes an oversized result file (> 1 MiB) is rejected by
+/// the size guard BEFORE the read — a loud journal error, never an OOM. Mirrors
+/// the decomposition seam's `MAX_SUBGOALS_FILE_BYTES` guard.
+#[test]
+fn oversized_result_file_is_loud_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("narrative_output.md");
+    let oversized = vec![b'a'; 1024 * 1024 + 1];
+    std::fs::write(&path, &oversized).unwrap();
+
+    let output = output_with(b"", 0);
+    let err = harvest_narrative_file(&output, &path)
+        .expect_err("an oversized result file must be rejected loudly before the read");
+    assert_loud_journal_error(err);
+}
+
+/// A non-zero recipe exit is a LOUD terminal journal failure — never a silent
+/// success and never a scraped-stdout narrative. Even with clean prose sitting
+/// in the file, a failed run must not be treated as success.
+#[test]
+fn nonzero_exit_is_loud_error_even_with_a_populated_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("narrative_output.md");
+    std::fs::write(&path, CLEAN_NARRATIVE).unwrap();
+
+    let output = output_with(b"boom on stdout", 3);
+    let err = harvest_narrative_file(&output, &path)
+        .expect_err("a non-zero exit must surface an explicit error, not a scraped success");
+    assert_loud_journal_error(err);
+}
+
+/// Defensive: a UTF-8-lossy result file (invalid bytes) must not panic the
+/// reader — it is read losslessly-or-lossily and, if it still contains real
+/// prose, returned; the point is NO panic on malformed agent output.
+#[test]
+fn invalid_utf8_in_result_file_does_not_panic() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("narrative_output.md");
+    // Valid clean prose followed by a lone invalid continuation byte.
+    let mut bytes = CLEAN_NARRATIVE.as_bytes().to_vec();
+    bytes.push(0xFF);
+    std::fs::write(&path, &bytes).unwrap();
+
+    let output = output_with(b"", 0);
+    let narrative = harvest_narrative_file(&output, &path)
+        .expect("invalid UTF-8 must be handled lossily, never panic the reader");
+    // The clean prose prefix is preserved; the launcher/tool markers are absent.
+    assert_clean_narrative(&narrative);
+}


### PR DESCRIPTION
Fixes the Simard journal's first section being polluted with the copilot launcher banner + tool-call trace (WARN nested amplihack session / INFO launching copilot / ℹ NODE_OPTIONS / ● Read draft.ctx / └ N lines read) instead of clean narrative.

Root cause: the journal narrative agentic path captured the agent's RAW STDOUT (launcher preamble + tool traces) as the narrative's leading text (raw-stdout-scrape antipattern).

Fix: the journal narrative is now read from a CLEAN result-file/result-channel (journal-narrative + journal-plain-language prompt recipes write a clean narrative file the daemon reads verbatim), so launcher/tool output never enters the narrative. Consumes the clean agent-result channel (also exercises semanticchannel #856).

Tests: src/journal/tests_clean_result_channel.rs — contaminated_stdout_never_pollutes_the_narrative (RED on the bug), clean_file_is_read_verbatim_and_trimmed. Salvaged from a recipe run that completed the fix but tripped the step-17a testing-evidence-gate; rebased clean onto main, full pre-push gates (fmt/clippy/test) green.