### PR TITLE
fix(ci): pin dtolnay/rust-toolchain to reachable v1 release so Dependabot resolves (completes #2864)

### DIFF
--- a/.github/actions/rust-runner-prep/action.yml
+++ b/.github/actions/rust-runner-prep/action.yml
@@ -70,10 +70,13 @@ runs:
         echo 'RUSTFLAGS=-C link-arg=-fuse-ld=mold' >> "$GITHUB_ENV"
 
     - name: Set up Rust
-      # SHA-pinned for supply-chain safety. This is the HEAD of dtolnay's
-      # `stable` branch, whose action.yml hard-defaults `toolchain: stable`,
-      # so pinning preserves the stable channel exactly (same pin as
-      # release.yml). The `# stable` comment documents the tracked branch.
-      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # SHA-pins the reachable `v1` release of dtolnay/rust-toolchain (an
+      # ancestor of the action's default branch) and selects the channel via
+      # the `toolchain:` input. The previous `# stable` pin was the HEAD of
+      # dtolnay's per-channel `stable` branch, whose commit is *diverged* from
+      # the default branch, so Dependabot's github_actions updater could not
+      # resolve it ("no such commit") and failed the dependabot-updates run.
+      uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
       with:
+        toolchain: stable
         components: ${{ inputs.rust-components }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,8 +32,13 @@ jobs:
         uses: ./.github/actions/rust-runner-prep
 
       - name: Install Rust nightly toolchain
-        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
+        # SHA-pins the reachable `v1` release of dtolnay/rust-toolchain (an
+        # ancestor of the action's default branch) and selects the channel via
+        # the `toolchain:` input. A diverged per-channel branch HEAD ("# nightly")
+        # breaks Dependabot's github_actions updater ("no such commit").
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: nightly
           components: llvm-tools-preview
 
       - name: Install cargo-llvm-cov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,13 @@ jobs:
 
       - name: Install Rust toolchain
         if: steps.tag_check.outputs.exists == 'false'
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        # SHA-pins the reachable `v1` release of dtolnay/rust-toolchain (an
+        # ancestor of the action's default branch) and selects the channel via
+        # the `toolchain:` input. A diverged per-channel branch HEAD ("# stable")
+        # breaks Dependabot's github_actions updater ("no such commit").
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
 
       - name: Cache cargo
         if: steps.tag_check.outputs.exists == 'false'

--- a/docs/reference/dependency-trust-policy.md
+++ b/docs/reference/dependency-trust-policy.md
@@ -101,6 +101,14 @@ Properties, identical to the other guardrail jobs:
   explicit `tool: cargo-vet` input that selects the tool. Do **not** pin
   `taiki-e`'s per-tool convenience tags (`# cargo-vet`): their commits are
   diverged from the default branch and break Dependabot (`no such commit …`).
+- **SHA-pinned** `dtolnay/rust-toolchain` (used by `coverage.yml`, `release.yml`
+  and the `rust-runner-prep` composite action) — pinned to its **`v1` release**
+  commit (`# v1`, reachable from the action's default branch so Dependabot can
+  resolve and bump it) with an explicit `toolchain: stable` / `toolchain: nightly`
+  input that selects the channel. Do **not** pin dtolnay's per-channel *branch*
+  HEADs (`# stable`, `# nightly`): those commits are diverged from the default
+  branch and break Dependabot the same way (`no such commit …`), failing the
+  default-branch `dependabot-updates` run.
 - **`--locked`** — fails on a dirty `Cargo.lock`.
 
 `cargo vet --locked` passes when every third-party crate in the locked graph is

--- a/tests/dependabot_action_pins.rs
+++ b/tests/dependabot_action_pins.rs
@@ -1,39 +1,53 @@
-//! Regression guard: `taiki-e/install-action` pins must stay
-//! Dependabot-resolvable.
+//! Regression guard: SHA-pinned GitHub Actions that Dependabot must be able to
+//! resolve must stay Dependabot-resolvable — specifically
+//! `taiki-e/install-action` and `dtolnay/rust-toolchain`.
 //!
 //! Background — a real default-branch CI failure this test prevents from
 //! recurring: the repository SHA-pins GitHub Actions for supply-chain
-//! hardening. For `taiki-e/install-action` the pins originally targeted the
-//! action's **per-tool tags** (`# cargo-audit`, `# cargo-deny`, ...). Those tag
-//! commits live on a lineage *diverged* from the action's default branch, so
-//! GitHub's Dependabot `github_actions` updater could not resolve them when it
-//! shallow-clones the action to look for newer versions:
+//! hardening. GitHub's Dependabot `github_actions` updater shallow-clones each
+//! action's **default branch** to look for newer versions, so a pin whose
+//! commit is *not reachable from that default branch* aborts the whole
+//! `dependabot/dependabot-updates` run with `error: no such commit ...`.
 //!
-//! ```text
-//! Error processing taiki-e/install-action (HelperSubprocessFailed)
-//! error: no such commit 754bf4dbae00ad1b16b244717154b96ba27d2416
-//! ```
+//! Two actions in this repo hit that trap:
 //!
-//! That aborted the whole `dependabot/dependabot-updates` run, turning the
-//! default branch's Actions health red even though every functional workflow
-//! was green. The fix pins the reachable `v2` release SHA and selects the tool
-//! via the `with: tool:` input, so the pin is both SHA-hardened *and*
-//! Dependabot-updatable.
+//!   * `taiki-e/install-action` was pinned to the action's **per-tool tags**
+//!     (`# cargo-audit`, `# cargo-deny`, ...), whose commits live on a lineage
+//!     diverged from the default branch:
+//!
+//!     ```text
+//!     Error processing taiki-e/install-action (HelperSubprocessFailed)
+//!     error: no such commit 754bf4dbae00ad1b16b244717154b96ba27d2416
+//!     ```
+//!
+//!   * `dtolnay/rust-toolchain` was pinned to the HEAD of dtolnay's per-channel
+//!     **branches** (`# stable`, `# nightly`), which are likewise diverged from
+//!     the action's default branch — the same `no such commit` failure.
+//!
+//! Both aborted the `dependabot-updates` run, turning the default branch's
+//! Actions health red even though every functional workflow was green. The fix
+//! pins each action's reachable **release SHA** (`taiki-e/install-action`'s `v2`
+//! release, `dtolnay/rust-toolchain`'s `v1` release) and selects the tool /
+//! toolchain channel via the `with:` input, so each pin is both SHA-hardened
+//! *and* Dependabot-updatable.
 //!
 //! This test encodes that invariant as a file-shaped, no-network assertion (an
 //! operator running the equivalent `grep` gets the same answer CI does): every
-//! `uses: taiki-e/install-action@<sha> # <comment>` in every workflow must
+//! `uses: <action>@<sha> # <comment>` in every workflow **and** in-repo
+//! composite `action.yml` must
 //!   1. SHA-pin (40 hex chars), matching the repo's supply-chain policy, and
-//!   2. carry a **version-tag** comment (`# v2`, `# v2.82.10`), i.e. a ref
-//!      reachable from the action's default branch — never a per-tool tag name.
+//!   2. carry a **version-tag** comment (`# v2`, `# v1`), i.e. a ref reachable
+//!      from the action's default branch — never a per-tool/per-channel name.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
-fn workflows_dir() -> PathBuf {
+fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(".github")
-        .join("workflows")
+}
+
+fn workflows_dir() -> PathBuf {
+    manifest_dir().join(".github").join("workflows")
 }
 
 /// Every `.yml`/`.yaml` file under `.github/workflows`.
@@ -60,23 +74,60 @@ fn workflow_files() -> Vec<PathBuf> {
     out
 }
 
-/// A single `uses: taiki-e/install-action@<sha> # <comment>` reference.
+/// Recursively collect in-repo composite `action.yml`/`action.yaml` definitions
+/// under `.github/actions`. Dependabot's `github_actions` updater reads these
+/// too, so a diverged pin here fails the update run just like a workflow does.
+fn composite_action_files() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    collect_action_yaml(&manifest_dir().join(".github").join("actions"), &mut out);
+    out.sort();
+    out
+}
+
+fn collect_action_yaml(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_action_yaml(&path, out);
+        } else if path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .is_some_and(|n| n == "action.yml" || n == "action.yaml")
+        {
+            out.push(path);
+        }
+    }
+}
+
+/// Every file Dependabot's `github_actions` updater reads for `uses:` pins:
+/// workflow files plus in-repo composite `action.yml` definitions.
+fn pin_source_files() -> Vec<PathBuf> {
+    let mut files = workflow_files();
+    files.extend(composite_action_files());
+    files
+}
+
+/// A single `uses: <action>@<sha> # <comment>` reference.
 struct Pin {
     file: String,
     sha: String,
     comment: String,
 }
 
-/// Parse `taiki-e/install-action` `uses:` lines out of a workflow file.
-fn parse_install_action_pins(path: &Path) -> Vec<Pin> {
+/// Parse `uses: <action>@<sha> # <comment>` lines for `action` out of a file.
+fn parse_pins(path: &Path, action: &str) -> Vec<Pin> {
     let file = path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("<unknown>")
+        .strip_prefix(manifest_dir())
+        .unwrap_or(path)
+        .display()
         .to_string();
     let contents =
         fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
 
+    let needle = format!("{action}@");
     let mut pins = Vec::new();
     for raw in contents.lines() {
         let line = raw.trim();
@@ -84,7 +135,7 @@ fn parse_install_action_pins(path: &Path) -> Vec<Pin> {
         if line.starts_with('#') || !line.contains("uses:") {
             continue;
         }
-        let Some(after) = line.split("taiki-e/install-action@").nth(1) else {
+        let Some(after) = line.split(&needle).nth(1) else {
             continue;
         };
         // `after` == "<sha> # <comment>" (or "<sha>" with no comment).
@@ -116,8 +167,8 @@ fn is_version_tag_comment(comment: &str) -> bool {
 #[test]
 fn taiki_install_action_pins_are_dependabot_resolvable() {
     let mut pins = Vec::new();
-    for f in workflow_files() {
-        pins.extend(parse_install_action_pins(&f));
+    for f in pin_source_files() {
+        pins.extend(parse_pins(&f, "taiki-e/install-action"));
     }
 
     assert!(
@@ -144,6 +195,49 @@ fn taiki_install_action_pins_are_dependabot_resolvable() {
              github_actions updater (`no such commit ...`) and fails the \
              default-branch dependabot-updates run. Pin the `v2` release SHA and \
              pass the tool via the `with: tool:` input instead.",
+            pin.file,
+            pin.sha,
+            if pin.comment.is_empty() {
+                "<no comment>"
+            } else {
+                &pin.comment
+            }
+        );
+    }
+}
+
+#[test]
+fn dtolnay_rust_toolchain_pins_are_dependabot_resolvable() {
+    let mut pins = Vec::new();
+    for f in pin_source_files() {
+        pins.extend(parse_pins(&f, "dtolnay/rust-toolchain"));
+    }
+
+    assert!(
+        !pins.is_empty(),
+        "expected at least one dtolnay/rust-toolchain pin under .github/workflows \
+         or .github/actions (the coverage/release jobs and the rust-runner-prep \
+         composite action); found none — did a job get renamed or removed?"
+    );
+
+    for pin in &pins {
+        assert!(
+            is_hex_sha(&pin.sha),
+            "{}: dtolnay/rust-toolchain must be SHA-pinned (40 hex chars) for \
+             supply-chain hardening, got `{}`.",
+            pin.file,
+            pin.sha
+        );
+        assert!(
+            is_version_tag_comment(&pin.comment),
+            "{}: dtolnay/rust-toolchain@{} must carry a VERSION-tag comment \
+             (e.g. `# v1`), not `# {}`. dtolnay maintains per-channel *branches* \
+             (`stable`, `nightly`, `beta`, ...) whose HEAD commits are diverged \
+             from the action's default branch, so pinning them breaks \
+             Dependabot's github_actions updater (`no such commit ...`) and fails \
+             the default-branch dependabot-updates run. Pin the `v1` release SHA \
+             (reachable from the default branch) and select the channel via the \
+             `with: toolchain:` input instead.",
             pin.file,
             pin.sha,
             if pin.comment.is_empty() {

--- a/tests/gadugi/dependabot-action-pins-resolvable.sh
+++ b/tests/gadugi/dependabot-action-pins-resolvable.sh
@@ -1,20 +1,26 @@
 #!/usr/bin/env bash
-# qa-team scenario — taiki-e/install-action pins stay Dependabot-resolvable.
+# qa-team scenario — taiki-e/install-action AND dtolnay/rust-toolchain pins
+# stay Dependabot-resolvable.
 #
 # Outside-in verification of the CI-health fix for the failing default-branch
-# `dependabot/dependabot-updates` (github_actions) run on rysweet/Simard:
+# `dependabot/dependabot-updates` (github_actions) run on rysweet/Simard, which
+# failed to update two actions with the same root cause:
 #
 #   Error processing taiki-e/install-action (HelperSubprocessFailed)
 #   error: no such commit 754bf4dbae00ad1b16b244717154b96ba27d2416
+#   ... plus dtolnay/rust-toolchain (unknown_error)
 #
-# The action was SHA-pinned to its per-tool tags (`# cargo-audit`, ...), whose
-# commits live on a lineage diverged from the action's default branch, so
-# Dependabot's shallow clone could not resolve them and the whole update job
-# failed. The fix pins the reachable `v2` release SHA and selects each tool via
-# the `with: tool:` input — SHA-hardened AND Dependabot-updatable.
+# taiki-e/install-action was SHA-pinned to its per-tool tags (`# cargo-audit`,
+# ...) and dtolnay/rust-toolchain to its per-channel branch HEADs (`# stable`,
+# `# nightly`) — commits that live on lineages *diverged* from each action's
+# default branch, so Dependabot's shallow clone could not resolve them and the
+# whole update job failed. The fix pins each action's reachable release SHA
+# (`taiki-e`'s `v2`, `dtolnay`'s `v1`) and selects the tool / toolchain channel
+# via the `with:` input — SHA-hardened AND Dependabot-updatable.
 #
 # This script asserts the operator-visible contract with file-shaped checks
-# across ALL workflow files (no network, deterministic) plus the Rust guard.
+# across ALL workflow files and in-repo composite `action.yml` definitions (no
+# network, deterministic) plus the Rust guard.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -25,15 +31,27 @@ fail() {
   exit 1
 }
 
-# Every workflow file (so a newly-added workflow with a bad pin is caught too).
-mapfile -t WORKFLOWS < <(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
-[ "${#WORKFLOWS[@]}" -ge 1 ] || fail "no workflow files found under .github/workflows"
+# Every workflow file plus in-repo composite action.yml (so a newly-added file
+# with a bad pin is caught too). Dependabot reads composite actions as well.
+mapfile -t FILES < <(
+  {
+    find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \)
+    find .github/actions -type f \( -name 'action.yml' -o -name 'action.yaml' \) 2>/dev/null
+  } | sort
+)
+[ "${#FILES[@]}" -ge 1 ] || fail "no workflow/action files found under .github"
 
-# 1) The previously-dead per-tool commit must be gone everywhere.
-if grep -rn "754bf4dbae00ad1b16b244717154b96ba27d2416" .github/ >/dev/null 2>&1; then
-  fail "the dead cargo-audit per-tool SHA 754bf4db... is still pinned (breaks Dependabot)"
-fi
-echo "OK: dead per-tool SHA 754bf4db... is absent"
+# 1) The previously-dead diverged commits must be gone everywhere.
+for dead in \
+  754bf4dbae00ad1b16b244717154b96ba27d2416 \
+  29eef336d9b2848a0b548edc03f92a220660cdb8 \
+  5b842231ba77f5c045dba54ac5560fed2db780e2 \
+; do
+  if grep -rn "$dead" .github/ >/dev/null 2>&1; then
+    fail "dead diverged-branch SHA ${dead:0:12}... is still pinned (breaks Dependabot)"
+  fi
+  echo "OK: dead diverged SHA ${dead:0:12}... is absent"
+done
 
 # 2) Every taiki-e/install-action `uses:` pin must be a 40-hex SHA carrying a
 #    version-tag comment (# v...), never a per-tool tag name.
@@ -55,16 +73,40 @@ while IFS= read -r line; do
   printf '%s' "$comment" | grep -Eq '^v[0-9]' \
     || fail "taiki-e/install-action@$sha has non-version comment '# ${comment:-<none>}' (per-tool tags break Dependabot; pin the v2 release SHA + 'with: tool:')"
   echo "OK: taiki-e/install-action@${sha:0:12} # $comment"
-done < <(grep -h "taiki-e/install-action@" "${WORKFLOWS[@]}")
+done < <(grep -h "taiki-e/install-action@" "${FILES[@]}")
 
 [ "$found" -ge 5 ] || fail "expected >=5 taiki-e/install-action pins (audit/deny/vet/llvm-cov/cyclonedx), found $found"
 echo "OK: all $found taiki-e/install-action pins are SHA+version-tag pinned"
 
-# 3) The Rust regression guard encodes the same invariant — run it.
+# 3) Every dtolnay/rust-toolchain `uses:` pin must be a 40-hex SHA carrying a
+#    version-tag comment (# v...), never a per-channel branch name (stable/nightly).
+found_rt=0
+while IFS= read -r line; do
+  case "$(printf '%s' "$line" | sed -e 's/^[[:space:]]*//')" in
+    \#*) continue ;;
+  esac
+  printf '%s' "$line" | grep -q "uses:" || continue
+
+  found_rt=$((found_rt + 1))
+  after="${line#*dtolnay/rust-toolchain@}"
+  sha="$(printf '%s' "$after" | sed -e 's/[[:space:]].*$//')"
+  comment="$(printf '%s' "$after" | sed -n 's/.*#[[:space:]]*//p')"
+
+  printf '%s' "$sha" | grep -Eq '^[0-9a-f]{40}$' \
+    || fail "dtolnay/rust-toolchain is not SHA-pinned (got '$sha')"
+  printf '%s' "$comment" | grep -Eq '^v[0-9]' \
+    || fail "dtolnay/rust-toolchain@$sha has non-version comment '# ${comment:-<none>}' (per-channel branch HEADs break Dependabot; pin the v1 release SHA + 'with: toolchain:')"
+  echo "OK: dtolnay/rust-toolchain@${sha:0:12} # $comment"
+done < <(grep -h "dtolnay/rust-toolchain@" "${FILES[@]}")
+
+[ "$found_rt" -ge 3 ] || fail "expected >=3 dtolnay/rust-toolchain pins (rust-runner-prep/coverage/release), found $found_rt"
+echo "OK: all $found_rt dtolnay/rust-toolchain pins are SHA+version-tag pinned"
+
+# 4) The Rust regression guard encodes the same invariant — run it.
 OUTPUT="$(cargo test --test dependabot_action_pins 2>&1)"
 printf '%s\n' "$OUTPUT"
 printf '%s\n' "$OUTPUT" | grep -E "test result: ok\. [0-9]+ passed; 0 failed" >/dev/null \
   || fail "dependabot_action_pins regression guard did not pass"
 echo "OK: dependabot_action_pins regression guard passed"
 
-echo "PASS: taiki-e/install-action pins are Dependabot-resolvable"
+echo "PASS: taiki-e/install-action and dtolnay/rust-toolchain pins are Dependabot-resolvable"

--- a/tests/gadugi/dependabot-action-pins-resolvable.yaml
+++ b/tests/gadugi/dependabot-action-pins-resolvable.yaml
@@ -1,5 +1,5 @@
-name: "Dependabot-resolvable taiki-e/install-action pins"
-description: "Outside-in verification that every taiki-e/install-action pin in the CI workflows is SHA-pinned to a default-branch-reachable version-tag release (# v2...) with the tool selected via the `with: tool:` input, so GitHub's Dependabot github_actions updater can resolve it. Guards against reintroducing the per-tool-tag pins whose diverged commits made the default-branch dependabot-updates run fail with 'no such commit'."
+name: "Dependabot-resolvable taiki-e/install-action and dtolnay/rust-toolchain pins"
+description: "Outside-in verification that every taiki-e/install-action and dtolnay/rust-toolchain pin in the CI workflows and in-repo composite actions is SHA-pinned to a default-branch-reachable version-tag release (# v2... / # v1) with the tool/toolchain selected via the `with:` input, so GitHub's Dependabot github_actions updater can resolve it. Guards against reintroducing the per-tool-tag or per-channel-branch pins whose diverged commits made the default-branch dependabot-updates run fail with 'no such commit'."
 version: "1.0.0"
 
 config:
@@ -27,7 +27,7 @@ agents:
         logLevel: "info"
 
 steps:
-  - name: "install-action pins are SHA + version-tag (Dependabot-resolvable)"
+  - name: "install-action & rust-toolchain pins are SHA + version-tag (Dependabot-resolvable)"
     agent: "cli-agent"
     action: "execute_command"
     params:


### PR DESCRIPTION
## Summary

Completes the Dependabot CI-health fix started in **#2864**. That PR fixed the failing default-branch `dependabot/dependabot-updates` (github_actions) run for **only one** of the two dependencies it broke on. This PR fixes the second one, `dtolnay/rust-toolchain`, so the run goes green on its next scheduled execution.

### Root cause (verified from the failing run log)

The failed run [28841063564](https://github.com/rysweet/Simard/actions/runs/28841063564) reported **two** dependencies failing to update with the same root cause:

```
| Dependency             | Error Type    |
| taiki-e/install-action | unknown_error |
| dtolnay/rust-toolchain | unknown_error |
```

Dependabot shallow-clones each action's **default branch** to look for newer versions, so a pin whose commit is *not reachable from the default branch* aborts the whole update run (`no such commit ...`). `#2864` repinned `taiki-e/install-action`; `dtolnay/rust-toolchain` was still pinned to the HEAD of dtolnay's per-channel **branches** (`# stable`, `# nightly`), which are diverged from the default branch:

```
$ gh api repos/dtolnay/rust-toolchain/compare/master...29eef336…  # was "# stable"
status=diverged   ahead_by=1 behind_by=2   # NOT reachable → Dependabot fails
$ gh api repos/dtolnay/rust-toolchain/compare/master...5b842231…  # was "# nightly"
status=diverged   ahead_by=1 behind_by=2   # NOT reachable → Dependabot fails
$ gh api repos/dtolnay/rust-toolchain/compare/master...e97e2d8c…  # v1 release
status=behind     ahead_by=0 behind_by=10  # ancestor of master → resolvable ✅
```

### Fix (same pattern #2864 applied to taiki-e)

Pin the reachable **`v1` release SHA** (`e97e2d8c…`, an ancestor of the default branch) and select the channel via the `with: toolchain:` input. Applied to all three pins:

| File | Channel |
| --- | --- |
| `.github/workflows/coverage.yml` | `nightly` |
| `.github/workflows/release.yml` | `stable` |
| `.github/actions/rust-runner-prep/action.yml` (composite) | `stable` |

Functionally equivalent — the same toolchains are installed; only the pin/selection mechanism changes to one Dependabot can resolve.

---

## Merge-ready evidence

### 1. qa-team scenario (gadugi)
Extended `tests/gadugi/dependabot-action-pins-resolvable.{sh,yaml}` to also guard `dtolnay/rust-toolchain` and to scan in-repo composite actions.
- `gadugi-test validate -f …` → **valid** (1 valid, 0 invalid).
- `gadugi-test run` → **Passed: 1, Failed: 0, All tests passed**.

### 2. Docs
`docs/reference/dependency-trust-policy.md` documents the `dtolnay/rust-toolchain` `v1`-release pin policy alongside the existing `taiki-e` policy. No other user-facing surface changed.

### 3. quality-audit (3 SEEK→VALIDATE→FIX cycles, ended clean)
- **Correctness** — `v1` SHA verified reachable from `master` (ancestor); action requires `toolchain` input (provided in all 3 sites, incl. release.yml which previously had none); stable→stable, nightly→nightly preserved.
- **Guard efficacy** — negative test: reintroducing a diverged `# stable` pin makes **both** the Rust guard and the gadugi `.sh` fail; reverting restores green.
- **Completeness** — repo-wide grep confirms no diverged SHA (`29eef336…`, `5b842231…`) remains in any `uses:` pin; all 3 dtolnay pins are `# v1`.

### 4. CI green (local mirrors)
- `pre-commit run --all-files` → **Passed** (rust-only gate, `cargo fmt --check`, `cargo clippy --release`).
- pre-push gate → **Passed** (`cargo clippy --all-targets --all-features --locked -D warnings`, race test subset).
- `cargo test --test dependabot_action_pins` → **2 passed; 0 failed**.

### 6. Focused diff
7 files, all directly related: 3 action pins + 1 Rust guard + 2 gadugi files + 1 doc. No unrelated edits.

---

Fixes the remaining red default-branch `dependabot-updates` dependency identified while verifying the CI-stewardship goal (the sibling failure #2864 did not cover).
