### PR TITLE
fix(creative-ideas): trigger-scoped prospective read so the dashboard shows persisted ideas (#122)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=e005a5963b38bc02610fa5b0bef7e52625dcd092#e005a5963b38bc02610fa5b0bef7e52625dcd092"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=901f63ad79eb0c2d87cd8263d26025877af43cc5#901f63ad79eb0c2d87cd8263d26025877af43cc5"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,16 @@ path = "src/bin/supply_chain_steward.rs"
 # with no lbug/engine change, so the store format stays v41. The pin points at an
 # upstream-`main` commit (not a feature branch), so the build can never be frozen
 # against an unmerged, GC-able ref.
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "e005a5963b38bc02610fa5b0bef7e52625dcd092", features = ["persistent"] }
+#
+# Bumped again (issue #122) to the squash-merge commit of amplihack-memory-lib
+# PR #125 on `main` (2 commits ahead of the #120 pin, no regression), which adds
+# `get_prospective_by_trigger(trigger, limit)` — a trigger-scoped, priority-
+# ordered prospective query whose LIMIT bounds only matching nodes — and makes
+# `get_all_prospective` sort-then-truncate. Simard consumes the new primitive to
+# fix the creative-ideas dashboard read path (ideas fell outside the unscoped
+# 512-row window in a large store). Still an upstream-`main` commit; store format
+# stays v41 (no lbug/engine change).
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "901f63ad79eb0c2d87cd8263d26025877af43cc5", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream

--- a/docs/design/creative-ideas-thread.md
+++ b/docs/design/creative-ideas-thread.md
@@ -19,6 +19,7 @@ status: draft
 related:
   - overseer.md
   - ../reference/creative-ideas-api.md
+  - ../reference/creative-ideas-trigger-scoped-read.md
   - ../howto/configure-creative-ideas-thread.md
   - ../concepts/operational-autonomy-model.md
   - ../reference/cognitive-thread-scheduling.md
@@ -250,9 +251,16 @@ pub trait CreativeIdeaStore {
 pub struct ProspectiveCreativeIdeaStore<'a> { mem: &'a dyn CognitiveMemoryOps }
 ```
 
-`list` calls `list_all_prospective`, keeps rows whose `trigger_condition ==
-"creative-idea"`, and deserializes the payload. Tests use an in-memory
-`FakeCreativeIdeaStore` **and** a round-trip test through a fake `CognitiveMemoryOps`.
+`list` calls `list_prospective_by_trigger("creative-idea", limit)` — a
+trigger-scoped, priority-ordered read whose `limit` bounds only creative-idea
+nodes — then keeps rows whose `trigger_condition == "creative-idea"` (a cheap
+fail-closed guard) and deserializes the payload. Before issue #122 `list` used
+the unfiltered `list_all_prospective` + post-filter, so on a live store the fixed
+read window filled with unrelated prospective memories and the idea nodes were
+truncated away (see
+[Creative Ideas trigger-scoped read](../reference/creative-ideas-trigger-scoped-read.md)).
+Tests use an in-memory `FakeCreativeIdeaStore` **and** a round-trip test through a
+fake `CognitiveMemoryOps`, plus a `>512`-node regression test.
 
 ## The generator thread
 

--- a/docs/reference/creative-ideas-api.md
+++ b/docs/reference/creative-ideas-api.md
@@ -21,6 +21,7 @@ related:
   - ../design/creative-ideas-thread.md
   - ../howto/configure-creative-ideas-thread.md
   - ./creative-ideas-durable-read-after-write.md
+  - ./creative-ideas-trigger-scoped-read.md
   - ./cognitive-thread-scheduling.md
   - ./goal-board-api.md
   - ./stewardship-api.md
@@ -283,12 +284,20 @@ pub trait CreativeIdeaStore {
 pub struct ProspectiveCreativeIdeaStore<'a> { /* mem: &'a dyn CognitiveMemoryOps */ }
 ```
 
-`store`/`update` call `store_prospective`; `list` calls `list_all_prospective`,
-keeps rows whose `trigger_condition == CREATIVE_IDEA_TRIGGER`, and deserializes
-the payload; `get` filters `list` by `node_id`. Tests use an in-memory
-`FakeCreativeIdeaStore` **and** a round-trip test through a fake
-`CognitiveMemoryOps` that asserts `trigger_condition == "creative-idea"` and
-payload fidelity (`links`, `context`, `success_metric`).
+`store`/`update` call `store_prospective`; `list` calls
+`list_prospective_by_trigger(CREATIVE_IDEA_TRIGGER, limit)` — a trigger-scoped,
+priority-ordered read whose `limit` bounds only creative-idea nodes — then keeps
+rows whose `trigger_condition == CREATIVE_IDEA_TRIGGER` (a cheap fail-closed
+guard) and deserializes the payload; `get` filters `list` by `node_id`. Before
+issue #122 `list` used the unfiltered `list_all_prospective` + post-filter, so on
+a live store the fixed read window filled with unrelated prospective memories and
+the idea nodes were truncated away — see
+[Creative Ideas trigger-scoped read](./creative-ideas-trigger-scoped-read.md).
+Tests use an in-memory `FakeCreativeIdeaStore` **and** a round-trip test through a
+fake `CognitiveMemoryOps` that asserts `trigger_condition == "creative-idea"` and
+payload fidelity (`links`, `context`, `success_metric`), plus a `>512`-node
+regression test that proves the pool survives a store full of unrelated
+prospectives.
 
 ## The generator thread
 
@@ -729,6 +738,7 @@ for the full list of assertions.
 - [Creative Ideas background thread — design](../design/creative-ideas-thread.md)
 - [Configure and operate the Creative Ideas thread](../howto/configure-creative-ideas-thread.md)
 - [Creative Ideas durable read-after-write](./creative-ideas-durable-read-after-write.md) — the persistence/read seam that keeps the dashboard tab non-empty and durable across restart (#2798)
+- [Creative Ideas trigger-scoped read](./creative-ideas-trigger-scoped-read.md) — the trigger-scoped, priority-ordered read that keeps the pool visible on a live store full of unrelated prospectives (#122)
 - [Cognitive-thread scheduling](./cognitive-thread-scheduling.md)
 - [Add a new cognitive thread](../howto/add-a-new-cognitive-thread.md)
 - [Goal board API](./goal-board-api.md) · [Stewardship API](./stewardship-api.md)

--- a/docs/reference/creative-ideas-trigger-scoped-read.md
+++ b/docs/reference/creative-ideas-trigger-scoped-read.md
@@ -1,0 +1,404 @@
+---
+title: Creative Ideas trigger-scoped read
+description: >
+  How the Creative Ideas dashboard reader retrieves persisted ideas out of a
+  live store that holds thousands of unrelated prospective memories, without the
+  ideas falling outside a LIMIT window. Documents the root cause (a
+  LIMIT-before-filter truncation in the prospective read path), the new
+  trigger-scoped, priority-ordered primitive
+  `CognitiveMemoryOps::list_prospective_by_trigger` and its four impls, the IPC
+  round-trip that carries it to tier-1 readers, the `ProspectiveCreativeIdeaStore`
+  read-path change, the amplihack-memory-lib pin bump that adds
+  `get_prospective_by_trigger`, the fail-closed contract, and the >512-node
+  regression test. Fixes issue #122.
+last_updated: 2026-07-07
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+status: current — shipped; the upstream `get_prospective_by_trigger` primitive
+  landed in amplihack-memory-lib PR #125 and the pin is bumped (see Pin bump)
+related:
+  - ./creative-ideas-api.md
+  - ./creative-ideas-durable-read-after-write.md
+  - ./cognitive-memory-fact-recall.md
+  - ./rpc-wire-protocol.md
+  - ../design/creative-ideas-thread.md
+  - ../howto/configure-creative-ideas-thread.md
+---
+
+# Creative Ideas trigger-scoped read
+
+The Creative Ideas thread persists a batch of ten candidate ideas per run into
+prospective memory. On a **live** brain — one that already holds thousands of
+ordinary prospective (trigger → action) memories — the dashboard **Creative
+Ideas** tab was empty: `GET /api/creative-ideas` returned `ideas: []` and every
+status count `0`, even while journald showed the thread reporting `10 persisted`
+on every tick.
+
+This page documents the shipped fix. The symptom was **not** a persistence bug
+(the ten ideas were durably written every run), **not** the read-after-write /
+state-root defect fixed earlier in
+[Creative Ideas durable read-after-write](./creative-ideas-durable-read-after-write.md)
+(#2798), and **not** a UI or status-filter bug. It was a distinct, second
+read-path defect: the reader asked the store for "up to N prospective nodes" and
+**then** filtered them down to creative ideas in Rust — so the `N`-row window was
+consumed by unrelated prospective facts and the ten idea nodes fell outside it.
+
+!!! note "Status — shipped; fail-closed (#122)"
+    The fix is implemented and green in CI: the trigger-scoped primitive
+    `list_prospective_by_trigger`, its four `CognitiveMemoryOps` impls (one trait
+    default + three production backends), the IPC request/dispatch/client wiring,
+    the `ProspectiveCreativeIdeaStore` read-path change, and the `>512`-node
+    regression test all land against the real code seams. The underlying
+    trigger-filtered, priority-ordered query is owned upstream in
+    `amplihack-memory-lib` (guideline G2) as `get_prospective_by_trigger`, which
+    landed in PR #125; Simard's pin is bumped to it (see
+    [Pin bump](#pin-bump)). No store-format change (v41 is unchanged). No type or
+    method contains the word `Bridge` (operator preference). Live verification
+    still requires a deploy plus a thread run (or the dashboard **Run now**
+    button) — the daemon persists ten ideas per run.
+
+---
+
+## Root cause — LIMIT applied before the trigger filter
+
+The creative-idea read path deserializes only the prospective nodes whose
+`trigger_condition` is the sentinel `CREATIVE_IDEA_TRIGGER` (`"creative-idea"`).
+Before this fix, `ProspectiveCreativeIdeaStore` obtained candidates with the
+**unfiltered** enumerator `list_all_prospective(limit)` and applied the sentinel
+filter afterward, in Rust:
+
+```
+READ PATH (before #122) — filter is too late
+--------------------------------------------
+GET /api/creative-ideas
+  load_ideas(state_root)
+    ProspectiveCreativeIdeaStore::list(IDEA_LIST_LIMIT = 512)
+      all_revisions(512)
+        mem.list_all_prospective(512)            <-- LIMIT 512 in the DB query
+          library get_all_prospective(512)        <-- returns 512 ARBITRARY nodes
+        .filter(trigger == "creative-idea")        <-- 0 survive on a live store
+```
+
+`list_all_prospective` routes to the library's `get_all_prospective(limit)`,
+which bounded the **whole** prospective-node set to `limit` rows *inside the DB
+query*, before any trigger predicate. On the dashboard's read window of
+`IDEA_LIST_LIMIT = 512`
+([`src/operator_commands_dashboard/creative_ideas.rs`](../reference/creative-ideas-api.md)),
+a live store with thousands of prospective facts fills all 512 slots with
+non-creative nodes; the ten creative-idea nodes sit outside the window and the
+post-filter yields **zero**. On a fresh/test store with only a handful of
+prospectives the bug is invisible — which is why it survived the earlier
+read-after-write fix and only reproduced in production.
+
+Raising `IDEA_LIST_LIMIT` is **not** the fix: it only moves the cliff and makes
+every read enumerate and deserialize the entire prospective store. The correct
+fix pushes the trigger predicate **into** the query so the `LIMIT` bounds only
+matching nodes.
+
+## The fix — a trigger-scoped, priority-ordered query
+
+The read path now calls a new primitive that filters by trigger **in the query**
+and orders by priority, so the `LIMIT` applies to *creative-idea nodes only*:
+
+```
+READ PATH (after #122) — filter is in the query
+-----------------------------------------------
+GET /api/creative-ideas
+  load_ideas(state_root)
+    ProspectiveCreativeIdeaStore::list(512)
+      all_revisions(512)
+        mem.list_prospective_by_trigger("creative-idea", 512)
+          library get_prospective_by_trigger("creative-idea", 512)  <-- filter, THEN limit
+        .filter(trigger == "creative-idea")   <-- cheap defensive guard (all pass)
+```
+
+Because the query returns at most 512 nodes that are *already* creative ideas,
+the ten persisted ideas are always in the window regardless of how many
+unrelated prospectives the brain holds.
+
+### New trait method — `CognitiveMemoryOps::list_prospective_by_trigger`
+
+Module `simard::cognitive_memory` (`src/cognitive_memory/mod.rs`). Additive; sits
+next to `list_all_prospective`.
+
+```rust
+/// Return up to `limit` prospective memories whose `trigger_condition` equals
+/// `trigger`, priority-ordered (highest first) — the trigger predicate is
+/// applied **in the query**, so `limit` bounds only matching nodes.
+///
+/// Unlike `list_all_prospective` (enumerate-all, then caller-side filter), the
+/// `limit` here is a bound on the *matching* set, so a caller reading a modest
+/// window (e.g. the creative-idea pool) never loses its rows to unrelated
+/// prospective memories that happen to sort ahead of them. A pure `&self` read:
+/// it neither mutates status (unlike `check_triggers`) nor filters by content.
+///
+/// The default returns empty so non-library backends degrade gracefully; the
+/// production impls (`LibraryCognitiveMemory`, `SharedMemory`,
+/// `RemoteCognitiveMemory`) override it.
+fn list_prospective_by_trigger(
+    &self,
+    trigger: &str,
+    limit: u32,
+) -> SimardResult<Vec<CognitiveProspective>> {
+    let _ = (trigger, limit);
+    Ok(vec![])
+}
+```
+
+The default-empty body keeps every existing `impl CognitiveMemoryOps` (including
+the many test mocks) compiling unchanged; only the three production backends
+override it. `trigger` is borrowed (`&str`); `limit` is `u32` to match the trait's
+other list methods and is widened to the library's `usize` only at the
+`LibraryCognitiveMemory` boundary (`limit as usize`; lossless on 64-bit).
+
+### Four impls (three production, one default)
+
+| Impl | Location | Behaviour |
+|---|---|---|
+| Trait default | `cognitive_memory/mod.rs` | `Ok(vec![])` — covers legacy stubs and the ~10 test mocks with no code change. |
+| `LibraryCognitiveMemory` | `cognitive_memory/library_adapter.rs` | Delegates to the library's `get_prospective_by_trigger(trigger, limit as usize)` under `lock()`, propagating its `Result` (mapped onto `RpcCallFailed` via `map_op_err` — **fail-closed**, never a masked empty) and mapping each `ProspectiveMemory` via `to_prospective`. Mirrors how `list_all_prospective` delegates to `get_all_prospective`. |
+| `SharedMemory` | `memory_ipc/mod.rs` | Forwards to the wrapped ops: `self.0.list_prospective_by_trigger(trigger, limit)`. `open_reader_client` hands the dashboard a `SharedMemory` for **both** the tier-0 in-process daemon-writer shortcut and the tier-2 direct-open reader, and the daemon also dispatches the tier-1 socket request into this backend — so this one delegation is what actually reaches `LibraryCognitiveMemory` on every non-socket read. |
+| `RemoteCognitiveMemory` | `memory_ipc/client.rs` | Issues the IPC request (below) and maps the `Prospectives` reply — so **tier-1** (socket) readers get the same trigger-scoped result as tier-0 (in-process). |
+
+`LibraryCognitiveMemory` override (shape):
+
+```rust
+fn list_prospective_by_trigger(
+    &self,
+    trigger: &str,
+    limit: u32,
+) -> SimardResult<Vec<CognitiveProspective>> {
+    Ok(self
+        .lock()?
+        .get_prospective_by_trigger(trigger, limit as usize)
+        .map_err(|e| map_op_err("list_prospective_by_trigger", e))?
+        .into_iter()
+        .map(to_prospective)
+        .collect())
+}
+```
+
+### IPC round-trip (tier-1)
+
+The dashboard reader may resolve to an in-process writer (tier-0) **or** a
+socket client (tier-1). To make both paths identical, the new method is carried
+over the memory IPC protocol (`src/memory_ipc`). It reuses the existing
+`MemoryResponse::Prospectives(Vec<CognitiveProspective>)` reply variant; only a
+new request variant is added.
+
+**Request** — `src/memory_ipc/mod.rs`:
+
+```rust
+pub enum MemoryRequest {
+    // ...
+    /// Issue #122: trigger-scoped, priority-ordered prospective read so a
+    /// bounded reader (creative-idea pool) is not truncated by unrelated
+    /// prospective memories. Reply: `MemoryResponse::Prospectives`.
+    ListProspectiveByTrigger { trigger: String, limit: u32 },
+}
+```
+
+**Server dispatch** — `src/memory_ipc/server.rs`:
+
+```rust
+MemoryRequest::ListProspectiveByTrigger { trigger, limit } => {
+    match memory.list_prospective_by_trigger(&trigger, limit) {
+        Ok(v) => MemoryResponse::Prospectives(v),
+        Err(e) => MemoryResponse::Error(e.to_string()),
+    }
+}
+```
+
+**Client** — `src/memory_ipc/client.rs` (`impl CognitiveMemoryOps for RemoteCognitiveMemory`):
+
+```rust
+fn list_prospective_by_trigger(
+    &self,
+    trigger: &str,
+    limit: u32,
+) -> SimardResult<Vec<CognitiveProspective>> {
+    match self.call(MemoryRequest::ListProspectiveByTrigger {
+        trigger: trigger.to_string(),
+        limit,
+    })? {
+        MemoryResponse::Prospectives(v) => Ok(v),
+        // Use the client's existing unexpected-reply convention. `ipc_err` takes
+        // a `(ctx: &str, err: impl Display)` pair, not a single formatted string;
+        // the established helper for a wrong reply variant is `Self::unexpected`.
+        other => Err(Self::unexpected("list_prospective_by_trigger", other)),
+    }
+}
+```
+
+End-to-end, a dashboard read reaching the daemon over the socket now returns the
+same trigger-scoped, priority-ordered nodes as an in-process read.
+
+### `ProspectiveCreativeIdeaStore` read-path change
+
+Module `simard::cognitive_memory::creative_idea`
+(`src/cognitive_memory/creative_idea.rs`). The internal enumerator swaps the
+unfiltered call for the trigger-scoped one; the public `list` / `get` and the
+`latest_revision_per_idea` dedupe are unchanged:
+
+```rust
+fn all_revisions(&self, limit: u32) -> SimardResult<Vec<CreativeIdea>> {
+    let nodes = self
+        .mem
+        .list_prospective_by_trigger(CREATIVE_IDEA_TRIGGER, limit)?;
+    nodes
+        .iter()
+        // Redundant now that the query filters, but retained as a cheap,
+        // fail-closed guard against a library regression or a mis-routed node.
+        .filter(|n| n.trigger_condition == CREATIVE_IDEA_TRIGGER)
+        .map(CreativeIdea::from_prospective)
+        .collect()
+}
+```
+
+The trailing `.filter(...)` is kept deliberately: it costs one string compare per
+node and preserves the fail-closed contract if the library ever returns a
+mis-tagged node. `CreativeIdea::from_prospective` independently rejects a node
+whose sentinel is wrong (`InvalidCreativeIdeaRecord`), so a stray non-creative
+node can never be silently deserialized as an idea.
+
+## Library primitive (amplihack-memory-lib)
+
+The trigger-filtered query is owned upstream (guideline G2 — the memory type and
+its queries live in `amplihack-memory-lib`, not Simard). The consumed API:
+
+```rust
+// amplihack-memory-lib
+impl CognitiveMemory {
+    /// Prospective nodes whose trigger equals `trigger`, priority-ordered
+    /// (highest first), bounded to `limit` MATCHING nodes. Fail-closed: a
+    /// backend read error is propagated as `Err`, never masked as empty.
+    pub fn get_prospective_by_trigger(
+        &self,
+        trigger: &str,
+        limit: usize,
+    ) -> Result<Vec<ProspectiveMemory>>;
+}
+```
+
+The same release also makes `get_all_prospective` **sort-then-truncate**
+(priority-order the full set before applying `limit`), so the two enumerators
+agree on ordering.
+
+### Pin bump
+
+`Cargo.toml` bumps the `amplihack-memory` git dependency from the prior pin
+(`e005a5963b38bc02610fa5b0bef7e52625dcd092`, issue #120) to the
+`amplihack-memory-lib` `main` commit (PR #125's squash-merge) that adds
+`get_prospective_by_trigger` — two commits ahead, no regression:
+
+```toml
+# Bump (issue #122) from e005a5963b38bc02610fa5b0bef7e52625dcd092 to the
+# amplihack-memory-lib main commit that adds get_prospective_by_trigger (a
+# trigger-filtered, priority-ordered prospective query) and makes
+# get_all_prospective sort-then-truncate. Store format stays v41.
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "901f63ad79eb0c2d87cd8263d26025877af43cc5", features = ["persistent"] }
+```
+
+Run `cargo build` after the bump to refresh `Cargo.lock`. No store-format
+migration is required (v41 unchanged); the change is purely a new read query plus
+an ordering guarantee on an existing one.
+
+## Fail-closed contract
+
+The read path is **additive and fail-closed** — there is no fallback to the old
+truncating behaviour and no path that silently yields an empty pool:
+
+- The creative-idea reader calls **only** `list_prospective_by_trigger`. It never
+  falls back to `list_all_prospective` + post-filter.
+- A backend read error is propagated as `Err` (surfaced by the dashboard as
+  `{"error": "...", "ideas": [], "counts": {}}`), never coerced into an
+  "empty pool" success.
+- The retained `trigger_condition == CREATIVE_IDEA_TRIGGER` guard plus
+  `from_prospective`'s sentinel check keep a mis-tagged node from ever being read
+  as an idea.
+- The trait default is `Ok(vec![])` **only** for backends that structurally hold
+  no prospective memory (test mocks, IPC stubs). The dashboard reader that
+  `open_reader_client` returns is always a `SharedMemory` (tier-0 in-process
+  daemon-writer shortcut, or tier-2 direct-open — each delegating to
+  `LibraryCognitiveMemory`) or a `RemoteCognitiveMemory` (tier-1 socket, whose
+  daemon dispatches into `LibraryCognitiveMemory`). All three production impls
+  override the method with a real query; the reader never resolves to a bare
+  trait-default backend.
+
+## Regression test
+
+`src/creative_ideas/tests.rs` (reusing the existing creative-idea harness — a
+real `LibraryCognitiveMemory::in_memory()` store wrapped by
+`ProspectiveCreativeIdeaStore`) adds a test that reproduces the live conditions:
+
+1. Store **more than 512** ordinary (non-creative) prospective memories directly
+   via `mem.store_prospective(desc, "some-other-trigger", action, priority)`.
+2. Store a handful of creative ideas through
+   `ProspectiveCreativeIdeaStore::store`.
+3. Assert `store.list(512)` returns exactly the creative ideas (by `idea_id`),
+   with none lost to the non-creative bulk.
+
+This test **fails before the fix** (the 512-row window is consumed by the
+non-creative nodes, so `list` returns zero ideas) and **passes after** (the
+trigger-scoped query bounds only creative-idea nodes). The existing
+creative-idea store/list/get/update/promote/prune tests remain green — the public
+`CreativeIdeaStore` surface is unchanged.
+
+## Dashboard HTTP contract (unchanged shape)
+
+`GET /api/creative-ideas` is unchanged in shape; it simply returns a non-empty
+pool once ideas exist. It reads the live pool (latest revision per idea, newest
+first) with a per-status count summary:
+
+```json
+{
+  "counts": { "New": 7, "UnderReview": 2, "AcceptedForImplementation": 1, "...": 0 },
+  "ideas": [
+    { "idea_id": "…", "node_id": "…", "status": "New", "idea": "…", "rationale": "…" }
+  ]
+}
+```
+
+`POST /api/creative-ideas/search` (status/free-text filter) reads the same pool
+and likewise benefits from the trigger-scoped read. See
+[Creative Ideas subsystem API reference](./creative-ideas-api.md#dashboard-http-api-operator-controls)
+for the full operator surface (Run now / Promote / Prune).
+
+## Operator verification (live)
+
+Verify the fix in the running system after a redeploy:
+
+1. Deploy the built binary (the reader change ships in the daemon **and** the
+   dashboard process).
+2. Trigger a generation run — either wait for the daily tick or press
+   **Run now** on the Creative Ideas tab (`POST /api/creative-ideas/run`).
+3. Reload the tab (or `curl` the endpoint):
+
+   ```console
+   $ curl -s http://127.0.0.1:PORT/api/creative-ideas | jq '.counts, (.ideas | length)'
+   ```
+
+   The pool is now non-empty — `counts` sums to ≥ 10 after one run and
+   `.ideas | length` is `> 0`, on a live store regardless of how many unrelated
+   prospective memories it holds.
+
+Live verification requires a deploy plus a thread run; the daemon persists ten
+ideas per run, so a single **Run now** is sufficient to observe `count > 0`.
+
+## Constraints honoured
+
+Additive (new method + new request variant; no signature churn on existing
+callers) · fail-closed (no `list_all_prospective` fallback on the creative-idea
+read; no silent empty) · no `*Bridge` names · no `println!`/`eprintln!` (tracing
+only) · store format v41 unchanged · CI green · never `--admin` / `--no-verify`.
+
+## See also
+
+- [Creative Ideas subsystem API reference](./creative-ideas-api.md) — the full
+  `CreativeIdeaStore` seam and dashboard surface.
+- [Creative Ideas durable read-after-write](./creative-ideas-durable-read-after-write.md)
+  — the earlier, distinct read-path fix (state-root resolver, #2798).
+- [Creative Ideas background thread (design)](../design/creative-ideas-thread.md)
+  — motivation, data model, and roadmap.
+- [Configure and operate the Creative Ideas thread](../howto/configure-creative-ideas-thread.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -370,6 +370,7 @@ nav:
     - Creative Ideas Subsystem API: reference/creative-ideas-api.md
     - Creative Ideas Durable Read-After-Write: reference/creative-ideas-durable-read-after-write.md
     - Creative-Ideas Goal Routing — Fail-Closed Persistence: reference/creative-ideas-goal-routing-fail-closed.md
+    - Creative Ideas Trigger-Scoped Read: reference/creative-ideas-trigger-scoped-read.md
   - Operations:
     - Overview: operations/index.md
     - Verified Backups of the Live Store: operations/verified-backups.md

--- a/src/cognitive_memory/creative_idea.rs
+++ b/src/cognitive_memory/creative_idea.rs
@@ -343,10 +343,24 @@ impl<'a> ProspectiveCreativeIdeaStore<'a> {
         Self { mem }
     }
 
-    /// Every stored revision (no dedupe) filtered by the sentinel — the raw
-    /// append-only stream. Used internally by [`Self::list`] and by tests.
+    /// Every stored revision (no dedupe) for the creative-idea sentinel — the
+    /// raw append-only stream. Used internally by [`Self::list`] and by tests.
+    ///
+    /// Reads through [`CognitiveMemoryOps::list_prospective_by_trigger`] so the
+    /// `limit` bounds only nodes carrying [`CREATIVE_IDEA_TRIGGER`] (issue
+    /// #122): the backend applies the trigger filter *in the query*, so ideas
+    /// survive no matter how many unrelated prospective memories the live store
+    /// accumulates. The old path (`list_all_prospective` + a Rust post-filter)
+    /// truncated the creative nodes out of the row window in a large store, so
+    /// the dashboard showed 0 ideas. **Fail-closed**: no fallback to the
+    /// unscoped enumeration — a read error propagates rather than masking as an
+    /// empty list. The retained sentinel `filter` is a cheap defensive guard
+    /// that keeps [`CreativeIdea::from_prospective`] from ever seeing a
+    /// non-creative node should a backend widen the match.
     fn all_revisions(&self, limit: u32) -> SimardResult<Vec<CreativeIdea>> {
-        let nodes = self.mem.list_all_prospective(limit)?;
+        let nodes = self
+            .mem
+            .list_prospective_by_trigger(CREATIVE_IDEA_TRIGGER, limit)?;
         nodes
             .iter()
             .filter(|n| n.trigger_condition == CREATIVE_IDEA_TRIGGER)

--- a/src/cognitive_memory/library_adapter.rs
+++ b/src/cognitive_memory/library_adapter.rs
@@ -1155,6 +1155,29 @@ impl CognitiveMemoryOps for LibraryCognitiveMemory {
             .collect())
     }
 
+    fn list_prospective_by_trigger(
+        &self,
+        trigger: &str,
+        limit: u32,
+    ) -> SimardResult<Vec<CognitiveProspective>> {
+        // Issue #122: trigger-scoped enumeration of prospective memories, all
+        // statuses, priority-ordered. Routes through the library's
+        // `get_prospective_by_trigger`, which pushes the `trigger_condition`
+        // equality filter into the node query so the `limit` bounds only
+        // matching nodes — unlike `get_all_prospective`, whose window is
+        // applied across every trigger. This is what keeps the creative-ideas
+        // dashboard complete in a large store. **Fail-closed**: the library
+        // returns a `Result`, so a genuine backend read error is propagated
+        // (mapped onto `RpcCallFailed`), never masked as an empty `Ok`.
+        Ok(self
+            .lock()?
+            .get_prospective_by_trigger(trigger, limit as usize)
+            .map_err(|e| map_op_err("list_prospective_by_trigger", e))?
+            .into_iter()
+            .map(to_prospective)
+            .collect())
+    }
+
     fn mark_episode_distilled(&self, node_id: &str) -> SimardResult<()> {
         // De-fork Phase 2b (issue #2307): the library now exposes a persistent,
         // one-way distilled latch. Delegate to it. The library returns `false`

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -596,6 +596,36 @@ pub trait CognitiveMemoryOps: Send + Sync {
         Ok(vec![])
     }
 
+    /// Return up to `limit` prospective memories whose `trigger_condition`
+    /// **equals** `trigger`, priority-ordered (highest first), across every
+    /// status (issue #122).
+    ///
+    /// The trigger-scoped counterpart of
+    /// [`list_all_prospective`](Self::list_all_prospective): the `limit` bounds
+    /// only *matching* nodes because the equality filter is pushed into the
+    /// backend query **before** the row cap, not applied in Rust afterwards.
+    /// This is the read the creative-ideas dashboard needs: a store holding
+    /// thousands of unrelated prospective facts must still surface every idea
+    /// under the [`crate::cognitive_memory::creative_idea::CREATIVE_IDEA_TRIGGER`]
+    /// sentinel, which the old "take `limit` rows across all triggers, then
+    /// filter" path truncated out of the window (`GET /api/creative-ideas`
+    /// returned 0 even though ideas were persisted).
+    ///
+    /// A pure read: like `list_all_prospective` it neither filters by content
+    /// nor mutates status the way [`check_triggers`](Self::check_triggers)
+    /// does. The default returns empty so non-library backends degrade
+    /// gracefully; [`LibraryCognitiveMemory`] overrides it via the library's
+    /// `get_prospective_by_trigger`, and the IPC client / `SharedMemory`
+    /// forward it so both tier-0 (in-process) and tier-1 (socket) dashboard
+    /// readers reach the trigger-scoped query.
+    fn list_prospective_by_trigger(
+        &self,
+        _trigger: &str,
+        _limit: u32,
+    ) -> SimardResult<Vec<CognitiveProspective>> {
+        Ok(vec![])
+    }
+
     fn get_statistics(&self) -> SimardResult<CognitiveStatistics>;
 
     /// Probe whether the store is *confirmed* empty, **failing closed** on a

--- a/src/creative_ideas/tests.rs
+++ b/src/creative_ideas/tests.rs
@@ -342,6 +342,135 @@ fn generated_idea_persists_as_prospective_node_and_round_trips() {
     assert_eq!(by_id.node_id, got.node_id);
 }
 
+/// Regression for the dashboard read path (#122): persisted creative ideas must
+/// appear even when the store already holds far more than the read window's
+/// worth of *unrelated* prospective memories.
+///
+/// The daemon persists ~10 ideas per Creative-Ideas run, but the live OODA
+/// store accumulates thousands of other prospective facts. The dashboard read
+/// path (`store.list(IDEA_LIST_LIMIT)`) used to fetch the first
+/// `IDEA_LIST_LIMIT` prospective nodes *across every trigger* and only then
+/// filter for the creative-idea sentinel — so once the store held more than
+/// `IDEA_LIST_LIMIT` non-creative prospectives the creative nodes fell outside
+/// the window and `GET /api/creative-ideas` returned 0 across all statuses
+/// ("I'm still not seeing any of the creative ideas work in the dashboard").
+///
+/// The fix scopes the `LIMIT` to the creative-idea trigger *in the query*
+/// (`list_prospective_by_trigger`), so every persisted idea survives regardless
+/// of how many unrelated prospectives exist. This test therefore FAILS before
+/// the fix (creative nodes truncated out of the window) and PASSES after it.
+#[test]
+fn creative_ideas_survive_beyond_the_prospective_read_window() {
+    // Mirror of the dashboard's module-private `IDEA_LIST_LIMIT`
+    // (`src/operator_commands_dashboard/creative_ideas.rs`).
+    const IDEA_LIST_LIMIT: u32 = 512;
+    // Flood the store far past the window (8x) so a naive "take LIMIT rows then
+    // filter" read reliably drops the creative nodes: the creative sentinel is a
+    // vanishing fraction of the prospective set, exactly the production shape.
+    const NON_CREATIVE_FLOOD: u32 = IDEA_LIST_LIMIT * 8;
+    const CREATIVE_IDEA_COUNT: usize = 10;
+
+    let mem = LibraryCognitiveMemory::in_memory().expect("in-memory store");
+
+    // Thousands of *non-creative* prospective memories under a distinct trigger
+    // — the noise the live OODA store accumulates around the ideas.
+    for i in 0..NON_CREATIVE_FLOOD {
+        mem.store_prospective(
+            &format!("unrelated prospective memory {i}"),
+            "some-unrelated-trigger",
+            "{}",
+            1,
+        )
+        .expect("store non-creative prospective");
+    }
+
+    // A handful of real creative ideas persisted through the store — the ~10/run
+    // the daemon logs as "10 persisted".
+    let store = ProspectiveCreativeIdeaStore::new(&mem);
+    let mut expected_ids = Vec::with_capacity(CREATIVE_IDEA_COUNT);
+    for i in 0..CREATIVE_IDEA_COUNT {
+        let idea = CreativeIdea::new(
+            format!("creative idea number {i}"),
+            sample_context(),
+            1_700_000_000 + i as u64,
+        );
+        expected_ids.push(store.store(&idea).expect("store creative idea"));
+    }
+
+    // The exact dashboard read path.
+    let listed = store.list(IDEA_LIST_LIMIT).expect("dashboard list");
+
+    // Every persisted idea must be visible — this is the user-facing bug.
+    for id in &expected_ids {
+        assert!(
+            listed.iter().any(|idea| &idea.node_id == id),
+            "persisted creative idea {id} is missing from the dashboard read: it \
+             was truncated out of the {IDEA_LIST_LIMIT}-row prospective window by \
+             the unrelated flood (the #122 read-path bug)"
+        );
+    }
+    assert_eq!(
+        listed.len(),
+        expected_ids.len(),
+        "the dashboard must list exactly the {} persisted creative ideas, not a \
+         limit-truncated subset (got {})",
+        expected_ids.len(),
+        listed.len(),
+    );
+}
+
+/// Contract for the new trigger-scoped prospective primitive
+/// ([`CognitiveMemoryOps::list_prospective_by_trigger`]) that backs the #122
+/// fix: the `limit` must bound only nodes matching the requested trigger, so a
+/// creative-idea read stays complete no matter how large the non-creative
+/// prospective population grows. Distinct from the store-level regression above,
+/// this pins the primitive directly on the library adapter.
+#[test]
+fn list_prospective_by_trigger_scopes_the_limit_to_matching_nodes() {
+    const LIMIT: u32 = 512;
+    const FLOOD: u32 = LIMIT * 8;
+
+    let mem = LibraryCognitiveMemory::in_memory().expect("in-memory store");
+
+    // A large non-creative prospective population under a different trigger.
+    for i in 0..FLOOD {
+        mem.store_prospective(&format!("noise {i}"), "unrelated-trigger", "{}", 1)
+            .expect("store noise prospective");
+    }
+    // A handful of creative-idea nodes (raw, under the sentinel trigger).
+    let mut creative_ids = Vec::new();
+    for i in 0..10i64 {
+        creative_ids.push(
+            mem.store_prospective(&format!("idea {i}"), CREATIVE_IDEA_TRIGGER, "{}", i)
+                .expect("store creative prospective"),
+        );
+    }
+
+    // Every creative node must come back even though `LIMIT` << `FLOOD`: the
+    // query filters by trigger BEFORE applying the limit (fail-closed — no
+    // fallback to an unfiltered `list_all_prospective`).
+    let got: Vec<CognitiveProspective> = mem
+        .list_prospective_by_trigger(CREATIVE_IDEA_TRIGGER, LIMIT)
+        .expect("list_prospective_by_trigger");
+
+    assert!(
+        got.iter()
+            .all(|p| p.trigger_condition == CREATIVE_IDEA_TRIGGER),
+        "the primitive must return only nodes matching the requested trigger"
+    );
+    for id in &creative_ids {
+        assert!(
+            got.iter().any(|p| &p.node_id == id),
+            "creative node {id} must survive the trigger-scoped read despite the flood"
+        );
+    }
+    assert_eq!(
+        got.len(),
+        creative_ids.len(),
+        "exactly the creative-trigger nodes are returned, none of the {FLOOD} flood"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // 3. Pipeline — all four reviewers + synthesis sets a legal status
 // ---------------------------------------------------------------------------

--- a/src/memory_ipc/client.rs
+++ b/src/memory_ipc/client.rs
@@ -360,6 +360,20 @@ impl CognitiveMemoryOps for RemoteCognitiveMemory {
         }
     }
 
+    fn list_prospective_by_trigger(
+        &self,
+        trigger: &str,
+        limit: u32,
+    ) -> SimardResult<Vec<CognitiveProspective>> {
+        match self.call(MemoryRequest::ListProspectiveByTrigger {
+            trigger: trigger.into(),
+            limit,
+        })? {
+            MemoryResponse::Prospectives(v) => Ok(v),
+            other => Err(Self::unexpected("list_prospective_by_trigger", other)),
+        }
+    }
+
     fn search_episodes_by_keywords(
         &self,
         keywords: &[String],

--- a/src/memory_ipc/mod.rs
+++ b/src/memory_ipc/mod.rs
@@ -246,6 +246,16 @@ pub enum MemoryRequest {
     ResolveProspective {
         node_id: String,
     },
+    /// Trigger-scoped prospective enumeration (issue #122). Carries the exact
+    /// `trigger_condition` to match plus the row cap; the server applies the
+    /// filter *in the backend query* so the cap bounds only matching nodes.
+    /// The creative-ideas dashboard reads through the IPC client (tier-1), so
+    /// this must round-trip end-to-end rather than fall back to the empty trait
+    /// default. Returns [`MemoryResponse::Prospectives`].
+    ListProspectiveByTrigger {
+        trigger: String,
+        limit: u32,
+    },
     /// PR-C (issue #2281, problem 4): keyword-overlap episodic search
     /// for `preparation_memory_operations`.
     SearchEpisodesByKeywords {
@@ -474,6 +484,13 @@ impl CognitiveMemoryOps for SharedMemory {
     }
     fn list_all_prospective(&self, limit: u32) -> SimardResult<Vec<CognitiveProspective>> {
         self.0.list_all_prospective(limit)
+    }
+    fn list_prospective_by_trigger(
+        &self,
+        trigger: &str,
+        limit: u32,
+    ) -> SimardResult<Vec<CognitiveProspective>> {
+        self.0.list_prospective_by_trigger(trigger, limit)
     }
     fn list_all_episodes(&self, limit: u32) -> SimardResult<Vec<CognitiveEpisode>> {
         self.0.list_all_episodes(limit)

--- a/src/memory_ipc/server.rs
+++ b/src/memory_ipc/server.rs
@@ -298,6 +298,12 @@ fn dispatch(memory: &dyn CognitiveMemoryOps, req: MemoryRequest) -> MemoryRespon
                 Err(e) => MemoryResponse::Error(e.to_string()),
             }
         }
+        MemoryRequest::ListProspectiveByTrigger { trigger, limit } => {
+            match memory.list_prospective_by_trigger(&trigger, limit) {
+                Ok(v) => MemoryResponse::Prospectives(v),
+                Err(e) => MemoryResponse::Error(e.to_string()),
+            }
+        }
         MemoryRequest::SearchEpisodesByKeywords { keywords, limit } => {
             match memory.search_episodes_by_keywords(&keywords, limit) {
                 Ok(v) => MemoryResponse::Episodes(v),

--- a/src/memory_ipc/tests_transport_roundtrip.rs
+++ b/src/memory_ipc/tests_transport_roundtrip.rs
@@ -446,6 +446,56 @@ fn prospective_store_trigger_and_resolve_over_socket() {
         .expect("resolve_prospective over socket must be acknowledged");
 }
 
+/// The #122 dashboard fix must work over the Unix-socket transport too: the
+/// dashboard reads through the IPC client (tier-1), so
+/// `list_prospective_by_trigger` has to round-trip end-to-end (client request →
+/// server dispatch → backend trigger-scoped query) rather than silently fall
+/// back to the empty trait default (the exact silent-empty-read hazard that
+/// left the dashboard showing 0 ideas).
+#[test]
+fn list_prospective_by_trigger_round_trips_over_socket() {
+    let fx = in_memory_fixture();
+
+    // A non-matching decoy under a different trigger — must NOT come back,
+    // proving the trigger filter is applied server-side, not on the client.
+    let decoy = fx
+        .client
+        .store_prospective("decoy", "unrelated-trigger", "{}", 9)
+        .expect("store decoy over socket");
+
+    // A handful of matching nodes under the creative-idea trigger.
+    let mut matching = Vec::new();
+    for i in 0i64..5 {
+        matching.push(
+            fx.client
+                .store_prospective(&format!("creative {i}"), "creative-idea", "{}", i)
+                .expect("store matching over socket"),
+        );
+    }
+
+    let got: Vec<CognitiveProspective> = fx
+        .client
+        .list_prospective_by_trigger("creative-idea", 512)
+        .expect("list_prospective_by_trigger over socket");
+
+    for id in &matching {
+        assert!(
+            got.iter().any(|p| &p.node_id == id),
+            "matching prospective {id} must round-trip back over the socket, not \
+             be dropped to the empty default"
+        );
+    }
+    assert!(
+        !got.iter().any(|p| p.node_id == decoy),
+        "the decoy under a different trigger must be filtered server-side"
+    );
+    assert_eq!(
+        got.len(),
+        matching.len(),
+        "exactly the trigger-matching nodes cross the wire"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Error paths.
 // ---------------------------------------------------------------------------
@@ -977,4 +1027,38 @@ fn shared_memory_forwards_the_whole_ops_surface_to_the_inner_store() {
 
     // checkpoint forwards (durability flush) without error.
     shared.checkpoint().expect("checkpoint must forward");
+}
+
+/// Tier-0 (in-process) path: the daemon's own dashboard reader goes through
+/// [`SharedMemory`], so it must forward `list_prospective_by_trigger` to the
+/// inner store rather than returning the empty trait default — the same
+/// silent-empty-read hazard (#2320 / #2331) that a missing forward would
+/// reintroduce, now on the #122 creative-ideas read path.
+#[test]
+fn shared_memory_forwards_list_prospective_by_trigger() {
+    use super::SharedMemory;
+
+    let inner: Arc<dyn CognitiveMemoryOps> =
+        Arc::new(LibraryCognitiveMemory::in_memory().expect("in-memory store"));
+    let shared = SharedMemory(Arc::clone(&inner));
+
+    let decoy = shared
+        .store_prospective("decoy", "unrelated-trigger", "{}", 1)
+        .expect("store decoy");
+    let target = shared
+        .store_prospective("idea", "creative-idea", "{}", 7)
+        .expect("store target");
+
+    let got = shared
+        .list_prospective_by_trigger("creative-idea", 512)
+        .expect("list_prospective_by_trigger must forward");
+
+    assert!(
+        got.iter().any(|p| p.node_id == target),
+        "SharedMemory must forward list_prospective_by_trigger to the inner store"
+    );
+    assert!(
+        !got.iter().any(|p| p.node_id == decoy),
+        "the forwarded call must preserve the inner store's trigger filtering"
+    );
 }

--- a/tests/issue_2626_amplihack_pin_bump.rs
+++ b/tests/issue_2626_amplihack_pin_bump.rs
@@ -9,10 +9,12 @@
 //! `main` and run the new code. The pins are advanced as upstream lands work:
 //!
 //!   * `amplihack-agent-eval`  59548a96… → **2a93441d…** (amplihack-rs main)
-//!   * `amplihack-memory`       f8003708… → **e005a596…** (memory-lib main —
-//!     the squash-merge of PR #120, which lands the first-class `creative_idea`
-//!     prospective memory type on top of PR #121's `measurement::precision_at_k`
-//!     recall-quality primitive, so the single pin carries both)
+//!   * `amplihack-memory`       e005a596… → **901f63ad…** (memory-lib main —
+//!     the squash-merge of PR #125, which adds the trigger-scoped, priority-
+//!     ordered `get_prospective_by_trigger(trigger, limit)` recall — whose LIMIT
+//!     bounds only matching nodes — and makes `get_all_prospective` sort-then-
+//!     truncate; Simard consumes it to fix the creative-ideas dashboard read
+//!     path, issue #122)
 //!
 //! These are the exact 40-char SHAs verified against `git ls-remote … main`
 //! at authoring time.
@@ -43,16 +45,17 @@ use std::path::PathBuf;
 /// amplihack-rs `main` HEAD carrying the `amplihack-agent-eval` crate to adopt.
 const AGENT_EVAL_TARGET_REV: &str = "14dc30b10e87764120c6f2bae7f3630522c29e5d";
 /// amplihack-memory-lib `main` commit carrying the `amplihack-memory` crate:
-/// PR #120's squash-merge (the first-class `creative_idea` prospective memory
-/// type — CreativeIdeaStatus lifecycle + typed MemoryLink/MemoryLinkKind — which
-/// Simard's Creative Ideas thread re-exports), which lands directly on top of
-/// PR #121's `measurement::precision_at_k` primitive, so this single rev carries
-/// BOTH upstream additions.
-const MEMORY_TARGET_REV: &str = "e005a5963b38bc02610fa5b0bef7e52625dcd092";
+/// PR #125's squash-merge — the trigger-scoped, priority-ordered
+/// `get_prospective_by_trigger(trigger, limit)` prospective recall (whose LIMIT
+/// bounds only nodes matching the trigger) plus a sort-then-truncate
+/// `get_all_prospective`. Simard consumes it to fix the creative-ideas
+/// dashboard read path (issue #122). Two commits ahead of the prior #120 pin,
+/// no regression.
+const MEMORY_TARGET_REV: &str = "901f63ad79eb0c2d87cd8263d26025877af43cc5";
 
 /// The stale revs the bump must move *off of* (anti-regression sentinels).
 const AGENT_EVAL_STALE_REV: &str = "59548a96049ab8d558110bcaf9c82a4316f1bbf0";
-const MEMORY_STALE_REV: &str = "f80037089a735bd0d394e3eec5cea9fcae1895ea";
+const MEMORY_STALE_REV: &str = "e005a5963b38bc02610fa5b0bef7e52625dcd092";
 
 /// The only git remotes these two crates may resolve from. A bump must never
 /// introduce a *new* git source (typosquat / allowlist-bypass guard, R1).


### PR DESCRIPTION
## Problem

The Creative Ideas dashboard showed **0 ideas** on a live store even though the daemon logs `10 persisted` every run (`GET /api/creative-ideas` returned `ideas: []`, all status counts `0`). Persistence was fine; the **read path** was broken.

`ProspectiveCreativeIdeaStore::all_revisions` called `list_all_prospective(512)` and filtered by the `creative-idea` sentinel **in Rust**. But `list_all_prospective` → library `get_all_prospective(limit)` truncated the *entire* prospective-node set to `limit` rows **in the DB query, before** any trigger predicate. On a live store with thousands of ordinary prospective facts, all 512 window slots fill with non-creative nodes and the ~10 idea nodes fall outside the window — so the post-filter yields zero. Invisible on a fresh/test store (few prospectives), which is why it only reproduced in production.

## Fix

Consume amplihack-memory-lib's new `get_prospective_by_trigger(trigger, limit)` — a trigger-filtered (equality pushed into the query), priority-ordered, **fail-closed** prospective read whose `LIMIT` bounds only *matching* nodes.

- **New trait method** `CognitiveMemoryOps::list_prospective_by_trigger(trigger, limit)` — default-empty so the ~10 test mocks / legacy stubs compile unchanged.
- **Three production overrides**:
  - `LibraryCognitiveMemory` → delegates to `get_prospective_by_trigger` under `lock()`, error mapped via `map_op_err` (**fail-closed** — a backend read error propagates, never a masked empty).
  - `SharedMemory` (memory_ipc) → forwards to the inner store (tier-0 in-process + tier-2 direct-open dashboard reads).
  - `RemoteCognitiveMemory` (memory_ipc client) → tier-1 socket round-trip.
- **IPC wired end-to-end**: new `MemoryRequest::ListProspectiveByTrigger { trigger, limit }` + server dispatch, reusing the existing `MemoryResponse::Prospectives`.
- **Store read-path change**: `ProspectiveCreativeIdeaStore::all_revisions` now calls `list_prospective_by_trigger(CREATIVE_IDEA_TRIGGER, limit)`. The sentinel `.filter(...)` is retained as a cheap, fail-closed defensive guard.

## Pin bump

`amplihack-memory` `e005a5963b38…` → `901f63ad79eb…` (amplihack-memory-lib **PR #125**, 2 commits ahead of the prior #120 pin — a clean fast-forward, no regression). Adds `get_prospective_by_trigger` and makes `get_all_prospective` sort-then-truncate. `Cargo.lock` refreshed; single `lbug` version preserved; store format v41 unchanged. The `issue_2626_amplihack_pin_bump` guard test's target/stale revs are updated accordingly.

## Tests

- `creative_ideas_survive_beyond_the_prospective_read_window` — floods the store with `512 × 8` non-creative prospectives + 10 real ideas, asserts `store.list(512)` returns all 10. **Fails before, passes after.**
- `list_prospective_by_trigger_scopes_the_limit_to_matching_nodes` — pins the primitive directly on the library adapter.
- `list_prospective_by_trigger_round_trips_over_socket` — tier-1 socket end-to-end (server-side trigger filter, decoy excluded).
- `shared_memory_forwards_list_prospective_by_trigger` — tier-0 forward.
- Existing creative-idea store/list/get/update/promote/prune tests stay green.

**Local verification (all green):** `cargo test --all-features --locked` (120 test groups), `cargo clippy --all-targets --all-features --locked -- -D warnings`, `cargo fmt --check`, `cargo build --release --no-default-features`, `mkdocs build --strict`.

## Live verification

Not observable in CI — requires a **deploy + a Creative Ideas thread run** (daily tick or the dashboard **Run now** button). After one run the daemon persists 10 ideas; `curl -s .../api/creative-ideas | jq '.counts, (.ideas|length)'` should show `count > 0` on a live store regardless of unrelated prospective volume.

## Constraints honoured

Additive · fail-closed (no fallback to `list_all_prospective`, no silent empty) · no `*Bridge` naming · no stray `println!`/`eprintln!` · store format v41 unchanged · never `--admin` / `--no-verify`.

Docs: new `docs/reference/creative-ideas-trigger-scoped-read.md` (+ nav) and updated design/API references.

Fixes #122.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>