### PR TITLE
fix(creative-ideas): fail-closed goal persistence so routed goals are never silently lost (#2896)

### DIFF
--- a/docs/howto/diagnose-lost-creative-ideas-goals.md
+++ b/docs/howto/diagnose-lost-creative-ideas-goals.md
@@ -1,0 +1,261 @@
+---
+title: How to diagnose and recover lost creative-ideas goals
+description: Operator walkthrough for verifying that ideas accepted by the creative-ideas thread become durable, visible goals tagged source:creative-ideas, reading the fail-closed route/review errors that now surface a dropped write, correlating memory-ipc Broken-pipe log lines, and recovering after the #2896 fix.
+last_updated: 2026-07-07
+owner: simard
+doc_type: howto
+status: howto
+related:
+  - ../reference/creative-ideas-goal-routing-fail-closed.md
+  - ../reference/creative-ideas-api.md
+  - ../reference/goal-labels.md
+  - ../reference/cognitive-memory-client-helpers.md
+  - ./label-and-filter-goals.md
+  - ./configure-creative-ideas-thread.md
+  - ./troubleshoot-goal-store.md
+---
+
+# How to diagnose and recover lost creative-ideas goals
+
+When the creative-ideas thread accepts an idea for implementation it routes the
+idea to a **goal** tagged `source:creative-ideas`. Before issue
+[#2896](https://github.com/rysweet/Simard/issues/2896) those goals could be
+**silently lost**: the thread logged `N → goal`, telemetry reported
+`0 review error(s)`, yet `simard goal list --tag source:creative-ideas`
+returned zero. The fix makes every persistence seam on that path **fail-closed**
+— a dropped write now surfaces as a route/review error, and an in-process write
+lands in the same store `goal list` reads. This guide shows how to verify the
+fix is working, how to read the new fail-closed signals, and how to recover.
+
+For the full contract see
+[Creative-ideas goal routing — fail-closed persistence](../reference/creative-ideas-goal-routing-fail-closed.md).
+
+## Prerequisites
+
+- [ ] You can reach the `simard` CLI (it resolves the same state root as the
+  daemon: `$SIMARD_STATE_ROOT`, else `$HOME/.simard/state`).
+- [ ] The OODA daemon is running with the creative-ideas thread enabled
+  (default-ON; opt-out via `SIMARD_CREATIVE_IDEAS_ENABLED`).
+- [ ] For dashboard steps, the operator dashboard is up and you have the
+  dashboard key (`~/.simard/.dashkey`).
+
+---
+
+## 1. Confirm creative-ideas goals are now visible
+
+This is the headline check — the query that returned `0` before the fix:
+
+```bash
+simard goal list --tag source:creative-ideas
+```
+
+After a run that accepts at least one idea, this returns **one or more** goals:
+
+```text
+active goals: 3 / 20 (filtered by tag)
+ID                              PRIORITY  STATUS       ASSIGNED  DESCRIPTION                       LABELS
+idea-live-tag-filter-dashboard  p2        not-started  -         Ship the live tag filter …        source:creative-ideas
+idea-goal-board-health-probe    p2        not-started  -         Probe goal-board health …         source:creative-ideas
+…
+```
+
+Cross-check the same result over the dashboard API:
+
+```bash
+DASHKEY="$(cat ~/.simard/.dashkey)"
+curl -s -u "operator:$DASHKEY" http://localhost:8080/api/goals \
+  | jq '[.active[], .backlog[]] | map(select((.labels // []) | index("source:creative-ideas"))) | length'
+```
+
+A non-zero count confirms the write path persists and is visible.
+
+---
+
+## 2. Trigger a run and watch it land
+
+Force a run instead of waiting for the schedule. There is no
+`simard creative-ideas` CLI subcommand; a run is triggered from the dashboard or
+its HTTP API (the schedule interval is `SIMARD_CREATIVE_IDEAS_INTERVAL_SECS`,
+default 86400 — each daemon restart pushes the next scheduled tick out again):
+
+- **Dashboard:** click **"Run now"** (Creative Ideas → "Run now", the
+  `ci-run-btn` control).
+- **Scriptable** — `POST /api/creative-ideas/run` (inherits the dashboard auth):
+
+  ```bash
+  DASHKEY="$(cat ~/.simard/.dashkey)"
+  curl -s -u "operator:$DASHKEY" -X POST \
+    http://localhost:8080/api/creative-ideas/run -d '{}' | jq
+  #   → {"ok": true, "report": {"persisted": …, "reviewed": …, "routed_goal": …}}
+  #   → {"running": true}  if a run is already in flight (re-entrancy guard)
+  ```
+
+Read the telemetry line for the run:
+
+```text
+creative_ideas: 10 generated, 10 reviewed (6 → goal, 3 → issue), 0 review error(s)
+```
+
+Then re-run the query from step 1. The count should rise by roughly the `→ goal`
+number (dedup-by-slug may collapse duplicates). The key invariant after #2896:
+
+> **`N → goal` with `0 review error(s)` now means N goals actually persisted.**
+> If a write is dropped, it is counted as a **review error**, not a phantom
+> `→ goal`.
+
+---
+
+## 3. Read the new fail-closed signals
+
+If a memory-IPC transport fault occurs during routing, it now surfaces instead
+of being swallowed.
+
+### Telemetry: dropped writes show up as review errors
+
+```text
+creative_ideas: 10 generated, 10 reviewed (4 → goal, 3 → issue), 2 review error(s)
+```
+
+`2 review error(s)` means two routes failed loudly. The routed-goal count
+(`4`) reflects only goals that actually persisted. Before #2896 this same
+scenario reported `6 → goal, 0 review error(s)` and lost two of them.
+
+### The daemon returns an explicit error
+
+A live-daemon transport failure on the write now yields a typed error rather
+than a silent fall-through, e.g.:
+
+```text
+cognitive-memory writer socket <state_root>/memory.sock is present and a daemon
+is listening, but the connection failed (…); refusing to fall back to a
+divergent direct-open handle that would silently drop the write (issue #2896).
+```
+
+Seeing this error is the **correct** behaviour — the write was refused rather
+than dropped. Re-run once the transport recovers (step 5).
+
+### Broken-pipe log lines no longer imply data loss
+
+You may still see:
+
+```text
+[simard] memory-ipc: connection error: bridge 'memory-ipc' transport error: write-len: Broken pipe (os error 32)
+```
+
+These reflect the underlying transport condition and are **expected to appear
+occasionally**. After #2896 they no longer correlate with lost goals: either the
+client reconnects and the write persists, or the route is recorded as a review
+error. To confirm there is no loss, correlate the log timestamps with step 1 —
+the tagged-goal count should still track the `→ goal` totals across runs.
+
+---
+
+## 4. Distinguish "empty board" from "read error"
+
+Before the fix, a transport error on the **read** path returned an empty list,
+so a healthy board could look empty. After #2896 the read path is fail-closed:
+
+- `simard goal list` returning an **empty** board means the store is genuinely
+  empty.
+- A read **transport error** now exits **non-zero** with an error message,
+  instead of silently printing an empty board.
+
+If `simard goal list` errors out, the daemon or state root is unreachable — see
+[Troubleshoot the goal store](./troubleshoot-goal-store.md). An empty-but-exit-0
+board is a real empty board, not a swallowed error.
+
+---
+
+## 5. Recover after a transport fault
+
+If a run reported `review error(s)` or you saw the fail-closed writer error:
+
+1. **Confirm the daemon is healthy.**
+
+   ```bash
+   simard status
+   ```
+
+   A running daemon owns the in-process writer; routed goals take the tier-0
+   in-process path and never touch the socket.
+
+2. **Check the socket and state-root permissions** (hardened by #2896 to
+   owner-only `0700` dir / `0600` socket):
+
+   ```bash
+   ls -ld  "${SIMARD_STATE_ROOT:-$HOME/.simard/state}"
+   ls -l   "${SIMARD_STATE_ROOT:-$HOME/.simard/state}/memory.sock" 2>/dev/null
+   ```
+
+   Expect `drwx------` on the directory and `srw-------` on the socket. Group- or
+   world-access is unexpected.
+
+3. **Re-run.** Because routing is now fail-closed, simply re-running recovers the
+   dropped ideas — accepted ideas that failed to persist were **not** marked
+   done, so the next run re-routes them. Trigger it from the dashboard
+   ("Run now") or `POST /api/creative-ideas/run` (step 2) and re-check the board:
+
+   ```bash
+   simard goal list --tag source:creative-ideas
+   ```
+
+4. If writer errors persist across runs with a healthy daemon, the underlying
+   memory-IPC transport needs attention — capture the daemon logs and see
+   [Cognitive-memory client helpers](../reference/cognitive-memory-client-helpers.md).
+
+---
+
+## 6. Verify end-to-end
+
+```bash
+# 1. Baseline count (rows are the idea-* goal IDs).
+before=$(simard goal list --tag source:creative-ideas | grep -c '^idea-' || true)
+
+# 2. Force a run: dashboard "Run now", or the HTTP API:
+#    curl -s -u "operator:$(cat ~/.simard/.dashkey)" -X POST \
+#      http://localhost:8080/api/creative-ideas/run -d '{}'
+
+# 3. Count again — accepted ideas produced visible, tagged goals.
+simard goal list --tag source:creative-ideas
+#    → count >= before; new goals carry source:creative-ideas
+
+# 4. A run with N → goal and 0 review error(s) means N goals persisted.
+```
+
+---
+
+## Troubleshooting
+
+### `simard goal list --tag source:creative-ideas` is still empty after a run
+
+Check the run telemetry (step 2). If it shows `0 → goal`, no idea was
+*accepted for implementation* this run — the reviewers routed everything to
+issues or rejected it. Try another run, or lower the acceptance bar per
+[Configure the creative-ideas thread](./configure-creative-ideas-thread.md). If
+it shows `N → goal` with `N > 0` and the count is still zero, that is a
+regression of #2896 — capture the daemon logs and file a bug referencing #2896.
+
+### A run reports `review error(s)` every time
+
+The write path is fail-closed and refusing to drop data — good — but the
+underlying transport keeps failing. Work through step 5; a persistently broken
+memory-IPC socket is the root cause, not the goal store.
+
+### `simard goal list` exits non-zero
+
+That is the fail-closed read path surfacing a transport error (it no longer
+prints an empty board on error). The daemon or state root is unreachable — see
+[Troubleshoot the goal store](./troubleshoot-goal-store.md).
+
+---
+
+## Related reading
+
+- [Creative-ideas goal routing — fail-closed persistence](../reference/creative-ideas-goal-routing-fail-closed.md)
+  — the full contract, API, and tests.
+- [Creative Ideas subsystem API](../reference/creative-ideas-api.md) — the
+  routing pipeline and the `run_now` / `POST /api/creative-ideas/run` entrypoint.
+- [How to label, categorize, and filter goals](./label-and-filter-goals.md) —
+  the `--tag` filter and `source:*` provenance.
+- [Configure and operate the creative-ideas thread](./configure-creative-ideas-thread.md).
+- [Troubleshoot the goal store](./troubleshoot-goal-store.md).

--- a/docs/reference/creative-ideas-goal-routing-fail-closed.md
+++ b/docs/reference/creative-ideas-goal-routing-fail-closed.md
@@ -1,0 +1,551 @@
+---
+title: Creative-ideas goal routing — fail-closed persistence
+description: >
+  How a creative idea accepted for implementation is routed to a durable,
+  visible GoalRecord tagged source:creative-ideas, with every persistence seam
+  on the path made fail-closed. Documents the #2896 fix for silent goal loss:
+  the in-process GoalStoreFactory that reuses the daemon's live memory handle
+  (InProcessGoalStore + put_via_ops / list_via_ops), the fail-closed
+  CognitiveMemoryGoalStore::list read path (no more Ok(empty) on transport
+  error), the fail-closed launch_writer_client / open_reader_client tier-1
+  contract (a live-daemon connect/transport failure is Err, never a silent
+  fall-through to a divergent direct-open handle), the shared write seam,
+  socket/state-root permissions, the hermetic regression tests, and the live
+  operator validation. Fixes issue #2896.
+last_updated: 2026-07-07
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+status: implemented
+related:
+  - ./creative-ideas-api.md
+  - ./creative-ideas-durable-read-after-write.md
+  - ./cognitive-memory-client-helpers.md
+  - ./goal-labels.md
+  - ./cognitive-memory-goal-store.md
+  - ./goal-board-api.md
+  - ../concepts/goal-board-persistence.md
+  - ../design/creative-ideas-thread.md
+  - ../howto/diagnose-lost-creative-ideas-goals.md
+  - ../howto/troubleshoot-goal-store.md
+---
+
+# Creative-ideas goal routing — fail-closed persistence
+
+> **Issue [#2896](https://github.com/rysweet/Simard/issues/2896).** When the
+> creative-ideas thread accepted an idea for implementation it routed the idea
+> to a goal, the daemon telemetry counted the route as a success
+> (`N → goal`, `0 review error(s)`), and `put()` returned `Ok` — yet
+> `simard goal list --tag source:creative-ideas` returned **zero** goals over
+> two days of runs. The goals were **silently lost**. This page documents the
+> shipped fix, which makes every persistence seam on the creative-ideas → goal
+> write path **fail-closed**: a dropped write now surfaces as a route/review
+> error instead of a phantom success, and an in-process write lands in the
+> **same** store the live `goal list` reads.
+
+The symptom was not a UI bug, a filter bug, or a "no ideas were accepted" bug.
+Routing *was* invoked in non-dry-run mode, `route_idea_to_goal` built a
+`GoalRecord` tagged `source:creative-ideas`, and `goals.put(record)?` returned
+`Ok`. The record still never became visible. Three independent silent-failure
+seams combined to turn a broken write into a counted success:
+
+| # | Seam | Symptom | Fix |
+|---|------|---------|-----|
+| **1** | `CognitiveMemoryGoalStore::list_via_reader` swallowed both a reader-open error **and** a `search_facts` error, returning `Ok(Vec::new())`. | A transport error on **read** looked identical to a genuinely empty store, so a persisted goal could be invisible. | [Fail-closed read path](#fix-1-fail-closed-read-path). Distinguish *empty store* from *transport error*; propagate the error as `Err`. |
+| **2** | `launch_writer_client` / `open_reader_client` tier-1: when the daemon socket was **present but the connection failed** (the "Broken pipe" logs), the launcher `eprintln!`d and **fell through to a tier-2 direct open** — a *different* store view than the daemon's live in-process handle. | An in-process write went to a divergent on-disk handle the daemon never read back; `put()` still returned `Ok`. | [Fail-closed launcher](#fix-2-fail-closed-launcher-tier-1). A live-daemon connect/transport failure is now `Err`; tier-2 is reserved for the genuine no-daemon case. |
+| **3** | The creative-ideas goal store opened a **fresh handle keyed on `state_root`** on every call, instead of reusing the daemon's live in-process `Arc`, so a tier-0 miss silently degraded to the socket/tier-2 path from seam #2. | Even without a transport error, the write could land in a store the live `goal list` did not read. | [In-process visibility](#fix-3-in-process-store-visibility). The factory reuses the daemon's `ctx.memory` handle so the write is visible **by construction**. |
+
+The tagging surface itself (`labels`, the `source:creative-ideas` provenance
+tag, and `simard goal list --tag`) already shipped in issue
+[#2743](https://github.com/rysweet/Simard/issues/2743) — see the
+[Goal labels reference](./goal-labels.md). This fix is what makes those tagged
+goals actually **persist and become visible**. No `amplihack-memory` engine
+change is required; the store format is unchanged.
+
+> **Naming constraint.** No type, struct, enum, or trait introduced by this fix
+> contains the word `Bridge` (operator preference). The existing runtime strings
+> that read `bridge 'memory-ipc'` are user-facing telemetry and are left
+> unchanged — renaming them is out of scope for this PR.
+
+---
+
+## Architecture
+
+### The two paths that must agree
+
+```
+WRITE PATH (OODA daemon, creative-ideas thread)          READ PATH (operator / dashboard / TUI)
+------------------------------------------------         --------------------------------------
+CreativeIdeasThread::run                                 simard goal list --tag source:creative-ideas
+  AgenticIdeaPipeline::review_and_route(ctx, idea)         GoalStore::list()  (cold open on state_root)
+    IdeaStatus::AcceptedForImplementation                    open_reader_client(state_root)
+      let goals = self.goals.open(ctx.memory, …)?  <-- reuse the live handle
+      route_idea_to_goal(idea, goals.as_ref(), now)?          tier 0: lookup_in_process_writer (daemon)
+        GoalRecord{ labels:[source:creative-ideas] }          tier 1: RemoteCognitiveMemory::connect
+        goals.put(record)?  ── put_via_ops(ctx.memory) ──────► SAME store the daemon serves
+```
+
+The daemon registers its live writer at bootstrap under its resolved state root
+(unchanged from prior work):
+
+```rust
+// src/operator_commands_ooda/daemon/mod.rs
+let state_root = state_root_override.unwrap_or_else(memory_ipc::default_state_root);
+memory_ipc::register_in_process_writer(state_root.clone(), Arc::clone(&shared_mem));
+```
+
+`ctx.memory` inside the creative-ideas thread is the `&dyn CognitiveMemoryOps`
+borrow of that **same** `shared_mem` — it is exactly the handle the prospective
+creative-idea store already uses (and which persists correctly). Before #2896
+the goal write path ignored `ctx.memory` and re-derived a handle from
+`ctx.state_root`; the fix threads `ctx.memory` all the way to `put()`.
+
+### Root cause
+
+`route_idea_to_goal` mints the record and calls `goals.put(record)?`. Under the
+pre-fix implementation `put()` re-resolved a handle from `state_root` through the
+memory-IPC launcher rather than reusing `ctx.memory`. Two facts about that
+launcher make the loss possible:
+
+1. **The in-process (tier-0) shortcut is keyed on `state_root`.**
+   `lookup_in_process_writer` returns the daemon's live `Arc` only when the
+   caller's `state_root` *canonicalizes to the same path* as the daemon's
+   registered key **and** the registered `Weak` still upgrades. When the
+   creative-ideas `ctx.state_root` does not canonicalize to the daemon's
+   registered root (a symlinked / overridden / non-canonical state root), tier-0
+   **misses** even though the caller is in the daemon process.
+2. **On a tier-0 miss the launcher tried tier-1, and `connect()` does a
+   handshake write.** `RemoteCognitiveMemory::connect` sends a `Ping` frame; if
+   the daemon is alive but the socket is wedged, that handshake `write_frame`
+   fails with the `write-len: Broken pipe (os error 32)` transport error seen in
+   the live logs. The launcher `eprintln!`d it and **silently fell through to a
+   tier-2 direct-open handle addressing a divergent on-disk view**.
+
+The write succeeded against *that* tier-2 handle, `put()` returned `Ok`,
+telemetry incremented `routed_goal`, and the daemon's live `goal list` (served
+from tier-0) never saw it. (Note: a Broken pipe on the *actual* `store_fact` RPC
+already propagates today — `put()` calls `store_fact_with_caller_key(…)?` — so
+the residual silent-loss vector is specifically this tier-2 *handle divergence*,
+not a swallowed write error.) The read path then compounded the problem: any
+transport hiccup on `list()` returned `Ok(Vec::new())`, so the loss was
+indistinguishable from "no goals".
+
+---
+
+## Fix 1 — Fail-closed read path
+
+`src/goals/cognitive_memory_store.rs`
+
+`CognitiveMemoryGoalStore::list_via_reader` no longer converts a transport
+failure into an empty result. A reader-open error and a `search_facts` error
+both **propagate** as `Err`; only a genuinely empty store yields an empty list.
+
+```rust
+// AFTER (#2896) — fail-closed
+fn list_via_reader(&self) -> SimardResult<Vec<GoalRecord>> {
+    let reader = open_reader_client(&self.state_root)?;   // was: Err(_) => Ok(Vec::new())
+    list_via_ops(reader.ops())                            // search_facts error now propagates
+}
+```
+
+```rust
+// BEFORE (#2896) — silent swallow (removed)
+let reader = match open_reader_client(&self.state_root) {
+    Ok(r) => r,
+    Err(_) => return Ok(Vec::new()),                     // <-- transport error looked empty
+};
+let facts = match reader.ops().search_facts(GOAL_STORE_FACT_CONCEPT, GOAL_STORE_LIST_LIMIT, 0.0) {
+    Ok(f) => f,
+    Err(e) => {
+        eprintln!("… search_facts failed ({e}) — returning empty record set");
+        return Ok(Vec::new());                           // <-- and so did a search error
+    }
+};
+```
+
+| Condition | Before | After |
+|-----------|--------|-------|
+| Store opened, no goal facts present | `Ok([])` | `Ok([])` *(unchanged — genuinely empty)* |
+| Reader-open transport error | `Ok([])` | **`Err`** |
+| `search_facts` transport error | `Ok([])` (+ `eprintln!`) | **`Err`** |
+| An individual fact fails to deserialize | skipped (data-quality) | skipped (data-quality) *(unchanged)* |
+
+> **Empty vs. error is the whole point.** A per-record deserialize failure is a
+> *data-quality* skip and stays a skip — it does not fail the whole list. A
+> *transport* failure is an infrastructure fault and is now surfaced, so a lost
+> write can never masquerade as an empty board.
+
+The stray `eprintln!` is removed; the error travels as a typed `SimardError`.
+
+---
+
+## Fix 2 — Fail-closed launcher tier-1
+
+`src/memory_ipc/launcher.rs`
+
+Both `launch_writer_client` and `open_reader_client` share a single tier-1
+contract. When the resolved socket for `state_root` **exists** but the
+connection cannot be established — for **any** reason: a non-socket file
+occupying the path, a refused connection, a broken pipe on the handshake, or a
+failed `Ping` — the launcher **returns `Err`**. It must never fall through to a
+divergent tier-2 direct-open handle, because a same-process daemon writes and
+reads through that socket and a tier-2 handle would address a *different* store —
+the silent-loss path #2896 forbids. Only a **genuinely absent** socket (no
+daemon) takes the legitimate tier-2 path.
+
+```rust
+// src/memory_ipc/launcher.rs — launch_writer_client (post-#2896)
+let sock = socket_path_for(state_root);
+if sock.exists() {
+    // Fail closed: a socket present but unconnectable means a daemon *should*
+    // own this store. Surface the error rather than diverging to tier-2.
+    let client = RemoteCognitiveMemory::connect(&sock).map_err(|e| {
+        SimardError::RpcSpawnFailed {
+            bridge: "memory-ipc".into(),
+            reason: format!(
+                "writer: socket {} present but unconnectable ({e}); refusing to fall \
+                 through to a divergent direct open (bug #2896)",
+                sock.display()
+            ),
+        }
+    })?;
+    return Ok(WriterClient::checked_new(Box::new(client)));
+}
+// (no socket at all → genuine no-daemon path → tier-2 direct open below)
+```
+
+`open_reader_client` applies the identical rule. The
+`eprintln!("… falling back to direct open")` lines are removed from both helpers
+— the failure is now a typed `Err`, not a log-and-degrade.
+
+> **Why fail closed even for a leftover socket file?** A socket file only
+> survives a daemon that did not shut down cleanly (the server unlinks its
+> socket on `Drop`, and again before every re-bind). While such a file is
+> present, a write that silently diverged to tier-2 would be invisible to the
+> daemon that is expected to own the store — precisely the #2896 failure.
+> Erroring loudly surfaces the wedged/leftover-socket condition; the daemon's
+> next re-bind removes the file and restores the tier-1 path. A genuinely
+> daemon-free host has **no** socket file and takes tier-2 unchanged. This is
+> the fail-closed mandate of #2896: no silent fallback when the socket says a
+> daemon should be there.
+
+### Tier ladder (post-fix)
+
+| Tier | Source | Condition |
+|------|--------|-----------|
+| 0 | Daemon-registered in-process `Arc<dyn CognitiveMemoryOps>` | Same-process caller; `state_root` canonicalizes to the registered key |
+| 1 | `RemoteCognitiveMemory::connect(socket_path_for(state_root))` | Socket exists. **Any** connect / handshake / transport failure here is now **`Err`** (was: silent fall-through to tier-2). |
+| 2 | `shared_tier2_store(state_root)` direct open | **No** socket present (genuine no-daemon / hermetic test / standalone CLI) |
+
+Tiers 0 and 2 are unchanged. Tier 1's *failure* semantics are what changed:
+`socket present + connect fails` was the silent-loss path and is now closed.
+Hermetic `TempDir` tests (which have **no** socket) still take tier-2 unchanged,
+so the fix does not perturb the isolated test suites.
+
+> This is a strengthening of the existing "no read-only fallback" contract
+> documented in [Cognitive-memory client helpers](./cognitive-memory-client-helpers.md#launch_writer_client).
+> That contract already refused to hand back a read-only writer; #2896 extends
+> it so a *live-daemon transport failure* also refuses to silently pick a
+> divergent store view.
+
+---
+
+## Fix 3 — In-process store visibility
+
+`src/creative_ideas/pipeline.rs`, `src/goals/cognitive_memory_store.rs`
+
+The creative-ideas goal write now reuses the daemon's **live** memory handle
+(`ctx.memory`), the same one the daemon serves `goal list` from — so the write
+is visible by construction, exactly as the prospective creative-idea store
+already is. The path-based `CognitiveMemoryGoalStore` is retained for the
+**cold-open CLI** case (`simard goal …` with no daemon in-process).
+
+### `GoalStoreFactory::open` — new signature
+
+```rust
+// src/creative_ideas/pipeline.rs
+pub trait GoalStoreFactory: Send {
+    /// Open a goal store bound to the caller's live memory handle.
+    ///
+    /// `memory` is the in-process `CognitiveMemoryOps` the daemon serves reads
+    /// and writes from (borrowed as `&'a dyn …`). `state_root` is retained for
+    /// the cold-open path and diagnostics. The returned store borrows `memory`,
+    /// so it may not outlive the borrow.
+    fn open<'a>(
+        &self,
+        memory: &'a dyn CognitiveMemoryOps,
+        state_root: &Path,
+    ) -> SimardResult<Box<dyn GoalStore + 'a>>;
+}
+```
+
+The default `CognitiveMemoryGoalStoreFactory` returns an in-process store that
+borrows `memory` directly — no `state_root`-keyed re-derivation, no tier-0 miss:
+
+```rust
+impl GoalStoreFactory for CognitiveMemoryGoalStoreFactory {
+    fn open<'a>(
+        &self,
+        memory: &'a dyn CognitiveMemoryOps,
+        _state_root: &Path,
+    ) -> SimardResult<Box<dyn GoalStore + 'a>> {
+        Ok(Box::new(InProcessGoalStore::new(memory)?))
+    }
+}
+```
+
+### `InProcessGoalStore<'a>`
+
+`src/goals/cognitive_memory_store.rs`
+
+A `GoalStore` that borrows a live `&'a dyn CognitiveMemoryOps`. It mirrors how
+`ProspectiveCreativeIdeaStore::new(ctx.memory)` already takes the handle, so a
+routed goal lands in the same store the prospective idea did.
+
+```rust
+pub struct InProcessGoalStore<'a> {
+    ops: &'a dyn CognitiveMemoryOps,
+    descriptor: BackendDescriptor,
+}
+
+impl<'a> InProcessGoalStore<'a> {
+    pub fn new(ops: &'a dyn CognitiveMemoryOps) -> SimardResult<Self> {
+        Ok(Self {
+            ops,
+            descriptor: BackendDescriptor::for_runtime_type::<Self>(
+                "goals::in-process-store",
+                "runtime-port:goal-store:in-process",
+                Freshness::now()?,
+            ),
+        })
+    }
+}
+
+impl GoalStore for InProcessGoalStore<'_> {
+    fn put(&self, record: GoalRecord) -> SimardResult<()> {
+        put_via_ops(self.ops, record)
+    }
+
+    fn list(&self) -> SimardResult<Vec<GoalRecord>> {
+        list_via_ops(self.ops)
+    }
+    // descriptor() + the top_goals_by_status / active_top_goals ranking
+    // delegate through the same shared helpers as CognitiveMemoryGoalStore
+}
+```
+
+### Shared `put_via_ops` / `list_via_ops` helpers
+
+`src/goals/cognitive_memory_store.rs`
+
+The encode / dedup-by-slug / prospective-mirror logic is extracted into two free
+functions over `&dyn CognitiveMemoryOps` so that `InProcessGoalStore` and the
+legacy path-based `CognitiveMemoryGoalStore` share **one** implementation and
+cannot drift (preserving the #2329 caller-key dedup and the #2207 prospective
+dual-write):
+
+```rust
+/// Persist `record` (dedup by slug, mirror Active goals to prospective memory).
+/// Fail-closed: any store_fact / prospective error propagates as Err.
+pub(crate) fn put_via_ops(ops: &dyn CognitiveMemoryOps, record: GoalRecord) -> SimardResult<()>;
+
+/// Read + dedup all goal records. Fail-closed: a search_facts transport error
+/// is Err; an empty store is Ok([]); a bad individual record is skipped.
+pub(crate) fn list_via_ops(ops: &dyn CognitiveMemoryOps) -> SimardResult<Vec<GoalRecord>>;
+```
+
+`CognitiveMemoryGoalStore` re-points its `put` and `list_via_reader` at these
+helpers after acquiring a client, so the cold-open CLI path and the in-process
+daemon path are byte-for-byte identical in how they encode and dedup.
+
+### Call site
+
+`src/creative_ideas/pipeline.rs` — `AgenticIdeaPipeline::review_and_route`:
+
+```rust
+IdeaStatus::AcceptedForImplementation => {
+    let goals = self.goals.open(ctx.memory, ctx.state_root)?;   // was: open(ctx.state_root)
+    route_idea_to_goal(idea, goals.as_ref(), ctx.now_epoch)?;   // put() now hits the live store
+    RouteOutcome::Goal
+}
+```
+
+`route_idea_to_goal` is unchanged — it still builds a `Proposed` `GoalRecord`
+stamped `labels: vec![SOURCE_CREATIVE_IDEAS]` and calls `goals.put(record)?`.
+The difference is that `put` now targets the daemon's live store and cannot
+silently drop.
+
+---
+
+## Configuration
+
+No new configuration is introduced. The relevant knobs are unchanged:
+
+| Variable | Meaning | Default |
+|----------|---------|---------|
+| `SIMARD_STATE_ROOT` | State root resolved by both the daemon and the CLI | `$HOME/.simard/state` |
+| `SIMARD_MEMORY_SOCKET` | Explicit socket override (rare cross-mount probe) | `<state_root>/memory.sock` |
+| `SIMARD_CREATIVE_IDEAS_ENABLED` | Creative-ideas thread on/off | on (opt-out) — see [creative-ideas API](./creative-ideas-api.md) |
+
+### Socket & state-root permissions (SR-1)
+
+As part of hardening the write seam, the launcher tightens local filesystem
+permissions opportunistically:
+
+- The state-root directory is created `0700` (owner-only).
+- The Unix-domain socket is `chmod 0600` immediately after `bind` in
+  `src/memory_ipc/server.rs`.
+
+The memory IPC boundary is a **same-user, local Unix socket**; the OS
+filesystem is the trust boundary. These permissions ensure the socket and state
+root are not group- or world-accessible. No new authentication, authorization,
+or crypto is added.
+
+---
+
+## Fail-closed contract (summary)
+
+The single rule across all three fixes: **a transport/connect failure on a
+persist or a read is an error, never a silently-dropped write or a
+falsely-empty read.**
+
+| Situation | Result |
+|-----------|--------|
+| Idea accepted, routed, and persisted to the live store | `put() → Ok`, goal visible in `list()` and `simard goal list --tag source:creative-ideas` |
+| Broken pipe / write-len error on the in-flight write | `put() → Err` → surfaces as a creative-ideas **route/review error** (telemetry `review error(s)` increments), not a phantom `routed_goal` |
+| Live daemon socket present but connect fails | launcher → `Err` (no divergent tier-2 handle) |
+| Socket file present but unconnectable (any cause: dead/wedged daemon, non-socket file) | launcher → `Err` (fail closed; the daemon's next re-bind clears a stale file) |
+| No socket present (genuine no-daemon CLI / hermetic test) | tier-2 direct open (`Ok`) |
+| Reader-open or `search_facts` transport error | `list() → Err` (not `Ok([])`) |
+| Store opened, no goals present | `list() → Ok([])` |
+| One malformed goal fact among many | skipped; the rest are returned |
+
+---
+
+## Tests
+
+All tests are hermetic (isolated `TempDir` state roots) and real.
+
+### Visibility regression (guards #2896)
+
+`src/creative_ideas/tests_visibility_2896.rs`
+
+Route an `AcceptedForImplementation` `CreativeIdea` through `route_idea_to_goal`
+against the real `CognitiveMemoryGoalStore`, and (in a companion test) through
+the production `CognitiveMemoryGoalStoreFactory` given a live in-process
+`CognitiveMemoryOps` handle; then call `GoalStore::list()` on the **same** store
+/ handle and assert the routed `GoalRecord` is returned, tagged
+`source:creative-ideas`. A third test injects a write-ok/read-fault backend and
+asserts that a "successful" route followed by a faulted read surfaces `Err`, not
+a phantom empty list.
+
+> These tests **fail before the fix**: with the read path swallowing an injected
+> transport error into `Ok([])`, the subsequent `list()` returns empty even
+> though `put()` returned `Ok` — the silent-loss signature of #2896.
+
+### Fail-closed put / list
+
+`src/goals/tests_fail_closed_2896.rs`
+
+A fault-injecting fake `CognitiveMemoryOps` (registered as the in-process tier-0
+writer) whose `store_fact*` / `search_facts` return a simulated `Broken pipe`
+transport error. Asserted through the real `CognitiveMemoryGoalStore` (which
+delegates to the shared `put_via_ops` / `list_via_ops`):
+
+- `store.put(record)` returns **`Err`** (never a silent `Ok`).
+- `store.list()` and `store.active_top_goals(..)` return **`Err`** (never
+  `Ok(Vec::new())`).
+
+### Launcher tier-1 fail-closed
+
+`src/memory_ipc/tests_launcher_fail_closed_2896.rs`
+
+- **Socket present but unconnectable** (a non-socket file at the socket path) →
+  `launch_writer_client` and `open_reader_client` return `Err` (no tier-2
+  divergence).
+- **No socket present** (hermetic `TempDir`) → tier-2 direct open returns `Ok`
+  (the standalone / test path is preserved).
+- **Live socket whose backend op errors** → the socket client op surfaces `Err`,
+  never a swallowed `Ok`.
+
+### Regression suites kept green
+
+The existing `creative_ideas`, `goals`, and `memory_ipc` suites (and the
+`tests/goal_stewardship.rs` / `tests/goal_store_flock.rs` / `tests/meeting_goals.rs`
+integration suites) remain green — the change is additive and the encode/dedup
+format is unchanged.
+
+---
+
+## Live validation (post-deploy)
+
+The fix's headline acceptance criterion is verifiable on a running daemon:
+
+```bash
+# 1. Trigger a creative-ideas run — dashboard "Run now" (the `ci-run-btn`
+#    control) or its HTTP API (there is no `simard creative-ideas` CLI
+#    subcommand). The scheduled run also produces goals; its interval is
+#    SIMARD_CREATIVE_IDEAS_INTERVAL_SECS (default 86400).
+DASHKEY="$(cat ~/.simard/.dashkey)"
+curl -s -u "operator:$DASHKEY" -X POST \
+  http://localhost:8080/api/creative-ideas/run -d '{}' | jq   # {"ok":true,"report":{…}}
+
+# 2. Any accepted idea now yields a durable, visible goal:
+simard goal list --tag source:creative-ideas
+#    → returns > 0 goals (was: always 0 before #2896)
+```
+
+If a memory-IPC transport error occurs during a run, it now shows up as a
+creative-ideas **review/route error** in the daemon telemetry
+(`… M review error(s)` with `M > 0`) rather than a phantom `N → goal` success —
+the loss is loud, not silent. The `bridge 'memory-ipc': … Broken pipe` log
+lines may still appear (they reflect the underlying transport condition), but
+they no longer correlate with lost writes: either the write reconnects and
+persists, or `put()` returns `Err` and the route is recorded as failed.
+
+See [Diagnose and recover lost creative-ideas goals](../howto/diagnose-lost-creative-ideas-goals.md)
+for the operator walkthrough.
+
+---
+
+## Scope and non-goals
+
+**In scope**
+
+- Fail-closed read path (`list_via_reader` / `list_via_ops`).
+- Fail-closed launcher tier-1 for both writer and reader helpers (one shared
+  seam, fixed once — so prospective-update, journal, and other in-process
+  writers inherit it).
+- In-process visibility for creative-ideas goal writes via `ctx.memory`.
+- Socket / state-root permission hardening (SR-1).
+- Hermetic regression tests.
+
+**Explicitly out of scope**
+
+- Eliminating the underlying `Broken pipe (os error 32)` transport condition in
+  the memory-IPC layer (this fix makes it *safe*, not *absent*).
+- Redesigning the tiered IPC architecture.
+- Renaming the user-facing `bridge 'memory-ipc'` runtime strings, or introducing
+  any new `*Bridge`-named type (operator preference).
+- The `labels` / `--tag` / `source:creative-ideas` surface itself, which already
+  shipped in [#2743](https://github.com/rysweet/Simard/issues/2743).
+
+---
+
+## Related reading
+
+- [Creative Ideas subsystem API](./creative-ideas-api.md) — `route_idea_to_goal`,
+  the `IdeaStatus` state machine, and the pipeline this write path lives in.
+- [Creative Ideas durable read-after-write](./creative-ideas-durable-read-after-write.md)
+  — the sibling read-after-write fix for the *prospective* creative-idea store
+  (#2798); this page is the analogous fix for the *goal* store.
+- [Cognitive-memory client helpers](./cognitive-memory-client-helpers.md) — the
+  `launch_writer_client` / `open_reader_client` ladder and the no-silent-
+  degradation contract this fix strengthens.
+- [Goal labels / tags API reference](./goal-labels.md) — the `labels` field and
+  the `source:creative-ideas` provenance tag (#2743).
+- [Cognitive-memory goal store adapter](./cognitive-memory-goal-store.md) —
+  the `CognitiveMemoryGoalStore` history and the cold-open CLI path.
+- [Goal board persistence — concept](../concepts/goal-board-persistence.md).
+- [Diagnose and recover lost creative-ideas goals](../howto/diagnose-lost-creative-ideas-goals.md)
+  — operator troubleshooting.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -184,6 +184,7 @@ nav:
     - Reconcile Goal–Prospective Drift: howto/reconcile-goal-prospective-drift.md
     - Recover the Goal Board: howto/recover-goal-board.md
     - Troubleshoot Goal Store: howto/troubleshoot-goal-store.md
+    - Diagnose and Recover Lost Creative-Ideas Goals: howto/diagnose-lost-creative-ideas-goals.md
     - Clean Fixture Leaks: howto/clean-fixture-leaks.md
     - Verify and Roll Back a Self-Deploy: howto/verify-and-roll-back-a-self-deploy.md
     - Run Self-Deploy from Any Directory: howto/run-self-deploy-from-any-directory.md
@@ -363,6 +364,7 @@ nav:
     - Cognitive-Thread Scheduling: reference/cognitive-thread-scheduling.md
     - Creative Ideas Subsystem API: reference/creative-ideas-api.md
     - Creative Ideas Durable Read-After-Write: reference/creative-ideas-durable-read-after-write.md
+    - Creative-Ideas Goal Routing — Fail-Closed Persistence: reference/creative-ideas-goal-routing-fail-closed.md
   - Operations:
     - Overview: operations/index.md
     - Verified Backups of the Live Store: operations/verified-backups.md

--- a/src/creative_ideas/mod.rs
+++ b/src/creative_ideas/mod.rs
@@ -26,6 +26,8 @@ pub mod synthesis;
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_visibility_2896;
 
 /// Master switch env var. When falsey/unset the thread never ticks and nothing
 /// is generated or routed.

--- a/src/creative_ideas/pipeline.rs
+++ b/src/creative_ideas/pipeline.rs
@@ -16,6 +16,7 @@
 
 use std::path::Path;
 
+use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::cognitive_memory::creative_idea::{
     CreativeIdea, CreativeIdeaStore, IdeaStatus, ProspectiveCreativeIdeaStore,
 };
@@ -30,7 +31,7 @@ use crate::creative_ideas::routing::{
 };
 use crate::creative_ideas::synthesis::DefaultSynthesizer;
 use crate::error::SimardResult;
-use crate::goals::{CognitiveMemoryGoalStore, GoalStore};
+use crate::goals::{GoalStore, InProcessGoalStore};
 
 /// Env var overriding the `owner/name` repo slug the routing seam targets.
 pub const REPO_ENV: &str = "SIMARD_REPO";
@@ -75,8 +76,16 @@ pub trait IdeaPipeline: Send {
 /// Opens the production goal store for a given state root. A seam so tests can
 /// inject an in-memory store without touching disk.
 pub trait GoalStoreFactory: Send {
-    /// Open a goal store rooted at `state_root`.
-    fn open(&self, state_root: &Path) -> SimardResult<Box<dyn GoalStore>>;
+    /// Open a goal store, reusing the caller's live in-process cognitive-memory
+    /// handle (`memory` — e.g. the daemon's `ctx.memory` `Arc`) so a routed goal
+    /// lands in the SAME store the daemon serves `goal list` from, visible by
+    /// construction (bug #2896). `state_root` is retained for factories that key
+    /// on it; the production factory reuses `memory` directly.
+    fn open<'a>(
+        &self,
+        memory: &'a dyn CognitiveMemoryOps,
+        state_root: &Path,
+    ) -> SimardResult<Box<dyn GoalStore + 'a>>;
 }
 
 /// Production factory: the cognitive-memory-backed goal store (the same store
@@ -85,10 +94,16 @@ pub trait GoalStoreFactory: Send {
 pub struct CognitiveMemoryGoalStoreFactory;
 
 impl GoalStoreFactory for CognitiveMemoryGoalStoreFactory {
-    fn open(&self, state_root: &Path) -> SimardResult<Box<dyn GoalStore>> {
-        Ok(Box::new(CognitiveMemoryGoalStore::new(
-            state_root.to_path_buf(),
-        )?))
+    fn open<'a>(
+        &self,
+        memory: &'a dyn CognitiveMemoryOps,
+        _state_root: &Path,
+    ) -> SimardResult<Box<dyn GoalStore + 'a>> {
+        // Reuse the daemon's live handle rather than re-deriving one from
+        // `state_root`, so the write is visible on the daemon's own store by
+        // construction — no tier-0 `state_root` mismatch, no divergent tier-2
+        // fallthrough (bug #2896).
+        Ok(Box::new(InProcessGoalStore::new(memory)?))
     }
 }
 
@@ -153,7 +168,7 @@ impl IdeaPipeline for AgenticIdeaPipeline {
         // 3. Route per the synthesized status.
         let outcome = match idea.status {
             IdeaStatus::AcceptedForImplementation => {
-                let goals = self.goals.open(ctx.state_root)?;
+                let goals = self.goals.open(ctx.memory, ctx.state_root)?;
                 route_idea_to_goal(idea, goals.as_ref(), ctx.now_epoch)?;
                 // The idea moves into flight once the goal exists.
                 idea.try_transition(IdeaStatus::ImplementationStarted)?;

--- a/src/creative_ideas/tests.rs
+++ b/src/creative_ideas/tests.rs
@@ -939,7 +939,11 @@ impl GoalStore for SharedGoalStore {
 struct SharedGoalStoreFactory(std::sync::Arc<InMemoryGoalStore>);
 
 impl GoalStoreFactory for SharedGoalStoreFactory {
-    fn open(&self, _state_root: &std::path::Path) -> SimardResult<Box<dyn GoalStore>> {
+    fn open<'a>(
+        &self,
+        _memory: &'a dyn crate::cognitive_memory::CognitiveMemoryOps,
+        _state_root: &std::path::Path,
+    ) -> SimardResult<Box<dyn GoalStore + 'a>> {
         Ok(Box::new(SharedGoalStore(std::sync::Arc::clone(&self.0))))
     }
 }

--- a/src/creative_ideas/tests_visibility_2896.rs
+++ b/src/creative_ideas/tests_visibility_2896.rs
@@ -1,0 +1,271 @@
+//! TDD (Step 7) — creative-ideas goal routing is visible on the SAME store, and
+//! read faults are surfaced, not silently swallowed (bug #2896).
+//!
+//! Bug #2896: an accepted [`CreativeIdea`] is routed to a goal, the write path
+//! reports success, yet `simard goal list --tag source:creative-ideas` returns
+//! zero. Two guarantees the fix must deliver, pinned here end-to-end through the
+//! real routing seam ([`route_idea_to_goal`]) and the production
+//! [`CognitiveMemoryGoalStore`]:
+//!
+//!   1. **Visibility (guard):** routing an accepted idea and then reading the
+//!      SAME cognitive-memory store returns the goal, tagged
+//!      `source:creative-ideas`. This is the persistence-and-visibility contract
+//!      that #2896 says is broken in production.
+//!   2. **Fail-closed read (RED before the fix):** when the write reports success
+//!      ("0 review error(s)") but the subsequent read hits a transport fault, the
+//!      store MUST surface `Err` — never a phantom empty list that makes the goal
+//!      look lost.
+//!
+//! Hermetic: no network, injected clock (`now_epoch`), `TempDir` state roots.
+//! Test 1 uses the real library-backed tier-2 store (no daemon). Test 2 injects a
+//! fault backend as the in-process writer. Both mutate process-global memory
+//! state, so they are `#[serial_test::serial(cognitive_memory)]` and reset it.
+
+use std::sync::Arc;
+
+use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::cognitive_memory::creative_idea::{CreativeIdea, IdeaContext, IdeaStatus};
+use crate::creative_ideas::pipeline::{CognitiveMemoryGoalStoreFactory, GoalStoreFactory};
+use crate::error::{SimardError, SimardResult};
+use crate::goal_curation::labels::SOURCE_CREATIVE_IDEAS;
+use crate::goals::{CognitiveMemoryGoalStore, GoalStatus, GoalStore, goal_slug};
+use crate::memory_cognitive::{
+    CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
+    CognitiveWorkingSlot,
+};
+use crate::memory_ipc::{
+    clear_in_process_writer, clear_tier2_store_cache, launch_writer_client,
+    register_in_process_writer,
+};
+
+use super::routing::route_idea_to_goal;
+
+fn accepted_idea(title: &str, node_id: &str) -> CreativeIdea {
+    let mut idea = CreativeIdea::new(
+        title,
+        IdeaContext {
+            source: "creative-ideas-thread".to_string(),
+            goals_snapshot: vec!["improve recall".to_string()],
+            observation_digest: "digest-2896".to_string(),
+            rationale: "recall precision has plateaued for 3 days".to_string(),
+        },
+        1_700_000_000,
+    );
+    idea.node_id = node_id.to_string();
+    idea.status = IdeaStatus::AcceptedForImplementation;
+    idea
+}
+
+/// Guard: route an accepted idea through the REAL cognitive-memory goal store
+/// (tier-2, no daemon) and prove the goal is visible via a subsequent `list()` on
+/// the same state root, tagged `source:creative-ideas`. This is the end-to-end
+/// persistence-and-visibility contract #2896 requires: the write and the read
+/// must address the same store.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn routed_creative_idea_goal_is_visible_via_same_cognitive_memory_store() {
+    clear_in_process_writer();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+
+    let store = CognitiveMemoryGoalStore::new(root.clone()).expect("construct goal store");
+    let idea = accepted_idea("distill meeting transcripts into facts", "pro_idea_2896");
+
+    let record = route_idea_to_goal(&idea, &store, 1_700_000_500).expect("route to goal");
+    assert_eq!(record.status, GoalStatus::Proposed);
+
+    // A SUBSEQUENT read of the same store must return the routed goal — this is
+    // the read that returns 0 in production today.
+    let goals = store.list().expect("list goals");
+    clear_tier2_store_cache();
+    clear_in_process_writer();
+
+    let persisted = goals
+        .iter()
+        .find(|g| g.slug == goal_slug(&idea.idea))
+        .unwrap_or_else(|| {
+            panic!(
+                "routed creative-idea goal must be visible on the same store, got {} goal(s): \
+                 {:?} (bug #2896: goals silently lost)",
+                goals.len(),
+                goals.iter().map(|g| &g.slug).collect::<Vec<_>>(),
+            )
+        });
+    assert!(
+        persisted.labels.iter().any(|l| l == SOURCE_CREATIVE_IDEAS),
+        "the visible goal must carry source:creative-ideas so `goal list --tag \
+         source:creative-ideas` finds it; labels were {:?}",
+        persisted.labels,
+    );
+}
+
+/// Seam #3 (bug #2896): the production [`CognitiveMemoryGoalStoreFactory`]
+/// reuses the caller's live in-process memory handle, so a routed goal is
+/// visible via that SAME handle — visible **by construction**, independent of
+/// any `state_root` tier-0 match. This is the "reuse `ctx.memory`" contract the
+/// daemon and dashboard routing paths depend on to guarantee the write lands in
+/// the store the daemon serves `goal list` from.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn production_factory_routes_to_the_caller_supplied_in_process_handle() {
+    clear_in_process_writer();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+
+    // A real, shared in-process cognitive-memory handle (the tier-2 library
+    // store, no daemon), standing in for the daemon's live `ctx.memory`.
+    let writer = launch_writer_client(&root).expect("open in-process writer");
+
+    // Route through the PRODUCTION factory, handing it the live handle.
+    let goals = CognitiveMemoryGoalStoreFactory
+        .open(writer.ops(), &root)
+        .expect("factory open");
+    let idea = accepted_idea("route via the live handle", "pro_idea_seam3");
+    let record = route_idea_to_goal(&idea, goals.as_ref(), 1_700_000_900).expect("route to goal");
+    assert_eq!(record.status, GoalStatus::Proposed);
+
+    // The goal is visible on the SAME handle the write went through.
+    let listed = goals.list().expect("list via the same handle");
+    clear_tier2_store_cache();
+    clear_in_process_writer();
+
+    let found = listed
+        .iter()
+        .find(|g| g.slug == goal_slug(&idea.idea))
+        .unwrap_or_else(|| {
+            panic!(
+                "routed goal must be visible via the caller's own memory handle, got {} goal(s): \
+                 {:?} (bug #2896: reuse ctx.memory)",
+                listed.len(),
+                listed.iter().map(|g| &g.slug).collect::<Vec<_>>(),
+            )
+        });
+    assert!(
+        found.labels.iter().any(|l| l == SOURCE_CREATIVE_IDEAS),
+        "the visible goal must carry source:creative-ideas; labels were {:?}",
+        found.labels,
+    );
+}
+
+/// A backend that ACKS writes (so `put` reports success, mirroring the bug's
+/// "0 review error(s)") but FAILS reads with a memory-ipc transport error,
+/// mirroring the "bridge 'memory-ipc' transport error: write-len: Broken pipe"
+/// lines in the live logs.
+struct WriteOkReadFaultMemory;
+
+impl WriteOkReadFaultMemory {
+    fn read_err() -> SimardError {
+        SimardError::RpcCallFailed {
+            bridge: "memory-ipc".to_string(),
+            method: "search_facts".to_string(),
+            reason: "write-len: Broken pipe (os error 32)".to_string(),
+        }
+    }
+}
+
+impl CognitiveMemoryOps for WriteOkReadFaultMemory {
+    fn record_sensory(&self, _m: &str, _r: &str, _t: u64) -> SimardResult<String> {
+        Ok("sensory".to_string())
+    }
+    fn prune_expired_sensory(&self) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn push_working(&self, _s: &str, _c: &str, _t: &str, _r: f64) -> SimardResult<String> {
+        Ok("working".to_string())
+    }
+    fn get_working(&self, _t: &str) -> SimardResult<Vec<CognitiveWorkingSlot>> {
+        Ok(vec![])
+    }
+    fn clear_working(&self, _t: &str) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn store_episode(
+        &self,
+        _c: &str,
+        _s: &str,
+        _m: Option<&serde_json::Value>,
+    ) -> SimardResult<String> {
+        Ok("episode".to_string())
+    }
+    fn consolidate_episodes(&self, _b: u32) -> SimardResult<Option<String>> {
+        Ok(None)
+    }
+    fn store_fact(
+        &self,
+        _c: &str,
+        _co: &str,
+        _cf: f64,
+        _t: &[String],
+        _s: &str,
+    ) -> SimardResult<String> {
+        Ok("fact".to_string())
+    }
+    fn store_fact_with_caller_key(
+        &self,
+        _caller_key: &str,
+        _concept: &str,
+        _content: &str,
+        _confidence: f64,
+        _tags: &[String],
+        _source_id: &str,
+    ) -> SimardResult<String> {
+        // Write "succeeds" — the router will count routed_goal and report 0 errors.
+        Ok("fact".to_string())
+    }
+    fn search_facts(&self, _q: &str, _l: u32, _m: f64) -> SimardResult<Vec<CognitiveFact>> {
+        Err(Self::read_err())
+    }
+    fn store_procedure(&self, _n: &str, _s: &[String], _p: &[String]) -> SimardResult<String> {
+        Ok("procedure".to_string())
+    }
+    fn recall_procedure(&self, _q: &str, _l: u32) -> SimardResult<Vec<CognitiveProcedure>> {
+        Ok(vec![])
+    }
+    fn store_prospective(&self, _d: &str, _tc: &str, _a: &str, _p: i64) -> SimardResult<String> {
+        Ok("prospective".to_string())
+    }
+    fn check_triggers(&self, _c: &str) -> SimardResult<Vec<CognitiveProspective>> {
+        Ok(vec![])
+    }
+    fn get_statistics(&self) -> SimardResult<CognitiveStatistics> {
+        Ok(CognitiveStatistics::default())
+    }
+}
+
+/// RED (fails before the #2896 fix): the full silent-loss signature. Routing an
+/// accepted idea reports SUCCESS (put returns Ok, matching "N → goal, 0 review
+/// error(s)"), but the subsequent `list()` read hits a transport fault. Today
+/// that fault is swallowed to `Ok(Vec::new())`, so the goal is silently lost.
+/// After the fix, `list()` MUST surface `Err`, turning a phantom success into a
+/// visible failure the caller can react to.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn routing_reports_success_but_read_fault_is_surfaced_not_silently_lost() {
+    clear_in_process_writer();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+    let mem: Arc<dyn CognitiveMemoryOps> = Arc::new(WriteOkReadFaultMemory);
+    register_in_process_writer(root.clone(), Arc::clone(&mem));
+
+    let store = CognitiveMemoryGoalStore::new(root.clone()).expect("construct goal store");
+    let idea = accepted_idea("cache distilled facts by concept", "pro_idea_lost");
+
+    // The write path reports success — exactly what the daemon telemetry shows.
+    let routed = route_idea_to_goal(&idea, &store, 1_700_000_777);
+    assert!(
+        routed.is_ok(),
+        "precondition: the write path reports success (bug #2896 telemetry says \
+         '0 review error(s)'); got {routed:?}",
+    );
+
+    // The read that backs `goal list` must NOT hide the transport fault behind an
+    // empty result — that empty result is the silent data loss of #2896.
+    let listed = store.list();
+
+    clear_in_process_writer();
+    assert!(
+        listed.is_err(),
+        "a broken-pipe read after a 'successful' route MUST surface as Err, not a \
+         phantom empty list that drops the goal (bug #2896). Got: {listed:?}",
+    );
+}

--- a/src/goals/cognitive_memory_store.rs
+++ b/src/goals/cognitive_memory_store.rs
@@ -20,6 +20,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
 use crate::memory_ipc::{launch_writer_client, open_reader_client};
 use crate::metadata::{BackendDescriptor, Freshness};
@@ -88,59 +89,19 @@ impl CognitiveMemoryGoalStore {
     /// Read all goal records currently visible in cognitive memory and
     /// dedup by slug, keeping the latest write per slug.
     fn list_via_reader(&self) -> SimardResult<Vec<GoalRecord>> {
-        // The reader bridge resolves through the in-process Arc shortcut
-        // first (zero-cost for daemon callers), then the IPC socket,
-        // then `open_read_only`. If none succeed (e.g. an uninitialised
-        // state_root), `list()` returns an empty Vec rather than
-        // surfacing the error — `GoalStore::list` is best-effort and the
-        // FileBackedGoalStore behaved the same way (`load_json_or_default`).
-        let reader = match open_reader_client(&self.state_root) {
-            Ok(r) => r,
-            Err(_) => return Ok(Vec::new()),
-        };
-        let facts =
-            match reader
-                .ops()
-                .search_facts(GOAL_STORE_FACT_CONCEPT, GOAL_STORE_LIST_LIMIT, 0.0)
-            {
-                Ok(f) => f,
-                Err(e) => {
-                    eprintln!(
-                        "[simard] CognitiveMemoryGoalStore::list: search_facts failed ({e}) — \
-                     returning empty record set"
-                    );
-                    return Ok(Vec::new());
-                }
-            };
-
-        // For each slug, keep the fact with the largest node_id (most
-        // recent UUID-v7).
-        let mut latest_by_slug: HashMap<String, (String, GoalRecord)> = HashMap::new();
-        for fact in facts {
-            if fact.concept != GOAL_STORE_FACT_CONCEPT {
-                continue;
-            }
-            let record: GoalRecord = match serde_json::from_str(&fact.content) {
-                Ok(r) => r,
-                Err(e) => {
-                    eprintln!(
-                        "[simard] CognitiveMemoryGoalStore::list: skipping unparseable record \
-                         (node_id={}): {e}",
-                        fact.node_id
-                    );
-                    continue;
-                }
-            };
-            let slug = record.slug.clone();
-            match latest_by_slug.get(&slug) {
-                Some((existing_id, _)) if existing_id >= &fact.node_id => {}
-                _ => {
-                    latest_by_slug.insert(slug, (fact.node_id, record));
-                }
-            }
-        }
-
-        Ok(latest_by_slug.into_values().map(|(_, r)| r).collect())
+        // Fail closed (bug #2896). The reader resolves through the in-process
+        // Arc shortcut first (zero-cost for daemon callers), then the IPC
+        // socket, then a direct tier-2 open (which creates the store for an
+        // uninitialised state_root, so a fresh root yields an empty — not
+        // errored — read). A reader-open or `search_facts` transport fault
+        // (e.g. the daemon's "write-len: Broken pipe" line) MUST propagate as
+        // `Err`. Swallowing it into `Ok(Vec::new())` is exactly how a persisted
+        // goal becomes invisible to `simard goal list` while the write path
+        // reports success — the silent data loss #2896 forbids. Callers decide
+        // how to react; the store never reports "no goals" for a transport
+        // error.
+        let reader = open_reader_client(&self.state_root)?;
+        list_via_ops(reader.ops())
     }
 
     /// Reconcile drift between goal state and prospective memory entries.
@@ -202,46 +163,8 @@ impl GoalStore for CognitiveMemoryGoalStore {
     }
 
     fn put(&self, record: GoalRecord) -> SimardResult<()> {
-        let content = Self::encode(&record)?;
         let writer = launch_writer_client(&self.state_root)?;
-
-        // Primary storage: semantic fact (authoritative record). Issue #2329:
-        // route through CallerKey dedup keyed per goal slug so each goal's record
-        // supersedes its own previous revision instead of appending a fresh fact
-        // every `put`. The read-side "max node_id per slug" dedup remains as a
-        // defensive guard.
-        writer.ops().store_fact_with_caller_key(
-            &format!("{GOAL_STORE_FACT_CONCEPT}:{}", record.slug),
-            GOAL_STORE_FACT_CONCEPT,
-            &content,
-            1.0,
-            &[GOAL_STORE_TAG.to_string()],
-            GOAL_STORE_SOURCE,
-        )?;
-
-        // Resolve any previous prospective memory for this goal so stale
-        // entries don't accumulate. Part of put()'s success contract (#2207):
-        // if the mirror update fails, the caller must know.
-        resolve_goal_prospectives(&record.slug, writer.ops())?;
-
-        // Dual-write: store Active goals as prospective memories so they
-        // surface via `check_triggers` during OODA preparation (#2207).
-        if record.status == GoalStatus::Active {
-            let description = format!("{}{}", GOAL_PROSPECTIVE_PREFIX, record.title);
-            let trigger_condition = prospective_trigger_for(&record);
-            let action_on_trigger = format!(
-                "Pursue goal: {} (p{}, {})",
-                record.title, record.priority, record.rationale,
-            );
-            writer.ops().store_prospective(
-                &description,
-                &trigger_condition,
-                &action_on_trigger,
-                i64::from(record.priority),
-            )?;
-        }
-
-        Ok(())
+        put_via_ops(writer.ops(), record)
     }
 
     fn list(&self) -> SimardResult<Vec<GoalRecord>> {
@@ -253,11 +176,169 @@ impl GoalStore for CognitiveMemoryGoalStore {
         status: GoalStatus,
         limit: usize,
     ) -> SimardResult<Vec<GoalRecord>> {
-        let mut records = self.list()?;
-        records.retain(|r| r.status == status);
-        records.sort_by(compare_goal_records);
-        records.truncate(limit);
-        Ok(records)
+        Ok(top_by_status(self.list()?, status, limit))
+    }
+
+    fn active_top_goals(&self, limit: usize) -> SimardResult<Vec<GoalRecord>> {
+        self.top_goals_by_status(GoalStatus::Active, limit)
+    }
+}
+
+/// Encode and persist a [`GoalRecord`] through an arbitrary in-process
+/// cognitive-memory handle (bug #2896).
+///
+/// Shared by [`CognitiveMemoryGoalStore::put`] (which re-derives the handle from
+/// `state_root`) and [`InProcessGoalStore::put`] (which reuses the daemon's live
+/// `ctx.memory` handle). Fail-closed: every step — the authoritative fact write,
+/// the stale-prospective resolve, and the Active dual-write — propagates its
+/// error, so a transport failure can never masquerade as a phantom `Ok`.
+pub(crate) fn put_via_ops(ops: &dyn CognitiveMemoryOps, record: GoalRecord) -> SimardResult<()> {
+    let content = CognitiveMemoryGoalStore::encode(&record)?;
+
+    // Primary storage: semantic fact (authoritative record). Issue #2329:
+    // route through CallerKey dedup keyed per goal slug so each goal's record
+    // supersedes its own previous revision instead of appending a fresh fact
+    // every `put`. The read-side "max node_id per slug" dedup remains as a
+    // defensive guard.
+    ops.store_fact_with_caller_key(
+        &format!("{GOAL_STORE_FACT_CONCEPT}:{}", record.slug),
+        GOAL_STORE_FACT_CONCEPT,
+        &content,
+        1.0,
+        &[GOAL_STORE_TAG.to_string()],
+        GOAL_STORE_SOURCE,
+    )?;
+
+    // Resolve any previous prospective memory for this goal so stale
+    // entries don't accumulate. Part of put()'s success contract (#2207):
+    // if the mirror update fails, the caller must know.
+    resolve_goal_prospectives(&record.slug, ops)?;
+
+    // Dual-write: store Active goals as prospective memories so they
+    // surface via `check_triggers` during OODA preparation (#2207).
+    if record.status == GoalStatus::Active {
+        let description = format!("{}{}", GOAL_PROSPECTIVE_PREFIX, record.title);
+        let trigger_condition = prospective_trigger_for(&record);
+        let action_on_trigger = format!(
+            "Pursue goal: {} (p{}, {})",
+            record.title, record.priority, record.rationale,
+        );
+        ops.store_prospective(
+            &description,
+            &trigger_condition,
+            &action_on_trigger,
+            i64::from(record.priority),
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Read and slug-dedup all goal records visible through an arbitrary in-process
+/// cognitive-memory handle (bug #2896).
+///
+/// Shared by [`CognitiveMemoryGoalStore::list`] and [`InProcessGoalStore::list`].
+/// Fail-closed: a `search_facts` transport fault propagates as `Err` rather than
+/// being swallowed into a phantom empty list — the silent-loss signature #2896
+/// forbids. (A per-record deserialise failure is a data-integrity skip, not a
+/// transport fault, so one corrupt record never hides every other goal.)
+pub(crate) fn list_via_ops(ops: &dyn CognitiveMemoryOps) -> SimardResult<Vec<GoalRecord>> {
+    let facts = ops.search_facts(GOAL_STORE_FACT_CONCEPT, GOAL_STORE_LIST_LIMIT, 0.0)?;
+
+    // For each slug, keep the fact with the largest node_id (most
+    // recent UUID-v7).
+    let mut latest_by_slug: HashMap<String, (String, GoalRecord)> = HashMap::new();
+    for fact in facts {
+        if fact.concept != GOAL_STORE_FACT_CONCEPT {
+            continue;
+        }
+        let record: GoalRecord = match serde_json::from_str(&fact.content) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!(
+                    "[simard] CognitiveMemoryGoalStore::list: skipping unparseable record \
+                     (node_id={}): {e}",
+                    fact.node_id
+                );
+                continue;
+            }
+        };
+        let slug = record.slug.clone();
+        match latest_by_slug.get(&slug) {
+            Some((existing_id, _)) if existing_id >= &fact.node_id => {}
+            _ => {
+                latest_by_slug.insert(slug, (fact.node_id, record));
+            }
+        }
+    }
+
+    Ok(latest_by_slug.into_values().map(|(_, r)| r).collect())
+}
+
+/// Filter to `status`, order by the board's canonical goal ranking, and take the
+/// top `limit`. Shared by both goal-store implementations.
+fn top_by_status(
+    mut records: Vec<GoalRecord>,
+    status: GoalStatus,
+    limit: usize,
+) -> Vec<GoalRecord> {
+    records.retain(|r| r.status == status);
+    records.sort_by(compare_goal_records);
+    records.truncate(limit);
+    records
+}
+
+/// A [`GoalStore`] that persists through a caller-provided in-process
+/// cognitive-memory handle (the daemon's live `ctx.memory` `Arc`) instead of
+/// re-deriving one from `state_root`.
+///
+/// Reusing the exact handle the daemon serves `goal list` from makes a
+/// same-process goal write visible **by construction** (bug #2896): the write
+/// and the daemon's later read address the identical store, so it cannot land in
+/// a divergent tier-2 view or be lost to a `state_root` tier-0 mismatch. This
+/// mirrors how [`ProspectiveCreativeIdeaStore`] already takes `ctx.memory`, and
+/// is why the creative-ideas routing path threads `ctx.memory` all the way to
+/// `put()` rather than re-opening from `ctx.state_root`.
+///
+/// [`ProspectiveCreativeIdeaStore`]: crate::cognitive_memory::creative_idea::ProspectiveCreativeIdeaStore
+pub struct InProcessGoalStore<'a> {
+    ops: &'a dyn CognitiveMemoryOps,
+    descriptor: BackendDescriptor,
+}
+
+impl<'a> InProcessGoalStore<'a> {
+    /// Wrap a live in-process cognitive-memory handle as a goal store.
+    pub fn new(ops: &'a dyn CognitiveMemoryOps) -> SimardResult<Self> {
+        Ok(Self {
+            ops,
+            descriptor: BackendDescriptor::for_runtime_type::<Self>(
+                "goals::in-process-store",
+                "runtime-port:goal-store:in-process",
+                Freshness::now()?,
+            ),
+        })
+    }
+}
+
+impl GoalStore for InProcessGoalStore<'_> {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn put(&self, record: GoalRecord) -> SimardResult<()> {
+        put_via_ops(self.ops, record)
+    }
+
+    fn list(&self) -> SimardResult<Vec<GoalRecord>> {
+        list_via_ops(self.ops)
+    }
+
+    fn top_goals_by_status(
+        &self,
+        status: GoalStatus,
+        limit: usize,
+    ) -> SimardResult<Vec<GoalRecord>> {
+        Ok(top_by_status(self.list()?, status, limit))
     }
 
     fn active_top_goals(&self, limit: usize) -> SimardResult<Vec<GoalRecord>> {

--- a/src/goals/mod.rs
+++ b/src/goals/mod.rs
@@ -7,8 +7,12 @@ mod types;
 #[path = "tests.rs"]
 mod coverage_tests;
 
+#[cfg(test)]
+mod tests_fail_closed_2896;
+
 // Re-export all public items so `crate::goals::X` still works.
 pub use cognitive_memory_store::CognitiveMemoryGoalStore;
+pub use cognitive_memory_store::InProcessGoalStore;
 pub use cognitive_memory_store::migrate_file_backed_goal_store_if_present;
 pub use cognitive_memory_store::reconcile_board_prospectives;
 pub(crate) use cognitive_memory_store::{GOAL_STORE_FACT_CONCEPT, GOAL_STORE_LIST_LIMIT};

--- a/src/goals/tests_fail_closed_2896.rs
+++ b/src/goals/tests_fail_closed_2896.rs
@@ -1,0 +1,237 @@
+//! TDD (Step 7) — fail-closed goal-store persistence for bug #2896.
+//!
+//! Bug #2896: the creative-ideas thread routes accepted ideas to goals, the
+//! write path reports success ("N → goal, 0 review error(s)"), yet ZERO goals
+//! labelled `source:creative-ideas` are visible via `simard goal list`. This is
+//! silent data loss. The confirmed mechanism on this branch is that
+//! [`CognitiveMemoryGoalStore::list`] SWALLOWS reader/transport errors and
+//! returns `Ok(Vec::new())` — so a broken-pipe read makes a persisted goal look
+//! absent, and a caller that trusts the empty list drops the record.
+//!
+//! These tests pin the fail-closed contract mandated by #2896 (NO silent-failure
+//! fallback anywhere):
+//!   * A reader/transport error surfaced during `list()` MUST propagate as `Err`
+//!     — never a phantom empty result. (RED before the fix.)
+//!   * A writer/transport error during `put()` MUST propagate as `Err` — never a
+//!     phantom `Ok`. (Guard: already fail-closed; must stay so.)
+//!
+//! Hermetic: a fault-injecting [`FaultyMemory`] is registered as the in-process
+//! writer (tier 0) for a `TempDir` state root, so both `put` and `list` route to
+//! it with no daemon, no socket, and no disk store. The registration mutates
+//! process-global state, so every test is `#[serial_test::serial(cognitive_memory)]`
+//! and clears the registration on entry and exit.
+
+use std::sync::Arc;
+
+use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::error::{SimardError, SimardResult};
+use crate::goals::{CognitiveMemoryGoalStore, GoalRecord, GoalStatus, GoalStore, GoalUpdate};
+use crate::memory_cognitive::{
+    CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
+    CognitiveWorkingSlot,
+};
+use crate::memory_ipc::{clear_in_process_writer, register_in_process_writer};
+use crate::session::{SessionId, SessionPhase};
+
+/// A cognitive-memory backend that simulates a memory-ipc transport failure on
+/// the read and/or write path, mirroring the real "bridge 'memory-ipc' transport
+/// error: write-len: Broken pipe" the bug reports. Non-faulted operations return
+/// benign values so the store can reach the faulted call.
+struct FaultyMemory {
+    /// Fault the read path (`search_facts`), simulating a broken-pipe read.
+    fail_reads: bool,
+    /// Fault the write path (`store_fact*`), simulating a broken-pipe write.
+    fail_writes: bool,
+}
+
+impl FaultyMemory {
+    fn transport_err(op: &str) -> SimardError {
+        // Same shape the real IPC client surfaces so the assertion reflects the
+        // production error, not a bespoke test-only variant.
+        SimardError::RpcCallFailed {
+            bridge: "memory-ipc".to_string(),
+            method: op.to_string(),
+            reason: "write-len: Broken pipe (os error 32)".to_string(),
+        }
+    }
+}
+
+impl CognitiveMemoryOps for FaultyMemory {
+    fn record_sensory(&self, _m: &str, _r: &str, _t: u64) -> SimardResult<String> {
+        Ok("sensory".to_string())
+    }
+    fn prune_expired_sensory(&self) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn push_working(&self, _s: &str, _c: &str, _t: &str, _r: f64) -> SimardResult<String> {
+        Ok("working".to_string())
+    }
+    fn get_working(&self, _t: &str) -> SimardResult<Vec<CognitiveWorkingSlot>> {
+        Ok(vec![])
+    }
+    fn clear_working(&self, _t: &str) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn store_episode(
+        &self,
+        _c: &str,
+        _s: &str,
+        _m: Option<&serde_json::Value>,
+    ) -> SimardResult<String> {
+        Ok("episode".to_string())
+    }
+    fn consolidate_episodes(&self, _b: u32) -> SimardResult<Option<String>> {
+        Ok(None)
+    }
+    fn store_fact(
+        &self,
+        _c: &str,
+        _co: &str,
+        _cf: f64,
+        _t: &[String],
+        _s: &str,
+    ) -> SimardResult<String> {
+        if self.fail_writes {
+            return Err(Self::transport_err("store_fact"));
+        }
+        Ok("fact".to_string())
+    }
+    fn store_fact_with_caller_key(
+        &self,
+        _caller_key: &str,
+        _concept: &str,
+        _content: &str,
+        _confidence: f64,
+        _tags: &[String],
+        _source_id: &str,
+    ) -> SimardResult<String> {
+        if self.fail_writes {
+            return Err(Self::transport_err("store_fact_with_caller_key"));
+        }
+        Ok("fact".to_string())
+    }
+    fn search_facts(&self, _q: &str, _l: u32, _m: f64) -> SimardResult<Vec<CognitiveFact>> {
+        if self.fail_reads {
+            return Err(Self::transport_err("search_facts"));
+        }
+        Ok(vec![])
+    }
+    fn store_procedure(&self, _n: &str, _s: &[String], _p: &[String]) -> SimardResult<String> {
+        Ok("procedure".to_string())
+    }
+    fn recall_procedure(&self, _q: &str, _l: u32) -> SimardResult<Vec<CognitiveProcedure>> {
+        Ok(vec![])
+    }
+    fn store_prospective(&self, _d: &str, _tc: &str, _a: &str, _p: i64) -> SimardResult<String> {
+        Ok("prospective".to_string())
+    }
+    fn check_triggers(&self, _c: &str) -> SimardResult<Vec<CognitiveProspective>> {
+        Ok(vec![])
+    }
+    fn get_statistics(&self) -> SimardResult<CognitiveStatistics> {
+        Ok(CognitiveStatistics::default())
+    }
+}
+
+/// A `TempDir` state root (never under `$HOME/.simard`, so the hermetic guard is
+/// satisfied) paired with a fault backend registered as the in-process writer.
+struct FaultFixture {
+    _dir: tempfile::TempDir,
+    root: std::path::PathBuf,
+    // Held so the registered `Weak` upgrades for the life of the test.
+    _mem: Arc<dyn CognitiveMemoryOps>,
+}
+
+fn register_fault_writer(fail_reads: bool, fail_writes: bool) -> FaultFixture {
+    clear_in_process_writer();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+    let mem: Arc<dyn CognitiveMemoryOps> = Arc::new(FaultyMemory {
+        fail_reads,
+        fail_writes,
+    });
+    register_in_process_writer(root.clone(), Arc::clone(&mem));
+    FaultFixture {
+        _dir: dir,
+        root,
+        _mem: mem,
+    }
+}
+
+fn sample_goal() -> GoalRecord {
+    GoalRecord::from_update(
+        GoalUpdate::new(
+            "Persist creative-idea goals durably",
+            "goals routed from creative ideas must not silently vanish",
+            GoalStatus::Proposed,
+            3,
+        )
+        .expect("goal update should be valid"),
+        "simard",
+        SessionId::parse("session-018f1f7e-4c5d-7b2a-8f10-b5c0d4f7b123")
+            .expect("session id should parse"),
+        SessionPhase::Planning,
+    )
+    .expect("goal record should be valid")
+}
+
+/// RED (fails before the #2896 fix): a reader/transport error during `list()`
+/// MUST surface as `Err`. Before the fix, `list_via_reader` catches the
+/// `search_facts` error and returns `Ok(Vec::new())`, so the goal that was just
+/// written looks like it was never there — the exact silent-loss signature of
+/// #2896 (`goal list` returns 0 of an accepted idea's goals).
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn list_surfaces_reader_transport_error_instead_of_phantom_empty() {
+    let fx = register_fault_writer(/*fail_reads=*/ true, /*fail_writes=*/ false);
+    let store = CognitiveMemoryGoalStore::new(fx.root.clone()).expect("construct goal store");
+
+    let result = store.list();
+
+    clear_in_process_writer();
+    assert!(
+        result.is_err(),
+        "a broken-pipe read MUST propagate as Err, never a phantom empty list \
+         (silent goal loss — bug #2896). Got: {result:?}",
+    );
+}
+
+/// RED companion: the same fail-closed guarantee must hold for the higher-level
+/// `active_top_goals` read used by the live goal board, so a transport fault can
+/// never masquerade as "no active goals".
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn active_top_goals_surfaces_reader_transport_error() {
+    let fx = register_fault_writer(/*fail_reads=*/ true, /*fail_writes=*/ false);
+    let store = CognitiveMemoryGoalStore::new(fx.root.clone()).expect("construct goal store");
+
+    let result = store.active_top_goals(5);
+
+    clear_in_process_writer();
+    assert!(
+        result.is_err(),
+        "active_top_goals MUST propagate a reader transport error, not silently \
+         report zero goals (bug #2896). Got: {result:?}",
+    );
+}
+
+/// Guard (already fail-closed; must stay so): a writer/transport error during
+/// `put()` MUST propagate as `Err`. The bug's "0 review error(s)" telemetry means
+/// a phantom `Ok` here would let the router increment `routed_goal` for a write
+/// that never landed. `put()` calls `store_fact_with_caller_key` first, so a
+/// faulted write must abort the whole `put`.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn put_surfaces_writer_transport_error_instead_of_phantom_ok() {
+    let fx = register_fault_writer(/*fail_reads=*/ false, /*fail_writes=*/ true);
+    let store = CognitiveMemoryGoalStore::new(fx.root.clone()).expect("construct goal store");
+
+    let result = store.put(sample_goal());
+
+    clear_in_process_writer();
+    assert!(
+        result.is_err(),
+        "a broken-pipe write MUST propagate as Err so the route is counted as a \
+         failure, not a phantom success (bug #2896). Got: {result:?}",
+    );
+}

--- a/src/memory_ipc/launcher.rs
+++ b/src/memory_ipc/launcher.rs
@@ -341,18 +341,23 @@ pub fn launch_writer_client(state_root: &Path) -> SimardResult<WriterClient> {
     // mount probe.
     let sock = socket_path_for(state_root);
     if sock.exists() {
-        match RemoteCognitiveMemory::connect(&sock) {
-            Ok(client) => {
-                return Ok(WriterClient::checked_new(Box::new(client)));
-            }
-            Err(e) => {
-                eprintln!(
-                    "[simard] launch_writer_client: socket {} present but connect failed \
-                     ({e}); falling back to direct open",
+        // Fail closed (bug #2896): a socket present at this state_root means a
+        // daemon *should* own the store. If the connect fails we MUST surface
+        // the error, never fall through to a direct tier-2 open — that would
+        // write to a DIFFERENT store than the live daemon reads, so the write
+        // "succeeds" yet is invisible (the silent-failure fallback #2896
+        // forbids). A genuinely absent socket (no daemon) still takes the
+        // legitimate tier-2 path below.
+        let client =
+            RemoteCognitiveMemory::connect(&sock).map_err(|e| SimardError::RpcSpawnFailed {
+                bridge: "memory-ipc".into(),
+                reason: format!(
+                    "writer: socket {} present but unconnectable ({e}); refusing to fall \
+                     through to a divergent direct open (bug #2896)",
                     sock.display()
-                );
-            }
-        }
+                ),
+            })?;
+        return Ok(WriterClient::checked_new(Box::new(client)));
     }
 
     // (2) No daemon — reap any stale lock and open the shared tier-2 store.
@@ -399,20 +404,23 @@ pub fn open_reader_client(state_root: &Path) -> SimardResult<ReaderClient> {
     // daemon is up on `~/.simard/state/memory.sock`.
     let sock = socket_path_for(state_root);
     if sock.exists() {
-        match RemoteCognitiveMemory::connect(&sock) {
-            Ok(client) => {
-                return Ok(ReaderClient {
-                    inner: Box::new(client),
-                });
-            }
-            Err(e) => {
-                eprintln!(
-                    "[simard] open_reader_client: socket {} present but connect failed ({e}); \
-                     falling back to direct open",
+        // Fail closed (bug #2896): mirror the writer path. A present-but-
+        // unconnectable socket must NOT fall through to a divergent tier-2
+        // reader — that is how a goal the daemon persisted becomes invisible
+        // here. Surface the connect error; a genuinely absent socket still
+        // takes the legitimate tier-2 path below.
+        let client =
+            RemoteCognitiveMemory::connect(&sock).map_err(|e| SimardError::RpcSpawnFailed {
+                bridge: "memory-ipc".into(),
+                reason: format!(
+                    "reader: socket {} present but unconnectable ({e}); refusing to fall \
+                     through to a divergent direct open (bug #2896)",
                     sock.display()
-                );
-            }
-        }
+                ),
+            })?;
+        return Ok(ReaderClient {
+            inner: Box::new(client),
+        });
     }
 
     // (2) De-fork Phase 2b (issue #2307): direct open of the library-backed

--- a/src/memory_ipc/mod.rs
+++ b/src/memory_ipc/mod.rs
@@ -25,6 +25,8 @@ mod tests_client_isolation;
 mod tests_default_state_root_1967;
 #[cfg(test)]
 mod tests_launcher;
+#[cfg(test)]
+mod tests_launcher_fail_closed_2896;
 // TDD (RED) for issue #2679: additive gated-write protocol (StoreFactGated /
 // StoreProcedureProvenance / FactWriteOutcome), the MAX_FRAME cap, and the
 // RemoteCognitiveMemory remember_* client wrappers. Symbols are added in the

--- a/src/memory_ipc/tests_launcher_fail_closed_2896.rs
+++ b/src/memory_ipc/tests_launcher_fail_closed_2896.rs
@@ -1,0 +1,243 @@
+//! TDD (Step 7) — the memory-ipc launcher must fail closed for bug #2896.
+//!
+//! Bug #2896 traces silent creative-ideas goal loss in part to the launcher's
+//! silent degradation: when the daemon socket is PRESENT but the connection
+//! cannot be established, `launch_writer_client` / `open_reader_client` today log
+//! an `eprintln!` and fall through to a DIVERGENT direct (tier-2) open. A caller
+//! then writes to a store that is not the one the live daemon reads, so the write
+//! "succeeds" but is invisible — exactly the silent-failure fallback #2896
+//! forbids.
+//!
+//! Contract pinned here (fail-closed; NO silent-failure fallback):
+//!   * RED: socket path OCCUPIED by a non-socket file (connect impossible) →
+//!     writer/reader launch MUST return `Err`, not a phantom tier-2 handle.
+//!   * GUARD: genuinely absent socket (hermetic tests / standalone CLI) → tier-2
+//!     is the legitimate path and MUST still succeed.
+//!   * GUARD: an established memory-ipc connection whose backend op fails
+//!     (broken-pipe / backend error) MUST surface as `Err` from the client op —
+//!     it must never be swallowed into a phantom `Ok`.
+//!
+//! Hermetic: `TempDir` state roots (never under `$HOME/.simard`), no live daemon.
+//! Global tier-0 / tier-2 caches are process-wide, so tests are
+//! `#[serial_test::serial(cognitive_memory)]` and reset the caches.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::error::{SimardError, SimardResult};
+use crate::memory_cognitive::{
+    CognitiveEpisode, CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
+    CognitiveWorkingSlot,
+};
+
+use super::{
+    clear_in_process_writer, clear_tier2_store_cache, launch_writer_client, open_reader_client,
+    socket_path_for, spawn_server,
+};
+use crate::cognitive_memory::CognitiveMemoryOps;
+
+/// Occupy the socket path with a plain file so `sock.exists()` is true but
+/// `RemoteCognitiveMemory::connect` fails (a non-socket occupant is not a
+/// reap-able stale daemon socket and is not the "no socket" case — it is a
+/// present-but-unusable endpoint that must NOT be papered over with a divergent
+/// tier-2 open).
+fn occupy_socket_path_with_regular_file(root: &std::path::Path) {
+    let sock = socket_path_for(root);
+    if let Some(parent) = sock.parent() {
+        std::fs::create_dir_all(parent).expect("create socket parent dir");
+    }
+    std::fs::write(&sock, b"not a socket").expect("write placeholder file at socket path");
+}
+
+/// RED (fails before the #2896 fix): a present-but-unconnectable socket must make
+/// the WRITER launch fail closed rather than silently opening a divergent tier-2
+/// store the live daemon never sees.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn launch_writer_client_fails_closed_when_socket_present_but_unconnectable() {
+    clear_in_process_writer();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    occupy_socket_path_with_regular_file(root);
+
+    let result = launch_writer_client(root);
+
+    clear_tier2_store_cache();
+    assert!(
+        result.is_err(),
+        "socket present but unconnectable MUST fail closed — never silently fall \
+         through to a divergent tier-2 writer (bug #2896: silent-failure fallback). \
+         Got Ok(_)",
+    );
+}
+
+/// RED (fails before the #2896 fix): same fail-closed contract for the READER —
+/// a divergent tier-2 reader is how a persisted goal becomes invisible.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn open_reader_client_fails_closed_when_socket_present_but_unconnectable() {
+    clear_in_process_writer();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    occupy_socket_path_with_regular_file(root);
+
+    let result = open_reader_client(root);
+
+    clear_tier2_store_cache();
+    assert!(
+        result.is_err(),
+        "socket present but unconnectable MUST fail closed for the reader too — \
+         never silently fall through to a divergent tier-2 reader (bug #2896). \
+         Got Ok(_)",
+    );
+}
+
+/// Guard: with NO socket at all (the hermetic-test / standalone-CLI case), tier-2
+/// remains the legitimate path and MUST succeed, so the fail-closed change does
+/// not break the no-daemon workflow the whole test suite relies on.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn launch_clients_succeed_when_no_socket_present() {
+    clear_in_process_writer();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    // No file at socket_path_for(root): genuinely absent.
+
+    let writer = launch_writer_client(root).expect("writer must open tier-2 when no socket exists");
+    // A brand-new tier-2 store fronts zero facts.
+    let stats = writer
+        .ops()
+        .get_statistics()
+        .expect("stats on fresh tier-2 writer");
+    assert_eq!(stats.semantic_count, 0);
+
+    let reader = open_reader_client(root).expect("reader must open tier-2 when no socket exists");
+    let facts = reader
+        .ops()
+        .search_facts("anything", 4, 0.0)
+        .expect("search on fresh tier-2 reader");
+    assert!(facts.is_empty());
+
+    clear_tier2_store_cache();
+}
+
+/// A backend whose every abstract op fails, so a request that reaches it over the
+/// socket produces an error the client must decode into `Err` (never a phantom
+/// `Ok`). The `Ping` handshake is served by the protocol layer, not the backend,
+/// so `connect` still succeeds — isolating the fail-closed guarantee to the op.
+struct AlwaysErrBackend;
+
+impl AlwaysErrBackend {
+    fn boom(op: &str) -> SimardError {
+        SimardError::RpcCallFailed {
+            bridge: "memory-ipc".to_string(),
+            method: op.to_string(),
+            reason: "write-len: Broken pipe (os error 32)".to_string(),
+        }
+    }
+}
+
+impl CognitiveMemoryOps for AlwaysErrBackend {
+    fn record_sensory(&self, _m: &str, _r: &str, _t: u64) -> SimardResult<String> {
+        Err(Self::boom("record_sensory"))
+    }
+    fn prune_expired_sensory(&self) -> SimardResult<usize> {
+        Err(Self::boom("prune_expired_sensory"))
+    }
+    fn push_working(&self, _s: &str, _c: &str, _t: &str, _r: f64) -> SimardResult<String> {
+        Err(Self::boom("push_working"))
+    }
+    fn get_working(&self, _t: &str) -> SimardResult<Vec<CognitiveWorkingSlot>> {
+        Err(Self::boom("get_working"))
+    }
+    fn clear_working(&self, _t: &str) -> SimardResult<usize> {
+        Err(Self::boom("clear_working"))
+    }
+    fn store_episode(
+        &self,
+        _c: &str,
+        _s: &str,
+        _m: Option<&serde_json::Value>,
+    ) -> SimardResult<String> {
+        Err(Self::boom("store_episode"))
+    }
+    fn consolidate_episodes(&self, _b: u32) -> SimardResult<Option<String>> {
+        Err(Self::boom("consolidate_episodes"))
+    }
+    fn store_fact(
+        &self,
+        _c: &str,
+        _co: &str,
+        _cf: f64,
+        _t: &[String],
+        _s: &str,
+    ) -> SimardResult<String> {
+        Err(Self::boom("store_fact"))
+    }
+    fn search_facts(&self, _q: &str, _l: u32, _m: f64) -> SimardResult<Vec<CognitiveFact>> {
+        Err(Self::boom("search_facts"))
+    }
+    fn store_procedure(&self, _n: &str, _s: &[String], _p: &[String]) -> SimardResult<String> {
+        Err(Self::boom("store_procedure"))
+    }
+    fn recall_procedure(&self, _q: &str, _l: u32) -> SimardResult<Vec<CognitiveProcedure>> {
+        Err(Self::boom("recall_procedure"))
+    }
+    fn store_prospective(&self, _d: &str, _tc: &str, _a: &str, _p: i64) -> SimardResult<String> {
+        Err(Self::boom("store_prospective"))
+    }
+    fn check_triggers(&self, _c: &str) -> SimardResult<Vec<CognitiveProspective>> {
+        Err(Self::boom("check_triggers"))
+    }
+    fn get_statistics(&self) -> SimardResult<CognitiveStatistics> {
+        Err(Self::boom("get_statistics"))
+    }
+    fn search_episodes_by_keywords(
+        &self,
+        _k: &[String],
+        _l: u32,
+    ) -> SimardResult<Vec<CognitiveEpisode>> {
+        Err(Self::boom("search_episodes_by_keywords"))
+    }
+}
+
+/// Guard (confirms the socket writer path stays fail-closed): a live daemon whose
+/// backend op errors (broken pipe / backend failure) must surface as `Err` from
+/// the writer op — never a swallowed `Ok`. This is the seam that keeps a routed
+/// goal's write from being a phantom success across the IPC transport.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn writer_socket_op_error_surfaces_as_err_not_phantom_ok() {
+    clear_in_process_writer();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+    let sock = socket_path_for(&root);
+
+    let handle = spawn_server(sock.clone(), Arc::new(AlwaysErrBackend)).expect("spawn_server");
+    // The listener binds on a background thread; wait for the socket to appear.
+    for _ in 0..100 {
+        if sock.exists() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    // Connect succeeds (Ping is protocol-level), so we exercise tier-1 (socket).
+    let writer = launch_writer_client(&root).expect("connect to live socket");
+    let result = writer.ops().store_fact_with_caller_key(
+        "goal-store:record:some-goal",
+        "goal-store:record",
+        "{\"slug\":\"some-goal\"}",
+        1.0,
+        &["goal-store".to_string()],
+        "goal-store",
+    );
+
+    drop(handle);
+    clear_tier2_store_cache();
+    assert!(
+        result.is_err(),
+        "a memory-ipc write whose backend/transport fails MUST surface as Err, \
+         never a swallowed Ok (bug #2896: phantom success across IPC). Got Ok(_)",
+    );
+}

--- a/src/operator_commands_dashboard/creative_ideas.rs
+++ b/src/operator_commands_dashboard/creative_ideas.rs
@@ -21,6 +21,7 @@ use axum::extract::Path as AxumPath;
 use serde_json::{Value, json};
 
 use super::routes::resolve_state_root;
+use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::cognitive_memory::creative_idea::{
     CreativeIdea, CreativeIdeaStore, IdeaStatus, ProspectiveCreativeIdeaStore, parse_idea_status,
 };
@@ -287,7 +288,7 @@ fn promote_idea(state_root: &Path, idea_id: &str, route_to_goal: bool) -> Value 
 
     // Best-effort route to a goal. Failure surfaces `goal_error` WITHOUT rolling
     // back the (already-persisted) acceptance.
-    match route_accepted_idea_to_goal(state_root, &store, &mut idea) {
+    match route_accepted_idea_to_goal(writer.ops(), state_root, &store, &mut idea) {
         Ok(goal) => {
             // Audit the goal injection into the autonomous executor (F4/R4.3),
             // recording the resulting goal_id. Resolve it before the macro so the
@@ -356,11 +357,12 @@ fn load_idea(
 /// a compact goal summary. Any failure is returned as `Err` (surfaced as
 /// `goal_error` by the caller, without rolling back the acceptance).
 fn route_accepted_idea_to_goal(
+    memory: &dyn CognitiveMemoryOps,
     state_root: &Path,
     store: &ProspectiveCreativeIdeaStore<'_>,
     idea: &mut CreativeIdea,
 ) -> SimardResult<Value> {
-    let goals = CognitiveMemoryGoalStoreFactory.open(state_root)?;
+    let goals = CognitiveMemoryGoalStoreFactory.open(memory, state_root)?;
     let record = route_idea_to_goal(idea, goals.as_ref(), now_epoch())?;
     idea.try_transition(IdeaStatus::ImplementationStarted)?;
     store.update(idea)?;


### PR DESCRIPTION
## Summary

Fixes #2896 — the creative-ideas thread routed accepted ideas to goals and reported success (`N → goal, 0 review error(s)`), yet **zero** goals tagged `source:creative-ideas` were ever visible via `simard goal list`. This was silent data loss. Three persistence seams on the write/read path could turn a transport fault (the `bridge 'memory-ipc' … write-len: Broken pipe` the daemon logs) into a **phantom success** or a **falsely-empty read**. All three are now **fail-closed with NO silent-failure fallback**.

## Root cause & fix (three seams)

| # | Seam | Before | After |
|---|------|--------|-------|
| 1 | `CognitiveMemoryGoalStore::list_via_reader` (`src/goals/cognitive_memory_store.rs`) | A reader-open **or** `search_facts` transport error was swallowed into `Ok(Vec::new())` — a broken-pipe read looked identical to an empty store. | Both propagate as **`Err`**. A per-record deserialize failure stays a data-quality skip (one bad record never hides the rest). Stray `eprintln!` on the swallow path removed. |
| 2 | `launch_writer_client` / `open_reader_client` tier-1 (`src/memory_ipc/launcher.rs`) | On *socket present but connect fails*, the launcher `eprintln!`d and fell through to a **divergent tier-2 direct open** — a different store than the live daemon serves, so the write "succeeded" invisibly. | **Any** connect/handshake failure while the socket exists returns **`Err`**; a genuinely absent socket still takes the legitimate tier-2 path. |
| 3 | Creative-ideas goal write (`src/creative_ideas/pipeline.rs`, goals) | The store re-derived a handle from `state_root`; a tier-0 `state_root` mismatch degraded to the socket/tier-2 path from seam 2. | `GoalStoreFactory::open` now takes the live `&dyn CognitiveMemoryOps` and returns a new **`InProcessGoalStore`** that writes through that exact handle — **visible by construction**, mirroring how the prospective creative-idea store already reuses `ctx.memory`. |

The encode / slug-dedup / prospective-mirror logic is extracted into shared `put_via_ops` / `list_via_ops` so the in-process and cold-open CLI paths cannot drift. The socket client op path was already fail-closed (backend errors surface as `Err`); a guard test pins that it stays so. The shared launcher seam is fixed **once**, so journal / prospective / other in-process writers inherit it (addresses the "same swallow elsewhere" requirement).

## Tests (real, hermetic — RED before the fix)

- `src/goals/tests_fail_closed_2896.rs` — a faulted read surfaces `Err` from `list()` / `active_top_goals()`; a faulted write surfaces `Err` from `put()`.
- `src/memory_ipc/tests_launcher_fail_closed_2896.rs` — a present-but-unconnectable socket fails closed (writer + reader); no-socket still opens tier-2; a live socket whose backend op errors surfaces `Err`.
- `src/creative_ideas/tests_visibility_2896.rs` — routing an accepted idea yields a `GoalRecord` a subsequent `list()` returns, tagged `source:creative-ideas`; the production factory routes to the caller-supplied in-process handle; a "successful" route followed by a read fault surfaces `Err`, not a phantom empty list.

## Validation

- `cargo test --lib`: **7919 passed, 0 failed**.
- Goal/memory/rpc integration suites (`goal_stewardship`, `goal_store_flock`, `meeting_goals`, `meeting_close_goal_writes`, `memory_durable`, `prospective_triggers_outside_in`, `no_bridge_naming`) green.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features --locked -- -D warnings`, and `mkdocs build --strict` all clean. Pre-commit and pre-push hooks passed (no `--admin` / `--no-verify`).

Post-deploy: after a creative-ideas run, `simard goal list --tag source:creative-ideas` returns > 0, and Broken-pipe log lines no longer correlate with lost writes — a transport failure now surfaces as a route/review error instead of a phantom success.

## Constraints honored

Additive; fail-closed everywhere; no new `*Bridge`-named types (existing runtime `bridge 'memory-ipc'` strings left untouched); no stray `println!`/`eprintln!` in the fixed prod paths; no `--admin` / `--no-verify`.

## Docs

- `docs/reference/creative-ideas-goal-routing-fail-closed.md` — the fail-closed persistence contract for all three seams.
- `docs/howto/diagnose-lost-creative-ideas-goals.md` — operator troubleshooting walkthrough.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
