### PR TITLE
test(live-migration): keystone fencing contract + outside-in migration acceptance tests (#2923)

### DIFF
--- a/tests/live_migration_fencing.rs
+++ b/tests/live_migration_fencing.rs
@@ -1,0 +1,255 @@
+//! TDD (tests-first) for the LIVE MIGRATION fencing / "exactly one primary"
+//! contract (issue #2923, design spike).
+//!
+//! The migration's hardest correctness requirement is split-brain avoidance:
+//! during promote/demote there must be EXACTLY ONE primary acting at a time,
+//! and a fenced-off old primary must be rejectable even if it is still alive.
+//!
+//! These tests characterize the invariants the migration's `primary-lease`
+//! component MUST uphold, expressed against the existing `LeaderSemaphore`
+//! primitive (PID owner + monotonic `generation` fencing token + heartbeat
+//! staleness). They compile and pass today, locking the fencing contract that
+//! the role/standby state machine and cutover orchestrator build upon.
+//!
+//! SCOPE / HONEST LIMITATION (do not misread a green run here): `LeaderSemaphore`
+//! is HOST-LOCAL — it observes liveness via `kill(pid, 0)` and a local JSON file,
+//! so it can only fence rivals on the SAME host. It is the *local half* of the
+//! role gate (same-host promote/demote + a monotonic fencing epoch). It is
+//! provably INSUFFICIENT for cross-host "exactly one primary" during a
+//! two-host migration; that requires the shared cross-host lease tracked by
+//! issue #2725 (candidate: an Azure Blob lease whose lease-id composes with the
+//! `generation` epoch, checked at every side-effecting actuator — OODA advance,
+//! engineer spawn, git merge/deploy, Signal send). These tests lock the local
+//! invariants the cross-host lease will build on and reconcile with; they do
+//! NOT claim cross-host safety.
+//!
+//! Any future migration lease implementation must keep these green.
+
+use simard::LeaderSemaphore;
+
+fn tmp_lock(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "simard-migration-fencing-{}-{}-{}.json",
+        name,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    p
+}
+
+/// Write the lock file directly with a heartbeat at epoch 0 (1970) so the
+/// recorded owner is UNAMBIGUOUSLY stale for any threshold — making seizure
+/// deterministic regardless of ambient PID liveness or whether the suite runs
+/// as root (`is_pid_alive` uses `kill(pid,0)`, whose EPERM handling differs by
+/// user). `try_acquire`'s block guard is `is_pid_alive(owner) && !is_stale`, so
+/// a stale owner short-circuits to "seizable" no matter the liveness result.
+/// Uses the documented on-disk format `{"pid","generation","heartbeat_epoch"}`.
+fn seed_stale_owner(path: &std::path::Path, pid: u32, generation: u64) {
+    std::fs::write(
+        path,
+        format!(
+            r#"{{"pid":{},"generation":{},"heartbeat_epoch":0}}"#,
+            pid, generation
+        ),
+    )
+    .expect("seed stale lock file");
+}
+
+/// INVARIANT: a live, non-stale primary blocks any other candidate from
+/// acquiring the lease. Two live primaries can never hold the lease at once.
+#[test]
+fn live_primary_blocks_second_acquirer_no_split_brain() {
+    let path = tmp_lock("block");
+    let sem = LeaderSemaphore::new(&path);
+
+    let me = std::process::id();
+    let primary = sem.try_acquire(me).expect("first acquire succeeds");
+    assert_eq!(primary.pid, me);
+    assert_eq!(primary.generation, 1, "first generation is 1");
+
+    // A different candidate PID must be rejected while the live primary holds
+    // a fresh (non-stale) lease. This is the split-brain guard.
+    let other_pid = me.wrapping_add(1).max(2);
+    let err = sem.try_acquire(other_pid);
+    assert!(
+        err.is_err(),
+        "second acquirer must be rejected while live primary holds the lease"
+    );
+
+    // The lease owner/token is unchanged after the rejected attempt.
+    let state = sem.read_state().unwrap().expect("state present");
+    assert_eq!(state.pid, me, "owner unchanged after rejected acquire");
+    assert_eq!(
+        state.generation, 1,
+        "fencing token unchanged after rejection"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// INVARIANT: the fencing token (`generation`) is monotonic across seizures.
+/// A stale/dead primary can be superseded, and the new primary always carries
+/// a STRICTLY GREATER token, so downstream writers can fence the old one out.
+///
+/// Seizure is forced via `seed_stale_owner` (heartbeat at epoch 0), NOT via the
+/// same-second `stale_threshold(0)` timing (seconds granularity means three
+/// acquires in one second are NOT stale by elapsed time) and NOT via ambient
+/// PID liveness (root vs non-root changes `kill(pid,0)`). This keeps the test
+/// deterministic in any CI environment.
+#[test]
+fn fencing_token_is_monotonic_across_seizures() {
+    let path = tmp_lock("monotonic");
+    let sem = LeaderSemaphore::new(&path).with_stale_threshold(0);
+
+    // Predecessor at generation 1, deterministically stale.
+    seed_stale_owner(&path, 900_001, 1);
+    let s2 = sem
+        .try_acquire(900_002)
+        .expect("seize over stale predecessor");
+    assert!(
+        s2.generation > 1,
+        "generation must strictly increase on seizure (1 -> {})",
+        s2.generation
+    );
+
+    // Re-stale the freshly written state, then seize again.
+    seed_stale_owner(&path, s2.pid, s2.generation);
+    let s3 = sem.try_acquire(900_003).expect("seize again over stale");
+    assert!(
+        s3.generation > s2.generation,
+        "generation must keep increasing ({} -> {})",
+        s2.generation,
+        s3.generation
+    );
+    assert_eq!(s3.pid, 900_003, "latest owner recorded");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// CHARACTERIZATION of the host-local LIMITATION (this is WHY cross-host safety
+/// needs the shared lease of #2725, not a defect in this primitive): once the
+/// current owner reads stale/dead, `try_acquire` lets ANY pid seize it —
+/// including a previously-demoted one. On a single host, `kill(pid,0)` liveness
+/// bounds this; ACROSS hosts, `kill(new_pid,0)` on the old host is meaningless,
+/// so a demoted old primary could reclaim and re-split-brain. The correct
+/// cross-host defense is FENCE-AT-WRITE (each resource rejects a stale fencing
+/// epoch via CAS), NOT merely holding/observing the lease. This test pins the
+/// limitation so it is not mistaken for cross-host safety.
+#[test]
+fn demoted_owner_can_reclaim_once_owner_is_stale_hostlocal_limitation() {
+    let path = tmp_lock("reclaim");
+    let sem = LeaderSemaphore::new(&path).with_stale_threshold(0);
+
+    let old_primary = 900_101u32;
+    let new_primary = 900_102u32;
+
+    // New primary holds the lease at generation 7, but reads stale.
+    seed_stale_owner(&path, new_primary, 7);
+    // The demoted old primary can seize it back precisely because the owner is
+    // stale — host-local liveness cannot prevent cross-host reclaim.
+    let reclaimed = sem
+        .try_acquire(old_primary)
+        .expect("a stale owner is seizable by anyone on the same host");
+    assert_eq!(
+        reclaimed.pid, old_primary,
+        "old primary reclaimed the lease"
+    );
+    assert!(
+        reclaimed.generation > 7,
+        "reclaim still bumps the monotonic token (7 -> {})",
+        reclaimed.generation
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// INVARIANT: clean cutover is a lease TRANSFER from the current primary to the
+/// standby. It only succeeds for the current owner and bumps the fencing token,
+/// modeling PROMOTE(secondary)/DEMOTE(primary) as a single atomic role swap.
+#[test]
+fn cutover_transfer_promotes_standby_and_bumps_token() {
+    let path = tmp_lock("transfer");
+    let sem = LeaderSemaphore::new(&path);
+
+    let primary_pid = 201u32;
+    let standby_pid = 202u32;
+
+    let acquired = sem.try_acquire(primary_pid).expect("primary acquires");
+    let promoted = sem
+        .transfer(primary_pid, standby_pid)
+        .expect("owner may transfer to standby");
+
+    assert_eq!(promoted.pid, standby_pid, "standby is now primary");
+    assert!(
+        promoted.generation > acquired.generation,
+        "cutover bumps fencing token ({} -> {})",
+        acquired.generation,
+        promoted.generation
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// INVARIANT: a fenced-off / demoted old primary CANNOT transfer or reclaim the
+/// lease. After cutover, only the new primary owns it — no reverse split-brain.
+#[test]
+fn demoted_primary_cannot_transfer_after_cutover() {
+    let path = tmp_lock("fenced");
+    let sem = LeaderSemaphore::new(&path);
+
+    let old_primary = 301u32;
+    let new_primary = 302u32;
+    let stray = 303u32;
+
+    sem.try_acquire(old_primary).expect("old primary acquires");
+    sem.transfer(old_primary, new_primary)
+        .expect("cutover to new primary");
+
+    // The demoted old primary attempting to hand the lease elsewhere must fail:
+    // it no longer owns the semaphore.
+    let err = sem.transfer(old_primary, stray);
+    assert!(
+        err.is_err(),
+        "demoted old primary must not be able to transfer the lease"
+    );
+
+    let state = sem.read_state().unwrap().expect("state present");
+    assert_eq!(
+        state.pid, new_primary,
+        "new primary remains the single lease owner"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// INVARIANT: releasing the lease is owner-scoped. A non-owner cannot release
+/// the current primary's lease (prevents a standby from evicting the primary).
+#[test]
+fn release_is_owner_scoped() {
+    let path = tmp_lock("release");
+    let sem = LeaderSemaphore::new(&path);
+
+    let owner = 401u32;
+    let intruder = 402u32;
+
+    sem.try_acquire(owner).expect("owner acquires");
+    sem.release(intruder).expect("non-owner release is a no-op");
+
+    let state = sem
+        .read_state()
+        .unwrap()
+        .expect("lease still held after non-owner release");
+    assert_eq!(state.pid, owner, "only the owner may release its lease");
+
+    sem.release(owner).expect("owner releases");
+    assert!(
+        sem.read_state().unwrap().is_none(),
+        "lease is cleared after owner release"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}

--- a/tests/test_graph_migration.py
+++ b/tests/test_graph_migration.py
@@ -1,0 +1,295 @@
+"""Outside-in TDD (tests-first) for the MEMORY GRAPH migrate capability.
+
+Issue #2923 — design spike. Per repo constraint G2, the ability to migrate the
+cognitive memory graph (facts, procedures, records, edges, provenance) to a new
+system with INTEGRITY VERIFICATION lives in **amplihack-memory-lib**, NOT forked
+into Simard. This suite drives that capability from the Simard side (matching
+the existing ``tests/test_ladybug_migration.py`` cross-repo pattern) so the
+end-to-end migration story has executable acceptance tests.
+
+The capability does not exist yet; every scenario ``pytest.skip``s cleanly until
+``amplihack_memory.migration`` (or an equivalent ``CognitiveMemory`` method
+surface) ships as its own green-CI PR. When it lands, the guards flip to hard
+assertions that drive the implementation.
+
+Design contract asserted here (single source of truth for the memory-lib PR):
+
+    from amplihack_memory.migration import (
+        export_graph,     # (memory, dest_dir, *, since=None) -> manifest: dict
+        import_graph,     # (memory, src_dir, *, verify=True) -> report: dict
+        verify_manifest,  # (src_dir) -> {"ok": bool, "mismatches": [...]}
+    )
+
+    manifest = {
+      "counts":     {sensory, working, episodic, semantic, procedural,
+                     prospective, edges: int},
+      "checksums":  {<same keys>: <hex str>},   # content-addressed per type
+      "provenance": {source_agent, exported_epoch, lbug_version,
+                     schema_version},
+      "watermark":  <opaque cursor for delta/incremental export>,
+    }
+
+Invariants: round-trip parity (counts + checksums), tamper detection is LOUD
+(no silent fallback), idempotent re-import, delta export, and export works
+while the store is live (read-only snapshot, single-writer lease respected).
+
+Run:
+    PYTHONPATH=~/src/amplihack-memory-lib/src \
+        python3 -m pytest tests/test_graph_migration.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Locate amplihack-memory-lib (the ONLY home for this capability — G2)
+# ---------------------------------------------------------------------------
+
+_MEM_LIB_CANDIDATES = [
+    Path.home() / "src" / "amplihack-memory-lib" / "src",
+    Path.home() / "src" / "amplirusty" / "amplihack-memory-lib" / "src",
+]
+for _c in _MEM_LIB_CANDIDATES:
+    if (_c / "amplihack_memory").exists() and str(_c) not in sys.path:
+        sys.path.insert(0, str(_c))
+        break
+
+REQUIRED_COUNT_KEYS = {
+    "sensory",
+    "working",
+    "episodic",
+    "semantic",
+    "procedural",
+    "prospective",
+    "edges",
+}
+REQUIRED_PROVENANCE_KEYS = {
+    "source_agent",
+    "exported_epoch",
+    "lbug_version",
+    "schema_version",
+}
+
+
+# ---------------------------------------------------------------------------
+# Capability discovery — skip cleanly until the migrate API ships (G2 PR)
+# ---------------------------------------------------------------------------
+
+
+def _cognitive_memory_cls():
+    try:
+        from amplihack_memory.cognitive_memory import CognitiveMemory
+    except Exception as exc:  # noqa: BLE001 - env without ladybug: skip, don't fail
+        pytest.skip(f"amplihack-memory-lib CognitiveMemory unavailable: {exc}")
+    return CognitiveMemory
+
+
+def _migration_api():
+    """Resolve (export_graph, import_graph, verify_manifest) or skip."""
+    try:
+        from amplihack_memory import migration as m
+    except Exception:  # noqa: BLE001
+        # Fall back to method surface on CognitiveMemory, if that is the chosen shape.
+        cm = _cognitive_memory_cls()
+        if all(hasattr(cm, n) for n in ("export_graph", "import_graph", "verify_manifest")):
+            return (
+                lambda mem, dest, **kw: mem.export_graph(dest, **kw),
+                lambda mem, src, **kw: mem.import_graph(src, **kw),
+                lambda src: cm.verify_manifest(src),
+            )
+        pytest.skip(
+            "memory-graph migrate capability not built yet (issue #2923, G2: "
+            "amplihack_memory.migration.export_graph/import_graph/verify_manifest)"
+        )
+    missing = [n for n in ("export_graph", "import_graph", "verify_manifest") if not hasattr(m, n)]
+    if missing:
+        pytest.skip(f"amplihack_memory.migration missing: {missing} (issue #2923, G2)")
+    return m.export_graph, m.import_graph, m.verify_manifest
+
+
+def _populate(cm) -> None:
+    """Write a representative sample across all cognitive memory types."""
+    for i in range(5):
+        cm.store_fact(concept=f"concept-{i}", content=f"fact content {i}", confidence=0.9)
+    cm.store_procedure(
+        name="promote-secondary",
+        steps=["final-sync", "acquire-lease", "promote", "demote-old"],
+        prerequisites=["standby-validated"],
+    )
+    cm.store_episode(
+        summary="migration rehearsal",
+        details="rehearsed cutover to throwaway VM",
+        importance=0.8,
+    ) if hasattr(cm, "store_episode") else None
+    if hasattr(cm, "store_prospective"):
+        cm.store_prospective(intention="run final-sync before cutover", trigger="cutover-start")
+
+
+# ===================================================================
+# Scenario 1: export produces a verifiable manifest
+# ===================================================================
+
+
+class TestExportManifest:
+    def test_export_writes_manifest_with_counts_checksums_provenance(self, tmp_path):
+        export_graph, _import, _verify = _migration_api()
+        CognitiveMemory = _cognitive_memory_cls()
+
+        cm = CognitiveMemory(agent_name="src-agent", db_path=str(tmp_path / "src_db"))
+        _populate(cm)
+        cm.close()
+
+        cm = CognitiveMemory(agent_name="src-agent", db_path=str(tmp_path / "src_db"))
+        manifest = export_graph(cm, str(tmp_path / "snapshot"))
+        cm.close()
+
+        assert REQUIRED_COUNT_KEYS <= set(manifest["counts"]), "manifest must count all 6 types + edges"
+        assert set(manifest["counts"]) <= set(manifest["checksums"]) | {"edges"} or set(
+            manifest["counts"]
+        ) == set(manifest["checksums"]), "each counted type needs a checksum"
+        assert REQUIRED_PROVENANCE_KEYS <= set(manifest["provenance"]), "manifest needs provenance"
+        assert manifest["counts"]["semantic"] >= 5
+
+
+# ===================================================================
+# Scenario 2: round-trip parity (counts + checksums) into a fresh store
+# ===================================================================
+
+
+class TestRoundTripParity:
+    def test_import_into_fresh_store_matches_source(self, tmp_path):
+        export_graph, import_graph, _verify = _migration_api()
+        CognitiveMemory = _cognitive_memory_cls()
+
+        src = CognitiveMemory(agent_name="src", db_path=str(tmp_path / "src_db"))
+        _populate(src)
+        src_stats = src.get_statistics()
+        manifest = export_graph(src, str(tmp_path / "snap"))
+        src.close()
+
+        dst = CognitiveMemory(agent_name="dst", db_path=str(tmp_path / "dst_db"))
+        report = import_graph(dst, str(tmp_path / "snap"), verify=True)
+        dst_stats = dst.get_statistics()
+        dst.close()
+
+        assert report.get("verified") is True, "round-trip import must verify integrity"
+        # Parity on the semantic store at minimum; full parity across all types.
+        for key in ("semantic_count", "procedural_count"):
+            assert dst_stats.get(key) == src_stats.get(key), f"{key} parity broken"
+        # Checksums recomputed on the destination must match the manifest.
+        assert report.get("checksums", manifest["checksums"]) == manifest["checksums"]
+
+
+# ===================================================================
+# Scenario 3: tamper detection is LOUD (no silent fallback)
+# ===================================================================
+
+
+class TestIntegrityTamperDetection:
+    def test_corrupted_snapshot_fails_verification_loudly(self, tmp_path):
+        export_graph, import_graph, verify_manifest = _migration_api()
+        CognitiveMemory = _cognitive_memory_cls()
+
+        src = CognitiveMemory(agent_name="src", db_path=str(tmp_path / "src_db"))
+        _populate(src)
+        export_graph(src, str(tmp_path / "snap"))
+        src.close()
+
+        # Corrupt one payload file in the snapshot directory.
+        snap = tmp_path / "snap"
+        payloads = [p for p in snap.rglob("*") if p.is_file() and "manifest" not in p.name.lower()]
+        assert payloads, "snapshot must contain payload files to tamper with"
+        target = payloads[0]
+        target.write_bytes(target.read_bytes() + b"\x00tampered")
+
+        # verify_manifest must report NOT ok with the specific mismatch.
+        result = verify_manifest(str(snap))
+        assert result.get("ok") is False, "verification must detect tampering"
+        assert result.get("mismatches"), "verification must name the mismatched entries"
+
+        # import with verify=True must refuse loudly (raise), never silently proceed.
+        dst = CognitiveMemory(agent_name="dst", db_path=str(tmp_path / "dst_db"))
+        with pytest.raises(Exception):
+            import_graph(dst, str(snap), verify=True)
+        dst.close()
+
+
+# ===================================================================
+# Scenario 4: idempotent re-import (no duplication)
+# ===================================================================
+
+
+class TestIdempotentImport:
+    def test_double_import_does_not_duplicate(self, tmp_path):
+        export_graph, import_graph, _verify = _migration_api()
+        CognitiveMemory = _cognitive_memory_cls()
+
+        src = CognitiveMemory(agent_name="src", db_path=str(tmp_path / "src_db"))
+        _populate(src)
+        export_graph(src, str(tmp_path / "snap"))
+        src.close()
+
+        dst = CognitiveMemory(agent_name="dst", db_path=str(tmp_path / "dst_db"))
+        import_graph(dst, str(tmp_path / "snap"), verify=True)
+        after_first = dst.get_statistics()
+        import_graph(dst, str(tmp_path / "snap"), verify=True)
+        after_second = dst.get_statistics()
+        dst.close()
+
+        assert after_first == after_second, "re-import must be idempotent (no duplication)"
+
+
+# ===================================================================
+# Scenario 5: delta / incremental export since a watermark
+# ===================================================================
+
+
+class TestDeltaExport:
+    def test_delta_export_only_carries_new_entries(self, tmp_path):
+        export_graph, import_graph, _verify = _migration_api()
+        CognitiveMemory = _cognitive_memory_cls()
+
+        src = CognitiveMemory(agent_name="src", db_path=str(tmp_path / "src_db"))
+        _populate(src)
+        base = export_graph(src, str(tmp_path / "full"))
+        watermark = base.get("watermark")
+        if watermark is None:
+            pytest.skip("delta export watermark not implemented yet (issue #2923, G2)")
+
+        # Add more after the watermark, then export only the delta.
+        for i in range(3):
+            src.store_fact(concept=f"delta-{i}", content=f"delta fact {i}", confidence=0.7)
+        delta = export_graph(src, str(tmp_path / "delta"), since=watermark)
+        src.close()
+
+        assert delta["counts"]["semantic"] == 3, "delta must carry only post-watermark facts"
+
+
+# ===================================================================
+# Scenario 6: export while LIVE (read-only snapshot, single-writer lease)
+# ===================================================================
+
+
+class TestLiveSnapshot:
+    def test_export_works_with_concurrent_reader(self, tmp_path):
+        export_graph, _import, _verify = _migration_api()
+        CognitiveMemory = _cognitive_memory_cls()
+
+        db_path = str(tmp_path / "live_db")
+        writer = CognitiveMemory(agent_name="live", db_path=db_path)
+        _populate(writer)
+        writer.close()
+
+        # Hold a read-only handle open (simulates the live primary still serving
+        # reads) while the exporter snapshots the graph.
+        reader = CognitiveMemory(agent_name="live", db_path=db_path, read_only=True)
+        exporter = CognitiveMemory(agent_name="live", db_path=db_path, read_only=True)
+        manifest = export_graph(exporter, str(tmp_path / "live_snap"))
+        exporter.close()
+        reader.close()
+
+        assert manifest["counts"]["semantic"] >= 5, "live snapshot must capture existing facts"

--- a/tests/test_live_migration.py
+++ b/tests/test_live_migration.py
@@ -1,0 +1,391 @@
+"""Outside-in TDD (tests-first) for Simard LIVE MIGRATION components.
+
+Issue #2923 — design spike: migrate Simard live to another host as a
+SECONDARY/STANDBY, validate parity without acting, then FINAL SYNC + CUTOVER
+with a clean, reversible role swap and exactly-one-primary at all times.
+
+These tests are written BEFORE the components exist. The migration surface is
+probed for presence; until it is built (a phase-D green-CI PR), its scenarios
+``pytest.skip`` with a clear reason + the tracking reference, so mainline CI
+stays green during the spike. When a component lands (a prebuilt ``simard``
+binary that exposes ``migrate`` with the required subcommands), the guards flip
+to hard assertions that drive the implementation.
+
+Design contracts asserted here (single source of truth for phase-D builders):
+
+  * A ``simard migrate`` CLI surface with subcommands:
+      provision | export-graph | import-graph | install | sync-config |
+      standby | validate | cutover | rollback | status
+  * A role-state file at ``$SIMARD_STATE_ROOT/migration/role.json`` with a
+      schema: {role: primary|standby, fencing_generation: int,
+               primary_lease_owner_pid: int, updated_epoch: int}
+  * A STANDBY that performs NO autonomous activity (no OODA advancement, no
+      engineer spawning, no merges/deploys, no Signal SENDING) until cutover.
+  * A migration orchestrator recipe with validation gates + LOUD rollback
+      (no silent fallback): a failed stage surfaces and rolls back.
+  * NO secrets in any committed / synced artifact; secure transfer only.
+  * Operator (rysweet) notified via the Signal self-notes channel at each
+      milestone.
+
+PROCESS-C REVIEW CORRECTIONS (multi-model/agent review of the spike design —
+apply these when flipping the skips to assertions; the schema above is the
+probe shape, NOT the authoritative design):
+  * SSOT for "who is primary" is the CROSS-HOST ``PrimaryLease`` (a shared
+      backend, e.g. an Azure Blob lease, holder + monotonic FENCING TOKEN).
+      ``role.json`` is only a LOCAL CACHE mirroring the lease — never
+      authoritative. If the lease is unreachable, ``require_primary()`` MUST
+      fail-safe to STANDBY and surface loudly; never trust the cached role.
+  * Fence cross-host by TOKEN, not by PID. ``primary_lease_owner_pid`` is
+      host-local and meaningless across hosts (the existing ``LeaderSemaphore``
+      uses ``kill(pid,0)`` liveness → single-host only). Prefer a
+      ``fencing_token``/lease-id checked at every side-effecting actuator
+      (memory store-write, engineer dispatch, signal send, git push).
+  * The orchestrator GENERALIZES the existing ``safe_update`` /``self_deploy``
+      phase machine (Drain→Snapshot→Validate→Rollback + health probes), it is
+      not a greenfield sequencer. Cutover = flip the lease LAST, after the
+      target validates in STANDBY (so pre-cutover stays cheap-to-reverse).
+  * The az provisioner extends the existing ``remote_azlin`` wrapper; the
+      graph-complete export/import lives in amplihack-memory-lib (G2) and
+      SUPERSEDES the deprecated, lossy ``src/remote_transfer/`` path.
+  See epic #2726 for the reviewed component list, contracts, and build order.
+
+Run:
+    python3 -m pytest tests/test_live_migration.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Repo + surface discovery (anchored to this file's own worktree)
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MIGRATION_SRC = REPO_ROOT / "src" / "migration"
+
+# Design-contract identifiers phase-D must satisfy.
+MIGRATE_SUBCOMMANDS = [
+    "provision",
+    "export-graph",
+    "import-graph",
+    "install",
+    "sync-config",
+    "standby",
+    "validate",
+    "cutover",
+    "rollback",
+    "status",
+]
+ROLE_SCHEMA_FIELDS = {
+    "role",
+    "fencing_generation",
+    "primary_lease_owner_pid",
+    "updated_epoch",
+}
+STANDBY_SUPPRESSED_ACTIVITIES = {
+    "ooda_advance",
+    "engineer_spawn",
+    "merge",
+    "deploy",
+    "signal_send",
+}
+# Current host `ia2` baseline the target must meet or exceed.
+MIN_VM_SIZE = "Standard_E64as_v5"
+MIN_VCPUS = 64
+
+
+def _simard_binary() -> Path | None:
+    """Return a prebuilt simard binary if one exists (never triggers a build)."""
+    for candidate in (
+        REPO_ROOT / "target" / "release" / "simard",
+        REPO_ROOT / "target" / "debug" / "simard",
+    ):
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def _migrate_help() -> str | None:
+    """`simard migrate --help` text, or None if the surface is unavailable.
+
+    Returns None both when no binary is built AND when a binary exists but does
+    not (yet) expose the ``migrate`` subcommand — the correct skip signal during
+    the spike.
+    """
+    binary = _simard_binary()
+    if binary is None:
+        return None
+    try:
+        proc = subprocess.run(
+            [str(binary), "migrate", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    return (proc.stdout or "") + (proc.stderr or "")
+
+
+def _run_migrate(*args: str, timeout: int = 120) -> subprocess.CompletedProcess:
+    binary = _simard_binary()
+    assert binary is not None, "simard binary required for this assertion"
+    return subprocess.run(
+        [str(binary), "migrate", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _require_migrate_surface():
+    """Skip unless the migrate surface is designed at all (source or CLI)."""
+    if not MIGRATION_SRC.exists() and _migrate_help() is None:
+        pytest.skip(
+            "migration surface not built yet (issue #2923 phase-D: "
+            "`simard migrate` CLI / src/migration). tests-first spec pending."
+        )
+
+
+def _require_migrate_cli():
+    """Skip unless a prebuilt binary actually exposes the `migrate` subcommand.
+
+    This is the gate for every test that *executes* the CLI: a bare `simard`
+    binary without the migrate surface must SKIP, not fail.
+    """
+    if _migrate_help() is None:
+        pytest.skip(
+            "`simard migrate` CLI not available yet (issue #2923 phase-D). "
+            "Build the binary with the migrate surface to run these assertions."
+        )
+
+
+# ===================================================================
+# Scenario A: `simard migrate` CLI surface exists with all subcommands
+# ===================================================================
+
+
+class TestMigrateCliSurface:
+    def test_migration_module_or_cli_present(self):
+        _require_migrate_surface()
+        assert MIGRATION_SRC.exists() or _migrate_help() is not None
+
+    @pytest.mark.parametrize("sub", MIGRATE_SUBCOMMANDS)
+    def test_subcommand_advertised(self, sub):
+        _require_migrate_cli()
+        help_text = _migrate_help()
+        assert sub in help_text, f"`simard migrate {sub}` must be advertised in --help"
+
+
+# ===================================================================
+# Scenario B: Role / standby state machine + fencing generation
+# ===================================================================
+
+
+class TestRoleStateMachine:
+    """The single source of truth for 'who is primary' with a fencing token."""
+
+    def _role_file(self) -> Path:
+        state_root = Path(os.environ.get("SIMARD_STATE_ROOT", Path.home() / ".simard"))
+        return state_root / "migration" / "role.json"
+
+    def test_role_file_schema_when_present(self):
+        role_file = self._role_file()
+        if not role_file.exists():
+            _require_migrate_surface()
+            pytest.skip("role.json not written yet (issue #2923 role-state component)")
+        data = json.loads(role_file.read_text())
+        missing = ROLE_SCHEMA_FIELDS - set(data)
+        assert not missing, f"role.json missing required fields: {missing}"
+        assert data["role"] in {"primary", "standby"}
+        assert isinstance(data["fencing_generation"], int)
+
+    def test_status_reports_single_role(self):
+        _require_migrate_cli()
+        proc = _run_migrate("status", "--json")
+        assert proc.returncode == 0, f"status failed: {proc.stderr}"
+        status = json.loads(proc.stdout)
+        assert status.get("role") in {"primary", "standby"}
+        assert "fencing_generation" in status
+
+
+# ===================================================================
+# Scenario C: STANDBY performs NO autonomous activity until cutover
+# ===================================================================
+
+
+class TestStandbySuppression:
+    """A secondary must be aware it is secondary and act on nothing."""
+
+    def test_standby_suppresses_all_autonomy(self):
+        _require_migrate_cli()
+        # Enter standby (dry / no side effects) and read suppression report.
+        proc = _run_migrate("standby", "--report", "--json")
+        assert proc.returncode == 0, f"standby report failed: {proc.stderr}"
+        report = json.loads(proc.stdout)
+        suppressed = set(report.get("suppressed", []))
+        assert STANDBY_SUPPRESSED_ACTIVITIES <= suppressed, (
+            "standby must suppress OODA advance, engineer spawn, merge, deploy, "
+            f"and Signal send; missing: {STANDBY_SUPPRESSED_ACTIVITIES - suppressed}"
+        )
+        assert report.get("role") == "standby"
+
+    def test_standby_refuses_signal_send(self):
+        _require_migrate_cli()
+        # Attempting an outbound send while standby must be refused LOUDLY
+        # (non-zero exit / explicit refusal), never silently swallowed.
+        proc = _run_migrate("standby", "--simulate-send", "hello")
+        assert proc.returncode != 0
+        assert re.search(r"standby|secondary|refus", proc.stderr, re.IGNORECASE)
+
+
+# ===================================================================
+# Scenario D: Target provisioner (az wrapper) — dry-run / plan only
+# ===================================================================
+
+
+class TestProvisionerDryRun:
+    """Provision a target VM >= current host without making real az calls."""
+
+    def test_provision_plan_meets_size_floor(self):
+        _require_migrate_cli()
+        proc = _run_migrate(
+            "provision",
+            "--dry-run",
+            "--json",
+            "--resource-group",
+            "rysweet-linux-vm-pool",
+        )
+        assert proc.returncode == 0, f"provision dry-run failed: {proc.stderr}"
+        plan = json.loads(proc.stdout)
+        assert int(plan.get("vcpus", 0)) >= MIN_VCPUS, (
+            f"target VM must have >= {MIN_VCPUS} vCPUs (>= {MIN_VM_SIZE})"
+        )
+        assert plan.get("premium_data_disk") is True, (
+            "target must attach a Premium SSD data disk for /home (like ia2_home)"
+        )
+        # Dry-run must NOT have created anything.
+        assert plan.get("created") in (False, None)
+
+    def test_dry_run_makes_no_real_az_mutation(self):
+        _require_migrate_cli()
+        proc = _run_migrate("provision", "--dry-run", "--json")
+        assert proc.returncode == 0
+        assert "az vm create" not in proc.stderr.lower() or "--dry-run" in proc.stderr
+
+
+# ===================================================================
+# Scenario E: Config + secret sync — NO secrets ever leak
+# ===================================================================
+
+
+class TestConfigSecretSync:
+    """config.toml [signal] + creds transferred securely; never committed."""
+
+    def test_sync_plan_excludes_secret_material_from_repo_artifacts(self):
+        _require_migrate_cli()
+        proc = _run_migrate("sync-config", "--plan", "--json")
+        assert proc.returncode == 0, f"sync-config plan failed: {proc.stderr}"
+        plan = json.loads(proc.stdout)
+        # Any artifact the plan would COMMIT/write into the repo must be marked
+        # secret-free; secrets must be routed via a secure (non-repo) channel.
+        for artifact in plan.get("repo_artifacts", []):
+            assert artifact.get("contains_secrets") is False, (
+                f"repo artifact {artifact.get('path')} must not contain secrets"
+            )
+        for item in plan.get("secret_items", []):
+            assert item.get("transport") in {"secure-copy", "kv", "ssh"}, (
+                "secrets must use a secure transport, never plaintext/repo"
+            )
+
+    def test_no_secret_regex_in_planned_repo_artifacts(self):
+        _require_migrate_cli()
+        proc = _run_migrate("sync-config", "--plan", "--emit-repo-artifacts", "--json")
+        assert proc.returncode == 0
+        plan = json.loads(proc.stdout)
+        secret_like = re.compile(
+            r"(BEGIN [A-Z ]*PRIVATE KEY|password\s*[:=]|token\s*[:=]|"
+            r"aws_secret|signal.*(password|pin))",
+            re.IGNORECASE,
+        )
+        for artifact in plan.get("repo_artifacts", []):
+            body = artifact.get("preview", "")
+            assert not secret_like.search(body), (
+                f"secret-looking content in planned repo artifact {artifact.get('path')}"
+            )
+
+
+# ===================================================================
+# Scenario F: Worktree quiesce + transfer (git worktrees are host-local)
+# ===================================================================
+
+
+class TestWorktreeQuiesce:
+    def test_quiesce_inventory_captures_active_worktrees(self):
+        _require_migrate_cli()
+        proc = _run_migrate("cutover", "--quiesce-plan", "--json")
+        assert proc.returncode == 0, f"quiesce plan failed: {proc.stderr}"
+        plan = json.loads(proc.stdout)
+        assert "worktrees" in plan, "quiesce must inventory active worktrees"
+        for wt in plan["worktrees"]:
+            # Each worktree needs branch + head so it can be re-created on target.
+            assert {"path", "branch", "head"} <= set(wt)
+        assert plan.get("engineers_paused") in (True, False)
+
+
+# ===================================================================
+# Scenario G: Orchestrator gates + LOUD rollback (no silent fallback)
+# ===================================================================
+
+
+class TestOrchestratorRollback:
+    def test_failed_stage_triggers_loud_rollback(self):
+        _require_migrate_cli()
+        # Inject a forced failure at the 'validate' gate; the orchestrator must
+        # surface it (non-zero) AND report a rollback — never silently continue.
+        proc = _run_migrate("cutover", "--dry-run", "--fail-at", "validate", "--json")
+        assert proc.returncode != 0, "a failed gate must surface loudly (non-zero)"
+        combined = (proc.stdout or "") + (proc.stderr or "")
+        assert re.search(r"rollback|rolled back|reverting", combined, re.IGNORECASE), (
+            "a failed migration stage must roll back, not silently fall back"
+        )
+
+    def test_rollback_is_idempotent_and_reversible(self):
+        _require_migrate_cli()
+        first = _run_migrate("rollback", "--dry-run")
+        second = _run_migrate("rollback", "--dry-run")
+        assert first.returncode == 0 and second.returncode == 0, (
+            "rollback must be safely re-runnable (idempotent)"
+        )
+
+
+# ===================================================================
+# Scenario H: Observability + operator Signal self-note at milestones
+# ===================================================================
+
+
+class TestMigrationObservability:
+    def test_milestones_emit_operator_notifications(self):
+        _require_migrate_cli()
+        proc = _run_migrate("status", "--milestones", "--json")
+        assert proc.returncode == 0, f"milestones query failed: {proc.stderr}"
+        data = json.loads(proc.stdout)
+        milestones = data.get("milestones", [])
+        # The design requires operator (rysweet) updates via Signal self-notes
+        # at each milestone; each milestone must carry a notification channel.
+        for m in milestones:
+            assert m.get("notify_channel") in {"signal-self-note", "none"}
+        # At minimum the lifecycle milestones must be enumerated.
+        names = {m.get("name") for m in milestones}
+        expected = {"provisioned", "graph-imported", "standby-up", "validated", "cutover"}
+        if milestones:
+            assert expected <= names, f"missing milestones: {expected - names}"


### PR DESCRIPTION
## Summary

First small, green-CI component of the **live self-migration design spike** (#2923, epic #2726). This is a **tests-first / outside-in** increment: it lands executable **contracts** for the migration, with **no fabricated "implemented" claims** and **no snapshot docs** (findings stay as issues #2719–2726).

> Spike discipline: research + reviewed plan + test strategy **before** building; memory-architecture work lands in amplihack-memory-lib (G2); no secrets in the repo; no silent fallbacks; every change is a green-CI PR.

### What this replaces
An earlier round left 7 uncommitted docs stamping `status: implemented` on a `simard migrate`/`role` CLI, an `az` provisioner, and a memory-graph API that **do not exist in the tree**. The security and tla-plus reviews both flagged that as a P0 hazard (an operator would hand-wire the flow around the host-local lock → two `unlimited`-autonomy hosts). Those docs were removed; the design is captured as issues instead.

## Changes (all green CI, verified locally)

| File | What it locks | State |
|------|---------------|-------|
| `tests/live_migration_fencing.rs` | Exactly-one-primary fencing invariants of the **existing** host-local `LeaderSemaphore` (owner PID + monotonic `generation` token + heartbeat): live primary blocks a 2nd acquirer; `generation` strictly monotonic across seizures; cutover = owner-only `transfer` bumping the token; demoted primary cannot transfer; release is owner-scoped; **+ a characterization test pinning the host-local reclaim limitation**. | 6 tests **pass** |
| `tests/test_graph_migration.py` | Contract for the graph-complete memory export/import that must live in **amplihack-memory-lib** (G2): counts + per-type checksums + provenance + delta watermark, round-trip parity, loud tamper detection. | skips until lib ships it |
| `tests/test_live_migration.py` | Contract for the migrate CLI / role / standby / orchestrator surface, with the Process-C review corrections in its header. | skips until built |

Verified: `cargo test --test live_migration_fencing` → **6 passed**; `pytest tests/test_graph_migration.py tests/test_live_migration.py` → **29 skipped, 0 fail**. `cargo clippy --all-targets --all-features --locked -D warnings` and `cargo fmt --all --check` clean.

## Honest scope / caveat (do not misread a green run)
`LeaderSemaphore` is **host-local** (`kill(pid,0)` + local file) — it fences rivals on the **same host only**. It is the *local half* of the role gate. Cross-host exactly-one-primary needs the shared lease of **#2725**, using **fence-at-write** (each resource rejects a stale, durable, monotonic `fenceEpoch` via CAS) — **not** check-then-act, and **not** a blob-lease GUID (GUIDs are unordered). The test header and a dedicated characterization test make this explicit so the contract can't be mistaken for cross-host safety.

## Process-C review
Reviewed by a wide range of models/agents — **crusty-old-engineer** (gpt-5.5), **rubber-duck** (claude-opus-4.8), **architect**, **security**, **tla-plus-expert**, and an independent **gemini-3.1-pro** reviewer. Consolidated findings + the reviewed component decomposition, corrected fencing design, and full test strategy are captured as a comment on epic **#2726**.

**Determinism fix from the opus review:** the monotonic-seizure test previously depended on ambient PID liveness — PIDs 101–103 are **live root kernel threads**, so the test would **fail under root CI** (it passed here only because non-root `kill(101,0)` returns EPERM → treated as dead). It now seeds a deterministically-stale predecessor (heartbeat epoch 0) so seizure is forced by staleness, independent of liveness/root.

## Test plan
- [x] `cargo test --test live_migration_fencing` — 6 passed
- [x] `pytest tests/test_graph_migration.py tests/test_live_migration.py` — 29 skipped
- [x] `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features --locked -- -D warnings`
- [x] rust-only gate (both `.py` files are under `tests/`, consistent with existing `tests/test_ladybug_migration.py`)

Refs #2923, #2726, #2725, #2724, #2723, #2721, #2720, #2719

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
