### PR TITLE
test(memory_ipc): cover the cross-process socket transport (69.8% -> 93.8%)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/memory_ipc/mod.rs
+++ b/src/memory_ipc/mod.rs
@@ -29,6 +29,8 @@ mod tests_launcher;
 mod tests_shared_store_2320;
 #[cfg(test)]
 mod tests_socket_path;
+#[cfg(test)]
+mod tests_transport_roundtrip;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/memory_ipc/tests_launcher.rs
+++ b/src/memory_ipc/tests_launcher.rs
@@ -49,11 +49,18 @@ fn launch_writer_client_succeeds_on_fresh_state_root_without_daemon() {
     let root = fresh_state_root("writer-fresh");
     let writer = launch_writer_client(&root)
         .expect("launch_writer_client must succeed without a daemon when state root is writable");
-    // ops() must hand back a usable trait object.
+    // ops() must hand back a usable trait object whose fresh-store state is
+    // concretely correct — a brand-new tier-2 store must hold zero facts. (The
+    // earlier version discarded the stats via `let _ =`, verifying only that the
+    // call did not error; asserting the count turns it into a behaviour check.)
     let ops: &dyn CognitiveMemoryOps = writer.ops();
-    let _ = ops
+    let stats = ops
         .get_statistics()
         .expect("get_statistics must work on a fresh writer bridge");
+    assert_eq!(
+        stats.semantic_count, 0,
+        "a freshly opened tier-2 writer must front an empty store (no facts)"
+    );
 }
 
 #[test]

--- a/src/memory_ipc/tests_transport_roundtrip.rs
+++ b/src/memory_ipc/tests_transport_roundtrip.rs
@@ -1,0 +1,933 @@
+//! End-to-end tests for the memory-IPC **Unix-socket transport** — the
+//! [`RemoteCognitiveMemory`] client ([`super::client`]) and the
+//! [`spawn_server`] / `serve_connection` / `dispatch` server
+//! ([`super::server`]).
+//!
+//! Motivation (coverage gap): every other `memory_ipc` test exercises the
+//! *in-process* launcher ladder (tier-0 `register_in_process_writer` and
+//! tier-2 `shared_tier2_store`) via [`launch_writer_client`] /
+//! [`open_reader_client`]. None of them drives the actual socket wire, so the
+//! whole cross-process transport — the reason the module exists — was almost
+//! untested (`client.rs` ~29 % / `server.rs` ~43 % line coverage). A protocol
+//! break there would silently sever cross-process cognitive-memory access
+//! (meeting REPL / engineer subprocess / dashboard ⇄ OODA daemon) with no
+//! failing test, exactly the "hollow success" class the launcher's
+//! no-read-only-fallback rule exists to prevent.
+//!
+//! These tests are **hermetic and behaviour-verifying**: each spins up a real
+//! server thread bound to a `TempDir` socket, backed by a real
+//! [`LibraryCognitiveMemory::in_memory()`] store (no disk, no network, no env,
+//! no shared global state), then asserts that data written through the socket
+//! *round-trips with its payload intact* — not merely that a call returns
+//! `Ok`. They therefore need no `#[serial(cognitive_memory)]` key: they never
+//! mutate a watched env var, construct `HermeticState`, or open the store at
+//! the env-derived default path (see `test_support::serial_guard`).
+//!
+//! Scope: "every op" below means every operation in the IPC **request
+//! protocol** (`MemoryRequest` / the `dispatch` arms), which is the subset of
+//! [`CognitiveMemoryOps`] that actually crosses the socket. `CognitiveMemoryOps`
+//! methods with no `MemoryRequest` variant (e.g. `store_fact_with_provenance`,
+//! `graph_stats`) are served locally via trait defaults on the client and do
+//! not traverse the wire; they are exercised against `SharedMemory` (the
+//! in-process adapter) rather than the socket.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
+use crate::error::{SimardError, SimardResult};
+use crate::memory_cognitive::{
+    CognitiveEpisode, CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
+    CognitiveWorkingSlot,
+};
+
+use super::{RemoteCognitiveMemory, ServerHandle, spawn_server};
+
+/// A live server (backed by an in-memory store) plus a connected client, all
+/// rooted in one `TempDir` whose lifetime keeps the socket path valid.
+struct Fixture {
+    client: RemoteCognitiveMemory,
+    _handle: ServerHandle,
+    _dir: tempfile::TempDir,
+}
+
+/// Spawn a server on a fresh `TempDir` socket backed by `backend`, wait for it
+/// to start accepting, and return a connected client.
+fn fixture_with_backend(backend: Arc<dyn CognitiveMemoryOps>) -> Fixture {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sock = dir.path().join("memory.sock");
+    let handle = spawn_server(sock.clone(), backend).expect("spawn_server");
+
+    // The listener binds on a background thread; poll until the socket file is
+    // present before connecting (matches the existing top-level round-trip
+    // test's start-up handshake).
+    for _ in 0..100 {
+        if sock.exists() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    let client = RemoteCognitiveMemory::connect(&sock).expect("client connect + Ping handshake");
+    Fixture {
+        client,
+        _handle: handle,
+        _dir: dir,
+    }
+}
+
+/// The common case: a real in-memory cognitive store behind the socket.
+fn in_memory_fixture() -> Fixture {
+    let backend: Arc<dyn CognitiveMemoryOps> =
+        Arc::new(LibraryCognitiveMemory::in_memory().expect("in-memory store"));
+    fixture_with_backend(backend)
+}
+
+// ---------------------------------------------------------------------------
+// Per-operation round-trips: each asserts the *payload* survives the wire, so
+// a broken serde tag / dispatch arm / response-variant match fails the test.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sensory_record_returns_id_and_fresh_record_is_not_pruned() {
+    let fx = in_memory_fixture();
+
+    // A long TTL means the record is *not* expired, so a prune immediately
+    // afterwards must reclaim nothing. This pins both the RecordSensory→Id and
+    // PruneExpiredSensory→Count wire mappings AND the "don't drop live data"
+    // behaviour — a prune that returned >0 here would be silently destroying a
+    // still-valid sensory memory.
+    let id = fx
+        .client
+        .record_sensory("text", "operator said hello", 3_600)
+        .expect("record_sensory over socket");
+    assert!(
+        !id.is_empty(),
+        "record_sensory must return a non-empty node id"
+    );
+
+    let pruned = fx
+        .client
+        .prune_expired_sensory()
+        .expect("prune_expired_sensory over socket");
+    assert_eq!(
+        pruned, 0,
+        "a sensory record with a 1-hour TTL must not be pruned immediately"
+    );
+}
+
+#[test]
+fn working_memory_push_get_clear_lifecycle_over_socket() {
+    let fx = in_memory_fixture();
+    let task = "task-abc";
+
+    let node_id = fx
+        .client
+        .push_working("plan", "draft the migration", task, 0.75)
+        .expect("push_working over socket");
+    assert!(!node_id.is_empty(), "push_working must return a node id");
+
+    let slots = fx
+        .client
+        .get_working(task)
+        .expect("get_working over socket");
+    assert_eq!(
+        slots.len(),
+        1,
+        "exactly the one pushed slot must be visible"
+    );
+    let slot = &slots[0];
+    assert_eq!(
+        slot.node_id, node_id,
+        "the retrieved slot must be the one push_working returned (id ties record to write)"
+    );
+    assert_eq!(
+        slot.content, "draft the migration",
+        "content must survive the wire"
+    );
+    assert_eq!(slot.slot_type, "plan", "slot_type must survive the wire");
+    assert_eq!(slot.task_id, task, "task_id must survive the wire");
+    assert!(
+        (slot.relevance - 0.75).abs() < 1e-9,
+        "relevance f64 must survive the wire; got {}",
+        slot.relevance
+    );
+
+    let cleared = fx
+        .client
+        .clear_working(task)
+        .expect("clear_working over socket");
+    assert_eq!(cleared, 1, "clear_working must report the one removed slot");
+    assert!(
+        fx.client
+            .get_working(task)
+            .expect("get_working after clear")
+            .is_empty(),
+        "the task's working set must be empty after clear_working"
+    );
+}
+
+#[test]
+fn episode_store_search_and_consolidate_over_socket() {
+    let fx = in_memory_fixture();
+
+    let e1 = fx
+        .client
+        .store_episode("engineer merged PR 42 to fix the socket race", "test", None)
+        .expect("store_episode #1");
+    let e2 = fx
+        .client
+        .store_episode(
+            "engineer merged PR 43 tightening the socket timeout",
+            "test",
+            None,
+        )
+        .expect("store_episode #2");
+    // A decoy episode WITHOUT the "socket" keyword: it must NOT come back from
+    // the keyword search, so the search is proven to actually filter on the
+    // wire (not just "return everything").
+    let decoy = fx
+        .client
+        .store_episode("engineer rewrote the onboarding README", "test", None)
+        .expect("store_episode decoy");
+    assert!(!e1.is_empty() && !e2.is_empty(), "episodes must get ids");
+    assert_ne!(e1, e2, "distinct episodes must get distinct ids");
+
+    // Keyword recall must reach the backend across the wire (this method has a
+    // real default-less client impl; a no-op default would return nothing).
+    let hits = fx
+        .client
+        .search_episodes_by_keywords(&["socket".to_string()], 10)
+        .expect("search_episodes_by_keywords over socket");
+    assert!(
+        hits.iter().any(|e: &CognitiveEpisode| e.node_id == e1)
+            && hits.iter().any(|e| e.node_id == e2),
+        "both 'socket' episodes must be recalled by keyword; got {} hits",
+        hits.len()
+    );
+    assert!(
+        !hits.iter().any(|e| e.node_id == decoy),
+        "the non-'socket' decoy episode must NOT be returned — proves the keyword \
+         filter is applied server-side, not ignored"
+    );
+
+    // With three un-compressed episodes available, a batch-2 consolidation must
+    // produce a non-empty summary node id (exercising the MaybeId variant).
+    let consolidated = fx
+        .client
+        .consolidate_episodes(2)
+        .expect("consolidate_episodes over socket");
+    let con_id = consolidated.expect("consolidating 2 available episodes must yield Some(id)");
+    assert!(
+        !con_id.is_empty(),
+        "the consolidated node id must be non-empty"
+    );
+}
+
+#[test]
+fn fact_store_search_and_statistics_over_socket() {
+    let fx = in_memory_fixture();
+
+    let stats_before = fx.client.get_statistics().expect("get_statistics (before)");
+    assert_eq!(
+        stats_before.semantic_count, 0,
+        "a fresh store must report zero semantic facts"
+    );
+
+    let id = fx
+        .client
+        .store_fact(
+            "gravity",
+            "objects fall at 9.8 m/s^2",
+            0.9,
+            &["physics".to_string(), "mechanics".to_string()],
+            "src-newton",
+        )
+        .expect("store_fact over socket");
+    assert!(!id.is_empty(), "store_fact must return a node id");
+
+    // Decoy 1: a query non-match (different concept). Decoy 2: a query match but
+    // LOW confidence. Together they let the two assertions below prove that BOTH
+    // the query filter AND the min_confidence filter are applied server-side —
+    // not that search_facts is a "return everything" stub.
+    fx.client
+        .store_fact("gardening", "water tomatoes weekly", 0.9, &[], "src-decoy")
+        .expect("store decoy fact (query non-match)");
+    fx.client
+        .store_fact("gravity", "gravity is a myth", 0.3, &[], "src-myth")
+        .expect("store decoy fact (low confidence)");
+
+    // (a) query filter: searching "gravity" at min_confidence 0.0 returns both
+    // gravity facts but NOT the gardening fact.
+    let by_query: Vec<CognitiveFact> = fx
+        .client
+        .search_facts("gravity", 10, 0.0)
+        .expect("search_facts over socket");
+    let real = by_query
+        .iter()
+        .find(|f| f.content == "objects fall at 9.8 m/s^2")
+        .expect("the stored fact's content must round-trip through the socket");
+    assert!(
+        (real.confidence - 0.9).abs() < 1e-9,
+        "the fact's confidence must round-trip; got {}",
+        real.confidence
+    );
+    assert!(
+        !by_query.iter().any(|f| f.concept == "gardening"),
+        "the query filter must exclude the unrelated 'gardening' fact over the wire"
+    );
+
+    // (b) confidence filter: raising min_confidence to 0.5 drops the 0.3 "myth"
+    // fact while keeping the 0.9 fact.
+    let by_conf: Vec<CognitiveFact> = fx
+        .client
+        .search_facts("gravity", 10, 0.5)
+        .expect("search_facts (min_confidence)");
+    assert!(
+        by_conf
+            .iter()
+            .any(|f| f.content == "objects fall at 9.8 m/s^2"),
+        "the high-confidence fact must survive the min_confidence filter"
+    );
+    assert!(
+        !by_conf.iter().any(|f| f.content == "gravity is a myth"),
+        "the min_confidence filter must drop the 0.3 fact over the wire"
+    );
+
+    let stats_after = fx.client.get_statistics().expect("get_statistics (after)");
+    assert_eq!(
+        stats_after.semantic_count, 3,
+        "statistics fetched over the socket must reflect all three stored facts"
+    );
+}
+
+#[test]
+fn procedure_store_and_recall_over_socket() {
+    let fx = in_memory_fixture();
+
+    let steps = vec![
+        "run cargo test".to_string(),
+        "open a PR".to_string(),
+        "merge when green".to_string(),
+    ];
+    let prereqs = vec!["clean worktree".to_string()];
+    let id = fx
+        .client
+        .store_procedure("ship_change", &steps, &prereqs)
+        .expect("store_procedure over socket");
+    assert!(!id.is_empty(), "store_procedure must return a node id");
+
+    // Decoy procedure whose name does not contain the query token, so a correct
+    // (server-side) name filter excludes it — proving recall_procedure filters
+    // rather than returning every stored procedure.
+    fx.client
+        .store_procedure("rollback_release", &["revert".to_string()], &[])
+        .expect("store decoy procedure");
+
+    let recalled: Vec<CognitiveProcedure> = fx
+        .client
+        .recall_procedure("ship_change", 10)
+        .expect("recall_procedure over socket");
+    let proc = recalled
+        .iter()
+        .find(|p| p.name == "ship_change")
+        .expect("the stored procedure must be recalled by name");
+    assert_eq!(
+        proc.node_id, id,
+        "the recalled procedure must be the one store_procedure returned"
+    );
+    assert_eq!(
+        proc.steps, steps,
+        "procedure steps must round-trip through the socket intact"
+    );
+    assert_eq!(
+        proc.prerequisites, prereqs,
+        "procedure prerequisites must round-trip through the socket intact"
+    );
+    assert!(
+        !recalled.iter().any(|p| p.name == "rollback_release"),
+        "recall_procedure must exclude the non-matching decoy procedure over the wire"
+    );
+}
+
+#[test]
+fn prospective_store_trigger_and_resolve_over_socket() {
+    let fx = in_memory_fixture();
+
+    let id = fx
+        .client
+        .store_prospective(
+            "notify on deploy",
+            "deploy production",
+            "send the release email",
+            5,
+        )
+        .expect("store_prospective over socket");
+    assert!(!id.is_empty(), "store_prospective must return a node id");
+
+    // A decoy prospective whose trigger shares NO tokens with the content below,
+    // so it must not fire — proving check_triggers actually matches on the wire
+    // rather than returning every prospective.
+    let decoy = fx
+        .client
+        .store_prospective("nightly backup", "backup nightly", "run pg_dump", 1)
+        .expect("store decoy prospective");
+
+    // check_triggers uses keyword-overlap matching; content sharing the trigger
+    // tokens must fire the prospective and return it over the wire.
+    let fired: Vec<CognitiveProspective> = fx
+        .client
+        .check_triggers("it is time to deploy production now")
+        .expect("check_triggers over socket");
+    let matched = fired
+        .iter()
+        .find(|p| p.node_id == id)
+        .expect("the matching prospective must fire and return over the socket");
+    assert_eq!(
+        matched.action_on_trigger, "send the release email",
+        "the fired prospective's action must round-trip intact"
+    );
+    assert!(
+        !fired.iter().any(|p| p.node_id == decoy),
+        "the non-matching decoy prospective must NOT fire — proves keyword \
+         matching is applied server-side"
+    );
+
+    // Resolving it must be acknowledged (Ack response variant → Ok(())).
+    fx.client
+        .resolve_prospective(&id)
+        .expect("resolve_prospective over socket must be acknowledged");
+}
+
+// ---------------------------------------------------------------------------
+// Error paths.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn connect_returns_spawn_error_when_socket_absent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir.path().join("nope.sock");
+
+    let err = match RemoteCognitiveMemory::connect(&missing) {
+        Ok(_) => panic!("connecting to a non-existent socket must fail, not succeed"),
+        Err(e) => e,
+    };
+    match err {
+        SimardError::RpcSpawnFailed { bridge, reason } => {
+            assert_eq!(bridge, "memory-ipc-client");
+            assert!(
+                reason.contains("not present"),
+                "error must explain the socket is absent; got: {reason}"
+            );
+        }
+        other => panic!("expected RpcSpawnFailed for a missing socket, got {other:?}"),
+    }
+}
+
+/// Backend whose every abstract op fails, so a call that reaches it produces a
+/// `MemoryResponse::Error`. Used to prove the server encodes backend errors and
+/// the client decodes them into a typed `RpcCallFailed` carrying the *method
+/// name* — the seam that stops an IPC store from silently "succeeding".
+struct AlwaysErrBackend;
+
+impl AlwaysErrBackend {
+    fn boom(op: &str) -> SimardError {
+        SimardError::RpcCallFailed {
+            bridge: "test-backend".into(),
+            method: op.into(),
+            reason: "synthetic backend failure".into(),
+        }
+    }
+}
+
+impl CognitiveMemoryOps for AlwaysErrBackend {
+    fn record_sensory(&self, _m: &str, _r: &str, _t: u64) -> SimardResult<String> {
+        Err(Self::boom("record_sensory"))
+    }
+    fn prune_expired_sensory(&self) -> SimardResult<usize> {
+        Err(Self::boom("prune_expired_sensory"))
+    }
+    fn push_working(&self, _s: &str, _c: &str, _t: &str, _r: f64) -> SimardResult<String> {
+        Err(Self::boom("push_working"))
+    }
+    fn get_working(&self, _t: &str) -> SimardResult<Vec<CognitiveWorkingSlot>> {
+        Err(Self::boom("get_working"))
+    }
+    fn clear_working(&self, _t: &str) -> SimardResult<usize> {
+        Err(Self::boom("clear_working"))
+    }
+    fn store_episode(
+        &self,
+        _c: &str,
+        _s: &str,
+        _m: Option<&serde_json::Value>,
+    ) -> SimardResult<String> {
+        Err(Self::boom("store_episode"))
+    }
+    fn consolidate_episodes(&self, _b: u32) -> SimardResult<Option<String>> {
+        Err(Self::boom("consolidate_episodes"))
+    }
+    fn store_fact(
+        &self,
+        _c: &str,
+        _co: &str,
+        _cf: f64,
+        _t: &[String],
+        _s: &str,
+    ) -> SimardResult<String> {
+        Err(Self::boom("store_fact"))
+    }
+    fn search_facts(&self, _q: &str, _l: u32, _m: f64) -> SimardResult<Vec<CognitiveFact>> {
+        Err(Self::boom("search_facts"))
+    }
+    fn store_procedure(&self, _n: &str, _s: &[String], _p: &[String]) -> SimardResult<String> {
+        Err(Self::boom("store_procedure"))
+    }
+    fn recall_procedure(&self, _q: &str, _l: u32) -> SimardResult<Vec<CognitiveProcedure>> {
+        Err(Self::boom("recall_procedure"))
+    }
+    fn store_prospective(&self, _d: &str, _tc: &str, _a: &str, _p: i64) -> SimardResult<String> {
+        Err(Self::boom("store_prospective"))
+    }
+    fn check_triggers(&self, _c: &str) -> SimardResult<Vec<CognitiveProspective>> {
+        Err(Self::boom("check_triggers"))
+    }
+    fn get_statistics(&self) -> SimardResult<CognitiveStatistics> {
+        Err(Self::boom("get_statistics"))
+    }
+    // These two are trait-default methods, but they ARE part of the IPC request
+    // surface (ResolveProspective / SearchEpisodesByKeywords dispatch arms).
+    // Override them to Err so the error-encoding test can pin their server Err
+    // arm and client decode arm too (a default Ok would mask a regression).
+    fn resolve_prospective(&self, _n: &str) -> SimardResult<()> {
+        Err(Self::boom("resolve_prospective"))
+    }
+    fn search_episodes_by_keywords(
+        &self,
+        _k: &[String],
+        _l: u32,
+    ) -> SimardResult<Vec<CognitiveEpisode>> {
+        Err(Self::boom("search_episodes_by_keywords"))
+    }
+}
+
+/// Assert a client result is the typed `RpcCallFailed` produced when the server
+/// encoded a backend error and the client decoded it — attributed to `method`
+/// and carrying the backend's message.
+fn assert_backend_err<T: std::fmt::Debug>(result: SimardResult<T>, method: &str) {
+    match result {
+        Ok(v) => panic!(
+            "{method}: expected a backend error, but got Ok({v:?}) — a failing IPC op must never silently succeed"
+        ),
+        Err(SimardError::RpcCallFailed {
+            bridge,
+            method: got,
+            reason,
+        }) => {
+            assert_eq!(bridge, "memory-ipc", "{method}: bridge label");
+            assert_eq!(
+                got, method,
+                "the failure must be attributed to the method the client called"
+            );
+            assert!(
+                reason.contains("synthetic backend failure"),
+                "{method}: the backend's error message must be carried back across the socket; got: {reason}"
+            );
+        }
+        Err(other) => panic!("{method}: expected RpcCallFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn every_op_encodes_backend_errors_as_rpc_call_failed() {
+    // The Ping handshake does not touch the backend, so connect still succeeds;
+    // then EVERY abstract op that reaches the failing backend must come back as
+    // a typed `RpcCallFailed` naming that op. This exercises the server's
+    // per-request `Err(..) => MemoryResponse::Error(..)` dispatch arm and the
+    // client's `other => Err(unexpected(..))` decode arm for the whole surface
+    // — the seam that prevents a cross-process write from "hollow-succeeding".
+    let fx = fixture_with_backend(Arc::new(AlwaysErrBackend));
+    let c = &fx.client;
+
+    assert_backend_err(c.record_sensory("m", "d", 1), "record_sensory");
+    assert_backend_err(c.prune_expired_sensory(), "prune_expired_sensory");
+    assert_backend_err(c.push_working("s", "c", "t", 0.1), "push_working");
+    assert_backend_err(c.get_working("t"), "get_working");
+    assert_backend_err(c.clear_working("t"), "clear_working");
+    assert_backend_err(c.store_episode("c", "s", None), "store_episode");
+    assert_backend_err(c.consolidate_episodes(2), "consolidate_episodes");
+    assert_backend_err(c.store_fact("c", "v", 1.0, &[], "s"), "store_fact");
+    assert_backend_err(c.search_facts("q", 1, 0.0), "search_facts");
+    assert_backend_err(c.store_procedure("n", &[], &[]), "store_procedure");
+    assert_backend_err(c.recall_procedure("q", 1), "recall_procedure");
+    assert_backend_err(c.store_prospective("d", "t", "a", 0), "store_prospective");
+    assert_backend_err(c.check_triggers("c"), "check_triggers");
+    assert_backend_err(c.get_statistics(), "get_statistics");
+    assert_backend_err(c.resolve_prospective("id"), "resolve_prospective");
+    assert_backend_err(
+        c.search_episodes_by_keywords(&["x".to_string()], 1),
+        "search_episodes_by_keywords",
+    );
+}
+
+#[test]
+fn client_socket_path_accessor_reports_the_connected_path() {
+    let fx = in_memory_fixture();
+    assert!(
+        fx.client.socket_path().ends_with("memory.sock"),
+        "socket_path() must report the path the client connected to; got {}",
+        fx.client.socket_path().display()
+    );
+}
+
+#[test]
+fn one_connection_serves_many_sequential_requests() {
+    // serve_connection loops reading framed requests until EOF; issue several
+    // ops on the same client (same UnixStream) and confirm each is answered,
+    // proving the per-connection request loop — not just the first frame — works.
+    let fx = in_memory_fixture();
+    for i in 0..5 {
+        let id = fx
+            .client
+            .store_fact(
+                &format!("concept-{i}"),
+                &format!("value-{i}"),
+                0.5,
+                &[],
+                "loop-src",
+            )
+            .unwrap_or_else(|e| panic!("store_fact #{i} on the shared connection failed: {e}"));
+        assert!(!id.is_empty(), "each looped store_fact must return an id");
+    }
+    let stats = fx.client.get_statistics().expect("final get_statistics");
+    assert_eq!(
+        stats.semantic_count, 5,
+        "all five sequential writes on one connection must have landed"
+    );
+}
+
+#[test]
+fn server_handle_drop_removes_the_socket_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sock = dir.path().join("memory.sock");
+    let backend: Arc<dyn CognitiveMemoryOps> =
+        Arc::new(LibraryCognitiveMemory::in_memory().expect("in-memory store"));
+    let handle = spawn_server(sock.clone(), backend).expect("spawn_server");
+    for _ in 0..100 {
+        if sock.exists() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(
+        sock.exists(),
+        "precondition: the server must have bound the socket"
+    );
+
+    drop(handle);
+    assert!(
+        !sock.exists(),
+        "dropping the ServerHandle must unlink the socket file so a later daemon can rebind it"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Stale-lock reaping: the live-owner branch (the existing top-level test only
+// covers the absent-file and empty-file/flock branches).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reap_stale_open_lock_keeps_a_lock_owned_by_a_live_process() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let lock = dir.path().join("cognitive_memory.ladybug.open.lock");
+    // Record *this* process's pid: it is provably alive, so the reaper must
+    // refuse to remove the lock (removing a live daemon's lock would let a
+    // second writer open the store concurrently and corrupt it).
+    std::fs::write(&lock, std::process::id().to_string()).expect("seed lock file");
+
+    let reaped = super::reap_stale_open_lock(dir.path()).expect("reap must not error");
+    assert!(!reaped, "a lock owned by a live pid must NOT be reaped");
+    assert!(
+        lock.exists(),
+        "the live-owned lock file must be left in place"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Server robustness: a malformed request frame must not take the server down.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn malformed_request_frame_does_not_kill_the_server() {
+    use std::os::unix::net::UnixStream;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sock = dir.path().join("memory.sock");
+    let backend: Arc<dyn CognitiveMemoryOps> =
+        Arc::new(LibraryCognitiveMemory::in_memory().expect("in-memory store"));
+    let _handle = spawn_server(sock.clone(), backend).expect("spawn_server");
+    for _ in 0..100 {
+        if sock.exists() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    // Send a well-framed but NON-JSON payload on a raw connection. The server's
+    // `serve_connection` must fail to parse it and drop *this* connection
+    // (serialize-request/parse-request error path) without aborting the accept
+    // loop.
+    {
+        let mut raw = UnixStream::connect(&sock).expect("raw connect");
+        super::write_frame(&mut raw, b"this is not valid json").expect("write malformed frame");
+        // Give the server's connection handler a moment to read + reject it.
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    // The server must still be alive: a fresh, well-behaved client connects and
+    // completes a real round-trip.
+    let client = RemoteCognitiveMemory::connect(&sock)
+        .expect("server must still accept new clients after a malformed frame");
+    let id = client
+        .store_fact("resilience", "one bad frame is not fatal", 1.0, &[], "src")
+        .expect("a healthy client must still be served after a peer sent garbage");
+    assert!(
+        !id.is_empty(),
+        "the post-malformed-frame round-trip must succeed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SharedMemory adapter: forwards the whole CognitiveMemoryOps surface to the
+// wrapped store. A missing forward is a silent-empty-read hazard (issue #2320 /
+// #2331) — the daemon (tier-0) and every tier-2 bridge read through this.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shared_memory_forwards_the_whole_ops_surface_to_the_inner_store() {
+    use super::SharedMemory;
+
+    let inner: Arc<dyn CognitiveMemoryOps> =
+        Arc::new(LibraryCognitiveMemory::in_memory().expect("in-memory store"));
+    let shared = SharedMemory(Arc::clone(&inner));
+
+    // Passthrough scalars.
+    assert!(
+        !shared.is_read_only(),
+        "a writable inner store must forward is_read_only=false"
+    );
+
+    // Sensory.
+    let sid = shared
+        .record_sensory("text", "hi", 3_600)
+        .expect("record_sensory");
+    assert!(!sid.is_empty());
+    assert_eq!(
+        shared.prune_expired_sensory().expect("prune"),
+        0,
+        "live sensory not pruned"
+    );
+
+    // Working.
+    let wid = shared
+        .push_working("plan", "step one", "task-1", 0.5)
+        .expect("push_working");
+    assert!(!wid.is_empty());
+    assert_eq!(shared.get_working("task-1").expect("get_working").len(), 1);
+    assert_eq!(shared.clear_working("task-1").expect("clear_working"), 1);
+
+    // Episodic (+ the default-less recall/distill methods whose trait defaults
+    // are empty no-ops — a missing forward would return nothing).
+    let ep = shared
+        .store_episode("engineer fixed the shared-memory forward", "test", None)
+        .expect("store_episode");
+    assert!(
+        shared
+            .list_all_episodes(10)
+            .expect("list_all_episodes")
+            .iter()
+            .any(|e| e.node_id == ep)
+    );
+    assert!(
+        shared
+            .search_episodes_by_keywords(&["shared-memory".to_string()], 10)
+            .expect("search_episodes_by_keywords")
+            .iter()
+            .any(|e| e.node_id == ep)
+    );
+    assert!(
+        shared
+            .list_undistilled_episodes(10)
+            .expect("list_undistilled_episodes")
+            .iter()
+            .any(|e| e.node_id == ep)
+    );
+    assert!(
+        shared
+            .search_episodes_starting_with("engineer fixed", 10)
+            .expect("search_episodes_starting_with")
+            .iter()
+            .any(|(content, _)| content == "engineer fixed the shared-memory forward"),
+        "search_episodes_starting_with must forward and return the matching episode's content"
+    );
+    shared
+        .mark_episode_distilled(&ep)
+        .expect("mark_episode_distilled");
+    assert!(
+        !shared
+            .list_undistilled_episodes(10)
+            .expect("list_undistilled after mark")
+            .iter()
+            .any(|e| e.node_id == ep),
+        "mark_episode_distilled must forward: the episode leaves the undistilled set"
+    );
+
+    // Semantic facts (+ provenance + ranked + caller-key dedup + pruning).
+    let f1 = shared
+        .store_fact("concept-a", "value-a", 0.9, &["t".to_string()], "src-a")
+        .expect("store_fact");
+    assert!(
+        shared
+            .search_facts("concept-a", 10, 0.0)
+            .expect("search_facts")
+            .iter()
+            .any(|f| f.node_id == f1 || f.concept == "concept-a")
+    );
+    assert!(
+        !shared
+            .recall_facts_ranked(
+                "concept-a",
+                10,
+                0.0,
+                crate::cognitive_memory::RecallWeightSet::default()
+            )
+            .expect("recall_facts_ranked")
+            .is_empty(),
+        "recall_facts_ranked must forward and find the stored fact"
+    );
+    let prov_fact = shared
+        .store_fact_with_provenance(
+            "lesson",
+            "keep it green",
+            0.8,
+            "src-p",
+            None,
+            None,
+            std::slice::from_ref(&ep),
+        )
+        .expect("store_fact_with_provenance");
+    assert!(
+        !shared
+            .episodes_for_fact(&prov_fact)
+            .expect("episodes_for_fact")
+            .is_empty(),
+        "episodes_for_fact must forward and surface the provenance edge"
+    );
+    // Caller-key dedup: storing the SAME key with the SAME content must REUSE
+    // the node (identical id), which the trait default (delegating to store_fact)
+    // would NOT do — so this proves the real caller-key path is forwarded.
+    let ck1 = shared
+        .store_fact_with_caller_key("k1", "dedup-concept", "v", 0.7, &[], "src-k")
+        .expect("store_fact_with_caller_key #1");
+    let ck2 = shared
+        .store_fact_with_caller_key("k1", "dedup-concept", "v", 0.7, &[], "src-k")
+        .expect("store_fact_with_caller_key #2");
+    assert!(!ck1.is_empty());
+    assert_eq!(
+        ck1, ck2,
+        "re-storing an identical caller-key fact must reuse the same node (dedup forwarded)"
+    );
+    // No caller-key fact was re-stored with CHANGED content and nothing was
+    // superseded, so prune_superseded must reclaim exactly zero — a concrete
+    // assertion (not just "did not error") that also proves it forwards.
+    assert_eq!(
+        shared
+            .prune_superseded()
+            .expect("prune_superseded must forward"),
+        0,
+        "with no superseded facts, prune_superseded must reclaim nothing"
+    );
+    // graph_stats must forward the real provenance edge (not the zeroed default).
+    assert!(
+        shared
+            .graph_stats()
+            .expect("graph_stats")
+            .derives_from_edges
+            >= 1,
+        "graph_stats must forward the DERIVES_FROM edge from the provenance fact"
+    );
+
+    // Procedural.
+    let pid = shared
+        .store_procedure("deploy", &["a".to_string(), "b".to_string()], &[])
+        .expect("store_procedure");
+    assert!(!pid.is_empty());
+    assert!(
+        shared
+            .recall_procedure("deploy", 10)
+            .expect("recall_procedure")
+            .iter()
+            .any(|p| p.name == "deploy")
+    );
+    assert!(
+        shared.procedure_exists("deploy").expect("procedure_exists"),
+        "procedure_exists must forward"
+    );
+    let pp = shared
+        .store_procedure_with_provenance(
+            "distilled-proc",
+            &["x".to_string()],
+            &[],
+            std::slice::from_ref(&ep),
+        )
+        .expect("store_procedure_with_provenance");
+    assert!(!pp.is_empty());
+    // The provenance forward must create a procedure->episode DERIVES_FROM edge;
+    // the trait default (delegating to store_procedure) would create none.
+    assert!(
+        shared
+            .graph_stats()
+            .expect("graph_stats after procedure provenance")
+            .procedure_derives_from_edges
+            >= 1,
+        "store_procedure_with_provenance must forward and record a procedure provenance edge"
+    );
+
+    // Prospective.
+    let pr = shared
+        .store_prospective("notify", "release now", "email", 3)
+        .expect("store_prospective");
+    assert!(
+        shared
+            .list_all_prospective(10)
+            .expect("list_all_prospective")
+            .iter()
+            .any(|p| p.node_id == pr),
+        "list_all_prospective must forward"
+    );
+    assert!(
+        shared
+            .check_triggers("release now please")
+            .expect("check_triggers")
+            .iter()
+            .any(|p| p.node_id == pr),
+        "check_triggers must forward"
+    );
+    shared
+        .resolve_prospective(&pr)
+        .expect("resolve_prospective must forward");
+
+    // Statistics reflect the writes made through the shared adapter.
+    let stats = shared.get_statistics().expect("get_statistics");
+    assert!(
+        stats.semantic_count >= 2,
+        "stats must forward and reflect the facts written via SharedMemory"
+    );
+    assert!(
+        stats.procedural_count >= 2,
+        "stats must reflect the procedures written via SharedMemory"
+    );
+
+    // checkpoint forwards (durability flush) without error.
+    shared.checkpoint().expect("checkpoint must forward");
+}

--- a/src/tests_memory_ipc.rs
+++ b/src/tests_memory_ipc.rs
@@ -33,17 +33,26 @@ fn reap_stale_lock_noop_when_absent() {
 }
 
 #[test]
-fn reap_stale_lock_removes_file_with_dead_pid() {
+fn reap_stale_lock_removes_unowned_empty_lock_via_flock_probe() {
     let dir = tempfile::tempdir().unwrap();
     let lock = dir.path().join("cognitive_memory.ladybug.open.lock");
-    // Use PID 1 doesn't work (it's always alive) so use a value that's
-    // definitely not a live pid: one with a high number that's unlikely.
-    // But `is_pid_alive` uses kill(0) which is unreliable. Use an empty
-    // file and rely on flock_held=false path instead.
+    // An empty lock file records no owner pid, so `reap_stale_open_lock` cannot
+    // consult `is_pid_alive` (which is unreliable for a fabricated pid anyway:
+    // `kill(pid, 0)` can return EPERM rather than ESRCH). It instead probes the
+    // flock: no live process holds it, the non-blocking `LOCK_EX` succeeds, and
+    // the stale file is reaped. This pins the unknown-owner/flock-not-held
+    // branch; the recorded-live-pid branch is covered by
+    // `memory_ipc::tests_transport_roundtrip::reap_stale_open_lock_keeps_a_lock_owned_by_a_live_process`.
     std::fs::write(&lock, b"").unwrap();
     let reaped = reap_stale_open_lock(dir.path()).unwrap();
-    assert!(reaped);
-    assert!(!lock.exists());
+    assert!(
+        reaped,
+        "an unowned (empty) lock with no flock holder must be reaped"
+    );
+    assert!(
+        !lock.exists(),
+        "the reaped lock file must be removed from disk"
+    );
 }
 
 #[test]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -273,7 +273,7 @@ version = "0.5.15"
 criteria = "safe-to-deploy"
 
 [[exemptions.crossbeam-epoch]]
-version = "0.9.18"
+version = "0.9.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.crossbeam-utils]]

--- a/tests/qa-scenarios/memory-ipc-socket-transport.yaml
+++ b/tests/qa-scenarios/memory-ipc-socket-transport.yaml
@@ -1,0 +1,57 @@
+name: memory-ipc-socket-transport
+app_type: cli
+description: |
+  Verify the cross-process cognitive-memory Unix-socket transport
+  (`memory_ipc::client::RemoteCognitiveMemory` ⇄ `memory_ipc::server`) end to
+  end. Before this change the socket path — the whole reason `memory_ipc`
+  exists — was almost untested (client.rs ~29% / server.rs ~43% line coverage):
+  every other test drove the in-process tier-0/tier-2 launcher ladder, never
+  the wire. A protocol break there would silently sever cross-process memory
+  reads/writes (meeting REPL / engineer subprocess / dashboard ⇄ OODA daemon)
+  with no failing test — the "hollow success" class the launcher's
+  no-read-only-fallback rule exists to prevent.
+
+  This scenario runs the new hermetic transport suite (real in-memory backend
+  behind a TempDir socket; no disk, no network, no env, no global state) plus
+  the two existing memory_ipc tests audited in the same change. All are
+  behaviour-verifying: they assert payloads round-trip intact and that backend
+  errors surface as typed `RpcCallFailed`, not silent `Ok`.
+agents:
+  - name: simard-cli
+    type: cli
+    command: cargo
+steps:
+  # (1) The new socket-transport suite: per-op round-trips for the whole
+  # CognitiveMemoryOps surface, the every-op error-encoding seam, ServerHandle
+  # drop unlinking the socket, malformed-frame robustness, SharedMemory
+  # forwarding, and the live-owner stale-lock branch. The first invocation may
+  # compile the lib test binary.
+  - action: run
+    params:
+      command: "cargo test --locked --lib memory_ipc::tests_transport_roundtrip"
+    timeout: 900000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # (2) The two existing tests improved by the same PR's test-quality audit:
+  # the fresh-writer launcher test now asserts the store is empty (was a
+  # value-discarding smoke check), and the stale-lock reap test is renamed to
+  # describe the branch it actually exercises (unowned/flock), not a "dead pid".
+  - action: run
+    params:
+      command: "cargo test --locked --lib -- memory_ipc::tests_launcher::launch_writer_client_succeeds_on_fresh_state_root_without_daemon tests_memory_ipc::reap_stale_lock_removes_unowned_empty_lock_via_flock_probe"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000


### PR DESCRIPTION
## Summary

One bounded, shippable increment of the "raise Simard's test coverage" umbrella goal: measure per-module line coverage (CI metric), pick the single **least-covered, highest-risk** module, and raise + audit it.

**Module selected: `memory_ipc`** — the cross-process cognitive-memory **Unix-socket transport** (memory-persistence core). Every existing `memory_ipc` test drives the *in-process* launcher ladder (tier-0 `register_in_process_writer` / tier-2 `shared_tier2_store`); **none exercised the actual socket wire**, so the module's whole reason for existing was almost untested (`client.rs` 29.3%, `server.rs` 43.3%). A protocol break there would silently sever cross-process cognitive-memory access (meeting REPL / engineer subprocess / dashboard ⇄ OODA daemon) with no failing test — the "hollow success" class the launcher's no-read-only-fallback rule exists to prevent. High blast-radius, hermetically testable.

Rejected alternatives: `operator_commands_ooda` (48.8% — but its uncovered mass is the long-running `daemon/mod.rs` harness, not hermetically testable glue); `ooda_actions` (74.4% — uncovered lines spawn real engineer subprocesses); `stewardship` (84.4% — already above target; its 0% `gh_client.rs` is live-network glue).

**This is the goal's first concrete increment — exactly one PR.**

## Coverage delta (criterion evidence)

Measured with the exact CI command from `.github/workflows/coverage.yml`:

```
cargo +nightly llvm-cov --workspace --lib --bins --ignore-filename-regex 'tests?/' --summary-only
```

| File | Before | After |
|------|-------:|------:|
| `src/memory_ipc/client.rs` | 29.3% (66/225) | 92.9% (209/225) |
| `src/memory_ipc/server.rs` | 43.3% (68/157) | 87.9% (138/157) |
| `src/memory_ipc/mod.rs` | 68.1% (179/263) | 93.9% (247/263) |
| `src/memory_ipc/launcher.rs` | 80.8% (105/130) | 80.8% (105/130) |
| **production subtotal** | **53.9% (418/775)** | **90.2% (699/775)** |
| **module total (CI metric, incl. test files)** | **69.8% (884/1266)** | **93.8% (1726/1840)** |

Module **69.8% → 93.8%** (production files **53.9% → 90.2%**), well past the ≥80% target. `launcher.rs` was already >80% and is not the socket transport, so it was left untouched (focused diff). Workspace total: 84.2% → 84.4%.

## Tests added — hermetic, behaviour-verifying (not coverage-padding)

New file `src/memory_ipc/tests_transport_roundtrip.rs` (14 tests). Each spins up a real `spawn_server` on a `TempDir` socket backed by a real `LibraryCognitiveMemory::in_memory()` store and a connected `RemoteCognitiveMemory` client — **no disk, no network, no env, no shared global state** (correctly needs no `serial(cognitive_memory)` key; the `serial_guard` meta-test confirms this).

- **Per-op round-trips** for the whole IPC request protocol (sensory, working, episodic, semantic, procedural, prospective, statistics): assert the **payload survives the wire** (ids tie to records, content/steps/confidence/relevance intact), not just `Ok`.
- **Server-side filtering is real, not a "return all" stub**: decoy non-matching records prove `search_facts` applies both the query filter *and* `min_confidence`, `search_episodes_by_keywords` applies the keyword filter, `recall_procedure` applies the name filter, and `check_triggers` applies keyword matching — all across the socket.
- **Error encoding**: every IPC op surfaces a backend failure as a typed `RpcCallFailed` naming the method (no silent `Ok`).
- **Robustness / lifecycle**: `ServerHandle::drop` unlinks the socket; a malformed request frame does not kill the server; one connection serves many sequential requests; `connect` to a missing socket errors cleanly.
- **`SharedMemory` adapter** forwards the whole ops surface to the inner store (incl. caller-key dedup reuse and procedure/fact provenance edges via `graph_stats`), and `reap_stale_open_lock` keeps a live-owned lock.

## Existing tests audited (criterion: flag & fix tautological/assertion-free/misleading)

Audited all 6 existing `memory_ipc` test files. Findings + fixes:

1. **`tests_memory_ipc.rs::reap_stale_lock_removes_file_with_dead_pid`** — **misleading name + incorrect comment**: the name/comment claim a dead-PID path, but the body writes an *empty* file and actually exercises the unknown-owner/flock branch (the author left a rambling, self-contradictory comment admitting `is_pid_alive` is unreliable). **Fixed**: renamed to `reap_stale_lock_removes_unowned_empty_lock_via_flock_probe`, corrected the comment, and cross-referenced the new live-PID-branch test. (The live-owner branch is now covered deterministically by the new test using the current process PID.)
2. **`tests_launcher.rs::launch_writer_client_succeeds_on_fresh_state_root_without_daemon`** — **value-discarding assertion**: called `get_statistics().expect(...)` then dropped the result via `let _ =`, verifying only that the call didn't error. **Fixed**: now asserts the fresh tier-2 store reports `semantic_count == 0` (a concrete behaviour check).

No tautological, over-mocked, or trivially-passing tests were found beyond these; the other four files (`tests_socket_path`, `tests_client_isolation`, `tests_shared_store_2320`, `tests_default_state_root_1967`) are high-quality and were left unchanged.

## qa-team / gadugi-test (criterion 1)

New scenario `tests/qa-scenarios/memory-ipc-socket-transport.yaml`.

- `gadugi-test validate --file tests/qa-scenarios/memory-ipc-socket-transport.yaml` → `✓ Scenario "memory-ipc-socket-transport" is valid`
- `gadugi-test run --directory tests/qa-scenarios --scenario memory-ipc-socket-transport` → `✓ Passed: 1 / ✗ Failed: 0 / All tests passed!` (runs the 14-test transport suite + the 2 audited tests).

## quality-audit (criterion 3: ≥3 SEEK→VALIDATE→FIX cycles, ended clean)

- **Cycle 1 (independent `code-review`)**: no significant issues; confirmed hermeticity, no flakiness, no wrong-reason assertions. One minor note (`prune_superseded` asserted non-error only) → **FIXED** to `== 0`.
- **Cycle 2 (flakiness/stress VALIDATE)**: ran the transport suite ×20 → **0 failures**; also passed under the pre-push `cargo test --release --lib (…|memory_ipc|…) --test-threads=nproc` gate.
- **Cycle 3 (independent `rubber-duck` logic review)**: hardened the round-trips into genuine filter/behaviour checks (decoys), tied returned ids to records, added the two missing error-path ops (`resolve_prospective`, `search_episodes_by_keywords`), strengthened `SharedMemory` dedup/provenance assertions, and corrected an over-broad "every op" doc claim. Final re-run + clippy + full suite **clean** (zero critical/high; zero medium correctness/security).

## CI / green checks (criterion 4)

Locally, matching CI's `verify.yml`:
- `cargo fmt --all -- --check` → pass
- `cargo clippy --all-targets --all-features --locked -- -D warnings` → pass
- `cargo clippy --release --no-deps -- -D warnings` (pre-commit) → pass
- `cargo test --lib` → **7582 passed, 0 failed, 7 ignored**; doctests pass
- pre-push `cargo test --release --lib (…|memory_ipc|…)` → pass

**GitHub Actions CI: 16/16 checks green, `mergeStateStatus: CLEAN`** on head `61904e01` — `pre-commit` (fmt/clippy/full `cargo test --all-features --locked`/builds), `coverage` (llvm-cov), `install-real`, `cargo-audit`, `cargo-deny`, `cargo-vet`, `npm-audit`, and GitGuardian all pass.

## CI unblock: RUSTSEC-2026-0204 (2nd commit)

Mid-PR, RustSec published **RUSTSEC-2026-0204** (2026-07-06) — an invalid pointer dereference in `crossbeam-epoch`'s `fmt::Pointer` impl for `Atomic`/`Shared`, patched in `>= 0.9.20`. The repo pins `crossbeam-epoch 0.9.18` **transitively** (`moka` → `rustyclawd-tools`), so `cargo audit` / `cargo deny --locked check` began failing **repo-wide on every PR** (and on `main`) the moment the advisory-db picked it up — unrelated to the test change, but it blocks this PR's required "CI 100% green" gate, and a second PR is disallowed for this increment.

The minimal upstream-recommended remediation is applied as a **separate commit** touching only supply-chain metadata: `Cargo.lock` (`cargo update -p crossbeam-epoch --precise 0.9.20` — one crate, version+checksum only; no `Cargo.toml` change, no public API impact) and `supply-chain/config.toml` (move the existing cargo-vet exemption for crossbeam-epoch from 0.9.18 to 0.9.20). Verified against a freshly-fetched advisory-db:
- `0.9.18` → `cargo audit` = `error: 1 vulnerability found!` (RUSTSEC-2026-0204)
- `0.9.20` → `cargo audit` ok; `cargo deny --locked check` = `advisories ok, bans ok, licenses ok, sources ok`; `cargo vet --locked` = `Vetting Succeeded`

## Scope confirmation (criterion 6)

Focused, two-commit diff:
1. **Test-only** coverage + audit work (5 files: 1 new test module, 1 module registration of 2 lines in `mod.rs`, 2 audited existing test files, 1 new qa-scenario). No production code modified; no user-facing surface changed → no docs update required (criterion 2: internal-only justification).
2. **Supply-chain-only** security bump (`Cargo.lock` crossbeam-epoch 0.9.18→0.9.20 + the matching `supply-chain/config.toml` cargo-vet exemption) to unblock the same-day repo-wide advisory failure described above.

No unrelated edits beyond these two clearly-scoped concerns.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Verdict: ✅ READY TO MERGE

Self-assessed merge-readiness verdict: **ready to merge.** Rationale — all six merge-ready criteria have substantive, concrete evidence:
1. **qa-team scenarios** — `tests/qa-scenarios/memory-ipc-socket-transport.yaml` written, `gadugi-test validate` → valid, `gadugi-test run` → 1 passed / 0 failed.
2. **Docs** — no user-facing surface changed (test-only + a transitive supply-chain lockfile bump); internal-only justification recorded above.
3. **quality-audit** — three SEEK→VALIDATE→FIX cycles (independent `code-review`, ×20 flakiness stress, independent `rubber-duck`), all findings fixed, final cycle clean (zero critical/high; zero medium correctness/security).
4. **CI** — 16/16 GitHub Actions checks green on head `61904e01`, `mergeStateStatus: CLEAN`.
5. **Evidence** — this description enumerates concrete evidence for criteria 1–4 and 6.
6. **Scope** — focused two-commit diff (test-only coverage/audit work; a minimal, upstream-recommended supply-chain security bump forced by a same-day repo-wide advisory); no unrelated edits.

Coverage target met with margin: `memory_ipc` 69.8% → 93.8% (production files 53.9% → 90.2%), well past ≥80%. This is the umbrella goal's first concrete, shippable increment — exactly one PR.
