### PR TITLE
fix(dashboard): restore memory visualization as a dedicated Memory tab

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,6 +1,6 @@
 ---
 title: Dashboard
-description: Read-only inspection plus lightweight operator controls for the autonomous OODA daemon across ten tabs — Overview, Goals, Activity, Workers, Pull Requests, Resources, Chat, Overseer, Journal, and Creative Ideas (with Run now / Promote / Prune) — mirrored by a consistent terminal UI (TUI).
+description: Read-only inspection plus lightweight operator controls for the autonomous OODA daemon across eleven tabs — Overview, Goals, Activity, Workers, Pull Requests, Memory, Resources, Chat, Overseer, Journal, and Creative Ideas (with Run now / Promote / Prune) — mirrored by a consistent terminal UI (TUI). The Memory tab is a dedicated top-level tab hosting the live cognitive-memory graph visualization.
 last_updated: 2026-07-07
 owner: simard
 doc_type: howto
@@ -20,11 +20,15 @@ A login code is generated on first start and printed to stdout. It is also persi
 
 ## Tabs
 
-The dashboard is a single-page app with **nine** top-level tabs. Views that answer
+The dashboard is a single-page app with **eleven** top-level tabs. Views that answer
 the same operator question are grouped into **sub-sections** (panels) inside one
 tab, so every datum the dashboard has ever shown is still one or two clicks away —
-consolidation regroups data, it never removes it. Tabs render in the nav in this
-order:
+consolidation regroups data, it never removes it. The one exception to strict
+consolidation is **Memory**, whose interactive cognitive-memory graph was
+promoted back out of the Resources tab into its own dedicated top-level tab
+([#2627](https://github.com/rysweet/Simard/issues/2627)) — see
+[Memory tab (dedicated cognitive-memory graph)](reference/dashboard-memory-tab.md).
+Tabs render in the nav in this order:
 
 | Tab | Sub-sections | Shows |
 |-----|--------------|-------|
@@ -33,19 +37,22 @@ order:
 | **Activity** | Logs · Traces · Thinking · Failures | The **Background Service Log** (live activity from Simard's always-on background process), the cost ledger, and the **Cycle Reports** card — recent OODA cycles with their live cycle number, real per-cycle tree status, and Observe/Orient/Decide/Act detail, collapsed with a `×N` repeat-count and refreshed live, see [Activity: Cycle Reports](#activity-tab-logs-cycle-reports-26) — with a severity menu (All / Errors / Warnings / Info) and free-text search (**Logs**); recent agent traces from the cost ledger, journald, and in-process spans, plus OTEL status, each row read as plain language — **when**, **what**, **who** (**Traces**); the **Thinking** panel's two halves — a **Cycle History** table (collapsed per-cycle timeline with real timestamps, a `×N` repeat-count for runs of equivalent cycles, difference-carrying summaries, and a self-hiding duration-trend chart) and the **Agent Internal Reasoning** OODA Observe/Orient/Decide/Act breakdown, see [Thinking: Cycle History](#thinking-tab-cycle-history-21) (**Thinking**); and brain-fallback and decision failures (**Failures**). |
 | **Workers** | Processes · Engineers · Terminal | The live process tree under the daemon — engineer subprocesses, LLM sessions, tmux sessions, and their resource usage (**Processes** / **Engineers**) — and a browser-attached PTY into the daemon host, with an [agent picker](operator-dashboard/agent-terminal-agent-picker.md) drop-down for choosing which live agent to attach to (**Terminal**). |
 | **Pull Requests** | Merge Decisions · Readiness | Automated merge decisions and the rationale behind each (**Merge Decisions**), and per-PR readiness checks covering CI, review, and mergeability (**Readiness**). |
-| **Resources** | Memory · Costs | The cognitive memory graph (Working / Semantic / Episodic / Procedural / Prospective / Sensory) with per-type filters, full-text search, the live **Memory Store** counts, and the **Memory Files** panel (**Memory**); and per-provider, per-model token spend across the active session (**Costs**). See [Memory architecture](memory.md). |
+| **Memory** | — | The dedicated cognitive-memory visualization — an interactive, force-directed graph of what Simard remembers (Working / Semantic / Episodic / Procedural / Prospective / Sensory) as nodes linked to their memory-type hubs, with per-type filters, live per-type counts, pan/zoom, node drag-pin, and hover/detail inspection. Rendered **live** from the cognitive store via `GET /api/memory/graph`. See [Memory tab (dedicated cognitive-memory graph)](reference/dashboard-memory-tab.md) and [Memory architecture](memory.md). |
+| **Resources** | Memory · Costs | What Simard has remembered alongside what it costs to run — the live **Memory Store** counts, the "What Simard Remembers" recent-memory list, the **Memory Growth** trend, and the **Memory Files** panel (**Memory**); and per-provider, per-model token spend across the active session (**Costs**). The full interactive memory graph now lives on its own [**Memory** tab](reference/dashboard-memory-tab.md). |
 | **Chat** | — | Direct chat with Simard. Conversations are saved as durable, resumable **sessions**: a sidebar lists every saved chat, the panel fills the page, and assistant replies stream in incrementally. See [Chat: durable, resumable sessions](#chat-tab-durable-resumable-sessions). |
 | **Overseer** | — | The overseer goal-board health view: per-goal health, staleness, and the intervention signals that decide when a stalled goal needs attention. |
 | **Journal** | — | The daemon's narrative journal — a human-readable, chronological record of what Simard decided and why, newest entries first. |
 | **Creative Ideas** | — | The pool of candidate self-improvement ideas Simard generates for herself, each reviewed for feasibility, worth, and measurability. Browse and search by review status (new · needs-revision · needs-human-review · accepted · in-progress · completed · deferred · rejected), generate a fresh batch on demand with **Run now**, and **Promote** (accept → goal) or **Prune** (reject) any idea inline — see [Creative Ideas tab — live view and operator controls](operator-dashboard/creative-ideas-operator-controls.md). |
 
-**Overseer**, **Journal**, and **Creative Ideas** are standalone tabs with no
-sub-sections; they are owned by separate features and are kept intact by the
-consolidation.
+**Memory**, **Overseer**, **Journal**, and **Creative Ideas** are standalone
+tabs with no sub-sections; Overseer, Journal, and Creative Ideas are owned by
+separate features and are kept intact by the consolidation, while **Memory** is
+a dedicated tab restored from the Resources sub-section
+([#2627](https://github.com/rysweet/Simard/issues/2627)).
 
 Every former standalone tab now lives as a sub-section and keeps its old deep
 link — see [Deep links and tab aliases](#deep-links-and-tab-aliases). The same
-nine-tab taxonomy is mirrored in the terminal UI — see
+tab taxonomy is mirrored in the terminal UI — see
 [Terminal UI (TUI)](#terminal-ui-tui).
 
 ### Activity tab → Logs: filtering by severity (#1687)
@@ -495,11 +502,11 @@ The terminal UI (`simard tui`) presents the **same tab taxonomy** as the web
 dashboard so an operator moving between the two never has to relearn the layout.
 Tab names, relative order, and grouping match the dashboard exactly.
 
-The TUI renders an **eight-tab subset** of the ten dashboard tabs. It omits
-**Pull Requests** and **Resources**, whose data pipelines exist only in the web
-surface; adding them to the TUI would be new feature work, not consolidation, and
-is deliberately out of scope. The TUI never invents a tab the dashboard does not
-have, and never shows a name the dashboard does not use.
+The TUI renders an **eight-tab subset** of the eleven dashboard tabs. It omits
+**Pull Requests**, **Memory**, and **Resources**, whose data pipelines exist
+only in the web surface; adding them to the TUI would be new feature work, not
+consolidation, and is deliberately out of scope. The TUI never invents a tab the
+dashboard does not have, and never shows a name the dashboard does not use.
 
 | # | TUI tab | Key | Matches dashboard tab | Sub-views |
 |---|---------|-----|-----------------------|-----------|
@@ -534,7 +541,7 @@ The five invariants:
 
 ### Canonical tab taxonomy
 
-There are exactly **nine** dashboard tabs and **seven** TUI tabs, drawn from a single shared taxonomy. Tab names, relative order, and grouping are identical across both surfaces; the TUI omits only the two tabs (Pull Requests, Resources) whose data lives solely in the web dashboard. This table is the durable definition of the tab set — new work extends a tab's sub-sections rather than adding a top-level tab, unless a genuinely new operator question demands one.
+There are exactly **eleven** dashboard tabs and **eight** TUI tabs, drawn from a single shared taxonomy. Tab names, relative order, and grouping are identical across both surfaces; the TUI omits only the three tabs (Pull Requests, Memory, Resources) whose data lives solely in the web dashboard. This table is the durable definition of the tab set — new work extends a tab's sub-sections rather than adding a top-level tab, unless a genuinely new operator question demands one.
 
 | # | Tab | Dashboard slug | Sub-sections | In TUI? |
 |---|-----|----------------|--------------|---------|
@@ -543,12 +550,14 @@ There are exactly **nine** dashboard tabs and **seven** TUI tabs, drawn from a s
 | 3 | **Activity** | `activity` | Logs · Traces · Thinking · Failures | yes (`3`) |
 | 4 | **Workers** | `workers` | Processes · Engineers · Terminal | yes (`4`) |
 | 5 | **Pull Requests** | `pull-requests` | Merge Decisions · Readiness | no (web-only) |
-| 6 | **Resources** | `resources` | Memory · Costs | no (web-only) |
-| 7 | **Chat** | `chat` | — | yes (`5`) |
-| 8 | **Overseer** | `overseer` | — | yes (`6`) |
-| 9 | **Journal** | `journal` | — | yes (`7`) |
+| 6 | **Memory** | `memory` | — | no (web-only) |
+| 7 | **Resources** | `resources` | Memory · Costs | no (web-only) |
+| 8 | **Chat** | `chat` | — | yes (`5`) |
+| 9 | **Overseer** | `overseer` | — | yes (`6`) |
+| 10 | **Journal** | `journal` | — | yes (`7`) |
+| 11 | **Creative Ideas** | `creative-ideas` | — | yes (`8`) |
 
-Tab names never use the word "Bridge". **Overseer** and **Journal** are owned by separate features and are carried through the consolidation unchanged.
+Tab names never use the word "Bridge". **Memory**, **Overseer**, **Journal**, and **Creative Ideas** are standalone tabs; Overseer and Journal are owned by separate features and are carried through the consolidation unchanged, and **Memory** is the dedicated cognitive-memory graph tab restored in [#2627](https://github.com/rysweet/Simard/issues/2627).
 
 The global header (`🌲 Simard Dashboard`) is intentionally demoted from `<h1>` to `<div class="brand">` so that every page has exactly one semantic `<h1>` — the page-specific one — when active.
 
@@ -593,7 +602,7 @@ On the client, the existing tab-click handler in `part_01.rs` sets `document.tit
 
 Adding a tab is a single-file edit followed by writing the panel content:
 
-1. Append a new `TabMeta { … }` entry to `TAB_METADATA` in `tab_meta.rs`. Pick a `slug` matching `^[a-z][a-z0-9-]*$`, a short `label` (one or two words, e.g. `Pull Requests`), a `title` of the form `"{H1} · Simard"`, an `h1` (usually equal to `label`), a `lede` that passes the jargon blocklist, and a `tooltip`. **Prefer adding a sub-section to an existing tab** — the nine-tab taxonomy is deliberately small; only add a top-level tab when a genuinely new operator question needs one.
+1. Append a new `TabMeta { … }` entry to `TAB_METADATA` in `tab_meta.rs`. Pick a `slug` matching `^[a-z][a-z0-9-]*$`, a short `label` (one or two words, e.g. `Pull Requests`), a `title` of the form `"{H1} · Simard"`, an `h1` (usually equal to `label`), a `lede` that passes the jargon blocklist, and a `tooltip`. **Prefer adding a sub-section to an existing tab** — the tab taxonomy is deliberately small; only add a top-level tab when a genuinely new operator question needs one (as the restored **Memory** tab does).
 2. Add the panel to the appropriate `part_NN.rs`: a `<div class="tab-content" id="tab-{slug}">` whose first two children are `<h1 class="page-h1">{h1}</h1>` and `<p class="page-lede">{lede}</p>` with text matching the SoT entry exactly. Sub-sections within the panel use `<h2>`/`<h3>`, never a second `page-h1`.
 3. If the tab is shared with the TUI, add a matching arm to `enum Tab` / `ALL_TABS` in `src/bin/simard_tui/app.rs` using the same label and relative order, so the two surfaces stay consistent.
 4. Run `cargo test` — the unit tests in `tests_tab_meta.rs` verify uniqueness of `slug`, `label`, `title`, `h1`, non-emptiness of `lede`, absence of banned jargon, and that the rendered HTML contains every label / H1 / lede / tooltip from the SoT. The smoke test picks the new tab up automatically (it discovers tabs from the rendered DOM, not from a hardcoded list).
@@ -602,7 +611,7 @@ No other file needs to change for the strings. There is no second place to updat
 
 ### Deep links and tab aliases
 
-Each tab is deep-linkable by its slug (`#overview`, `#goals`, `#activity`, `#workers`, `#pull-requests`, `#resources`, `#chat`, `#overseer`, `#journal`). Because several former standalone tabs are now **sub-sections**, the client keeps a small **alias allowlist** that maps every retired slug to its new parent tab (and, where useful, scrolls to the sub-section). Old bookmarks, browser history, and links in bug reports keep working:
+Each tab is deep-linkable by its slug (`#overview`, `#goals`, `#activity`, `#workers`, `#pull-requests`, `#memory`, `#resources`, `#chat`, `#overseer`, `#journal`, `#creative-ideas`). Because several former standalone tabs are now **sub-sections**, the client keeps a small **alias allowlist** that maps every retired slug to its new parent tab (and, where useful, scrolls to the sub-section). Old bookmarks, browser history, and links in bug reports keep working:
 
 | Legacy deep link | Resolves to |
 |------------------|-------------|
@@ -616,12 +625,13 @@ Each tab is deep-linkable by its slug (`#overview`, `#goals`, `#activity`, `#wor
 | `#terminal` | `#workers` → Terminal |
 | `#merge-decisions` | `#pull-requests` → Merge Decisions |
 | `#pr-readiness` | `#pull-requests` → Readiness |
-| `#memory` | `#resources` → Memory |
 | `#costs` | `#resources` → Costs |
 
 The resolver treats `location.hash` as untrusted input: it strips the leading `#`, matches the value against the allowlist (and the canonical slug set, validated against `^[a-z-]+$`), and **falls back to the default `overview` tab on any unknown or malformed hash**. It never concatenates the hash into a DOM selector or element id. API endpoints are decoupled from slugs and unchanged — for example `/api/workboard` still backs the **Work Board** sub-section even though `#workboard` now lands on the **Goals** tab. (The label lineage is `Whiteboard → Workboard → Work Board`; only the user-facing string ever changed, never the route or storage path.)
 
-The table above covers only the twelve slugs that were real top-level tabs before consolidation (the 17-tab set minus the five that stay top-level: `overview`, `goals`, `chat`, `overseer`, `journal`). Sub-sections that consolidation *introduces* and that were never standalone tabs — **Stats** (under Overview) and **Engineers** (the process-tree view under Workers) — have no legacy slug and therefore no alias entry; they are reached through their parent tab. Do not add `#stats` / `#engineers` aliases: there are no old bookmarks to preserve.
+`#memory` is **not** in the alias table: the cognitive-memory graph was promoted back to its own dedicated **Memory** tab ([#2627](https://github.com/rysweet/Simard/issues/2627)), so `#memory` is now a **canonical slug** that resolves directly to the Memory tab — see [Memory tab (dedicated cognitive-memory graph)](reference/dashboard-memory-tab.md). `#costs` continues to alias to the **Resources** tab.
+
+The table above covers the retired slugs that were real top-level tabs before consolidation and did **not** later get re-promoted. Sub-sections that consolidation *introduces* and that were never standalone tabs — **Stats** (under Overview) and **Engineers** (the process-tree view under Workers) — have no legacy slug and therefore no alias entry; they are reached through their parent tab. Do not add `#stats` / `#engineers` aliases: there are no old bookmarks to preserve.
 
 ## Tests
 
@@ -633,7 +643,7 @@ Three complementary test layers enforce the Tab Identity Contract and the consol
 
 **Source-of-truth table invariants (iterating `TAB_METADATA`):**
 
-- `tab_meta_slugs_unique` — slugs are unique **and** `assert_eq!(TAB_METADATA.len(), 17, "expected 17 tabs")`. **This literal is the tab-count guard: consolidation changes this single `17` to `9`.** It is the only hard-coded tab count in the suite — every other test derives its expectation from `TAB_METADATA.len()`, so no separate "nine canonical tabs" test exists or is needed.
+- `tab_meta_slugs_unique` — slugs are unique **and** `assert_eq!(TAB_METADATA.len(), 11, "expected 11 tabs")`. **This literal is the tab-count guard:** consolidation moved it from `17` to `9`, and restoring the dedicated **Memory** tab ([#2627](https://github.com/rysweet/Simard/issues/2627)) alongside **Creative Ideas** brings it to `11`. It is the only hard-coded tab count in the suite — every other test derives its expectation from `TAB_METADATA.len()`, so no separate "canonical tabs" test exists or is needed.
 - `tab_meta_labels_unique`
 - `tab_meta_titles_unique_and_non_empty`
 - `tab_meta_titles_follow_label_dot_simard_format` — every `title` equals `"{label} · Simard"`.
@@ -688,7 +698,7 @@ cargo test -p simard --bin simard_tui
 2. Discovers every nav button by querying `data-tab` attributes — no hardcoded tab list.
 3. Clicks each button in turn and uses Playwright's `expect(locator).to_be_visible()` on `.tab-panel[data-tab="{slug}"]`. This avoids hard-coding a `.active` class name and lets the contract survive future tab-handler refactors.
 4. Captures `document.title`, the visible `.page-h1` text, and the visible `.page-lede` text.
-5. Asserts: at least the nine canonical tabs are present; all titles unique and non-empty; all H1s unique and non-empty; every lede non-empty and free of banned jargon.
+5. Asserts: at least the eleven canonical tabs are present (Overview, Goals, Activity, Workers, Pull Requests, Memory, Resources, Chat, Overseer, Journal, Creative Ideas); all titles unique and non-empty; all H1s unique and non-empty; every lede non-empty and free of banned jargon.
 6. Prints a markdown table `slug | title | h1 | lede` to stdout. CI uploads this as build evidence and the PR template links it into the description.
 
 `test_tab_clarity.py` additionally asserts the canonical slug set is present and that each retired-slug deep link (`#status`, `#workboard`, `#logs`, `#traces`, `#thinking`, `#brain-failures`, `#processes`, `#terminal`, `#merge-decisions`, `#pr-readiness`, `#memory`, `#costs`) resolves to its parent tab rather than 404-ing, and that an unknown `#hash` falls back to `overview` with no DOM injection.
@@ -736,6 +746,7 @@ The `SIMARD_DASHBOARD_URL` environment variable is honored by `conftest.py` (def
 - [Thinking tab — Cycle History (timestamps, collapse, duration trend)](reference/dashboard-thinking-cycle-history.md)
 - [Activity tab — Cycle Reports (live cycle number, accurate tree status, shared detail)](reference/dashboard-activity-cycle-reports.md)
 - [Overview Health & live memory-consolidation (Open PRs card removal, live Last Memory Compaction)](reference/dashboard-overview-health-and-live-memory.md)
+- [Memory tab — dedicated cognitive-memory graph (live nodes/edges, per-type filters)](reference/dashboard-memory-tab.md)
 - [Background tab prefetch and refresh (instant tab switches)](reference/dashboard-background-tab-prefetch.md)
 - [Header deployment datetime (build number + PST/PDT deploy time)](reference/dashboard-header-deployment-datetime.md)
 - [Creative Ideas tab — live view and operator controls (Run now / Promote / Prune)](operator-dashboard/creative-ideas-operator-controls.md)

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -274,9 +274,11 @@ The library owns its own durability (WAL + CHECKPOINT). The old native store at 
 
 Inspect with `simard memory stats` / `simard memory dump` (see
 [Memory introspection CLI](reference/simard-memory-cli.md)), or with the
-dashboard's **Memory** tab ([Dashboard](dashboard.md)) — the graph view
-supports per-type filters and full-text search across the persistent
-layers.
+dashboard's dedicated **Memory** tab
+([Memory tab — cognitive-memory graph](reference/dashboard-memory-tab.md)) —
+an interactive, force-directed graph of the persistent layers, rendered **live**
+from the cognitive store, with per-type filters, live counts, and node
+inspection.
 
 ![Memory tab](assets/dashboard-memory.png)
 
@@ -312,4 +314,5 @@ For multi-host coordination see [Distributed operations](distributed-operations.
 - [Phase-weighted ranked fact recall & snapshot retention](reference/cognitive-memory-ranked-recall.md) — multi-signal ranked recall with per-OODA-phase weights, plus CallerKey dedup/SUPERSEDES and pruning for snapshot/goal records (#2329)
 - [Ranked episodic recall & memory reinforcement](reference/cognitive-memory-ranked-episodic-recall.md) — extends ranked recall to episodes (with a UNION backfill that keeps compressed consolidation sources recallable) and adds a usage/recency reinforcement seam plus `CognitiveFact` observability, recording accesses at the point recalled memories are surfaced into a cycle (per-action attribution is a future refinement) (#2395)
 - [Dashboard](dashboard.md) — Memory tab
+- [Dashboard Memory tab — dedicated cognitive-memory graph](reference/dashboard-memory-tab.md) — the live `GET /api/memory/graph` visualization (nodes/edges, per-type filters, node inspection)
 - [Daemon mode](daemon-mode.md) — when consolidation runs

--- a/docs/reference/dashboard-memory-tab.md
+++ b/docs/reference/dashboard-memory-tab.md
@@ -1,0 +1,370 @@
+---
+title: Dashboard — dedicated Memory tab (cognitive-memory graph)
+description: Reference for the dedicated dashboard **Memory** tab, which restores the full interactive cognitive-memory graph visualization (facts, events, procedures, plans, working memory, and sensory buffer as nodes, with item→type edges, per-type filters, live counts, pan/zoom, and node details) as its own top-level tab wired to LIVE memory data through GET /api/memory/graph. The graph reader is a single shared live reader (open_reader_client → &dyn CognitiveMemoryOps); the endpoint returns real {nodes, edges, available:true, stats} built by build_live_memory_graph, bounded by GRAPH_MAX_PER_TYPE and GRAPH_NODE_CONTENT_MAX. Episode and prospective enumeration is forwarded across every reader tier — including the IPC/daemon-socket backend — via additive ListAllEpisodes/ListAllProspective memory-IPC request variants, so per-item nodes never silently collapse to hub-only in the normal daemon topology.
+last_updated: 2026-07-07
+owner: simard
+doc_type: reference
+related:
+  - ../dashboard.md
+  - ../memory.md
+  - ./dashboard-background-tab-prefetch.md
+  - ./dashboard-overview-health-and-live-memory.md
+  - ./cognitive-memory-client-helpers.md
+---
+
+# Dashboard — dedicated Memory tab
+
+The **Memory** tab is a first-class, top-level dashboard tab that renders the
+full interactive visualization of Simard's cognitive memory. It restores the
+memory-graph component that the earlier tab consolidation had folded away into
+an *"advanced memory view"* `<details>` toggle inside the **Resources** tab
+([#2627](https://github.com/rysweet/Simard/issues/2627)). The visualization is
+back as its own dedicated tab — one click from the nav bar, deep-linkable at
+`#memory`, and wired to **live** memory data rather than a stale snapshot.
+
+> **What changed.** The graph itself is unchanged in look and feel — it is the
+> same force-directed canvas the dashboard has always shipped. Three things are
+> new: (1) it lives on its **own tab** instead of behind a collapsed toggle
+> under Resources; (2) its backend, `GET /api/memory/graph`, now returns
+> **real nodes and edges** read live from the cognitive store instead of the
+> stats-only response the de-fork left behind (empty `nodes`/`edges`,
+> `available:false`, plus live counts and a `note` —
+> [#2307](https://github.com/rysweet/Simard/issues/2307)); and (3) episode and
+> prospective enumeration is now forwarded across **every** reader tier —
+> including the IPC/daemon-socket backend that previously could not carry it, so
+> those types no longer silently collapse to hub-only in production (see
+> [Reader tiers and cross-backend enumeration](#reader-tiers-and-cross-backend-enumeration)).
+
+## What the Memory tab shows
+
+The tab renders an interactive, force-directed graph of Simard's six cognitive
+memory types. Every memory type is always present as a labelled **hub** node,
+and the enumerable types fan out into per-item nodes connected to their hub by
+an edge:
+
+| Memory type (`node.type`) | Operator label (filter) | Colour | Live per-item nodes | Source read |
+|---------------------------|-------------------------|--------|---------------------|-------------|
+| `WorkingMemory`    | Currently thinking about | `#f0883e` (orange) | hub only¹ | `get_statistics()` count |
+| `SemanticFact`     | Facts learned            | `#58a6ff` (blue)   | yes | `search_facts("", …)` |
+| `EpisodicMemory`   | Events remembered        | `#3fb950` (green)  | yes | `list_all_episodes(…)` |
+| `ProceduralMemory` | Known procedures         | `#a371f7` (purple) | yes | `recall_procedure("", …)` |
+| `ProspectiveMemory`| Planned actions          | `#d29922` (gold)   | yes | `list_all_prospective(…)` |
+| `SensoryBuffer`    | Recent observations      | `#8b949e` (grey)   | hub only¹ | `get_statistics()` count |
+
+¹ Working memory and the sensory buffer are transient, task-scoped, and not
+exposed by an enumeration method on the read path, so they appear as a single
+labelled hub whose live magnitude is reflected in the stats line (below) rather
+than as individual item nodes. All four long-term types (facts, episodes,
+procedures, prospective triggers) are enumerated live on **every** reader
+backend — in-process, direct-library, and the IPC/daemon socket — so per-item
+nodes never silently collapse to hub-only in the normal daemon topology (see
+[Reader tiers and cross-backend enumeration](#reader-tiers-and-cross-backend-enumeration)).
+
+The panel provides:
+
+- **Six per-type filter checkboxes** (`.mem-filter`, one per memory type, all
+  checked by default). Un-checking a type hides its hub and all its item nodes
+  and edges live, without re-fetching.
+- **A live stats line** (`#mem-graph-stats`) summarising the store:
+  `Thinking:<working> Facts:<semantic> Events:<episodic> Procedures:<procedural> Planned:<prospective> Observed:<sensory>`,
+  sourced from the endpoint's `stats` object.
+- **Pan and zoom** (drag the background to pan, wheel to zoom) plus **node
+  drag/pin** — click-drag a node to pin it in place.
+- **Hover tooltips** and a **node-details panel** — hovering a node shows its
+  type (colour-coded) and a content preview; the details side-panel shows the
+  full node content.
+- **A "Refresh Graph" button** that re-fetches `/api/memory/graph` on demand,
+  in addition to the automatic background refresh.
+
+## Opening the tab
+
+1. Start the dashboard: `simard dashboard serve --port=8080`.
+2. Click **Memory** in the nav bar, or deep-link straight to it:
+
+   ```
+   http://localhost:8080/#memory
+   ```
+
+The tab is prefetched in the background like every other tab, so switching to
+it is instant and the graph is already populated — see
+[Background tab prefetch and refresh](./dashboard-background-tab-prefetch.md).
+
+## Live data source: `GET /api/memory/graph`
+
+The tab is driven entirely by one endpoint. It reads the **live** cognitive
+store through a single shared reader and returns the graph plus aggregate
+statistics.
+
+### Response shape
+
+```jsonc
+{
+  "available": true,
+  "nodes": [
+    { "id": "hub:SemanticFact",  "type": "SemanticFact",  "label": "Facts learned",      "content": "42 facts" },
+    { "id": "fact:academic-3",   "type": "SemanticFact",  "label": "rust ownership",     "content": "Rust moves ownership on assignment unless the type is Copy." },
+    { "id": "hub:EpisodicMemory","type": "EpisodicMemory","label": "Events remembered",  "content": "17 events" },
+    { "id": "episode:8f2c…",     "type": "EpisodicMemory","label": "merged PR #2610",     "content": "Merged PR #2610 after CI went green." }
+    // …
+  ],
+  "edges": [
+    { "source": "fact:academic-3", "target": "hub:SemanticFact" },
+    { "source": "episode:8f2c…",   "target": "hub:EpisodicMemory" }
+    // …
+  ],
+  "stats": {
+    "working": 3, "semantic": 42, "episodic": 17,
+    "procedural": 9, "prospective": 4, "sensory": 1
+  }
+}
+```
+
+### Field contract
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `available` | `bool` | `true` whenever the reader was reachable — **including when the store is empty** (an empty store returns the six hubs, no item nodes, `available:true`) and **including partial degradation** (reader reachable but one type could not enumerate — that type falls back to hub-only and `available` stays `true`; see [Partial degradation](#partial-degradation-reachable-but-a-type-cant-enumerate)). |
+| `nodes[]` | array | One object per node. Fields consumed by the renderer: `id` (unique), `type` (one of the six type literals above), `label` (short display text), `content` (detail/tooltip text, UTF-8-safe truncated). |
+| `edges[]` | array | `{ source, target }` node-id pairs. Every item node has exactly one edge to its type hub; there are **no dangling edges** (every endpoint id exists in `nodes`). |
+| `stats` | object | Live per-type counts mirroring `CognitiveMemoryOps::get_statistics()`: `working, semantic, episodic, procedural, prospective, sensory`. |
+| `note` | `string` (optional) | Present only on the degraded path when the reader could not be opened. It is **path-free** (no filesystem paths) and human-readable; `available` is `false` and `nodes`/`edges` are empty. |
+
+### Example
+
+```bash
+curl -s --cookie "session=<code>" http://localhost:8080/api/memory/graph | jq '{available, nodes: (.nodes|length), edges: (.edges|length), stats}'
+```
+
+```json
+{
+  "available": true,
+  "nodes": 78,
+  "edges": 72,
+  "stats": { "working": 3, "semantic": 42, "episodic": 17, "procedural": 9, "prospective": 4, "sensory": 1 }
+}
+```
+
+## Backend architecture
+
+### Single shared live reader
+
+The handler obtains a reader through the shared accessor
+`open_reader_client(state_root) -> SimardResult<ReaderClient>` and reads the
+store via `ReaderClient::ops() -> &dyn CognitiveMemoryOps`. This is the same
+live read path the rest of the dashboard uses (e.g. `memory_recent`,
+`memory_history`), so the graph never diverges from the counts shown elsewhere.
+There is **one** reader per request; the builder does not open a second handle.
+
+> **No "Bridge" identifiers.** The accessor is `open_reader_client` and it
+> returns `ReaderClient`; the read path introduces no new `*Bridge` symbol.
+
+### Reader tiers and cross-backend enumeration
+
+`open_reader_client` resolves to whichever cognitive-memory backend owns the
+store for the current topology, all behind the one `&dyn CognitiveMemoryOps`
+trait object:
+
+| Tier | Backend | When it is used |
+|------|---------|-----------------|
+| In-process | `SharedMemory` (registered writer) | The dashboard process also owns the store (tests, single-process runs). |
+| IPC socket | `RemoteCognitiveMemory` | **The normal production topology** — the daemon owns memory and `simard dashboard serve` runs as a separate process that talks to it over the memory IPC socket. |
+| Direct library | `LibraryCognitiveMemory` | The reader opens the on-disk library store directly. |
+
+The graph must enumerate the same live items on **all three** tiers. Facts
+(`search_facts("", …)`) and procedures (`recall_procedure("", …)`) already
+round-trip over IPC. Episodes and prospective triggers did **not**:
+`list_all_episodes` / `list_all_prospective` have empty default trait impls
+(`cognitive_memory/mod.rs` — "the default returns empty so non-library backends
+degrade gracefully"), and the IPC client `RemoteCognitiveMemory` did not
+override them. So under the daemon-socket tier those two types fell through to
+`Ok(vec![])` and rendered hub-only **even while `get_statistics()` reported
+non-zero `Events` / `Planned`** — the graph diverging from the counts shown
+beside it. That divergence is exactly the failure this tab must not have.
+
+This feature closes the gap by extending the memory IPC protocol so the two
+missing enumerators traverse the socket like the others:
+
+| New IPC element | Location | Purpose |
+|-----------------|----------|---------|
+| `MemoryRequest::ListAllEpisodes { limit }` | `memory_ipc/mod.rs` | Request variant carrying the per-type cap. |
+| `MemoryRequest::ListAllProspective { limit }` | `memory_ipc/mod.rs` | Request variant carrying the per-type cap. |
+| Server dispatch arms → `MemoryResponse::Episodes` / `Prospectives` | `memory_ipc/server.rs` | Forward each request to `memory.list_all_episodes` / `list_all_prospective` on the daemon-side store. |
+| `RemoteCognitiveMemory::list_all_episodes` / `list_all_prospective` | `memory_ipc/client.rs` | Client overrides that issue the new requests instead of inheriting the empty defaults. |
+
+The response variants already exist (`MemoryResponse::Episodes`,
+`MemoryResponse::Prospectives`), so the change is purely additive: two new
+request arms plus two client overrides, mirroring the existing
+`SearchEpisodesByKeywords` round-trip. After it, every reader tier returns
+identical live episode and prospective nodes, and the graph never diverges from
+the stats counts regardless of topology.
+
+### Pure builder: `build_live_memory_graph`
+
+The graph is assembled by a pure function that takes the trait object and
+returns the JSON value, so it is unit-testable without HTTP:
+
+```rust
+fn build_live_memory_graph(ops: &dyn CognitiveMemoryOps) -> serde_json::Value
+```
+
+It:
+
+1. Emits the **six type hubs** unconditionally (`id = "hub:<Type>"`), so the
+   graph always shows the full memory taxonomy even on an empty store.
+2. Enumerates each long-term type from the live store and emits a node per item
+   with an edge to its hub:
+   - `SemanticFact` ← `search_facts("", GRAPH_MAX_PER_TYPE, 0.0)`
+   - `EpisodicMemory` ← `list_all_episodes(GRAPH_MAX_PER_TYPE)`
+   - `ProceduralMemory` ← `recall_procedure("", GRAPH_MAX_PER_TYPE)`
+   - `ProspectiveMemory` ← `list_all_prospective(GRAPH_MAX_PER_TYPE)`
+
+   Every call goes through the same `&dyn CognitiveMemoryOps` trait object, so on
+   the daemon-socket tier `list_all_episodes` / `list_all_prospective` reach the
+   store via the new IPC request arms above (not the empty default impls) — the
+   builder itself is backend-agnostic and unchanged across tiers.
+3. Attaches `stats` from `ops.get_statistics()`.
+4. Sets `available: true`.
+
+Node ids are namespaced per type (`graph_node_id`) so ids never collide across
+types and every edge endpoint resolves to a real node.
+
+### Bounds and truncation
+
+Two constants keep the payload bounded without dropping live fidelity:
+
+| Constant | Value | Purpose |
+|----------|-------|---------|
+| `GRAPH_MAX_PER_TYPE` | `200` | Maximum item nodes emitted per enumerable type. |
+| `GRAPH_NODE_CONTENT_MAX` | `2048` | Maximum `content` length in bytes; longer content is truncated by `truncate_graph_content`, which cuts on a UTF-8 char boundary (never mid-codepoint). |
+
+### Degraded path
+
+If `open_reader_client` fails (reader unreachable), the handler returns
+`available:false`, empty `nodes`/`edges`, the `stats` it could obtain (zeros if
+none), and a short, **path-free** `note`. This is a real fallback, not a
+placeholder for the normal path: when the reader is reachable the endpoint
+always returns live data, even if the store happens to be empty.
+
+### Partial degradation (reachable but a type can't enumerate)
+
+The degraded path above is for a reader that cannot be opened at all. A
+distinct, softer case is a reader that **is** reachable but cannot enumerate one
+specific type — for example a version-skewed daemon that predates the
+`ListAllEpisodes` / `ListAllProspective` IPC arms, or a per-type read error. In
+that case the builder does **not** fail the whole request: the affected type
+falls back to **hub-only** (its magnitude still shown from `stats`), the other
+types still enumerate, and `available` stays `true`. This keeps the graph
+resilient to a mismatched daemon while never fabricating item nodes it could not
+read. It is a defence-in-depth backstop — with the IPC arms in place (above) the
+normal daemon topology enumerates all four long-term types fully.
+
+### No stray diagnostics
+
+The read path emits **no** `println!` / `eprintln!` — errors are surfaced
+through the `note` field and normal `Result` handling, keeping production
+output clean.
+
+## Registration and wiring
+
+The Memory tab is registered in exactly the places every dashboard tab is:
+
+| Concern | Location | Entry |
+|---------|----------|-------|
+| Tab identity (label, title, h1, lede, tooltip) | `index_html/tab_meta.rs` → `TAB_METADATA` | `slug: "memory", label: "Memory"` |
+| Client tab allowlist | rendered `const CANONICAL_TABS=[…]` (`index_html/part_01.rs`) | includes `'memory'` |
+| Panel markup (`<div class="tab-content" id="tab-memory">`) | `index_html/part_00.rs` | H1 `Memory`, lede, filters, `#mem-graph-canvas`, tooltip, details panel |
+| Renderer + fetch (`fetchMemoryGraph`, `mgColors`, force layout) | `index_html/part_03.rs` | canvas graph engine |
+| Background prefetch / refresh | rendered `const TAB_LOADERS={…}` (`index_html/part_05.rs`) | `'memory': [{ fn: fetchMemoryGraph, intervalMs: 120000, paths: ['/api/memory/graph'] }, …]` |
+| Endpoint | `operator_commands_dashboard/memory.rs` → `memory_graph()` | `GET /api/memory/graph` |
+| IPC enumeration plumbing (daemon tier) | `memory_ipc/{mod,server,client}.rs` | `MemoryRequest::ListAllEpisodes` / `ListAllProspective` variants + server dispatch arms + `RemoteCognitiveMemory` overrides |
+
+Because Memory is a real top-level tab, `#memory` is now a **canonical slug**,
+not a deep-link alias. The retired-tab alias table no longer maps `#memory` to
+`#resources`; `#costs` continues to resolve to the **Resources** tab.
+
+### Styling and refresh consistency
+
+The Memory tab uses the same page shell as every other tab: one
+`<h1 class="page-h1">Memory</h1>`, a plain-English `<p class="page-lede">`, and
+the shared card styling. Its loaders run on the standard 120 s background
+refresh cadence used by the other data-heavy tabs, so the graph and stats stay
+current while the tab is open and are pre-warmed before it is first shown.
+
+## Tests
+
+Three tests lock the feature in place — an in-process build test, an IPC-path
+enumeration roundtrip, and a registration/nav check — plus a reconciliation of a
+pre-existing tooltip guard:
+
+1. **`mod tests_memory_graph` — in-process build** (in
+   `operator_commands_dashboard/memory.rs`). Seeds a live cognitive store via a
+   `HermeticState` temp root and an in-process writer (`register_in_process_writer`,
+   which selects the `SharedMemory` tier), stores at least one fact, episode,
+   procedure, and prospective trigger, then asserts that
+   `build_live_memory_graph(ops)` (reading through `open_reader_client`):
+   - reports `available: true`;
+   - contains all **six** type hubs;
+   - emits live per-item nodes whose `type` is one of the six allowlisted
+     literals (matching `mgColors`);
+   - has **no dangling edges** (every `source`/`target` id resolves to a node,
+     and every item node links to its hub);
+   - has `stats` equal to `ops.get_statistics()`; and
+   - honours `GRAPH_MAX_PER_TYPE` (per-type node cap) and
+     `GRAPH_NODE_CONTENT_MAX` (UTF-8-safe content truncation).
+
+2. **IPC-path enumeration roundtrip** (in `memory_ipc/`, alongside the existing
+   transport roundtrip tests). Drives enumeration through a **real socket** so the
+   reader is `RemoteCognitiveMemory` (the daemon-socket tier), seeds an episode
+   and a prospective trigger on the server-side store, and asserts that
+   `list_all_episodes` / `list_all_prospective` return them over IPC — i.e. that
+   the new `ListAllEpisodes` / `ListAllProspective` request arms forward and the
+   client overrides them. **This test is required, not optional:** the in-process
+   test in (1) exercises the one backend that already overrides the enumerators,
+   so without an explicit socket-tier test the production IPC path could silently
+   return empty episode/prospective nodes while the suite stays green.
+
+3. **Registration / nav test** (in `index_html/tests_tab_meta.rs`). Asserts that
+   `TAB_METADATA` contains an entry with `slug == "memory"` and
+   `label == "Memory"`, that `tab_nav_html()` renders a **Memory** nav button,
+   and that the rendered `CANONICAL_TABS` allowlist lists `memory` so its panel
+   is reachable. The existing tab-identity cross-checks (unique labels/titles/
+   H1s, no banned jargon, every SoT string present in the HTML) continue to pass
+   with the new tab included.
+
+> **Reconcile the tab-count tooltip guard.** The pre-existing test
+> `index_html_all_eleven_tabs_have_tooltips`
+> (`operator_commands_dashboard/tests_routes_a.rs`) hard-codes its `tabs` array
+> and a literal `assert_eq!(tabs.len(), …)` that is already stale relative to its
+> own name (it lists nine slugs and asserts nine, despite "eleven" in the
+> identifier). It iterates the canonical tab list to prove each tab has a
+> non-empty `title="…"` tooltip, so it **must** gain `"memory"` and have its
+> length assertion updated to the final canonical count; otherwise Memory's
+> tooltip is never verified here and the test remains internally inconsistent.
+> Keep the array and the count in lock-step with whatever tab set this guard
+> covers.
+
+## Constraints honoured
+
+- **Additive / back-compatible.** No memory endpoint is removed;
+  `/api/memory`, `/api/memory/recent`, `/api/memory/history`, and
+  `/api/memory/search` are unchanged. The Memory tab is added, not swapped in.
+- **Additive IPC protocol.** The two new memory-IPC request variants
+  (`ListAllEpisodes`, `ListAllProspective`) are appended to `MemoryRequest` and
+  reuse the existing `MemoryResponse::Episodes` / `Prospectives` variants; no
+  existing variant or its wire encoding changes, and a reader still degrades
+  gracefully (hub-only for that type) against a daemon that predates them — see
+  [Partial degradation](#partial-degradation-reachable-but-a-type-cant-enumerate).
+- **Live data only.** The graph renders real nodes/edges read from the live
+  cognitive store; there is no stale snapshot or placeholder on the normal path.
+- **No new `println!` / `eprintln!`** in the production read path.
+- **No new `*Bridge` identifiers** — the reader is `open_reader_client` →
+  `ReaderClient`.
+- **Never `--admin` / `--no-verify`.**
+
+## Related
+
+- [Dashboard](../dashboard.md) — full tab catalogue and the Tab Identity Contract.
+- [Memory architecture](../memory.md) — the cognitive memory model behind the graph.
+- [Background tab prefetch and refresh](./dashboard-background-tab-prefetch.md) — how the Memory tab is pre-warmed and refreshed.
+- [Cognitive-memory client helpers](./cognitive-memory-client-helpers.md) — `open_reader_client` and the read path.
+- [Overview Health & live memory-consolidation](./dashboard-overview-health-and-live-memory.md) — the sibling live-memory display fix.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -237,6 +237,7 @@ nav:
     - Overseer Root-Cause (WHY) API: reference/overseer-root-cause-why-api.md
     - simard-engineer-step CLI: reference/simard-engineer-step.md
     - simard-tui Dashboard: reference/simard-tui.md
+    - Dashboard Memory Tab: reference/dashboard-memory-tab.md
     - Journal API: reference/journal-api.md
     - Journal Narrative Result Channel: reference/journal-narrative-result-channel.md
     - npx / npm Install: reference/npx-npm-install.md

--- a/src/memory_ipc/client.rs
+++ b/src/memory_ipc/client.rs
@@ -303,6 +303,27 @@ impl CognitiveMemoryOps for RemoteCognitiveMemory {
         }
     }
 
+    fn list_all_episodes(&self, limit: u32) -> SimardResult<Vec<CognitiveEpisode>> {
+        // Additive socket forward (issue #2627): mirror the library override so a
+        // reader on the daemon-socket tier enumerates live episodes instead of the
+        // empty `list_all_episodes` trait default — the dashboard Memory-tab graph
+        // relies on this to render per-item episode nodes over the wire.
+        match self.call(MemoryRequest::ListAllEpisodes { limit })? {
+            MemoryResponse::Episodes(v) => Ok(v),
+            other => Err(Self::unexpected("list_all_episodes", other)),
+        }
+    }
+
+    fn list_all_prospective(&self, limit: u32) -> SimardResult<Vec<CognitiveProspective>> {
+        // Additive socket forward (issue #2627): companion of `list_all_episodes`
+        // so prospective memories enumerate over the wire for the Memory-tab
+        // graph instead of collapsing to the empty trait default.
+        match self.call(MemoryRequest::ListAllProspective { limit })? {
+            MemoryResponse::Prospectives(v) => Ok(v),
+            other => Err(Self::unexpected("list_all_prospective", other)),
+        }
+    }
+
     fn store_prospective(
         &self,
         description: &str,

--- a/src/memory_ipc/mod.rs
+++ b/src/memory_ipc/mod.rs
@@ -259,6 +259,26 @@ pub enum MemoryRequest {
     DrainPassLedger {
         pass_id: String,
     },
+    /// Enumerate up to `limit` episodes (newest-first, including
+    /// compressed/consolidated ones) across the socket, so a reader on the
+    /// daemon-socket tier gets the same live enumeration as an in-process reader.
+    /// Additive (issue #2627): the dashboard Memory-tab graph reads live per-item
+    /// episode nodes through this; without it the socket client would fall back
+    /// to the empty `list_all_episodes` trait default and the graph would
+    /// silently collapse episodes to their type hub. Returns
+    /// [`MemoryResponse::Episodes`].
+    ListAllEpisodes {
+        limit: u32,
+    },
+    /// Enumerate up to `limit` prospective (trigger → action) memories in every
+    /// status, priority-ordered, across the socket. Additive companion of
+    /// [`ListAllEpisodes`](MemoryRequest::ListAllEpisodes) for the Memory-tab
+    /// graph (issue #2627) — without it a socket-tier reader collapses
+    /// prospective memories to their type hub. Returns
+    /// [`MemoryResponse::Prospectives`].
+    ListAllProspective {
+        limit: u32,
+    },
     GetStatistics,
 }
 

--- a/src/memory_ipc/server.rs
+++ b/src/memory_ipc/server.rs
@@ -304,6 +304,14 @@ fn dispatch(memory: &dyn CognitiveMemoryOps, req: MemoryRequest) -> MemoryRespon
                 Err(e) => MemoryResponse::Error(e.to_string()),
             }
         }
+        MemoryRequest::ListAllEpisodes { limit } => match memory.list_all_episodes(limit) {
+            Ok(v) => MemoryResponse::Episodes(v),
+            Err(e) => MemoryResponse::Error(e.to_string()),
+        },
+        MemoryRequest::ListAllProspective { limit } => match memory.list_all_prospective(limit) {
+            Ok(v) => MemoryResponse::Prospectives(v),
+            Err(e) => MemoryResponse::Error(e.to_string()),
+        },
         MemoryRequest::DrainPassLedger { pass_id } => {
             MemoryResponse::Count(drain_pass_ledger(&pass_id))
         }

--- a/src/memory_ipc/tests_transport_roundtrip.rs
+++ b/src/memory_ipc/tests_transport_roundtrip.rs
@@ -351,6 +351,53 @@ fn procedure_store_and_recall_over_socket() {
 }
 
 #[test]
+fn list_all_episodes_and_prospective_enumerate_over_socket() {
+    // Issue #2627: the dashboard Memory-tab graph reads live per-item nodes for
+    // episodes and prospective memories through `list_all_episodes` /
+    // `list_all_prospective`. Both have empty trait defaults, so unless the
+    // socket client FORWARDS them (and the server dispatches them) a reader on
+    // the daemon-socket tier would silently collapse both types to their type
+    // hub — exactly the regression this additive forward prevents.
+    let fx = in_memory_fixture();
+
+    let ep = fx
+        .client
+        .store_episode("engineer restored the memory tab graph", "test", None)
+        .expect("store_episode over socket");
+    let pr = fx
+        .client
+        .store_prospective(
+            "watch for memory-graph regressions",
+            "when a memory socket test fails",
+            "page the on-call engineer",
+            7,
+        )
+        .expect("store_prospective over socket");
+
+    let episodes = fx
+        .client
+        .list_all_episodes(50)
+        .expect("list_all_episodes over socket");
+    assert!(
+        episodes.iter().any(|e: &CognitiveEpisode| e.node_id == ep),
+        "the stored episode must enumerate over the socket (a missing forward \
+         would return the empty trait default); got {} episodes",
+        episodes.len()
+    );
+
+    let prospective = fx
+        .client
+        .list_all_prospective(50)
+        .expect("list_all_prospective over socket");
+    assert!(
+        prospective.iter().any(|p| p.node_id == pr),
+        "the stored prospective memory must enumerate over the socket; got {} \
+         prospective",
+        prospective.len()
+    );
+}
+
+#[test]
 fn prospective_store_trigger_and_resolve_over_socket() {
     let fx = in_memory_fixture();
 

--- a/src/operator_commands_dashboard/index_html/mod.rs
+++ b/src/operator_commands_dashboard/index_html/mod.rs
@@ -13,6 +13,9 @@ mod tests_tab_meta;
 #[cfg(test)]
 mod tests_tab_prefetch;
 
+#[cfg(test)]
+mod tests_memory_tab;
+
 use part_00::PART_00;
 use part_01::PART_01;
 use part_02::PART_02;

--- a/src/operator_commands_dashboard/index_html/part_00.rs
+++ b/src/operator_commands_dashboard/index_html/part_00.rs
@@ -384,8 +384,25 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
       </div>
     </div>
 
-    <details id="mem-advanced-toggle">
-      <summary style="cursor:pointer;color:var(--accent);font-size:.85rem;margin-bottom:1rem;user-select:none">▸ Show advanced memory view (graph, search, raw data)</summary>
+    <span class="section-anchor" id="section-costs"></span>
+    <h2 class="subsection">Costs</h2>
+    <div class="grid">
+      <div class="card"><h2>Daily Costs <button class="btn" onclick="fetchCosts()">Refresh</button></h2><div id="costs-daily"><span class="loading">Loading…</span></div></div>
+      <div class="card"><h2>Weekly Costs</h2><div id="costs-weekly"><span class="loading">Loading…</span></div></div>
+      <div class="card"><h2>Budget Settings</h2>
+        <div style="display:flex;gap:1rem;align-items:center;flex-wrap:wrap">
+          <label>Daily $<input id="budget-daily" type="number" step="0.01" style="width:8rem;padding:4px;background:#1a1a2e;border:1px solid #333;color:#e0e0e0;border-radius:4px"></label>
+          <label>Weekly $<input id="budget-weekly" type="number" step="0.01" style="width:8rem;padding:4px;background:#1a1a2e;border:1px solid #333;color:#e0e0e0;border-radius:4px"></label>
+          <button class="btn" onclick="saveBudget()">Save</button>
+          <span id="budget-status"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="tab-content" id="tab-memory">
+    <h1 class="page-h1">Memory</h1>
+    <p class="page-lede">A living map of what Simard knows — an interactive graph of the facts, events, procedures, and plans it holds, colour-coded by memory type and drawn live from what it currently remembers.</p>
 
     <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1rem">
       <h2 style="margin:0">Memory Graph</h2>
@@ -427,21 +444,6 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
       </div>
       <div class="card" style="flex:1"><h2>Memory Overview</h2><div id="mem-overview"><span class="loading">Loading…</span></div></div>
       <div class="card" style="flex:1"><h2>Memory Files</h2><div id="mem-files"><span class="loading">Loading…</span></div></div>
-    </div>
-    </details>
-    <span class="section-anchor" id="section-costs"></span>
-    <h2 class="subsection">Costs</h2>
-    <div class="grid">
-      <div class="card"><h2>Daily Costs <button class="btn" onclick="fetchCosts()">Refresh</button></h2><div id="costs-daily"><span class="loading">Loading…</span></div></div>
-      <div class="card"><h2>Weekly Costs</h2><div id="costs-weekly"><span class="loading">Loading…</span></div></div>
-      <div class="card"><h2>Budget Settings</h2>
-        <div style="display:flex;gap:1rem;align-items:center;flex-wrap:wrap">
-          <label>Daily $<input id="budget-daily" type="number" step="0.01" style="width:8rem;padding:4px;background:#1a1a2e;border:1px solid #333;color:#e0e0e0;border-radius:4px"></label>
-          <label>Weekly $<input id="budget-weekly" type="number" step="0.01" style="width:8rem;padding:4px;background:#1a1a2e;border:1px solid #333;color:#e0e0e0;border-radius:4px"></label>
-          <button class="btn" onclick="saveBudget()">Save</button>
-          <span id="budget-status"></span>
-        </div>
-      </div>
     </div>
   </div>
 "#;

--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -955,8 +955,8 @@ pub(crate) const PART_01: &str = r#"
        validated against ^[a-z-]+$, matched against the allowlist, and falls
        back to 'overview' on any miss. The hash is never concatenated into a
        DOM selector, so a crafted hash cannot inject markup. */
-    const CANONICAL_TABS=['overview','goals','activity','workers','pull-requests','resources','chat','overseer','journal','creative-ideas'];
-    const TAB_ALIASES={"status":"overview","workboard":"goals","logs":"activity","traces":"activity","thinking":"activity","brain-failures":"activity","processes":"workers","terminal":"workers","merge-decisions":"pull-requests","pr-readiness":"pull-requests","memory":"resources","costs":"resources"};
+    const CANONICAL_TABS=['overview','goals','activity','workers','pull-requests','memory','resources','chat','overseer','journal','creative-ideas'];
+    const TAB_ALIASES={"status":"overview","workboard":"goals","logs":"activity","traces":"activity","thinking":"activity","brain-failures":"activity","processes":"workers","terminal":"workers","merge-decisions":"pull-requests","pr-readiness":"pull-requests","costs":"resources"};
 
     /* #2649: the per-tab fetch/refresh chain that used to live here
        (runTabFetches / clearTabTimers) is retired. Background prefetch and

--- a/src/operator_commands_dashboard/index_html/part_05.rs
+++ b/src/operator_commands_dashboard/index_html/part_05.rs
@@ -519,11 +519,12 @@ pub(crate) const PART_05: &str = r#"      try {
       'activity':[{fn:fetchLogs,intervalMs:15000,paths:['/api/logs']},{fn:fetchTraces,intervalMs:30000,paths:['/api/traces']},{fn:fetchThinking,intervalMs:30000,paths:['/api/ooda-thinking']},{fn:fetchOodaCycles,intervalMs:30000,paths:['/api/ooda-cycles']},{fn:fetchBrainFailures,intervalMs:30000,paths:['/api/brain-failures']}],
       'workers':[{fn:fetchSubagentSessions,intervalMs:5000,paths:['/api/subagent-sessions']},{fn:fetchTmuxSessions,intervalMs:10000,paths:['/api/azlin/tmux-sessions']},{fn:fetchProcessTree,intervalMs:15000,paths:['/api/processes']}],
       'pull-requests':[{fn:fetchMergeJudge,intervalMs:30000,paths:['/api/merge-judge']},{fn:fetchPrReadiness,intervalMs:30000,paths:['/api/prs']}],
-      'resources':[{fn:fetchRecentMemories,intervalMs:120000,paths:['/api/memory/recent']},{fn:fetchMemoryHistory,intervalMs:120000,paths:['/api/memory/history']},{fn:fetchMemoryGraph,intervalMs:120000,paths:['/api/memory/graph']},{fn:fetchMemory,intervalMs:120000,paths:['/api/memory']},{fn:fetchCosts,intervalMs:120000,paths:['/api/costs']}],
+      'resources':[{fn:fetchRecentMemories,intervalMs:120000,paths:['/api/memory/recent']},{fn:fetchMemoryHistory,intervalMs:120000,paths:['/api/memory/history']},{fn:fetchCosts,intervalMs:120000,paths:['/api/costs']}],
       'chat':[{fn:loadChatSessions,intervalMs:120000,paths:['/api/chat/sessions']}],
       'overseer':[{fn:fetchOverseer,intervalMs:30000,paths:['/api/overseer']}],
       'journal':[{fn:loadJournal,intervalMs:120000,paths:['/api/journal/dates']}],
-      'creative-ideas':[{fn:loadCreativeIdeas,intervalMs:120000,paths:['/api/creative-ideas']}]
+      'creative-ideas':[{fn:loadCreativeIdeas,intervalMs:120000,paths:['/api/creative-ideas']}],
+      'memory':[{fn:fetchMemoryGraph,intervalMs:120000,paths:['/api/memory/graph']},{fn:fetchMemory,intervalMs:120000,paths:['/api/memory']}]
     };
     window.TAB_LOADERS=TAB_LOADERS;
 

--- a/src/operator_commands_dashboard/index_html/tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tab_meta.rs
@@ -113,6 +113,18 @@ pub const TAB_METADATA: &[TabMeta] = &[
         lede: "Every pull request Simard is managing — the merge judge's approve, reject, and defer decisions plus the CI, review, and blocker status that shows what is ready to merge.",
         tooltip: "Merge decisions and per-PR readiness for managed PRs",
     },
+    // #2627 regression fix: the memory-graph visualization dropped during the
+    // 17->9 tab consolidation (folded into Resources as a collapsed sub-section
+    // and a deep-link alias) is restored here as its OWN dedicated top-level tab,
+    // sitting alongside Resources (which keeps the memory recall summary).
+    TabMeta {
+        slug: "memory",
+        label: "Memory",
+        title: "Memory · Simard",
+        h1: "Memory",
+        lede: "A living map of what Simard knows — an interactive graph of the facts, events, procedures, and plans it holds, colour-coded by memory type and drawn live from what it currently remembers.",
+        tooltip: "Interactive live graph of what Simard remembers, by memory type",
+    },
     TabMeta {
         slug: "resources",
         label: "Resources",
@@ -158,7 +170,7 @@ pub const TAB_METADATA: &[TabMeta] = &[
 /// Browser title shown on first page load. The client-side tab handler
 /// updates this when a different tab is activated. Uses `TAB_METADATA[0]`
 /// directly because [`tab_meta_slugs_unique`] asserts the table has
-/// exactly nine entries — an empty table would already fail other tests.
+/// exactly eleven entries — an empty table would already fail other tests.
 pub fn default_title() -> &'static str {
     TAB_METADATA[0].title
 }

--- a/src/operator_commands_dashboard/index_html/tests_memory_tab.rs
+++ b/src/operator_commands_dashboard/index_html/tests_memory_tab.rs
@@ -50,7 +50,8 @@ fn tab_panel<'h>(html: &'h str, slug: &str) -> &'h str {
 }
 
 /// The `memory` tab must be registered in the single-source-of-truth tab table
-/// with the human label/H1 "Memory" and no `Bridge` naming (binding constraint).
+/// with the human label/H1 "Memory" and accurate, non-legacy naming (binding
+/// constraint; the repo-wide no-legacy-naming linter enforces this globally).
 #[test]
 fn memory_tab_registered_in_metadata() {
     let meta = TAB_METADATA.iter().find(|t| t.slug == "memory").expect(
@@ -68,10 +69,8 @@ fn memory_tab_registered_in_metadata() {
         meta.h1
     );
     assert!(
-        !meta.slug.contains("bridge")
-            && !meta.label.contains("Bridge")
-            && !meta.h1.contains("Bridge"),
-        "the memory tab must not use any `Bridge` identifier (binding constraint)"
+        !meta.slug.contains("bridge"),
+        "the memory tab slug must use accurate, non-legacy vocabulary (binding constraint)"
     );
 }
 

--- a/src/operator_commands_dashboard/index_html/tests_memory_tab.rs
+++ b/src/operator_commands_dashboard/index_html/tests_memory_tab.rs
@@ -1,0 +1,202 @@
+//! Contract tests for the dedicated **Memory** dashboard tab (issue #2627).
+//!
+//! REGRESSION: the ~17->9 tab consolidation dropped the memory-graph
+//! visualization — it was folded into a collapsed `<details id="mem-advanced-toggle">`
+//! inside the Resources tab and demoted to a deep-link alias
+//! (`"memory":"resources"`). This restores it as its OWN first-class top-level
+//! "Memory" tab, wired to the LIVE cognitive-memory read path
+//! (`GET /api/memory/graph`, see `memory.rs`).
+//!
+//! These assertions are the Rust half of the contract; the behavioural half is
+//! `tests/e2e-dashboard/specs/memory-tab.spec.ts`.
+//!
+//! TDD note (Step 7 / red): every assertion here is expected to **FAIL**
+//! against the current build — `memory` is still a RETIRED slug, absent from
+//! `TAB_METADATA` and the JS `CANONICAL_TABS` allowlist, and the graph canvas
+//! is buried under `mem-advanced-toggle` inside `#tab-resources`. They pass
+//! once the Memory tab is registered and the viz is promoted into its panel.
+
+#![cfg(test)]
+
+use super::INDEX_HTML;
+use super::tab_meta::TAB_METADATA;
+
+/// The six memory-type literals the client renderer keys on (`mgColors` /
+/// `data-type=` filters in the parts). Every restored filter must map to one.
+const MEMORY_TYPES: [&str; 6] = [
+    "WorkingMemory",
+    "SemanticFact",
+    "EpisodicMemory",
+    "ProceduralMemory",
+    "ProspectiveMemory",
+    "SensoryBuffer",
+];
+
+/// Return the HTML of the `id="tab-<slug>"` panel: everything from that panel's
+/// id marker up to the next `id="tab-` (the next sibling panel), or end of
+/// document. Panics if the panel is absent so a missing Memory tab fails loudly
+/// with a clear message rather than a silent false-negative.
+fn tab_panel<'h>(html: &'h str, slug: &str) -> &'h str {
+    let open = format!(r#"id="tab-{slug}""#);
+    let start = html.find(&open).unwrap_or_else(|| {
+        panic!(
+            "no tab-content panel with id=\"tab-{slug}\" in the rendered dashboard — \
+             the dedicated Memory tab (#2627) is not rendered"
+        )
+    });
+    let rest = &html[start + open.len()..];
+    let end = rest.find(r#"id="tab-"#).unwrap_or(rest.len());
+    &rest[..end]
+}
+
+/// The `memory` tab must be registered in the single-source-of-truth tab table
+/// with the human label/H1 "Memory" and no `Bridge` naming (binding constraint).
+#[test]
+fn memory_tab_registered_in_metadata() {
+    let meta = TAB_METADATA.iter().find(|t| t.slug == "memory").expect(
+        "TAB_METADATA must register a top-level `memory` tab (issue #2627); \
+             it is currently a RETIRED slug folded into Resources",
+    );
+    assert_eq!(
+        meta.label, "Memory",
+        "the memory tab's nav label must be \"Memory\", got {:?}",
+        meta.label
+    );
+    assert_eq!(
+        meta.h1, "Memory",
+        "the memory tab's page-h1 must be \"Memory\", got {:?}",
+        meta.h1
+    );
+    assert!(
+        !meta.slug.contains("bridge")
+            && !meta.label.contains("Bridge")
+            && !meta.h1.contains("Bridge"),
+        "the memory tab must not use any `Bridge` identifier (binding constraint)"
+    );
+}
+
+/// The tab must be reachable: a nav button plus a content panel carrying the
+/// standard page-h1 + page-lede identity block like every other tab.
+#[test]
+fn memory_tab_has_nav_button_and_panel() {
+    let html: &str = &INDEX_HTML;
+    assert!(
+        html.contains(r#"data-tab="memory""#),
+        "the rendered nav must include a data-tab=\"memory\" button so the \
+         Memory tab is clickable"
+    );
+    assert!(
+        html.contains(r#"id="tab-memory""#),
+        "the rendered HTML must include the id=\"tab-memory\" content panel"
+    );
+    let panel = tab_panel(html, "memory");
+    assert!(
+        panel.contains(r#"<h1 class="page-h1">Memory</h1>"#),
+        "the Memory panel must own a <h1 class=\"page-h1\">Memory</h1> heading"
+    );
+    assert!(
+        panel.contains(r#"class="page-lede""#),
+        "the Memory panel must carry a <p class=\"page-lede\"> intro like every \
+         other tab (tab-identity contract)"
+    );
+}
+
+/// The client-side `CANONICAL_TABS` allowlist gates which panels `activateTab`
+/// will show; a slug missing here renders a nav button whose panel never
+/// activates (falls back to Overview).
+#[test]
+fn memory_tab_in_js_canonical_allowlist() {
+    let html: &str = &INDEX_HTML;
+    let start = html
+        .find("const CANONICAL_TABS=[")
+        .expect("rendered HTML has the CANONICAL_TABS JS allowlist");
+    let tail = &html[start..];
+    let end = tail.find("];").expect("CANONICAL_TABS array is closed");
+    assert!(
+        tail[..end].contains("'memory'"),
+        "the JS CANONICAL_TABS allowlist must list 'memory' or its panel never \
+         activates (activateTab falls back to Overview). Array was: {}",
+        &tail[..end]
+    );
+}
+
+/// The restored visualization itself: the force-directed graph canvas, the six
+/// memory-type filters, and the live-data fetch — all INSIDE the dedicated
+/// Memory panel (not buried in Resources' `<details>`).
+#[test]
+fn memory_tab_renders_the_graph_visualization() {
+    let html: &str = &INDEX_HTML;
+    let panel = tab_panel(html, "memory");
+    assert!(
+        panel.contains(r#"id="mem-graph-canvas""#),
+        "the Memory tab must render the memory-graph <canvas id=\"mem-graph-canvas\">"
+    );
+    for ty in MEMORY_TYPES {
+        let needle = format!(r#"data-type="{ty}""#);
+        assert!(
+            panel.contains(&needle),
+            "the Memory tab must expose the {ty} type filter ({needle}) so all six \
+             memory types are toggleable"
+        );
+    }
+    assert!(
+        panel.contains("fetchMemoryGraph"),
+        "the Memory tab must wire fetchMemoryGraph() to pull the LIVE graph from \
+         /api/memory/graph"
+    );
+}
+
+/// Moving (not copying) the canvas is mandatory: a duplicated DOM id breaks the
+/// `getElementById('mem-graph-canvas')` the renderer relies on.
+#[test]
+fn memory_graph_canvas_is_not_duplicated() {
+    let html: &str = &INDEX_HTML;
+    let n = html.matches(r#"id="mem-graph-canvas""#).count();
+    assert_eq!(
+        n, 1,
+        "the memory-graph canvas must exist exactly once (MOVED into the Memory \
+         tab, not copied) — {n} occurrences means a duplicate DOM id that breaks \
+         document.getElementById"
+    );
+}
+
+/// Background prefetch/refresh parity: the Memory tab must have its own loader
+/// entry in the `TAB_LOADERS` registry (the graph loader moves out of the old
+/// `resources` entry), so it refreshes on its own like the sibling tabs.
+#[test]
+fn memory_tab_has_background_loader() {
+    let html: &str = &INDEX_HTML;
+    let start = html
+        .find("const TAB_LOADERS=")
+        .expect("rendered HTML has the TAB_LOADERS registry");
+    let tail = &html[start..];
+    let end = tail.find("};").expect("TAB_LOADERS object is closed");
+    let registry = &tail[..end];
+    let mstart = registry.find("'memory':[").unwrap_or_else(|| {
+        panic!(
+            "TAB_LOADERS must register a 'memory':[...] entry so the Memory tab \
+             background-prefetches/refreshes like the other tabs (#2627)"
+        )
+    });
+    let mtail = &registry[mstart..];
+    let mend = mtail.find(']').unwrap_or(mtail.len());
+    assert!(
+        mtail[..mend].contains("fetchMemoryGraph"),
+        "the 'memory' loader entry must call fetchMemoryGraph for live refresh; \
+         got: {}",
+        &mtail[..mend]
+    );
+}
+
+/// Deep-link migration: `#memory` now resolves to the canonical Memory tab, so
+/// the dead `"memory":"resources"` alias must be gone (the resolver checks
+/// canonical before alias — a stale alias silently misroutes the bookmark).
+#[test]
+fn memory_deeplink_alias_to_resources_removed() {
+    let html: &str = &INDEX_HTML;
+    assert!(
+        !html.contains(r#""memory":"resources""#),
+        "the retired-slug alias \"memory\":\"resources\" must be removed once \
+         Memory is a canonical tab (#2627)"
+    );
+}

--- a/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
@@ -21,7 +21,7 @@ fn tab_meta_slugs_unique() {
             t.slug
         );
     }
-    assert_eq!(TAB_METADATA.len(), 10, "expected 10 tabs");
+    assert_eq!(TAB_METADATA.len(), 11, "expected 11 tabs");
 }
 
 #[test]
@@ -767,15 +767,22 @@ fn feedback_widget_posts_report_and_context_to_authed_endpoint() {
 // of this taxonomy lives in `docs/dashboard.md#canonical-tab-taxonomy`; these
 // tests pin the source-of-truth table and the rendered HTML to it.
 
-/// The nine canonical dashboard tabs, in nav-render order, paired with the
+/// The canonical dashboard tabs, in nav-render order, paired with the
 /// label each must expose. This is the single in-test statement of the
-/// consolidated taxonomy that `docs/dashboard.md` documents.
+/// consolidated taxonomy that `docs/dashboard.md` documents. The trailing
+/// `memory` entry is the #2627 regression fix (its viz was dropped by the
+/// 17->9 consolidation and is restored as a dedicated tab).
 const CANONICAL_TABS: &[(&str, &str)] = &[
     ("overview", "Overview"),
     ("goals", "Goals"),
     ("activity", "Activity"),
     ("workers", "Workers"),
     ("pull-requests", "Pull Requests"),
+    // #2627 regression fix: the memory-graph visualization dropped during the
+    // 17->9 consolidation is restored as its OWN dedicated top-level tab
+    // (previously folded into Resources as a sub-section / deep-link alias),
+    // sitting alongside Resources.
+    ("memory", "Memory"),
     ("resources", "Resources"),
     ("chat", "Chat"),
     ("overseer", "Overseer"),
@@ -786,11 +793,13 @@ const CANONICAL_TABS: &[(&str, &str)] = &[
 /// Slugs that were real top-level tabs in the 17-tab set and must NOT survive
 /// as nav tabs after consolidation — each is now a sub-section reachable via
 /// its deep-link alias.
+///
+/// `memory` is deliberately absent: issue #2627 promotes it back to a
+/// first-class top-level tab, so it now lives in [`CANONICAL_TABS`] instead.
 const RETIRED_SLUGS: &[&str] = &[
     "traces",
     "logs",
     "processes",
-    "memory",
     "costs",
     "workboard",
     "thinking",
@@ -877,14 +886,16 @@ fn js_canonical_tabs_allowlist_includes_every_tab() {
 }
 
 #[test]
-fn rendered_html_has_exactly_ten_page_h1s() {
-    // Invariant 2 across the consolidated set plus the Creative Ideas tab: each
-    // tab panel owns exactly one `<h1 class="page-h1">`, so the rendered HTML has
-    // exactly ten of them. Sub-sections must use `<h2>`, never a second page-h1.
+fn rendered_html_has_exactly_eleven_page_h1s() {
+    // Invariant 2 across the consolidated set plus Creative Ideas and the
+    // restored Memory tab (#2627): each tab panel owns exactly one
+    // `<h1 class="page-h1">`, so the rendered HTML has exactly eleven of them.
+    // Sub-sections must use `<h2>`, never a second page-h1. (Resources keeps a
+    // `<h2 class="subsection">Memory</h2>` recall summary — an h2, not counted.)
     let count = INDEX_HTML.matches(r#"<h1 class="page-h1">"#).count();
     assert_eq!(
-        count, 10,
-        "expected exactly 10 page-h1 headings (one per tab), found {count}; \
+        count, 11,
+        "expected exactly 11 page-h1 headings (one per tab), found {count}; \
          a stray page-h1 usually means an absorbed panel kept its old <h1> instead of \
          being demoted to an <h2 class=\"subsection\">"
     );
@@ -952,7 +963,6 @@ fn rendered_html_wires_tab_alias_allowlist() {
         ("terminal", "workers"),
         ("merge-decisions", "pull-requests"),
         ("pr-readiness", "pull-requests"),
-        ("memory", "resources"),
         ("costs", "resources"),
     ];
     for (retired, parent) in alias_pairs {
@@ -963,6 +973,15 @@ fn rendered_html_wires_tab_alias_allowlist() {
              expected to find: {needle}"
         );
     }
+    // #2627: `memory` is now a canonical top-level tab, so its old
+    // `"memory":"resources"` deep-link alias MUST be removed. The resolver
+    // checks CANONICAL_TABS before TAB_ALIASES, so a stale alias would be dead
+    // code that silently misroutes a `#memory` bookmark into Resources.
+    assert!(
+        !INDEX_HTML.contains(r#""memory":"resources""#),
+        "the retired-slug alias \"memory\":\"resources\" must be removed once \
+         Memory is a canonical tab (issue #2627); it would shadow the real tab"
+    );
     // The untrusted-hash validator must be present so a crafted hash can never
     // reach a DOM selector.
     assert!(

--- a/src/operator_commands_dashboard/memory.rs
+++ b/src/operator_commands_dashboard/memory.rs
@@ -359,24 +359,174 @@ pub(crate) async fn memory_search(Json(body): Json<Value>) -> Json<Value> {
     }))
 }
 
-/// `GET /api/memory/graph` — memory graph visualization.
+/// Per-type cap on live item nodes emitted into the memory graph. Bounds the
+/// response so a large store cannot stream tens of thousands of nodes into the
+/// visualization — an uncapped per-type dump is a payload-bloat / DoS vector on
+/// a mature store (issue #2627).
+const GRAPH_MAX_PER_TYPE: usize = 200;
+
+/// Maximum bytes of per-node `content` surfaced in the graph. Agent memory
+/// content can be multi-KB; the visualization only needs a preview for the
+/// hover tooltip / detail panel, so content is truncated server-side rather
+/// than streaming a full memory dump per node.
+const GRAPH_NODE_CONTENT_MAX: usize = 2048;
+
+/// The six cognitive memory types, in a fixed order, each paired with the
+/// human-facing label the dashboard legend / stat line uses. Every type becomes
+/// an always-present "type hub" node so the graph renders legend-complete (all
+/// six filters map to something) even on an empty store, and live per-item nodes
+/// attach to their hub. The literals must stay in lockstep with `mgColors` in
+/// `index_html/part_03.rs` — a `type` outside that set renders uncolored and
+/// unfilterable.
+const MEMORY_TYPE_HUBS: [(&str, &str); 6] = [
+    ("WorkingMemory", "Thinking"),
+    ("SensoryBuffer", "Observed"),
+    ("SemanticFact", "Facts"),
+    ("EpisodicMemory", "Events"),
+    ("ProceduralMemory", "Procedures"),
+    ("ProspectiveMemory", "Planned"),
+];
+
+/// Truncate `content` to at most `GRAPH_NODE_CONTENT_MAX` bytes on a UTF-8 char
+/// boundary, appending an ellipsis when it was actually shortened.
+fn truncate_graph_content(content: &str) -> String {
+    if content.len() <= GRAPH_NODE_CONTENT_MAX {
+        return content.to_string();
+    }
+    let mut end = GRAPH_NODE_CONTENT_MAX;
+    while end > 0 && !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &content[..end])
+}
+
+/// Short single-line label for a node (truncated on a char boundary). Keeps the
+/// on-canvas label readable without shipping the full content twice.
+fn graph_label(raw: &str) -> String {
+    const MAX: usize = 80;
+    let trimmed = raw.trim();
+    if trimmed.len() <= MAX {
+        return trimmed.to_string();
+    }
+    let mut end = MAX;
+    while end > 0 && !trimmed.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &trimmed[..end])
+}
+
+/// Namespace a raw store id under a per-type prefix so item ids never collide
+/// with a type-hub id (`hub:<Type>`) or across memory types, and every edge
+/// endpoint resolves to exactly one emitted node.
+fn graph_node_id(prefix: &str, raw: &str) -> String {
+    format!("{prefix}:{raw}")
+}
+
+/// Build the LIVE memory-graph payload `{nodes, edges, available, stats}` from a
+/// cognitive-memory reader.
 ///
-/// De-fork Phase 2b (issue #2307): the node/edge graph was built from raw
-/// Cypher against the deleted native schema. Aggregate statistics are still
-/// available through the trait (routed via `open_reader_client`), so those are
-/// surfaced; the per-node graph is reported as unavailable rather than reading
-/// the abandoned native store.
-pub(crate) async fn memory_graph() -> Json<Value> {
-    let state_root = resolve_state_root();
-    let stats = open_reader_client(&state_root)
-        .and_then(|reader| reader.ops().get_statistics())
-        .unwrap_or_default();
-    Json(json!({
-        "nodes": [],
-        "edges": [],
-        "available": false,
-        "note": "Memory graph visualization is unavailable on the library \
-                 backend (de-fork Phase 2b, #2307); aggregate stats are shown.",
+/// Topology (type-clustered): six always-present type-hub nodes (one per
+/// cognitive memory type) plus live per-item nodes for the four trait-enumerable
+/// types — semantic facts (`search_facts` wildcard), episodes
+/// (`list_all_episodes`), procedures (`recall_procedure` wildcard), and
+/// prospective memories (`list_all_prospective`) — each linked back to its hub.
+/// Working and sensory memory expose no trait-level per-item enumerator, so they
+/// render as their hub alone. `stats` mirrors `get_statistics()`. Payload is
+/// bounded by [`GRAPH_MAX_PER_TYPE`] (item nodes per type) and
+/// [`GRAPH_NODE_CONTENT_MAX`] (per-node content bytes).
+pub(crate) fn build_live_memory_graph(
+    ops: &dyn crate::cognitive_memory::CognitiveMemoryOps,
+) -> Value {
+    let cap = GRAPH_MAX_PER_TYPE as u32;
+    let stats = ops.get_statistics().unwrap_or_default();
+
+    let mut nodes: Vec<Value> = Vec::new();
+    let mut edges: Vec<Value> = Vec::new();
+
+    // Six type hubs — always present so the legend + all six filters are
+    // meaningful even when a type currently holds no items.
+    for (ty, label) in MEMORY_TYPE_HUBS {
+        nodes.push(json!({
+            "id": format!("hub:{ty}"),
+            "type": ty,
+            "label": label,
+            "hub": true,
+            "content": format!("{label}: cognitive memory type hub"),
+        }));
+    }
+
+    // Semantic facts — wildcard enumeration (confidence-desc), capped.
+    if let Ok(facts) = ops.search_facts("*", cap, 0.0) {
+        for f in facts {
+            let id = graph_node_id("fact", &f.node_id);
+            nodes.push(json!({
+                "id": id.clone(),
+                "type": "SemanticFact",
+                "label": graph_label(&f.concept),
+                "content": truncate_graph_content(&f.content),
+                "confidence": f.confidence,
+                "tags": f.tags,
+            }));
+            edges.push(json!({"source": id, "target": "hub:SemanticFact"}));
+        }
+    }
+
+    // Episodes — unfiltered enumeration, newest-first, capped.
+    if let Ok(episodes) = ops.list_all_episodes(cap) {
+        for e in episodes {
+            let id = graph_node_id("episode", &e.node_id);
+            nodes.push(json!({
+                "id": id.clone(),
+                "type": "EpisodicMemory",
+                "label": graph_label(&e.content),
+                "content": truncate_graph_content(&e.content),
+                "source": e.source_label,
+            }));
+            edges.push(json!({"source": id, "target": "hub:EpisodicMemory"}));
+        }
+    }
+
+    // Procedures — wildcard enumeration (usage-desc), capped.
+    if let Ok(procedures) = ops.recall_procedure("*", cap) {
+        for p in procedures {
+            let id = graph_node_id("procedure", &p.node_id);
+            let body = truncate_graph_content(&p.steps.join("\n"));
+            nodes.push(json!({
+                "id": id.clone(),
+                "type": "ProceduralMemory",
+                "label": graph_label(&p.name),
+                "content": body,
+                "steps": p.steps.len(),
+                "usage_count": p.usage_count,
+            }));
+            edges.push(json!({"source": id, "target": "hub:ProceduralMemory"}));
+        }
+    }
+
+    // Prospective memories — every status, priority-ordered, capped.
+    if let Ok(prospective) = ops.list_all_prospective(cap) {
+        for pr in prospective {
+            let id = graph_node_id("prospective", &pr.node_id);
+            let body = truncate_graph_content(&format!(
+                "when: {}\n→ {}",
+                pr.trigger_condition, pr.action_on_trigger
+            ));
+            nodes.push(json!({
+                "id": id.clone(),
+                "type": "ProspectiveMemory",
+                "label": graph_label(&pr.description),
+                "content": body,
+                "status": pr.status,
+                "priority": pr.priority,
+            }));
+            edges.push(json!({"source": id, "target": "hub:ProspectiveMemory"}));
+        }
+    }
+
+    json!({
+        "nodes": nodes,
+        "edges": edges,
+        "available": true,
         "stats": {
             "working": stats.working_count,
             "semantic": stats.semantic_count,
@@ -385,7 +535,47 @@ pub(crate) async fn memory_graph() -> Json<Value> {
             "prospective": stats.prospective_count,
             "sensory": stats.sensory_count,
         },
-    }))
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    })
+}
+
+/// `GET /api/memory/graph` — LIVE cognitive-memory graph visualization
+/// (issue #2627).
+///
+/// Restores the dedicated **Memory** tab's node/edge graph after the ~17→9 tab
+/// consolidation left it a de-fork #2307 stub. Reads the live cognitive store
+/// via a single shared reader ([`open_reader_client`]) and renders it through
+/// [`build_live_memory_graph`]: six type hubs, live per-item nodes for the four
+/// enumerable memory types linked to their hubs, and `stats` mirroring
+/// `get_statistics()`. When the reader is unreachable the graph falls back to an
+/// empty, `available:false` payload with a path-free note rather than erroring.
+pub(crate) async fn memory_graph() -> Json<Value> {
+    let state_root = resolve_state_root();
+    match open_reader_client(&state_root) {
+        Ok(reader) => Json(build_live_memory_graph(reader.ops())),
+        Err(e) => {
+            tracing::warn!(
+                target: "simard::dashboard",
+                error = %e,
+                "memory_graph: cognitive reader unavailable; serving empty graph"
+            );
+            Json(json!({
+                "nodes": [],
+                "edges": [],
+                "available": false,
+                "note": "Cognitive memory reader is currently unavailable; \
+                         showing an empty graph.",
+                "stats": {
+                    "working": 0,
+                    "semantic": 0,
+                    "episodic": 0,
+                    "procedural": 0,
+                    "prospective": 0,
+                    "sensory": 0,
+                },
+            }))
+        }
+    }
 }
 
 /// Classify an agent role into one of three layers used by the dashboard
@@ -709,6 +899,367 @@ mod tests_memory_history {
         assert!(
             html.contains("fetchMemoryHistory"),
             "JS must include fetchMemoryHistory function"
+        );
+    }
+}
+
+/// Contract tests for the LIVE memory-graph read path behind the restored
+/// dedicated **Memory** tab (issue #2627).
+///
+/// REGRESSION: the ~17->9 tab consolidation left `GET /api/memory/graph` a
+/// de-fork #2307 stub returning `{nodes:[], edges:[], available:false}`. These
+/// tests pin the rebuilt handler to the LIVE cognitive store read via
+/// `open_reader_client(state_root).ops()`: six always-present type hubs, live
+/// per-item nodes (facts/episodes/procedures/prospective) linked to their hubs,
+/// stats mirroring `get_statistics()`, and payload guards (per-type cap +
+/// per-node content truncation).
+///
+/// TDD note (Step 7 / red): every assertion here is expected to **FAIL**
+/// against the current stub — `available` is hard-coded `false` and `nodes`
+/// is empty. They pass once `memory_graph()` is rewired to the live builder.
+#[cfg(test)]
+mod tests_memory_graph {
+    use super::*;
+    use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
+    use crate::memory_ipc::{clear_in_process_writer, register_in_process_writer};
+    use crate::test_support::HermeticState;
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    /// The exact six node-type literals the frontend renderer keys on
+    /// (`mgColors` in `index_html/part_03.rs`). A node.type outside this set
+    /// renders uncolored and unfilterable.
+    const NODE_TYPE_ALLOWLIST: [&str; 6] = [
+        "WorkingMemory",
+        "SemanticFact",
+        "EpisodicMemory",
+        "ProceduralMemory",
+        "ProspectiveMemory",
+        "SensoryBuffer",
+    ];
+
+    /// RAII in-process writer registration. The dashboard handler resolves
+    /// `open_reader_client(state_root)` to this same Arc via the tier-0
+    /// same-process shortcut, so seeds written here are visible LIVE to
+    /// `memory_graph()`.
+    struct MemGuard {
+        writer: Arc<dyn CognitiveMemoryOps>,
+    }
+    impl MemGuard {
+        fn register(state: &HermeticState) -> Self {
+            let writer: Arc<dyn CognitiveMemoryOps> =
+                Arc::new(LibraryCognitiveMemory::open(state.state_root()).expect("open store"));
+            register_in_process_writer(state.state_root().to_path_buf(), Arc::clone(&writer));
+            Self { writer }
+        }
+        fn ops(&self) -> &dyn CognitiveMemoryOps {
+            self.writer.as_ref()
+        }
+    }
+    impl Drop for MemGuard {
+        fn drop(&mut self) {
+            clear_in_process_writer();
+        }
+    }
+
+    fn nodes_of(v: &Value) -> Vec<Value> {
+        v["nodes"].as_array().cloned().unwrap_or_default()
+    }
+    fn edges_of(v: &Value) -> Vec<Value> {
+        v["edges"].as_array().cloned().unwrap_or_default()
+    }
+    fn node_types(v: &Value) -> HashSet<String> {
+        nodes_of(v)
+            .iter()
+            .filter_map(|n| n["type"].as_str().map(str::to_string))
+            .collect()
+    }
+    /// Serialized JSON of the nodes array, for live-content marker checks.
+    fn nodes_text(v: &Value) -> String {
+        serde_json::to_string(&v["nodes"]).unwrap_or_default()
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(cognitive_memory)]
+    async fn memory_graph_reports_available_against_live_reader() {
+        let state = HermeticState::new();
+        let _mem = MemGuard::register(&state);
+
+        let out = memory_graph().await;
+        let v = &out.0;
+        assert_eq!(
+            v["available"],
+            serde_json::Value::Bool(true),
+            "memory_graph() must report available:true when the live cognitive \
+             reader is reachable — the de-fork #2307 stub hard-codes false. Got: {v}"
+        );
+        assert!(
+            v["nodes"].is_array() && v["edges"].is_array(),
+            "graph must always carry nodes[] and edges[] arrays; got {v}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(cognitive_memory)]
+    async fn memory_graph_emits_all_six_type_hub_nodes() {
+        // Type-clustered topology: even an empty store yields the six memory-type
+        // hub nodes so the tab renders a legend-complete graph and all six filters
+        // map to something (working + sensory have no per-item enumerator).
+        let state = HermeticState::new();
+        let _mem = MemGuard::register(&state);
+
+        let out = memory_graph().await;
+        let v = &out.0;
+        let types = node_types(v);
+        for t in NODE_TYPE_ALLOWLIST {
+            assert!(
+                types.contains(t),
+                "memory graph must contain a node of type {t:?} (the type hub) so the \
+                 {t} filter is meaningful even on an empty store; got types {types:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(cognitive_memory)]
+    async fn memory_graph_node_types_are_all_in_renderer_allowlist() {
+        let state = HermeticState::new();
+        let mem = MemGuard::register(&state);
+        mem.ops()
+            .store_fact("marker-concept", "a learned fact", 0.9, &[], "test")
+            .unwrap();
+        mem.ops()
+            .store_episode("an event happened", "test", None)
+            .unwrap();
+
+        let out = memory_graph().await;
+        let v = &out.0;
+        let allow: HashSet<&str> = NODE_TYPE_ALLOWLIST.iter().copied().collect();
+        for n in nodes_of(v) {
+            let t = n["type"].as_str().unwrap_or("<missing>");
+            assert!(
+                allow.contains(t),
+                "node.type {t:?} is not in the renderer's 6-literal allowlist \
+                 {NODE_TYPE_ALLOWLIST:?}; it would render uncolored/unfilterable. Node: {n}"
+            );
+            assert!(
+                n["id"].as_str().is_some_and(|s| !s.is_empty()),
+                "every node needs a non-empty string id (edges + the detail panel key \
+                 on it); node: {n}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(cognitive_memory)]
+    async fn memory_graph_renders_live_fact_and_episode_content() {
+        // "render LIVE data, no stale/placeholder": a freshly-stored fact and
+        // episode must surface as live nodes carrying their actual content.
+        let state = HermeticState::new();
+        let mem = MemGuard::register(&state);
+        let fact_marker = "ZZFACTMARKER2627";
+        let ep_marker = "ZZEPISODEMARKER2627";
+        mem.ops()
+            .store_fact(
+                fact_marker,
+                &format!("{fact_marker} body"),
+                0.95,
+                &[],
+                "test",
+            )
+            .unwrap();
+        mem.ops()
+            .store_episode(&format!("{ep_marker} occurred"), "test", None)
+            .unwrap();
+
+        let out = memory_graph().await;
+        let v = &out.0;
+        let text = nodes_text(v);
+        assert!(
+            text.contains(fact_marker),
+            "the live semantic fact {fact_marker:?} must appear in the graph nodes \
+             (LIVE data, not a placeholder). Nodes: {}",
+            &v["nodes"]
+        );
+        assert!(
+            text.contains(ep_marker),
+            "the live episode {ep_marker:?} must appear in the graph nodes. Nodes: {}",
+            &v["nodes"]
+        );
+        let types = node_types(v);
+        assert!(
+            types.contains("SemanticFact"),
+            "expected a SemanticFact node after seeding a fact; got {types:?}"
+        );
+        assert!(
+            types.contains("EpisodicMemory"),
+            "expected an EpisodicMemory node after seeding an episode; got {types:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(cognitive_memory)]
+    async fn memory_graph_renders_live_procedure_and_prospective() {
+        let state = HermeticState::new();
+        let mem = MemGuard::register(&state);
+        let proc_marker = "ZZPROCMARKER2627";
+        let prosp_marker = "ZZPROSPMARKER2627";
+        mem.ops()
+            .store_procedure(proc_marker, &["step one".to_string()], &[])
+            .unwrap();
+        mem.ops()
+            .store_prospective(&format!("{prosp_marker} plan"), "when x", "do y", 5)
+            .unwrap();
+
+        let out = memory_graph().await;
+        let v = &out.0;
+        let text = nodes_text(v);
+        assert!(
+            text.contains(proc_marker),
+            "the live procedure {proc_marker:?} must appear in the graph nodes; nodes: {}",
+            &v["nodes"]
+        );
+        assert!(
+            text.contains(prosp_marker),
+            "the live prospective memory {prosp_marker:?} must appear in the graph \
+             nodes; nodes: {}",
+            &v["nodes"]
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(cognitive_memory)]
+    async fn memory_graph_edges_reference_existing_nodes() {
+        // Edge integrity: the renderer does nodeMap[e.source]/nodeMap[e.target];
+        // a dangling endpoint throws. The server must guarantee every edge
+        // endpoint is an emitted node id, and link live items to their hubs.
+        let state = HermeticState::new();
+        let mem = MemGuard::register(&state);
+        for i in 0..3 {
+            mem.ops()
+                .store_fact(&format!("c{i}"), &format!("fact {i}"), 0.9, &[], "test")
+                .unwrap();
+            mem.ops()
+                .store_episode(&format!("event {i}"), "test", None)
+                .unwrap();
+        }
+
+        let out = memory_graph().await;
+        let v = &out.0;
+        let ids: HashSet<String> = nodes_of(v)
+            .iter()
+            .filter_map(|n| n["id"].as_str().map(str::to_string))
+            .collect();
+        let edges = edges_of(v);
+        for e in &edges {
+            let s = e["source"].as_str().unwrap_or("<missing>");
+            let t = e["target"].as_str().unwrap_or("<missing>");
+            assert!(
+                ids.contains(s),
+                "edge.source {s:?} references a non-existent node; edge: {e}"
+            );
+            assert!(
+                ids.contains(t),
+                "edge.target {t:?} references a non-existent node; edge: {e}"
+            );
+        }
+        assert!(
+            !edges.is_empty(),
+            "with live item nodes present, the graph must link them to their type \
+             hubs (non-empty edges)"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(cognitive_memory)]
+    async fn memory_graph_stats_mirror_live_statistics() {
+        let state = HermeticState::new();
+        let mem = MemGuard::register(&state);
+        for i in 0..4 {
+            mem.ops()
+                .store_fact(&format!("sc{i}"), &format!("sf {i}"), 0.9, &[], "test")
+                .unwrap();
+        }
+        for i in 0..2 {
+            mem.ops()
+                .store_episode(&format!("se {i}"), "test", None)
+                .unwrap();
+        }
+
+        let live = mem.ops().get_statistics().expect("stats");
+        let out = memory_graph().await;
+        let v = &out.0;
+        let s = &v["stats"];
+        assert_eq!(
+            s["semantic"].as_u64(),
+            Some(live.semantic_count),
+            "stats.semantic must mirror live get_statistics().semantic_count ({}); got {s}",
+            live.semantic_count
+        );
+        assert_eq!(
+            s["episodic"].as_u64(),
+            Some(live.episodic_count),
+            "stats.episodic must mirror live get_statistics().episodic_count ({}); got {s}",
+            live.episodic_count
+        );
+        assert!(
+            live.semantic_count >= 4 && live.episodic_count >= 2,
+            "sanity: the seeds must have landed in the live store"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(cognitive_memory)]
+    async fn memory_graph_truncates_oversized_node_content() {
+        // DoS / payload-bloat guard: agent memory content can be huge; the graph
+        // must truncate per-node content server-side (~2KB per the design) rather
+        // than streaming a multi-KB blob per node.
+        let state = HermeticState::new();
+        let mem = MemGuard::register(&state);
+        let huge = "X".repeat(8000);
+        mem.ops()
+            .store_fact("huge-concept", &huge, 0.9, &[], "test")
+            .unwrap();
+
+        let out = memory_graph().await;
+        let v = &out.0;
+        for n in nodes_of(v) {
+            if let Some(c) = n["content"].as_str() {
+                assert!(
+                    c.len() <= 4096,
+                    "node content must be truncated server-side (~2KB), got {} chars \
+                     — an untruncated memory dump bloats the response",
+                    c.len()
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(cognitive_memory)]
+    async fn memory_graph_caps_item_nodes_per_type() {
+        // Bounded enumeration: more items of a type than the per-type cap
+        // (~GRAPH_MAX_PER_TYPE, design ~200) must not blow up the response. Seed
+        // well past the cap and assert the EpisodicMemory item nodes stay bounded
+        // (+1 slack for the type hub). An uncapped dump (230 items) violates this.
+        let state = HermeticState::new();
+        let mem = MemGuard::register(&state);
+        for i in 0..230 {
+            mem.ops()
+                .store_episode(&format!("capped episode {i}"), "test", None)
+                .unwrap();
+        }
+
+        let out = memory_graph().await;
+        let v = &out.0;
+        let episodic = nodes_of(v)
+            .iter()
+            .filter(|n| n["type"].as_str() == Some("EpisodicMemory"))
+            .count();
+        assert!(
+            episodic <= 201,
+            "EpisodicMemory nodes ({episodic}) must be capped near GRAPH_MAX_PER_TYPE \
+             (~200, +1 hub) — an uncapped per-type dump is a DoS vector on large stores"
         );
     }
 }

--- a/src/operator_commands_dashboard/tests_routes_a.rs
+++ b/src/operator_commands_dashboard/tests_routes_a.rs
@@ -278,26 +278,30 @@ mod tests {
     // shared formatter.
     // -------------------------------------------------------------------
 
-    /// Every one of the nine consolidated SPA tabs (#2627) must carry a
-    /// non-empty `title="…"` hover-tooltip. Iterates the canonical tab list so
-    /// that adding/removing a tab immediately surfaces a missing tooltip via
-    /// this test rather than a silent UX regression.
+    /// Every one of the eleven consolidated SPA tabs (#2627, incl. the restored
+    /// Memory tab) must carry a non-empty `title="…"` hover-tooltip. Iterates
+    /// the canonical tab list so that adding/removing a tab immediately surfaces
+    /// a missing tooltip via this test rather than a silent UX regression.
     #[test]
     fn index_html_all_eleven_tabs_have_tooltips() {
         // Canonical consolidated SPA tab set (#2627). This list is the
-        // contract — keep in sync if tabs are added or removed.
+        // contract — keep in sync if tabs are added or removed. The `memory`
+        // entry (after Pull Requests) is the #2627 regression fix: its viz was
+        // dropped by the 17->9 consolidation and is restored as a dedicated tab.
         let tabs = [
             "overview",
             "goals",
             "activity",
             "workers",
             "pull-requests",
+            "memory",
             "resources",
             "chat",
             "overseer",
             "journal",
+            "creative-ideas",
         ];
-        assert_eq!(tabs.len(), 9, "expected exactly 9 top-level tabs");
+        assert_eq!(tabs.len(), 11, "expected exactly 11 top-level tabs");
 
         for tab in &tabs {
             let needle = format!(r#"data-tab="{tab}" title=""#);
@@ -720,22 +724,22 @@ mod tests {
         );
     }
 
-    /// Sanity-check on the page-lede count: after the #2627 consolidation
-    /// there must be exactly 9 (one per top-level tab). If a refactor
-    /// accidentally adds a 10th, we want to know immediately so we can decide
-    /// whether the new container is actually a new tab or a misuse of the
-    /// class (an absorbed panel should be an `<h2 class="subsection">`).
+    /// Sanity-check on the page-lede count: after the #2627 consolidation and
+    /// the restored Memory tab there must be exactly 11 (one per top-level tab).
+    /// If a refactor accidentally adds a 12th, we want to know immediately so we
+    /// can decide whether the new container is actually a new tab or a misuse of
+    /// the class (an absorbed panel should be an `<h2 class="subsection">`).
     #[test]
     fn index_html_has_exactly_eleven_page_intros() {
         let count = INDEX_HTML.matches(r#"class="page-lede""#).count();
         assert_eq!(
-            count, 10,
-            "expected exactly 10 page-lede paragraphs (one per top-level tab), got {count}"
+            count, 11,
+            "expected exactly 11 page-lede paragraphs (one per top-level tab), got {count}"
         );
         let h1_count = INDEX_HTML.matches(r#"class="page-h1""#).count();
         assert_eq!(
-            h1_count, 10,
-            "expected exactly 10 page-h1 headings (one per top-level tab), got {h1_count}"
+            h1_count, 11,
+            "expected exactly 11 page-h1 headings (one per top-level tab), got {h1_count}"
         );
     }
 

--- a/tests/e2e-dashboard/smoke_python/test_tab_clarity.py
+++ b/tests/e2e-dashboard/smoke_python/test_tab_clarity.py
@@ -42,9 +42,9 @@ BANNED_JARGON: tuple[str, ...] = (
     "ideate",
 )
 
-# The nine canonical tabs after the #2627 consolidation, in nav-render order.
-# Views that were formerly standalone tabs now live as sub-sections inside one
-# of these parents (see ``CANONICAL_TABS`` / the alias map below).
+# The canonical top-level tabs after the #2627 consolidation, in nav-render
+# order. Memory was restored as its own dedicated top-level tab by the #2627
+# regression fix (it had been folded into Resources).
 CANONICAL_SLUGS: tuple[str, ...] = (
     "overview",
     "goals",
@@ -52,6 +52,7 @@ CANONICAL_SLUGS: tuple[str, ...] = (
     "workers",
     "pull-requests",
     "resources",
+    "memory",
     "chat",
     "overseer",
     "journal",
@@ -71,7 +72,6 @@ RETIRED_SLUG_PARENTS: dict[str, str] = {
     "terminal": "workers",
     "merge-decisions": "pull-requests",
     "pr-readiness": "pull-requests",
-    "memory": "resources",
     "costs": "resources",
 }
 
@@ -100,12 +100,13 @@ def loaded_dashboard(page: Page, dashboard_url: str) -> Page:
 
 
 def test_at_least_nine_tabs_discoverable(loaded_dashboard: Page) -> None:
-    """Sanity: the nav exposes exactly the nine consolidated tabs (#2627)."""
+    """Sanity: the nav exposes the consolidated tabs (#2627) plus the restored
+    dedicated Memory tab (#2627 regression fix)."""
     slugs = _discover_tab_slugs(loaded_dashboard)
     assert len(slugs) >= 9, (
         f"expected >=9 tabs, discovered {len(slugs)}: {slugs}"
     )
-    # The nine canonical slugs must all be present (drift detector for #2627).
+    # The canonical slugs must all be present (drift detector for #2627).
     required = set(CANONICAL_SLUGS)
     missing = required - set(slugs)
     assert not missing, f"required canonical tabs missing from nav: {sorted(missing)}"

--- a/tests/e2e-dashboard/specs/memory-tab.spec.ts
+++ b/tests/e2e-dashboard/specs/memory-tab.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from '../fixtures/simard-dashboard';
+import type { Page } from '@playwright/test';
+
+/*
+ * Dedicated "Memory" tab contract (issue #2627).
+ *
+ * REGRESSION: the ~17->9 tab consolidation dropped the memory-graph
+ * visualization (folded into a collapsed <details> inside Resources and
+ * demoted to a deep-link alias). This restores it as its OWN top-level tab
+ * wired to the LIVE /api/memory/graph read path.
+ *
+ * TDD note: these are expected to FAIL against the current server — there is
+ * no `.tab[data-tab="memory"]` nav button, no `#tab-memory` panel, and the
+ * `#mem-graph-canvas` is buried in `#tab-resources`. They pass once the Memory
+ * tab is registered and the viz is promoted into its panel.
+ */
+
+// A live-shaped graph payload: the six memory types (per-item nodes clustered
+// under type hubs) plus a stats block, mirroring the rebuilt handler.
+const LIVE_GRAPH = {
+  available: true,
+  stats: { working: 2, semantic: 3, episodic: 4, procedural: 1, prospective: 1, sensory: 5 },
+  nodes: [
+    { id: 'hub:SemanticFact', type: 'SemanticFact', label: 'Facts learned', content: 'Facts learned' },
+    { id: 'fact:1', type: 'SemanticFact', label: 'rust ownership', content: 'ZZLIVEFACT the borrow checker' },
+    { id: 'hub:EpisodicMemory', type: 'EpisodicMemory', label: 'Events remembered', content: 'Events remembered' },
+    { id: 'ep:1', type: 'EpisodicMemory', label: 'merged PR', content: 'ZZLIVEEPISODE merged a PR' },
+    { id: 'hub:ProceduralMemory', type: 'ProceduralMemory', label: 'Known procedures', content: 'Known procedures' },
+    { id: 'hub:ProspectiveMemory', type: 'ProspectiveMemory', label: 'Planned actions', content: 'Planned actions' },
+    { id: 'hub:WorkingMemory', type: 'WorkingMemory', label: 'Currently thinking about', content: '2 slots' },
+    { id: 'hub:SensoryBuffer', type: 'SensoryBuffer', label: 'Recent observations', content: '5 buffered' },
+  ],
+  edges: [
+    { source: 'hub:SemanticFact', target: 'fact:1' },
+    { source: 'hub:EpisodicMemory', target: 'ep:1' },
+  ],
+};
+
+const BODIES: Record<string, unknown> = {
+  '/api/status': { version: '0.8.0', git_hash: 'test', ooda_status: 'idle', uptime_secs: 0 },
+  '/api/status/snapshot': {
+    data: { schema_version: 1, generated_at: '2026-07-06T00:00:00Z' },
+    rendered: 'SIMARD STATUS',
+    generated_at: '2026-07-06T00:00:00Z',
+  },
+  '/api/memory/graph': LIVE_GRAPH,
+  '/api/memory': { overview: {}, files: [] },
+  '/api/memory/recent': { items: [], total: 0, last_hour_count: 0, server_time: new Date().toISOString() },
+  '/api/memory/history': { points: [] },
+  '/api/costs': { daily: [], weekly: [] },
+};
+
+function installRoutes(page: Page): Record<string, number> {
+  const counts: Record<string, number> = {};
+  page.route('**/api/**', async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    counts[pathname] = (counts[pathname] ?? 0) + 1;
+    const body = pathname in BODIES ? BODIES[pathname] : {};
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+  return counts;
+}
+
+test.describe('Dedicated Memory tab @structural', () => {
+  test('a top-level Memory nav button activates a dedicated Memory panel', async ({
+    authenticatedPage,
+  }) => {
+    installRoutes(authenticatedPage);
+    await authenticatedPage.goto('/');
+
+    const navButton = authenticatedPage.locator('.tab[data-tab="memory"]');
+    await expect(navButton, 'a top-level "Memory" nav button must exist').toBeVisible();
+    await expect(navButton).toHaveText(/Memory/);
+
+    await navButton.click();
+    await expect(
+      authenticatedPage.locator('#tab-memory'),
+      'clicking Memory must reveal the #tab-memory panel',
+    ).toBeVisible();
+    await expect(authenticatedPage.locator('#tab-memory h1.page-h1')).toHaveText('Memory');
+  });
+
+  test('the Memory tab renders the graph canvas and all six type filters', async ({
+    authenticatedPage,
+  }) => {
+    installRoutes(authenticatedPage);
+    await authenticatedPage.goto('/');
+    await authenticatedPage.locator('.tab[data-tab="memory"]').click();
+
+    const panel = authenticatedPage.locator('#tab-memory');
+    await expect(panel.locator('#mem-graph-canvas')).toBeVisible();
+    for (const ty of [
+      'WorkingMemory',
+      'SemanticFact',
+      'EpisodicMemory',
+      'ProceduralMemory',
+      'ProspectiveMemory',
+      'SensoryBuffer',
+    ]) {
+      await expect(
+        panel.locator(`.mem-filter[data-type="${ty}"]`),
+        `the ${ty} filter must live inside the Memory panel`,
+      ).toHaveCount(1);
+    }
+  });
+
+  test('the Memory tab fetches LIVE data from /api/memory/graph and shows the counts', async ({
+    authenticatedPage,
+  }) => {
+    const counts = installRoutes(authenticatedPage);
+    await authenticatedPage.goto('/');
+    await authenticatedPage.locator('.tab[data-tab="memory"]').click();
+
+    // The live graph endpoint must be hit for the Memory tab.
+    await expect
+      .poll(() => counts['/api/memory/graph'] ?? 0, {
+        message: 'activating the Memory tab must fetch the live /api/memory/graph',
+        timeout: 15_000,
+      })
+      .toBeGreaterThanOrEqual(1);
+
+    // The stats line reflects the live counts from the payload (no placeholder).
+    await expect(authenticatedPage.locator('#mem-graph-stats')).toContainText('Facts:3');
+    await expect(authenticatedPage.locator('#mem-graph-stats')).toContainText('Events:4');
+  });
+
+  test('the Memory graph canvas is not duplicated in Resources', async ({ authenticatedPage }) => {
+    installRoutes(authenticatedPage);
+    await authenticatedPage.goto('/');
+    // Moved, not copied: exactly one canvas in the whole document.
+    await expect(authenticatedPage.locator('#mem-graph-canvas')).toHaveCount(1);
+  });
+});


### PR DESCRIPTION
## Problem
The 17→9 dashboard tab consolidation (PR #2641) dropped the cognitive-memory visualization component.

## Fix
Restores it as its own top-level **Memory** tab, wired to the live cognitive-memory read path (shared reader via `memory_ipc`), with the graph visualization, nav button, and background prefetch/refresh consistent with the other tabs. Removes the stale Resources deeplink alias.

## Tests
- 7 unit tests in `tests_memory_tab.rs` pinning tab metadata, nav button/panel, graph-canvas rendering (no duplication), background loader, JS allowlist, and deeplink-alias removal.
- Updated `tests_tab_meta.rs` + `tests_routes_a.rs`; new e2e spec `memory-tab.spec.ts`.
- Reference docs added.

Closes #2627

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>