### PR TITLE
fix(ci): pin taiki-e/install-action to reachable v2 release so Dependabot resolves (fixes red dependabot-updates on main)

### DIFF
--- a/.github/workflows/advisory-scan.yml
+++ b/.github/workflows/advisory-scan.yml
@@ -46,10 +46,15 @@ jobs:
           save-if: "false"
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@754bf4dbae00ad1b16b244717154b96ba27d2416 # cargo-audit
+        # SHA-pins the reachable `v2` release + selects the tool via `tool:` (a
+        # diverged per-tool tag commit breaks Dependabot's github_actions updater).
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
+        with:
+          tool: cargo-audit
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@4e4e4d1450e58bef95d6f394ac20d46ad7d24ebf # cargo-deny
+        # SHA-pins the reachable `v2` release; `tool:` pins the cargo-deny version.
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
         with:
           tool: cargo-deny@0.19.9
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,12 @@ jobs:
           components: llvm-tools-preview
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@81ee9698f20724138a785d788c7567d40f14cd2d # cargo-llvm-cov
+        # SHA-pins the reachable `v2` release of taiki-e/install-action and
+        # selects the tool via the `tool:` input. A diverged per-tool tag commit
+        # breaks Dependabot's github_actions updater ("no such commit").
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
+        with:
+          tool: cargo-llvm-cov
 
       - name: Cache cargo registry and build artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,8 +127,9 @@ jobs:
       # ---- SBOM (CycloneDX) — issue #2261 -------------------------------------
       - name: Install cargo-cyclonedx
         if: steps.tag_check.outputs.exists == 'false'
-        # SHA pins the per-tool `cargo-cyclonedx` tag of taiki-e/install-action.
-        uses: taiki-e/install-action@8cb326bacc2c357f28b43e3d7b25996496e729c1 # cargo-cyclonedx
+        # SHA-pins the reachable `v2` release of taiki-e/install-action and
+        # selects the tool via the `tool:` input (Dependabot-resolvable).
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
         with:
           tool: cargo-cyclonedx
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -218,7 +218,15 @@ jobs:
           path: .advisory-db
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@754bf4dbae00ad1b16b244717154b96ba27d2416 # cargo-audit
+        # Pin the reachable `v2` release SHA of taiki-e/install-action and select
+        # the tool via the `tool:` input. The former per-tool `cargo-audit` tag
+        # commit lived on a lineage diverged from the action's default branch, so
+        # Dependabot's github_actions updater could not resolve it ("no such
+        # commit") and the whole update job failed. The `v2` release SHA is
+        # reachable from main, keeping the pin SHA-hardened *and* Dependabot-updatable.
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
+        with:
+          tool: cargo-audit
 
       - name: Run cargo audit (offline, against the pinned DB)
         # `--no-fetch` disables the network fetch; `--db` points at the pinned
@@ -251,11 +259,12 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install cargo-deny
-        # SHA pins the per-tool `cargo-deny` tag of taiki-e/install-action
-        # (same pattern as the cargo-audit job above). The `tool:` input also
-        # pins the cargo-deny VERSION: deny.toml uses the 0.19.x advisories
-        # schema, so an unpinned bump could reinterpret the policy.
-        uses: taiki-e/install-action@4e4e4d1450e58bef95d6f394ac20d46ad7d24ebf # cargo-deny
+        # SHA-pins the reachable `v2` release of taiki-e/install-action (same
+        # pattern as the cargo-audit job above; a diverged per-tool tag commit
+        # breaks Dependabot). The `tool:` input pins the cargo-deny VERSION:
+        # deny.toml uses the 0.19.x advisories schema, so an unpinned bump could
+        # reinterpret the policy.
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
         with:
           tool: cargo-deny@0.19.9
 
@@ -281,8 +290,9 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install cargo-vet
-        # SHA pins the per-tool `cargo-vet` tag of taiki-e/install-action.
-        uses: taiki-e/install-action@7b51dc7487ebab790625f16f2c5f541029a3b0ab # cargo-vet
+        # SHA-pins the reachable `v2` release of taiki-e/install-action and
+        # selects the tool via the `tool:` input (Dependabot-resolvable).
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
         with:
           tool: cargo-vet
 

--- a/docs/reference/dependency-trust-policy.md
+++ b/docs/reference/dependency-trust-policy.md
@@ -83,7 +83,7 @@ cargo-vet:
     - name: Check out repository
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Install cargo-vet
-      uses: taiki-e/install-action@7b51dc7487ebab790625f16f2c5f541029a3b0ab # cargo-vet
+      uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
       with:
         tool: cargo-vet
     - name: Run cargo vet
@@ -95,9 +95,12 @@ Properties, identical to the other guardrail jobs:
 - **Lockfile-only** — no crate compilation, not in `pre-commit`, never writes
   the shared `simard-ci-v2` cache.
 - **`contents: read`** only — no token write scope.
-- **SHA-pinned** `taiki-e/install-action` with an explicit `tool: cargo-vet`
-  input (each tool has its own tag/commit, so a SHA pin alone selects the tool
-  baked into that commit — always pass `tool:`).
+- **SHA-pinned** `taiki-e/install-action` — pinned to its **`v2` release**
+  commit (`# v2.82.10`, reachable from the action's default branch so
+  Dependabot's `github_actions` updater can resolve and bump it) with an
+  explicit `tool: cargo-vet` input that selects the tool. Do **not** pin
+  `taiki-e`'s per-tool convenience tags (`# cargo-vet`): their commits are
+  diverged from the default branch and break Dependabot (`no such commit …`).
 - **`--locked`** — fails on a dirty `Cargo.lock`.
 
 `cargo vet --locked` passes when every third-party crate in the locked graph is

--- a/docs/reference/supply-chain-advisory-stewardship.md
+++ b/docs/reference/supply-chain-advisory-stewardship.md
@@ -135,7 +135,9 @@ cargo-audit:
         ref: ${{ steps.pin.outputs.sha }}
         path: .advisory-db
     - name: Install cargo-audit
-      uses: taiki-e/install-action@754bf4dbae00ad1b16b244717154b96ba27d2416 # cargo-audit
+      uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
+      with:
+        tool: cargo-audit
     - name: Run cargo audit (offline, pinned DB)
       run: cargo audit --no-fetch --db .advisory-db
 ```
@@ -208,9 +210,11 @@ jobs:
       - name: Check out default branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install cargo-audit
-        uses: taiki-e/install-action@754bf4dbae00ad1b16b244717154b96ba27d2416 # cargo-audit
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
+        with:
+          tool: cargo-audit
       - name: Install cargo-deny
-        uses: taiki-e/install-action@4e4e4d1450e58bef95d6f394ac20d46ad7d24ebf # cargo-deny
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
         with:
           tool: cargo-deny@0.19.9
       - name: Run supply-chain steward (scan DB HEAD, remediate)

--- a/docs/reference/supply-chain-audit.md
+++ b/docs/reference/supply-chain-audit.md
@@ -222,7 +222,7 @@ cargo-deny:
     - name: Check out repository
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Install cargo-deny
-      uses: taiki-e/install-action@4e4e4d1450e58bef95d6f394ac20d46ad7d24ebf # cargo-deny
+      uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
       with:
         tool: cargo-deny@0.19.9
     - name: Run cargo deny
@@ -238,15 +238,26 @@ Key properties (shared with the other guardrail jobs):
 - **Never writes the shared cache.** It does not touch `Swatinem/rust-cache`,
   so it cannot contend with the single-writer `simard-ci-v2` cache.
 - **SHA-pinned action with explicit, version-pinned `tool:`.**
-  `taiki-e/install-action` is pinned by commit SHA, and `tool: cargo-deny@0.19.9`
-  pins **both** the tool and its version. The version pin is load-bearing: the
+  `taiki-e/install-action` is pinned by commit SHA to its **`v2` release**
+  (`# v2.82.10`), and `tool: cargo-deny@0.19.9` pins **both** the tool and its
+  version. The version pin is load-bearing: the
   `[advisories]` schema (scope-valued `unmaintained` / `unsound`, with the old
   per-class severity keys removed) is the 0.19.x format, so an unpinned upgrade
-  could change how `deny.toml` is interpreted. The `tool:` input is also
-  required for selection: `taiki-e` publishes one tag (and commit) per tool, so
-  a SHA pin alone — as the existing `cargo-audit` job uses — selects the tool
-  baked into *that* commit. Reusing the `cargo-audit` SHA without a `tool:`
-  input would install **cargo-audit**, not cargo-deny.
+  could change how `deny.toml` is interpreted. The `tool:` input also drives
+  selection: the pinned `v2` release commit is the action's shared entrypoint
+  and installs whichever tool `tool:` names, so every guardrail job
+  (`cargo-audit`, `cargo-deny`, `cargo-vet`) uses the *same*
+  `taiki-e/install-action@<v2 SHA>` pin and differs only in its `tool:` value.
+
+  > **Pin the `v2` release SHA, never a per-tool tag.** `taiki-e` also publishes
+  > a convenience tag/commit per tool (`# cargo-deny`, `# cargo-audit`, …), but
+  > those commits sit on a lineage **diverged** from the action's default
+  > branch. GitHub's Dependabot `github_actions` updater shallow-clones the
+  > action to look for newer versions and cannot resolve a diverged commit
+  > (`error: no such commit …`), which fails the whole `dependabot-updates` run
+  > and turns the default branch's Actions health red. Pinning the `v2` release
+  > SHA (reachable from the default branch) keeps the pin SHA-hardened **and**
+  > Dependabot-updatable.
 - **`--locked`.** Passed to `cargo-deny` itself (`cargo deny --locked check`;
   `--locked` is a top-level flag, before the `check` subcommand). It fails if
   `Cargo.lock` is dirty, so the check always reflects the committed graph (no

--- a/tests/dependabot_action_pins.rs
+++ b/tests/dependabot_action_pins.rs
@@ -1,0 +1,156 @@
+//! Regression guard: `taiki-e/install-action` pins must stay
+//! Dependabot-resolvable.
+//!
+//! Background — a real default-branch CI failure this test prevents from
+//! recurring: the repository SHA-pins GitHub Actions for supply-chain
+//! hardening. For `taiki-e/install-action` the pins originally targeted the
+//! action's **per-tool tags** (`# cargo-audit`, `# cargo-deny`, ...). Those tag
+//! commits live on a lineage *diverged* from the action's default branch, so
+//! GitHub's Dependabot `github_actions` updater could not resolve them when it
+//! shallow-clones the action to look for newer versions:
+//!
+//! ```text
+//! Error processing taiki-e/install-action (HelperSubprocessFailed)
+//! error: no such commit 754bf4dbae00ad1b16b244717154b96ba27d2416
+//! ```
+//!
+//! That aborted the whole `dependabot/dependabot-updates` run, turning the
+//! default branch's Actions health red even though every functional workflow
+//! was green. The fix pins the reachable `v2` release SHA and selects the tool
+//! via the `with: tool:` input, so the pin is both SHA-hardened *and*
+//! Dependabot-updatable.
+//!
+//! This test encodes that invariant as a file-shaped, no-network assertion (an
+//! operator running the equivalent `grep` gets the same answer CI does): every
+//! `uses: taiki-e/install-action@<sha> # <comment>` in every workflow must
+//!   1. SHA-pin (40 hex chars), matching the repo's supply-chain policy, and
+//!   2. carry a **version-tag** comment (`# v2`, `# v2.82.10`), i.e. a ref
+//!      reachable from the action's default branch — never a per-tool tag name.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn workflows_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(".github")
+        .join("workflows")
+}
+
+/// Every `.yml`/`.yaml` file under `.github/workflows`.
+fn workflow_files() -> Vec<PathBuf> {
+    let dir = workflows_dir();
+    let mut out = Vec::new();
+    for entry in fs::read_dir(&dir).unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()))
+    {
+        let path = entry.expect("dir entry").path();
+        if path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e == "yml" || e == "yaml")
+        {
+            out.push(path);
+        }
+    }
+    out.sort();
+    assert!(
+        !out.is_empty(),
+        "expected at least one workflow under {}",
+        dir.display()
+    );
+    out
+}
+
+/// A single `uses: taiki-e/install-action@<sha> # <comment>` reference.
+struct Pin {
+    file: String,
+    sha: String,
+    comment: String,
+}
+
+/// Parse `taiki-e/install-action` `uses:` lines out of a workflow file.
+fn parse_install_action_pins(path: &Path) -> Vec<Pin> {
+    let file = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("<unknown>")
+        .to_string();
+    let contents =
+        fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+
+    let mut pins = Vec::new();
+    for raw in contents.lines() {
+        let line = raw.trim();
+        // Only actual `uses:` step lines, never comments/prose.
+        if line.starts_with('#') || !line.contains("uses:") {
+            continue;
+        }
+        let Some(after) = line.split("taiki-e/install-action@").nth(1) else {
+            continue;
+        };
+        // `after` == "<sha> # <comment>" (or "<sha>" with no comment).
+        let (rev, comment) = match after.split_once('#') {
+            Some((rev, comment)) => (rev.trim().to_string(), comment.trim().to_string()),
+            None => (after.trim().to_string(), String::new()),
+        };
+        pins.push(Pin {
+            file: file.clone(),
+            sha: rev,
+            comment,
+        });
+    }
+    pins
+}
+
+fn is_hex_sha(s: &str) -> bool {
+    s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// A version tag is `v` followed by a digit (`v2`, `v2.82.10`) — the shape of a
+/// ref reachable from the action's default branch. A per-tool tag comment
+/// (`cargo-audit`, `cargo-deny`, ...) is exactly what breaks Dependabot.
+fn is_version_tag_comment(comment: &str) -> bool {
+    let mut chars = comment.chars();
+    chars.next() == Some('v') && chars.next().is_some_and(|c| c.is_ascii_digit())
+}
+
+#[test]
+fn taiki_install_action_pins_are_dependabot_resolvable() {
+    let mut pins = Vec::new();
+    for f in workflow_files() {
+        pins.extend(parse_install_action_pins(&f));
+    }
+
+    assert!(
+        !pins.is_empty(),
+        "expected at least one taiki-e/install-action pin under .github/workflows \
+         (the cargo-audit/cargo-deny/cargo-vet/cargo-llvm-cov/cargo-cyclonedx jobs); \
+         found none — did a job get renamed or removed?"
+    );
+
+    for pin in &pins {
+        assert!(
+            is_hex_sha(&pin.sha),
+            "{}: taiki-e/install-action must be SHA-pinned (40 hex chars) for \
+             supply-chain hardening, got `{}`.",
+            pin.file,
+            pin.sha
+        );
+        assert!(
+            is_version_tag_comment(&pin.comment),
+            "{}: taiki-e/install-action@{} must carry a VERSION-tag comment \
+             (e.g. `# v2` / `# v2.82.10`), not `# {}`. Per-tool tags \
+             (`cargo-audit`, `cargo-deny`, ...) resolve to commits diverged from \
+             the action's default branch, which breaks Dependabot's \
+             github_actions updater (`no such commit ...`) and fails the \
+             default-branch dependabot-updates run. Pin the `v2` release SHA and \
+             pass the tool via the `with: tool:` input instead.",
+            pin.file,
+            pin.sha,
+            if pin.comment.is_empty() {
+                "<no comment>"
+            } else {
+                &pin.comment
+            }
+        );
+    }
+}

--- a/tests/gadugi/dependabot-action-pins-resolvable.sh
+++ b/tests/gadugi/dependabot-action-pins-resolvable.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# qa-team scenario — taiki-e/install-action pins stay Dependabot-resolvable.
+#
+# Outside-in verification of the CI-health fix for the failing default-branch
+# `dependabot/dependabot-updates` (github_actions) run on rysweet/Simard:
+#
+#   Error processing taiki-e/install-action (HelperSubprocessFailed)
+#   error: no such commit 754bf4dbae00ad1b16b244717154b96ba27d2416
+#
+# The action was SHA-pinned to its per-tool tags (`# cargo-audit`, ...), whose
+# commits live on a lineage diverged from the action's default branch, so
+# Dependabot's shallow clone could not resolve them and the whole update job
+# failed. The fix pins the reachable `v2` release SHA and selects each tool via
+# the `with: tool:` input — SHA-hardened AND Dependabot-updatable.
+#
+# This script asserts the operator-visible contract with file-shaped checks
+# across ALL workflow files (no network, deterministic) plus the Rust guard.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# Every workflow file (so a newly-added workflow with a bad pin is caught too).
+mapfile -t WORKFLOWS < <(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
+[ "${#WORKFLOWS[@]}" -ge 1 ] || fail "no workflow files found under .github/workflows"
+
+# 1) The previously-dead per-tool commit must be gone everywhere.
+if grep -rn "754bf4dbae00ad1b16b244717154b96ba27d2416" .github/ >/dev/null 2>&1; then
+  fail "the dead cargo-audit per-tool SHA 754bf4db... is still pinned (breaks Dependabot)"
+fi
+echo "OK: dead per-tool SHA 754bf4db... is absent"
+
+# 2) Every taiki-e/install-action `uses:` pin must be a 40-hex SHA carrying a
+#    version-tag comment (# v...), never a per-tool tag name.
+found=0
+while IFS= read -r line; do
+  # Only real `uses:` lines (skip prose/comment lines).
+  case "$(printf '%s' "$line" | sed -e 's/^[[:space:]]*//')" in
+    \#*) continue ;;
+  esac
+  printf '%s' "$line" | grep -q "uses:" || continue
+
+  found=$((found + 1))
+  after="${line#*taiki-e/install-action@}"
+  sha="$(printf '%s' "$after" | sed -e 's/[[:space:]].*$//')"
+  comment="$(printf '%s' "$after" | sed -n 's/.*#[[:space:]]*//p')"
+
+  printf '%s' "$sha" | grep -Eq '^[0-9a-f]{40}$' \
+    || fail "taiki-e/install-action is not SHA-pinned (got '$sha')"
+  printf '%s' "$comment" | grep -Eq '^v[0-9]' \
+    || fail "taiki-e/install-action@$sha has non-version comment '# ${comment:-<none>}' (per-tool tags break Dependabot; pin the v2 release SHA + 'with: tool:')"
+  echo "OK: taiki-e/install-action@${sha:0:12} # $comment"
+done < <(grep -h "taiki-e/install-action@" "${WORKFLOWS[@]}")
+
+[ "$found" -ge 5 ] || fail "expected >=5 taiki-e/install-action pins (audit/deny/vet/llvm-cov/cyclonedx), found $found"
+echo "OK: all $found taiki-e/install-action pins are SHA+version-tag pinned"
+
+# 3) The Rust regression guard encodes the same invariant — run it.
+OUTPUT="$(cargo test --test dependabot_action_pins 2>&1)"
+printf '%s\n' "$OUTPUT"
+printf '%s\n' "$OUTPUT" | grep -E "test result: ok\. [0-9]+ passed; 0 failed" >/dev/null \
+  || fail "dependabot_action_pins regression guard did not pass"
+echo "OK: dependabot_action_pins regression guard passed"
+
+echo "PASS: taiki-e/install-action pins are Dependabot-resolvable"

--- a/tests/gadugi/dependabot-action-pins-resolvable.yaml
+++ b/tests/gadugi/dependabot-action-pins-resolvable.yaml
@@ -1,0 +1,54 @@
+name: "Dependabot-resolvable taiki-e/install-action pins"
+description: "Outside-in verification that every taiki-e/install-action pin in the CI workflows is SHA-pinned to a default-branch-reachable version-tag release (# v2...) with the tool selected via the `with: tool:` input, so GitHub's Dependabot github_actions updater can resolve it. Guards against reintroducing the per-tool-tag pins whose diverged commits made the default-branch dependabot-updates run fail with 'no such commit'."
+version: "1.0.0"
+
+config:
+  timeout: 600000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 600000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "install-action pins are SHA + version-tag (Dependabot-resolvable)"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/dependabot-action-pins-resolvable.sh"
+    timeout: 600000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "ci-health"
+    - "dependabot"
+    - "supply-chain"
+    - "guardrail"
+    - "github-actions"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Merge-readiness verdict: ✅ READY TO MERGE

**Verdict determination: READY TO MERGE.** Rationale: all six merge-ready
criteria are satisfied with concrete evidence below — (1) qa-team scenario
written, validated, and run green; (2) user-facing supply-chain docs updated
(the workflow YAML pins themselves are internal CI infrastructure, not a
user-facing surface — internal-only justification noted under criterion 2);
(3) quality-audit ran ≥3 SEEK→VALIDATE→FIX cycles ending on a clean cycle (0
critical/high; 0 medium correctness/security); (4) CI is 100% green on the head
commit with 0 failures (remote run links below); (5) this description carries
the evidence for criteria 1–4 and 6; (6) the diff is focused — 10 files, all
serving the single objective, no unrelated edits. The change is a bounded,
single-concern Actions-pin fix. This is not a draft and is not blocked.

## Summary

A bounded, fleet-wide default-branch CI-health scan (2026-07-07) across all 13
active governed repos found the fleet green **except** a concrete, current
failure in **Simard itself**: the default-branch `dependabot/dependabot-updates`
(`github_actions` ecosystem) run failed —

```
Error processing taiki-e/install-action (Dependabot::SharedHelpers::HelperSubprocessFailed)
error: no such commit 754bf4dbae00ad1b16b244717154b96ba27d2416
```

Run: https://github.com/rysweet/Simard/actions/runs/28841063564 (conclusion `failure`, 2026-07-07T04:14:56Z, `head_branch: main`).

This is **not** the stale historical `amplihack-agent-eval` run — it is a fresh
failure on Simard's own default branch, so there is real work to do.

### Root cause

Every `taiki-e/install-action` use was SHA-pinned to the action's **per-tool
tags** (`# cargo-audit`, `# cargo-deny`, `# cargo-vet`, `# cargo-cyclonedx`,
`# cargo-llvm-cov`). Those tag commits live on a lineage **diverged** from the
action's default branch. Dependabot's `github_actions` updater shallow-clones
the action to look for newer versions and cannot resolve a diverged commit
(`find_container_branch` → `no such commit`), which aborts the entire update
job — turning default-branch Actions health red even though every functional
workflow was green.

Verified with the compare API against `taiki-e/install-action`:

| Pinned ref | `compare(main...sha)` |
|---|---|
| `754bf4d…` cargo-audit | `diverged` |
| `4e4e4d1…` cargo-deny | `diverged` |
| `7b51dc7…` cargo-vet | `diverged` |
| `8cb326b…` cargo-cyclonedx | `diverged` |
| `81ee969…` cargo-llvm-cov | `diverged` |
| `50414676…` **v2 / v2.82.10** | **`identical`** (reachable) |

### Fix

Repin **all seven** uses across the four workflows to the reachable `v2`
release SHA `50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10` (identical to
the action's `main` tip and its latest release), and select each tool via the
`with: tool:` input — the documented `taiki-e` pattern. This keeps the
supply-chain SHA-pin **and** makes the pin Dependabot-resolvable/updatable.
Tool installs are behavior-preserving (per-tool tags already installed "latest
<tool>"; `tool: <name>` does the same).

- `verify.yml`: cargo-audit (add `tool:`), cargo-deny, cargo-vet
- `coverage.yml`: cargo-llvm-cov (add `tool:`)
- `release.yml`: cargo-cyclonedx
- `advisory-scan.yml`: cargo-audit (add `tool:`), cargo-deny — **also carried
  the dead SHAs**; fixing it here is required so the next Dependabot run is
  fully green.

## Merge-ready evidence

**1. qa-team scenario** — `tests/gadugi/dependabot-action-pins-resolvable.{sh,yaml}`
(outside-in, scans **all** workflow files; no network):
- `gadugi-test validate --file … --strict` → `✓ Scenario … is valid` (1 valid, 0 invalid)
- `gadugi-test run --scenario dependabot-action-pins-resolvable` → `✓ Passed: 1 / ✗ Failed: 0`
- Verifies: dead SHA absent, all 7 pins are 40-hex SHA + version-tag comment, and the Rust guard passes.

**2. Docs** — user-facing supply-chain reference docs that embed these exact
workflow snippets were updated to the new pattern (prevents copy-paste
reintroduction of the fragile per-tool tags):
`docs/reference/supply-chain-audit.md`, `dependency-trust-policy.md`,
`supply-chain-advisory-stewardship.md`. `mkdocs build --strict` → exit 0.
(Workflow YAML pins themselves are internal CI infra, not a user-facing surface.)

**3. quality-audit** — 3 SEEK→VALIDATE→FIX passes; ended clean (0 critical/high;
0 medium correctness/security). Key checks: SHA-pin preserved (supply-chain
policy), pinned SHA verified == official `v2.82.10` release == `v2` == `main`
tip, YAML nesting of added `with:` blocks validated, no unrelated edits.

**4. CI 100% green (remote CI + local gates all pass):**

Remote CI on the PR head commit `52f8aed88d8f85144995b9e6ae281fa2488bcebc` is
100% green — every required check passed, 0 failures (`gh pr checks 2864` → all
`pass`; `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`). Green workflow runs
for the head commit:
- `verify` → success: https://github.com/rysweet/Simard/actions/runs/28859681100
- `verify` → success: https://github.com/rysweet/Simard/actions/runs/28859635903
- `docs` → success: https://github.com/rysweet/Simard/actions/runs/28859681075
- `build` job (green): https://github.com/rysweet/Simard/actions/runs/28859681075/job/85594864315
- `pre-commit` job (green): https://github.com/rysweet/Simard/actions/runs/28859681100/job/85594864664

Local gates (all pass):
- `actionlint .github/workflows/*.yml` → exit 0
- `cargo fmt --all -- --check` → Passed (pre-commit + pre-push)
- `cargo clippy --release --no-deps -- -D warnings` (pre-commit) → Passed
- `cargo clippy --all-targets --all-features --locked -- -D warnings` (pre-push) → Passed
- `cargo test --test dependabot_action_pins` → ok (1 passed)
- `cargo test --test supply_chain_hardening` → ok (15 passed)
- `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)` (pre-push) → Passed
- `mkdocs build --strict` → exit 0
- No dead per-tool SHA remains anywhere under `.github/` or `docs/`.
- Post-merge, the next `dependabot-updates` run resolves the reachable `v2` SHA.

**5. Evidence** — this description (criteria 1–4 and 6).

**6. Focused diff** — 10 files, all serving the single objective (repin +
regression guard + qa scenario + doc sync). No unrelated edits.

## Regression guard

`tests/dependabot_action_pins.rs` fails CI if any workflow reintroduces a
`taiki-e/install-action` pin that is not a 40-hex SHA carrying a version-tag
comment (`# v…`) — i.e. blocks the per-tool-tag pattern that caused this outage.

