### PR TITLE
fix(stewardship): default-repo routing fallback so overseer gap-scan files issues (#2934)

### DIFF
--- a/docs/concepts/stewardship-mode.md
+++ b/docs/concepts/stewardship-mode.md
@@ -25,16 +25,24 @@ file. The orchestrator-failure sub-mode of Goal Stewardship:
    for outer-loop / recipe-runner / orchestrator infrastructure failures, and
    `rysweet/Simard` for inner-loop module failures (`engineer_loop`,
    `base_type`, `self_improve`, `goal_curation`, `agent_loop`,
-   `session_builder`, `simard::*`).
+   `session_builder`, `simard::*`). A `source_module` that matches **no**
+   keyword — for example the Overseer's own `"overseer"` workstream-gap briefs —
+   routes to the configured **default repo** (`rysweet/Simard`, the
+   `DEFAULT_TARGET_REPO` constant) and the fallback is recorded with
+   `tracing::warn!`. Routing is therefore *total*: it never errors and never
+   drops a gap on the floor.
 3. **Deduplicates** the failure against existing open issues using a stable
    SHA-256 signature embedded in each issue body.
 4. **Files** a new issue (or matches an existing one) via the `gh` CLI.
 5. **Enqueues** the resulting issue into Simard's own backlog through
    `src/goal_curation`, so the next curation cycle can pick it up.
 
-There are **no fallbacks**. Any ambiguity, `gh` failure, or invalid input
-surfaces as a `SimardError` — the loop never silently degrades, never
-picks a default repo, and never files duplicate issues.
+The loop **never silently degrades**. Any `gh` failure or invalid input
+surfaces as a `SimardError`, and the loop never files duplicate issues. Routing
+is the one deliberately *total* step: an unmatched `source_module` is **not** an
+error — it falls back to the default repo (`rysweet/Simard`) and is logged via
+`tracing::warn!`, so the originating gap or failure is always tracked somewhere
+rather than lost. This is a *logged, non-error* recovery, not a silent one.
 
 ## Loop at a Glance
 
@@ -45,7 +53,7 @@ OrchestratorRunSummary
   validate(run)                          ── invalid → StewardshipInvalidRunSummary
         │
         ▼
-  route_failure(source_module)           ── unknown → StewardshipRoutingAmbiguous
+  route_failure(source_module)           ── unknown → default repo (rysweet/Simard), warn-logged
         │
         ▼
   failure_signature(kind, error_text)
@@ -60,8 +68,13 @@ OrchestratorRunSummary
 
 ## Invariants
 
-- **Routing totality.** A successful outcome implies routing succeeded.
-- **No filing without routing.** Routing failure short-circuits before any I/O.
+- **Routing totality.** `route_failure` is total — every input yields a
+  `TargetRepo`. A matched keyword pins the repo; an unmatched `source_module`
+  falls back to the default repo (`rysweet/Simard`) and is `tracing::warn!`-logged.
+  Routing can therefore never short-circuit the loop.
+- **No filing without valid input.** Validation failure (an empty required
+  field) short-circuits before any I/O. Routing never blocks filing, but a
+  malformed `OrchestratorRunSummary` still does.
 - **No filing without search.** `create_issue` runs only after a successful
   search returns no signature match.
 - **At most one create per call.** Each call yields exactly one of
@@ -72,7 +85,10 @@ OrchestratorRunSummary
 - **Closed issues do not match.** Signature search is scoped to open issues
   only; recurrence after manual close files a fresh issue.
 - **Fail-loud.** Missing `gh`, non-zero `gh` exit, malformed JSON, or empty
-  required fields all produce errors. There is no silent recovery path.
+  required fields all produce errors. There is no silent recovery path. The
+  routing default-fallback is the one exception, and it is **not silent** — it
+  is a logged (`tracing::warn!`), first-class routing outcome, not an error and
+  not a swallow.
 
 ## Routing Matrix
 
@@ -83,11 +99,20 @@ lowercased source string against ordered keyword sets:
 |-------|--------------------------------------------------------------------------------------------------|--------------------|
 | 1     | `amplihack`, `recipe-runner`, `orchestrator`, `recipe::`                                         | `rysweet/amplihack` |
 | 2     | `engineer_loop`, `base_type`, `self_improve`, `goal_curation`, `agent_loop`, `session_builder`, `simard::` | `rysweet/Simard`    |
-| —     | none                                                                                             | `Err(StewardshipRoutingAmbiguous)` |
+| —     | none (default fallback)                                                                          | `rysweet/Simard` (`DEFAULT_TARGET_REPO`), logged via `tracing::warn!` |
 
 Amplihack keywords are checked first. If a source string contains both
 families (e.g. `amplihack::engineer_loop`), the outer-system tag wins by
 design; this precedence is pinned by tests.
+
+When no keyword matches, `route_failure` **does not error**. It returns the
+`DEFAULT_TARGET_REPO` constant (`TargetRepo::Simard` → `rysweet/Simard`) and
+emits a single `tracing::warn!` carrying the unmatched `source_module` and the
+chosen default slug. `DEFAULT_TARGET_REPO` is a compile-time constant — the one
+named source of truth for the default — so the fallback can never be an
+attacker-chosen or dynamically-supplied repo. This is what lets the Overseer's
+own `source_module = "overseer"` gap-scan briefs file/upsert tracking issues in
+`rysweet/Simard` instead of failing every tick.
 
 ## Failure Signature
 

--- a/docs/howto/file-stewardship-issues-from-orchestrator-runs.md
+++ b/docs/howto/file-stewardship-issues-from-orchestrator-runs.md
@@ -42,7 +42,19 @@ let run = OrchestratorRunSummary {
 Pick `source_module` carefully — it is the routing key. The amplihack family
 includes `amplihack`, `recipe-runner`, `orchestrator`, and `recipe::`; the
 Simard family includes `engineer_loop`, `base_type`, `self_improve`,
-`goal_curation`, `agent_loop`, `session_builder`, and `simard::`.
+`goal_curation`, `agent_loop`, `session_builder`, and `simard::`. A source that
+matches **no** keyword (for example a bare `"overseer"`) is not rejected — it
+falls back to the **default repo** (`rysweet/Simard`) and the fallback is
+logged via `tracing::warn!`. Prefer an explicit `simard::` / `amplihack::`
+prefix when you know the right home; rely on the default only when you
+deliberately want unclassified work tracked in `rysweet/Simard`.
+
+> **Keep secrets out of the payload.** `error_text` is rendered **verbatim into
+> a public GitHub issue body**, and an unmatched `source_module` is echoed at
+> `WARN` log level by the routing fallback. Never place tokens, credentials, or
+> PII in either field — redact them in the producer before constructing the
+> `OrchestratorRunSummary`. The default-repo fallback broadens where issues can
+> be written, so this hygiene is what keeps that reach safe.
 
 ## 2. Choose a `GhClient` implementation
 
@@ -85,10 +97,12 @@ with the same `OrchestratorRunSummary` is idempotent.
 
 ## 4. Handle errors loudly
 
-The loop has no fallbacks. Propagate every error up to your orchestrator's
-failure path; do not catch and swallow. The snippet below is shown inside a
-function returning `SimardResult<()>` so the `return Err(other)` arm
-type-checks:
+The loop surfaces `gh` and input failures as first-class errors — propagate
+every one up to your orchestrator's failure path; do not catch and swallow.
+Routing itself no longer errors: an unmatched `source_module` falls back to the
+default repo (`rysweet/Simard`) and is `tracing::warn!`-logged, so you never
+need to handle a routing error. The snippet below is shown inside a function
+returning `SimardResult<()>` so the `return Err(other)` arm type-checks:
 
 ```rust
 use simard::error::{SimardError, SimardResult};
@@ -101,11 +115,6 @@ fn handle_failed_run(
 ) -> SimardResult<()> {
     if let Err(err) = process_orchestrator_run(run, gh, board) {
         match err {
-            SimardError::StewardshipRoutingAmbiguous { source } => {
-                // Add the missing keyword to the routing matrix and re-run;
-                // do not pick a default repo.
-                tracing::error!(%source, "stewardship routing ambiguous");
-            }
             SimardError::StewardshipGhCommandFailed { reason } => {
                 // gh is broken / unauthenticated / rate-limited; surface as a
                 // first-class operational failure.
@@ -115,6 +124,9 @@ fn handle_failed_run(
                 // Bug in the caller — fix the producer of OrchestratorRunSummary.
                 tracing::error!(field, "stewardship invalid run summary");
             }
+            // Routing never returns StewardshipRoutingAmbiguous anymore — an
+            // unmatched source falls back to the default repo (see step 1). The
+            // variant is retained only for API stability.
             other => return Err(other),
         }
     }
@@ -142,10 +154,12 @@ score `0.6`.
 
 ## Common Pitfalls
 
-- **Routing ambiguous.** Means your `source_module` does not contain any
-  known keyword. Fix: change the producer to emit a routable string (e.g.
-  prefix it with `simard::` or `amplihack::`). Do not edit the routing
-  matrix without also adding a test.
+- **Unmatched `source_module`.** A source that contains no known keyword is
+  **not** an error — it routes to the default repo (`rysweet/Simard`) and emits
+  a `tracing::warn!` naming the source and the chosen default. If you meant it
+  to land elsewhere, change the producer to emit a routable string (e.g. prefix
+  it with `simard::` or `amplihack::`), or add the keyword to the routing matrix
+  (with a test). Watch for the warn line if issues show up in an unexpected repo.
 - **`gh` not authenticated.** `StewardshipGhCommandFailed` will carry the
   trimmed stderr — usually a hint to run `gh auth login`.
 - **Backlog appears unchanged after a match.** Expected: the deterministic

--- a/docs/reference/overseer-workstream-gap-scan.md
+++ b/docs/reference/overseer-workstream-gap-scan.md
@@ -291,7 +291,14 @@ machinery — the same paths `goal_health` and M1 use — with no new bypass:
    silently dropped; an unconfigured channel is `Queued` and logged.
 3. **FileIssue.** File a **deduped** stewardship issue per gap signature through
    the same `IssueFiler` path M1 uses
-   (`stewardship::process_orchestrator_run` + `find_existing`).
+   (`stewardship::process_orchestrator_run` + `find_existing`). The gap briefs
+   carry `source_module = "overseer"`, which matches no routing keyword; the
+   stewardship router's **default-repo fallback** therefore routes them to
+   `rysweet/Simard` (the `DEFAULT_TARGET_REPO` constant) and logs the fallback
+   with `tracing::warn!`. This is what lets the gap-scan actually file/upsert one
+   rolling tracking issue per gap signature every tick, rather than failing with
+   `overseer intervention failed … flag_workstream_gaps … cannot route
+   source-module 'overseer'`.
 
 Both the notify and the file happen as **side effects of this one act** — exactly
 as `goal_health`'s escalate notifies both channels from a single intervention.

--- a/docs/reference/stewardship-api.md
+++ b/docs/reference/stewardship-api.md
@@ -13,25 +13,38 @@ For the broader Goal Stewardship Mode, see `Specs/ProductArchitecture.md`
 
 ```
 src/stewardship/
-├── mod.rs           public entrypoint and re-exports (the only public surface)
-├── types.rs         OrchestratorRunSummary, StewardshipOutcome, TargetRepo
-├── routing.rs       route_failure
-├── dedup.rs         normalize, failure_signature, find_existing
-├── gh_client.rs     trait GhClient, GhIssue, RealGhClient, FakeGhClient (cfg(test))
-└── tests.rs         unit and end-to-end tests
+├── mod.rs                 public entrypoint (process_orchestrator_run) and re-exports
+├── types.rs               OrchestratorRunSummary, StewardshipOutcome, TargetRepo
+├── routing.rs             route_failure (total; DEFAULT_TARGET_REPO fallback)
+├── dedup.rs               normalize, failure_signature, find_existing
+├── gh_client.rs           trait GhClient, GhIssue, RealGhClient, FakeGhClient (test-utils)
+├── merge_authority.rs     gated squash-merge authority (merge-readiness path)
+├── merge_judge.rs         MergeJudge trait, LLM judge, objective-gate verdicts
+├── recipe_merge_judge.rs  recipe-runner-backed MergeJudge implementation
+├── tests.rs               unit and end-to-end tests (cfg(test))
+└── tests_extra.rs         TDD contract tests incl. routing-fallback coverage (cfg(test))
 ```
 
-`mod.rs` re-exports the public API:
+The routing-fallback behaviour documented on this page is exercised by
+`tests_extra.rs`. The `merge_authority` / `merge_judge` / `recipe_merge_judge`
+modules are a separate merge-readiness path unrelated to the orchestrator-failure
+loop described here.
+
+`mod.rs` re-exports the failure-filing API — the focus of this page:
 
 ```rust
+pub use dedup::{failure_signature, find_existing, normalize};
 pub use gh_client::{GhClient, GhIssue, RealGhClient};
 pub use routing::route_failure;
 pub use types::{OrchestratorRunSummary, StewardshipOutcome, TargetRepo};
 
-// Test-only helpers re-exported for downstream test consumers.
+// Test-only helper re-exported for downstream test consumers.
 #[cfg(any(test, feature = "test-utils"))]
 pub use gh_client::FakeGhClient;
 ```
+
+It additionally re-exports the merge-readiness surface (`merge_authority::*`,
+`merge_judge::*`, `recipe_merge_judge::RecipeMergeJudge`).
 
 `stewardship` depends on `goal_curation` (one direction only). It does **not**
 depend on `engineer_loop`, `base_type_*`, or `self_improve`.
@@ -55,10 +68,13 @@ resulting issue handle into the curation `board`.
 | Variant                          | When                                                       |
 |----------------------------------|------------------------------------------------------------|
 | `StewardshipInvalidRunSummary`   | A required field on `OrchestratorRunSummary` is empty.     |
-| `StewardshipRoutingAmbiguous`    | `source_module` matches no routing keyword set.            |
 | `StewardshipGhCommandFailed`     | `gh` is missing, exited non-zero, or returned malformed JSON. |
 
 No success branch is taken on any of these errors; `board` is left untouched.
+
+Routing no longer contributes an error variant: `route_failure` is total (see
+[Routing](#routing)). An unmatched `source_module` falls back to the default
+repo rather than aborting `process_orchestrator_run`.
 
 ## Types
 
@@ -109,11 +125,28 @@ In both cases, `enqueue_stewardship_issue` was called with the issue handle.
 
 ```rust
 pub fn route_failure(source_module: &str) -> SimardResult<TargetRepo>;
+
+// The one named source of truth for the default target repo.
+const DEFAULT_TARGET_REPO: TargetRepo = TargetRepo::Simard; // rysweet/Simard
 ```
 
-Pure, total over the routing matrix; performs zero I/O. See the
+Pure, **total**, and performs zero I/O. See the
 [routing matrix](../concepts/stewardship-mode.md#routing-matrix) for the
-keyword sets.
+keyword sets. Keyword checks run first (amplihack before Simard); if **no**
+keyword matches, `route_failure` returns `Ok(DEFAULT_TARGET_REPO)` and emits a
+single `tracing::warn!` carrying the unmatched `source_module` and the default
+slug:
+
+```text
+WARN stewardship routing: no keyword match, routing to default repo
+     source_module="overseer" default="rysweet/Simard"
+```
+
+The signature returns `SimardResult<TargetRepo>` for API stability, but the
+`Err` arm is now unreachable — every input resolves to a `TargetRepo`. This is
+what unblocks the Overseer's workstream-gap-scan, whose briefs carry
+`source_module = "overseer"` (no keyword match): they now route to
+`rysweet/Simard` and file/upsert a deduped tracking issue instead of failing.
 
 ## Deduplication
 
@@ -223,11 +256,14 @@ Repeated `MatchedExisting` outcomes therefore do not grow the backlog.
 // src/error/mod.rs
 pub enum SimardError {
     // ...existing variants...
-    StewardshipRoutingAmbiguous { source: String },
+    StewardshipRoutingAmbiguous { source: String }, // retained for API stability; no longer produced by route_failure
     StewardshipGhCommandFailed  { reason: String },
     StewardshipInvalidRunSummary{ field: &'static str },
 }
 ```
 
 Each variant has a `Display` arm and an associated unit test alongside
-existing error-variant tests.
+existing error-variant tests. `StewardshipRoutingAmbiguous` is **retained** so
+its `Display` contract stays stable and downstream matches keep compiling, but
+`route_failure` no longer emits it — an unmatched source now falls back to
+`DEFAULT_TARGET_REPO` (see [Routing](#routing)).

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -251,7 +251,9 @@ pub enum SimardError {
     PromptNotFound {
         name: String,
     },
-    /// Stewardship: source-module → repo routing has no matching keyword. Fail-loud — no default repo.
+    /// Stewardship: source-module → repo routing had no matching keyword.
+    /// Retained for API/`Display` stability; **no longer produced by
+    /// `route_failure`**, which now falls back to the default repo instead.
     StewardshipRoutingAmbiguous {
         source: String,
     },

--- a/src/overseer/tests_gap_scan.rs
+++ b/src/overseer/tests_gap_scan.rs
@@ -666,6 +666,51 @@ fn flags_gaps_notifies_both_channels_files_once_then_dedupes_on_repeat() {
 }
 
 #[test]
+fn flagged_gap_brief_source_module_routes_to_default_repo() {
+    use crate::stewardship::{TargetRepo, route_failure};
+
+    // Regression for issue #2934: `act_flag_workstream_gaps` files each gap with
+    // the bare source_module "overseer", which matches NO stewardship routing
+    // keyword. Before the default-repo fallback, the real `StewardshipIssueFiler`
+    // rejected this with `StewardshipRoutingAmbiguous`, so `flag_workstream_gaps`
+    // failed every tick ("overseer intervention failed ...
+    // intervention=flag_workstream_gaps error=... cannot route source-module
+    // 'overseer'"). This test pins that the brief the gap path actually produces
+    // routes to a real repo — the configured default (rysweet/Simard) — so the
+    // issue gets filed instead of erroring.
+    let gaps = vec![sample_goal_gap()];
+    let filed = Arc::new(Mutex::new(Vec::new()));
+    let (notifier, _email_log, _signal_log) = dual_recording_notifier();
+
+    let mut ov = Overseer::new(caps_for_gaps(gaps, filed.clone()))
+        .with_identity(overseer_identity())
+        .with_gap_scan_enabled(true)
+        .with_operator_notifier(Box::new(notifier));
+
+    let report = overseer_tick(&mut ov);
+    assert_eq!(
+        report.workstream_gaps_detected, 1,
+        "the genuine gap is flagged"
+    );
+    assert_eq!(report.errors, 0, "the gap intervention must not error");
+    assert!(!report.panicked);
+
+    let briefs = filed.lock().unwrap();
+    assert_eq!(briefs.len(), 1, "one deduped issue filed for the gap");
+    let src = &briefs[0].source_module;
+
+    // The exact value the gap path emits must resolve — never ambiguous.
+    let target = route_failure(src).unwrap_or_else(|e| {
+        panic!("gap brief source_module {src:?} must route to a real repo, got {e:?}")
+    });
+    assert!(
+        matches!(target, TargetRepo::Simard),
+        "an overseer gap brief routes to the default repo (rysweet/Simard): {src:?}"
+    );
+    assert_eq!(target.slug(), "rysweet/Simard");
+}
+
+#[test]
 fn disabled_gap_scan_holds_the_whole_action() {
     let gaps = vec![sample_goal_gap()];
     let filed = Arc::new(Mutex::new(Vec::new()));

--- a/src/stewardship/mod.rs
+++ b/src/stewardship/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! Pipeline:
 //! 1. Validate the [`OrchestratorRunSummary`] (fail-loud on missing fields).
-//! 2. Route `source_module` → [`TargetRepo`] (no default).
+//! 2. Route `source_module` → [`TargetRepo`] (unmatched → default repo).
 //! 3. Compute a noise-stripped [`failure_signature`].
 //! 4. Search the target repo for an open issue with that signature.
 //! 5. If found → [`StewardshipOutcome::MatchedExisting`].

--- a/src/stewardship/routing.rs
+++ b/src/stewardship/routing.rs
@@ -1,9 +1,18 @@
 //! Source-module → target-repo routing for the stewardship loop.
 //!
-//! Fail-loud on ambiguity — there is **no default repo**.
+//! Routing is **total**: a matched keyword pins the repo, and any
+//! `source_module` that matches no keyword falls back to
+//! [`DEFAULT_TARGET_REPO`] (`rysweet/Simard`), logged via `tracing::warn!`.
+//! Routing therefore never errors and never drops a failure on the floor.
 
 use super::types::TargetRepo;
-use crate::error::{SimardError, SimardResult};
+use crate::error::SimardResult;
+
+/// The one named source of truth for the default target repo. An unmatched
+/// `source_module` routes here rather than erroring, so gap/issue briefs whose
+/// source has no keyword (e.g. the Overseer's `"overseer"` workstream-gap
+/// briefs) always land in a real repo instead of failing every tick.
+const DEFAULT_TARGET_REPO: TargetRepo = TargetRepo::Simard;
 
 /// Keywords that pin a failure to the amplihack workflow runtime. Checked
 /// first so an `amplihack::engineer_loop` source pins to amplihack.
@@ -23,7 +32,10 @@ const SIMARD_KEYWORDS: &[&str] = &[
 /// Route a `source_module` string (e.g. `"simard::engineer_loop"`) to the
 /// target repo for issue filing.
 ///
-/// Returns [`SimardError::StewardshipRoutingAmbiguous`] when no keyword matches.
+/// Total over all inputs. Keyword sets are checked first (amplihack before
+/// Simard). If **no** keyword matches, the source falls back to
+/// [`DEFAULT_TARGET_REPO`] (`rysweet/Simard`) and the fallback is recorded with
+/// `tracing::warn!` — routing never returns an error and never drops a source.
 pub fn route_failure(source_module: &str) -> SimardResult<TargetRepo> {
     let lc = source_module.to_lowercase();
     if AMPLIHACK_KEYWORDS.iter().any(|kw| lc.contains(kw)) {
@@ -32,7 +44,10 @@ pub fn route_failure(source_module: &str) -> SimardResult<TargetRepo> {
     if SIMARD_KEYWORDS.iter().any(|kw| lc.contains(kw)) {
         return Ok(TargetRepo::Simard);
     }
-    Err(SimardError::StewardshipRoutingAmbiguous {
-        source: source_module.to_string(),
-    })
+    tracing::warn!(
+        source_module = %source_module,
+        default = DEFAULT_TARGET_REPO.slug(),
+        "stewardship routing: no keyword match, routing to default repo"
+    );
+    Ok(DEFAULT_TARGET_REPO)
 }

--- a/src/stewardship/tests.rs
+++ b/src/stewardship/tests.rs
@@ -149,12 +149,26 @@ fn route_simard_keywords() {
 }
 
 #[test]
-fn route_ambiguous_errors() {
-    let err = route_failure("unknown_subsystem").unwrap_err();
-    assert!(matches!(
-        err,
-        SimardError::StewardshipRoutingAmbiguous { .. }
-    ));
+fn route_unmatched_falls_back_to_default() {
+    // The Overseer's gap-scan brief files with the bare source-module
+    // "overseer", which matches no keyword. Rather than erroring — the old
+    // `StewardshipRoutingAmbiguous` behavior that broke `flag_workstream_gaps`
+    // every tick — the router now falls back to the configured DEFAULT repo
+    // (rysweet/Simard) and logs the fallback. Routing must NEVER silently drop
+    // a source: an unmatched source always resolves to the default repo.
+    for src in &[
+        "overseer",
+        "unknown_subsystem",
+        "totally_unmapped_subsystem",
+    ] {
+        let target = route_failure(src)
+            .unwrap_or_else(|e| panic!("{src}: unmatched source must fall back, got {e:?}"));
+        assert!(
+            matches!(target, TargetRepo::Simard),
+            "{src} should route to the default repo (rysweet/Simard)"
+        );
+        assert_eq!(target.slug(), "rysweet/Simard", "{src}");
+    }
 }
 
 #[test]

--- a/src/stewardship/tests_extra.rs
+++ b/src/stewardship/tests_extra.rs
@@ -297,20 +297,93 @@ fn process_run_propagates_gh_create_failure() {
 }
 
 #[test]
-fn process_run_does_not_call_gh_when_routing_ambiguous() {
+fn process_run_routes_overseer_to_default_and_dedups() {
+    // Regression for the `flag_workstream_gaps` failure: the Overseer files gap
+    // issues with the bare source_module "overseer" (no keyword match). Before
+    // the routing fallback this returned `StewardshipRoutingAmbiguous` and the
+    // whole intervention failed every tick ("intervention failed ...
+    // flag_workstream_gaps"). Now the router must route the unmatched source to
+    // the DEFAULT repo (rysweet/Simard), file exactly ONE issue, and dedup on a
+    // rerun with the same gap signature (no duplicate issues).
     let gh = FakeGhClient::new();
     let mut board = GoalBoard::new();
     let mut run = sample_run();
-    run.source_module = "totally_unknown_subsystem".to_string();
+    run.source_module = "overseer".to_string();
+    let sig = failure_signature(&run.failure_kind, &run.error_text);
 
-    let err = process_orchestrator_run(&run, &gh, &mut board).unwrap_err();
-    assert!(matches!(
-        err,
-        SimardError::StewardshipRoutingAmbiguous { .. }
-    ));
-    assert_eq!(gh.search_call_count(), 0);
-    assert_eq!(gh.create_call_count(), 0);
-    assert!(board.backlog.is_empty());
+    // First tick: no existing issue in the default repo → file exactly one.
+    gh.seed_search("rysweet/Simard", &sig, Ok(vec![]));
+    gh.seed_create(
+        "rysweet/Simard",
+        Ok(GhIssue {
+            number: 314,
+            url: "https://github.com/rysweet/Simard/issues/314".into(),
+            title: "[stewardship] workstream gap".into(),
+            body: format!("stewardship-signature: {sig}"),
+        }),
+    );
+
+    let first = process_orchestrator_run(&run, &gh, &mut board).unwrap();
+    match first {
+        StewardshipOutcome::FiledNew {
+            repo, issue_number, ..
+        } => {
+            assert_eq!(
+                repo, "rysweet/Simard",
+                "an unmatched source_module routes to the default repo"
+            );
+            assert_eq!(issue_number, 314);
+        }
+        other => panic!("expected FiledNew in rysweet/Simard, got {other:?}"),
+    }
+    // The router must have searched the DEFAULT repo (not amplihack) and created
+    // exactly one tracking issue.
+    assert_eq!(
+        gh.search_call_count(),
+        1,
+        "must search the default repo before filing"
+    );
+    assert_eq!(
+        gh.create_call_count(),
+        1,
+        "exactly one gap issue filed on the first tick"
+    );
+    assert_eq!(board.backlog.len(), 1);
+
+    // Second tick, SAME gap signature: search now returns the existing issue →
+    // MatchedExisting and NO second create (idempotent per signature — one
+    // rolling tracking issue per distinct gap, never a duplicate each tick).
+    gh.seed_search(
+        "rysweet/Simard",
+        &sig,
+        Ok(vec![GhIssue {
+            number: 314,
+            url: "https://github.com/rysweet/Simard/issues/314".into(),
+            title: "[stewardship] workstream gap".into(),
+            body: format!("stewardship-signature: {sig}"),
+        }]),
+    );
+    let second = process_orchestrator_run(&run, &gh, &mut board).unwrap();
+    assert!(
+        matches!(
+            second,
+            StewardshipOutcome::MatchedExisting {
+                issue_number: 314,
+                ..
+            }
+        ),
+        "rerun with the same gap signature must dedup to the existing issue: {second:?}"
+    );
+    assert_eq!(
+        gh.create_call_count(),
+        1,
+        "idempotent per gap signature — no duplicate issue on rerun"
+    );
+    assert_eq!(
+        board.backlog.len(),
+        1,
+        "no duplicate backlog row across ticks for the same gap"
+    );
 }
 
 // ─────────────────────────── Input validation ───────────────────────────


### PR DESCRIPTION
## Problem

The Overseer's workstream-gap intervention failed **every tick**:

```
overseer intervention failed ... intervention="flag_workstream_gaps"
error=capability file_issue failed: stewardship: cannot route source-module
'overseer' to a target repo (no matching keyword)
```

`act_flag_workstream_gaps` files each gap brief with the bare
`source_module = "overseer"`. That string matches neither the amplihack nor the
Simard keyword set, so `stewardship::route_failure` returned
`StewardshipRoutingAmbiguous` and the whole intervention aborted — the
gap-tracking issue was never filed and dedup/backlog enqueue never happened.

## Fix — "overseer routing fallback"

Make stewardship routing **total**:

- Add a single named `DEFAULT_TARGET_REPO` constant (`TargetRepo::Simard` →
  `rysweet/Simard`) in `src/stewardship/routing.rs`.
- When no keyword matches, `route_failure` now returns `Ok(DEFAULT_TARGET_REPO)`
  and logs the fallback via `tracing::warn!(source_module, default)` instead of
  erroring. Routing never errors and never silently drops a source.
- Existing keyword routes are **unchanged** (amplihack precedence first, then
  Simard subsystems).
- Filing stays **idempotent per gap signature** through the existing
  search-before-create dedup path (`find_existing`) — one rolling tracking issue
  per distinct gap signature, never a duplicate each tick.
- `StewardshipRoutingAmbiguous` is **retained** for API/`Display` stability but
  is no longer produced by `route_failure`.

## Tests (real)

- `route_unmatched_falls_back_to_default`: `overseer` + other unmapped sources
  route to `rysweet/Simard`.
- `route_amplihack_keywords` / `route_simard_keywords` / overlap-precedence:
  unchanged, still green.
- `process_run_routes_overseer_to_default_and_dedups`: `source_module="overseer"`
  searches the default repo, files exactly one issue (`FiledNew`), then returns
  `MatchedExisting` with no second create on rerun (idempotent per signature).
- `flagged_gap_brief_source_module_routes_to_default_repo`: the exact brief the
  gap path emits routes to `rysweet/Simard`; the tick reports `errors == 0`.

## Verification

Full local suite green: `cargo test` (all pass), `cargo clippy --all-targets
--all-features -- -D warnings` clean, `cargo fmt --check` clean. No stray
`println!`/`eprintln!`, no `*Bridge` naming. Additive change; routing fails
loud only via the logged fallback (never silent). Docs updated
(concepts/stewardship-mode, reference/stewardship-api, reference/overseer-
workstream-gap-scan, howto/file-stewardship-issues).

Closes #2934

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>