### PR TITLE
feat(ooda): raise per-cycle goal-coverage parallelism ceiling to 24 (#2935)

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ simard bootstrap run <identity> <base-type> <topology> <objective>
 | `SIMARD_LLM_PROVIDER` | Override the LLM provider selected from `~/.simard/config.toml` |
 | `SIMARD_COPILOT_GH_ACCOUNT` | GitHub account for Copilot auth (e.g., `rysweet_microsoft`) |
 | `SIMARD_COMMIT_GH_ACCOUNT` | GitHub account for git commits (e.g., `rysweet`) |
+| `SIMARD_OODA_MAX_CONCURRENT` | Per-OODA-cycle goal-coverage parallelism ceiling — how many independent goals a cycle may cover. Default `24`, range `1..=64`, fail-closed to `24` on an invalid value (logged via `tracing::warn!`). Seeds the AIMD scaler base and ceiling. Legacy `SIMARD_MAX_CONCURRENT_ACTIONS` is honoured when this is unset. Raising it only *allows* more coverage — the resource-admission and overlap gates still bound actual spawns. See [OODA coverage parallelism ceiling](docs/reference/ooda-coverage-parallelism-ceiling.md). |
 
 Runtime configuration lives at `~/.simard/config.toml`. The runtime fails loudly when required configuration is missing — there are no silent defaults.
 

--- a/docs/concepts/adaptive-scaling.md
+++ b/docs/concepts/adaptive-scaling.md
@@ -6,6 +6,7 @@ owner: simard
 doc_type: concept
 related:
   - ../reference/adaptive-scaling-api.md
+  - ../reference/ooda-coverage-parallelism-ceiling.md
   - ../howto/configure-adaptive-scaling.md
   - ../daemon-mode.md
   - ../reference/ooda-brain-api.md
@@ -74,7 +75,7 @@ value on the Linux hosts where Simard typically runs.
 | Low pressure threshold | 0.3 | Below this, there is ample headroom to grow |
 | Error window | 300s (5 min) | Matches typical Copilot rate-limit reset periods |
 | Floor | 1 | Always dispatch at least one action |
-| Ceiling | `initial × 4` | Proportional to configured base; prevents runaway |
+| Ceiling | `= configured base` (default 24) | The configured per-cycle max; prevents runaway |
 
 ### Decision flow
 
@@ -119,7 +120,8 @@ scaler contains internal synchronization (`AtomicU32`, `Mutex` for the
 error window) and may be referenced from multiple action-dispatcher
 threads. The field uses `#[serde(skip)]` because the scaler is
 runtime-only — it is reconstructed from the `SIMARD_SCALING` env var
-on boot via `OodaConfig::with_env_scaler()`, not persisted.
+on boot by `OodaConfig::default()` (which consults `SIMARD_SCALING` and
+builds the `AdaptiveScaler`), not persisted.
 
 **Why not mutate `OodaConfig` directly?** `OodaConfig` is immutable
 after construction and may be shared. Cloning it into an
@@ -127,6 +129,9 @@ after construction and may be shared. Cloning it into an
 
 ## See also
 
+- [OODA coverage parallelism ceiling](../reference/ooda-coverage-parallelism-ceiling.md)
+  — the default-24 ceiling, the `SIMARD_OODA_MAX_CONCURRENT` override, and why
+  the ceiling never bypasses the resource-admission gate.
 - [Adaptive scaling API reference](../reference/adaptive-scaling-api.md)
   — Rust types, methods, and integration points.
 - [How to configure adaptive scaling](../howto/configure-adaptive-scaling.md)

--- a/docs/howto/configure-adaptive-scaling.md
+++ b/docs/howto/configure-adaptive-scaling.md
@@ -7,6 +7,7 @@ doc_type: howto
 related:
   - ../concepts/adaptive-scaling.md
   - ../reference/adaptive-scaling-api.md
+  - ../reference/ooda-coverage-parallelism-ceiling.md
   - ../daemon-mode.md
   - ./run-ooda-daemon.md
 ---
@@ -43,7 +44,7 @@ ExecStart=/usr/local/bin/simard ooda run
 ```
 
 When `SIMARD_SCALING` is unset or set to `fixed`, the daemon uses the
-static `max_concurrent_actions` value from `OodaConfig` (default: `3`).
+static `max_concurrent_actions` value from `OodaConfig` (default: `24`).
 
 ---
 
@@ -84,17 +85,46 @@ The scaler uses AIMD (Additive Increase / Multiplicative Decrease):
 - **Medium pressure** (0.3–0.8, no 429s): hold steady.
 
 The concurrency is bounded by a floor (default: 1) and ceiling
-(default: `max_concurrent_actions × 4`, e.g. 20 when the base is 5).
-The floor guarantees at least one engineer dispatch per cycle even
-under maximum pressure.
+(default: the configured `max_concurrent_actions`, i.e. **24**). The floor
+guarantees at least one engineer dispatch per cycle even under maximum
+pressure; the ceiling caps how many independent goals a single cycle can
+cover.
 
 ---
 
-## 4. Override the static fallback
+## 4. Set the concurrency ceiling
 
-When scaling is disabled (`SIMARD_SCALING=fixed` or unset), the daemon
-uses the static `max_concurrent_actions` from `OodaConfig`. This value
-defaults to `3` and can be adjusted in the config if needed.
+Both the scaler's starting value **and** its ceiling come from
+`OodaConfig.max_concurrent_actions`. Set it with `SIMARD_OODA_MAX_CONCURRENT`:
+
+```bash
+# Cover up to 40 independent goals per cycle (when resources allow).
+SIMARD_OODA_MAX_CONCURRENT=40 SIMARD_SCALING=auto simard ooda run
+```
+
+| Variable | Default | Range | Notes |
+|----------|---------|-------|-------|
+| `SIMARD_OODA_MAX_CONCURRENT` | `24` | `1..=64` | Preferred. Seeds base **and** ceiling. |
+| `SIMARD_MAX_CONCURRENT_ACTIONS` | `24` | `1..=64` | Legacy fallback, used only when the preferred variable is unset. |
+
+Both variables are **fail-closed**: a non-numeric, zero, or out-of-range value
+is rejected with a `tracing::warn!` on the `simard::ooda_loop::types` target
+(the module defining the parser, so no custom `target:` override is needed) and
+the default `24` is used instead — the daemon never applies the bad value and
+never crashes.
+
+```
+WARN simard::ooda_loop::types: invalid value for SIMARD_OODA_MAX_CONCURRENT; using default 24 key="SIMARD_OODA_MAX_CONCURRENT" value="0" min=1 max=64 default=24
+```
+
+> **24 is a ceiling, not a guarantee.** Raising this value only *allows* more
+> goals to be covered per cycle. The resource-admission gate (disk / memory /
+> load) and the overlap/dependency gate still bound how many engineers actually
+> spawn, and the AIMD scaler still backs off under pressure. See
+> [OODA coverage parallelism ceiling](../reference/ooda-coverage-parallelism-ceiling.md).
+
+When scaling is disabled (`SIMARD_SCALING=fixed` or unset), the same
+`max_concurrent_actions` value (default `24`) is used as a static cap.
 
 ---
 
@@ -156,22 +186,31 @@ set a static value.
 
 ### Want to change the floor or ceiling
 
-The floor is always 1. The ceiling defaults to `max_concurrent_actions × 4`
-(computed from `OodaConfig`). To change the effective ceiling, adjust
-`SIMARD_MAX_CONCURRENT_ACTIONS`:
+The floor is always 1. The ceiling equals the configured
+`max_concurrent_actions` (default `24`). To change the effective ceiling, set
+`SIMARD_OODA_MAX_CONCURRENT` (preferred) or the legacy
+`SIMARD_MAX_CONCURRENT_ACTIONS`, within the valid range `1..=64`:
 
 ```bash
-# Base=3 → ceiling=12, base=10 → ceiling=40
-SIMARD_MAX_CONCURRENT_ACTIONS=10 SIMARD_SCALING=auto simard ooda run
+# base = ceiling = 12
+SIMARD_OODA_MAX_CONCURRENT=12 SIMARD_SCALING=auto simard ooda run
+
+# base = ceiling = 40
+SIMARD_OODA_MAX_CONCURRENT=40 SIMARD_SCALING=auto simard ooda run
 ```
 
-Environment-variable overrides for independent floor and ceiling values
-are a candidate for a follow-up issue.
+Values outside `1..=64` (or non-numeric) are rejected and the default `24` is
+used, with a `tracing::warn!` recording the ignored value. Environment-variable
+overrides for an *independent* floor and ceiling remain a candidate for a
+follow-up issue.
 
 ---
 
 ## See also
 
+- [OODA coverage parallelism ceiling](../reference/ooda-coverage-parallelism-ceiling.md)
+  — the 24 default, `SIMARD_OODA_MAX_CONCURRENT`, and the ceiling-vs-guarantee
+  distinction.
 - [Adaptive scaling concept](../concepts/adaptive-scaling.md) — design
   rationale.
 - [Adaptive scaling API reference](../reference/adaptive-scaling-api.md)

--- a/docs/reference/adaptive-scaling-api.md
+++ b/docs/reference/adaptive-scaling-api.md
@@ -7,6 +7,7 @@ doc_type: reference
 related:
   - ../concepts/adaptive-scaling.md
   - ../howto/configure-adaptive-scaling.md
+  - ./ooda-coverage-parallelism-ceiling.md
   - ./ooda-brain-api.md
   - ../daemon-mode.md
 ---
@@ -41,6 +42,13 @@ SIMARD_SCALING=auto simard ooda run
 SIMARD_SCALING=fixed simard ooda run
 ```
 
+The scaler's **base and ceiling** (its starting value and upper bound) come
+from `OodaConfig.max_concurrent_actions`, which defaults to **24** and is
+overridable with `SIMARD_OODA_MAX_CONCURRENT` (fail-closed, range `1..=64`;
+legacy `SIMARD_MAX_CONCURRENT_ACTIONS` is honoured when the new variable is
+unset). See
+[OODA coverage parallelism ceiling](./ooda-coverage-parallelism-ceiling.md).
+
 ---
 
 ## Public API
@@ -74,9 +82,9 @@ impl AdaptiveScaler {
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `initial` | Value of `OodaConfig.max_concurrent_actions` | Starting concurrency level |
+| `initial` | Value of `OodaConfig.max_concurrent_actions` (default **24**) | Starting concurrency level |
 | `floor` | `1` | Minimum concurrency (never scales below this) |
-| `ceiling` | `initial × 4` | Maximum concurrency (scales proportionally to config) |
+| `ceiling` | `initial` (the configured max) | Maximum concurrency (equals the configured base, default **24**) |
 
 Bounds are validated on construction:
 
@@ -230,32 +238,39 @@ pub struct OodaConfig {
 `Option` because the scaler is `None` when `SIMARD_SCALING=fixed` or
 unset. `Arc` because the scaler contains atomics and a mutex and may be
 shared across the action dispatcher threads. `#[serde(skip)]` because
-the scaler is runtime-only — it is reconstructed from the
-`SIMARD_SCALING` env var on boot, not persisted to JSON.
+the scaler is runtime-only — it is rebuilt by `OodaConfig::default()`
+from the `SIMARD_SCALING` env var on boot, not persisted to JSON.
 
-When `OodaConfig` is deserialized from a snapshot, the `scaler` field
-defaults to `None`. Call `config.with_env_scaler()` after
-deserialization to reconstruct the scaler from the current environment.
+When `OodaConfig` is deserialized from a snapshot, the `scaler` field is
+skipped and stays `None` (verified by
+`ooda_config_scaler_skipped_on_serde_roundtrip`). There is no
+post-deserialization reconstruction call — the scaler is built only by
+`OodaConfig::default()`, which reads `SIMARD_SCALING` on the boot path.
 
 ### Construction
 
 The scaler is constructed during `OodaConfig::default()` when
-`SIMARD_SCALING=auto`:
+`SIMARD_SCALING=auto`. The base (`max_concurrent_actions`) is resolved from the
+environment via the fail-closed `env_u32_bounded` helper — preferring
+`SIMARD_OODA_MAX_CONCURRENT`, falling back to the legacy
+`SIMARD_MAX_CONCURRENT_ACTIONS`, else the default **24** (range `1..=64`; see
+[OODA coverage parallelism ceiling](./ooda-coverage-parallelism-ceiling.md)):
 
 ```rust
-let ceiling = max_concurrent_actions.saturating_mul(4).max(1);
+let ceiling = max_concurrent_actions.max(1); // = the configured base
 let scaler = Some(Arc::new(AdaptiveScaler::new(
     max_concurrent_actions, 1, ceiling,
 )));
 ```
 
-The ceiling is dynamic: `initial × 4` (e.g., if
-`SIMARD_MAX_CONCURRENT_ACTIONS=5`, ceiling is 20). This scales
-proportionally to the operator's configured baseline rather than
-using a fixed cap.
+The ceiling **equals the configured base** (e.g., if
+`SIMARD_OODA_MAX_CONCURRENT=24`, ceiling is 24). 24 is therefore the true
+per-cycle ceiling: the scaler starts at the base, halves toward the floor under
+pressure, and recovers `+1` per low-pressure cycle back up to the base. Raising
+the base with the env override raises the ceiling with it.
 
-The same formula is used in `with_env_scaler()` for deserialized
-configs.
+This construction lives solely in `OodaConfig::default()`; a deserialized
+config keeps `scaler: None` until a fresh default is built on boot.
 
 ### Per-cycle integration point
 
@@ -339,6 +354,9 @@ src/ooda_loop/
 
 ## See also
 
+- [OODA coverage parallelism ceiling](./ooda-coverage-parallelism-ceiling.md)
+  — the 24 default, the `SIMARD_OODA_MAX_CONCURRENT` override, and why 24 is a
+  ceiling rather than a guarantee.
 - [Adaptive scaling concept](../concepts/adaptive-scaling.md) — design
   rationale and theory.
 - [How to configure adaptive scaling](../howto/configure-adaptive-scaling.md)

--- a/docs/reference/maximum-safe-parallelism.md
+++ b/docs/reference/maximum-safe-parallelism.md
@@ -9,6 +9,7 @@ related:
   - ./concurrent-engineer-dispatch.md
   - ./goal-coverage-allocation.md
   - ./adaptive-scaling-api.md
+  - ./ooda-coverage-parallelism-ceiling.md
   - ./ooda-decide-prompt.md
   - ./simard-cli.md
   - ../concepts/adaptive-scaling.md
@@ -104,16 +105,25 @@ Pressure is `max(cpu_pressure, mem_pressure)` from `/proc/stat` and
 `report_reason`.
 
 **Production bounds.** `OodaConfig::default()` constructs the scaler as
-`AdaptiveScaler::new(base, 1, ceiling)` where `base =
-SIMARD_MAX_CONCURRENT_ACTIONS` (default **5**) and `ceiling = base × 4` (default
-**20**). Once per cycle the daemon logs the cap it used in the coverage line
-`[simard] OODA cycle: coverage — … (cap N)`, where `N` is the scaler's
-`current_max()` (or `max_concurrent_actions` when `SIMARD_SCALING` is off). That
-cap **starts at `base` and climbs additively** toward the ceiling under low
-pressure — so the machine fills over a few cycles rather than all at once. The ceiling of 20 is
-already ample for "fill the machine"; raise both the base and ceiling together
-by setting `SIMARD_MAX_CONCURRENT_ACTIONS` (the ceiling tracks at 4× the base).
-The additive-increase + pressure/error backoff behavior is unchanged by this.
+`AdaptiveScaler::new(base, 1, ceiling)` where `base` is resolved from the
+environment (preferring `SIMARD_OODA_MAX_CONCURRENT`, falling back to the legacy
+`SIMARD_MAX_CONCURRENT_ACTIONS`, else the default **24**; range `1..=64`,
+fail-closed) and `ceiling = base` (default **24**). Once per cycle the daemon
+logs the cap it used in the coverage line `[simard] OODA cycle: coverage — …
+(cap N)`, where `N` is the scaler's `current_max()` (or `max_concurrent_actions`
+when `SIMARD_SCALING` is off). That cap **starts at `base` and adapts** — it
+holds at the ceiling under low pressure, halves under CPU/memory/429 pressure,
+and recovers `+1` per calm cycle. The default ceiling of **24** lets a single
+cycle cover up to 24 genuinely-independent goals; raise or lower it with
+`SIMARD_OODA_MAX_CONCURRENT`. The additive-increase + pressure/error backoff
+behavior is unchanged by this — only the base and ceiling values moved
+(from 5/20 to 24/24). See
+[OODA coverage parallelism ceiling](./ooda-coverage-parallelism-ceiling.md).
+
+> **The ceiling is not a spawn guarantee.** 24 is the number of goals coverage
+> may *plan* per cycle; the resource-admission gate (disk / memory / load) and
+> the overlap/dependency gate still bound how many engineers actually spawn. A
+> full board at cap 24 under disk pressure still defers.
 
 > The cap is a **hard ceiling**: coverage never emits more than `cap` actions,
 > and the scaler shrinks the cap under CPU/memory/429 pressure. Filling the
@@ -218,4 +228,7 @@ The Rust parsers are untouched; the prompts keep their existing shapes:
 - [`simard goal add` CLI reference](./simard-cli.md) — the mechanism the
   decomposition uses to create one per-issue goal per distinct issue.
 - [Configure adaptive scaling](../howto/configure-adaptive-scaling.md) — how to
-  widen the ceiling via `SIMARD_MAX_CONCURRENT_ACTIONS`.
+  widen the ceiling via `SIMARD_OODA_MAX_CONCURRENT`.
+- [OODA coverage parallelism ceiling](./ooda-coverage-parallelism-ceiling.md) —
+  the default-24 ceiling, its env override, and why it never bypasses the
+  resource-admission or overlap gates.

--- a/docs/reference/ooda-coverage-parallelism-ceiling.md
+++ b/docs/reference/ooda-coverage-parallelism-ceiling.md
@@ -1,0 +1,247 @@
+---
+title: OODA coverage parallelism ceiling reference
+description: >
+  The per-OODA-cycle goal-coverage parallelism ceiling — its default of 24,
+  the SIMARD_OODA_MAX_CONCURRENT environment override (fail-closed, range
+  1..=64), how it seeds the AIMD scaler's base and ceiling, and why 24 is a
+  ceiling rather than a guarantee — the resource-admission and
+  overlap/dependency gates still bound actual engineer spawns.
+last_updated: 2026-07-07
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+status: implemented
+related:
+  - ./maximum-safe-parallelism.md
+  - ./goal-coverage-allocation.md
+  - ./adaptive-scaling-api.md
+  - ./resource-admission-api.md
+  - ../concepts/adaptive-scaling.md
+  - ../concepts/resource-aware-engineer-admission.md
+  - ../concepts/dependency-overlap-aware-scheduling.md
+  - ../howto/configure-adaptive-scaling.md
+---
+
+# OODA coverage parallelism ceiling reference
+
+> **Issue [#2935](https://github.com/rysweet/Simard/issues/2935).** The
+> per-OODA-cycle goal-coverage parallelism ceiling now defaults to **24**
+> (previously ~6 early in a run, under an AIMD ceiling of 20) and is
+> **environment-configurable** via
+> `SIMARD_OODA_MAX_CONCURRENT`. This lets Simard cover up to 24 genuinely
+> independent incomplete goals in a single cycle when the host has headroom,
+> while the resource-admission and overlap/dependency gates continue to bound
+> the number of engineers actually spawned.
+
+Modules: `simard::ooda_loop::types` (`OodaConfig`, `env_u32_bounded`),
+`simard::ooda_loop::adaptive_scaling` (`AdaptiveScaler`),
+`simard::ooda_loop::coverage` (`ensure_goal_coverage`),
+`simard::ooda_loop::cycle` (per-cycle `coverage_cap`).
+
+## The problem
+
+Each OODA cycle derives a **coverage cap** — the maximum number of distinct
+`AdvanceGoal` actions [`ensure_goal_coverage`](./goal-coverage-allocation.md)
+may emit — from the AIMD scaler's `current_max()` (or the static
+`OodaConfig.max_concurrent_actions` when `SIMARD_SCALING` is off):
+
+```rust
+let coverage_cap = config
+    .scaler
+    .as_ref()
+    .map(|s| s.current_max() as usize)
+    .unwrap_or(config.max_concurrent_actions as usize);
+```
+
+Historically `max_concurrent_actions` defaulted to **5**, and with
+`SIMARD_SCALING=auto` the AIMD ceiling was `base × 4 = 20`. So the *ceiling*
+was 20 — but the scaler *started at the base (5)* and only added `+1` per
+low-pressure cycle, so in practice the effective cap started near **6** and
+rarely climbed far toward 20 before the run ended or pressure reset it:
+
+```
+[simard] OODA cycle: coverage — covered 6/12 incomplete goals, deferred 6 due to cap (cap 6)
+```
+
+That early-run cap of ~6 was an **arbitrary low starting point**, not a
+resource limit. On a host with spare disk, memory, and CPU — and a board full
+of independent, non-overlapping goals — Simard left work uncovered every cycle
+for no safety reason.
+
+## What changed
+
+Two coupled changes raise the ceiling to 24 and make it configurable, while
+leaving every downstream safety gate intact:
+
+1. **Base default raised 5 → 24.** `OodaConfig.max_concurrent_actions` now
+   defaults to **24**. Because the coverage cap reads `current_max()`, and the
+   scaler's initial value *is* the base, raising only the AIMD ceiling would
+   have left the cap stuck near 6 — the **base** had to rise too.
+2. **AIMD ceiling = configured max.** With `SIMARD_SCALING=auto`, the scaler is
+   constructed as `AdaptiveScaler::new(base, 1, base)` — floor `1`, ceiling
+   equal to the configured base (24 by default). 24 is therefore the *true*
+   per-cycle ceiling, and the AIMD back-off/recover behaviour operates inside
+   `[1, 24]`.
+
+Both values are seeded from the same resolved number (see
+[Configuration](#configuration)), so one environment variable moves the base
+and the ceiling together.
+
+## Configuration
+
+| Variable | Default | Range | Precedence | Effect |
+| --- | --- | --- | --- | --- |
+| `SIMARD_OODA_MAX_CONCURRENT` | `24` | `1..=64` | highest | Preferred knob. Seeds both the scaler base and ceiling, and the static `max_concurrent_actions` fallback. |
+| `SIMARD_MAX_CONCURRENT_ACTIONS` | `24` | `1..=64` | legacy fallback | Still honoured when `SIMARD_OODA_MAX_CONCURRENT` is unset. Retained for backward compatibility. |
+
+**Resolution order.** The preferred variable wins whenever it is *present*.
+Each step is **fail-closed independently**: an invalid value uses the default
+**24** and does **not** fall through to a lower-precedence source (otherwise a
+typo in the preferred variable would silently resurrect a stale legacy value).
+
+1. `SIMARD_OODA_MAX_CONCURRENT` **present** → use it if valid, else **24**
+   (warn). The legacy variable is ignored in this case.
+2. else `SIMARD_MAX_CONCURRENT_ACTIONS` (legacy) **present** → use it if valid,
+   else **24** (warn).
+3. else the default **24**.
+
+```rust
+// The preferred var wins when present. An invalid *present* value fails
+// closed to 24 — it does NOT fall through to the legacy var. The legacy
+// var is consulted only when the preferred var is entirely absent.
+let max_concurrent_actions = if std::env::var("SIMARD_OODA_MAX_CONCURRENT").is_ok() {
+    env_u32_bounded("SIMARD_OODA_MAX_CONCURRENT", 24, 1, 64)
+} else {
+    env_u32_bounded("SIMARD_MAX_CONCURRENT_ACTIONS", 24, 1, 64)
+};
+```
+
+### Fail-closed validation
+
+Parsing is done by `env_u32_bounded`, a bounded, fail-closed helper. It is
+**not** the silent `env_u32` used by other config fields — an invalid value
+here would otherwise be an easy way to mis-size machine load.
+
+```rust
+/// Parse an unsigned integer from `key`, accepting only values in
+/// `min..=max`. On an absent key, returns `default` silently. On a present
+/// but non-numeric / zero / out-of-range value, logs a `tracing::warn!` and
+/// returns `default` (fail-closed) rather than propagating a bad cap.
+fn env_u32_bounded(key: &str, default: u32, min: u32, max: u32) -> u32;
+```
+
+| Input for `SIMARD_OODA_MAX_CONCURRENT` | Result | Logged? |
+| --- | --- | --- |
+| unset | fallback chain → `24` | no (absence is normal) |
+| `"24"` | `24` | no |
+| `"1"` … `"64"` | that value | no |
+| `"0"` | fallback (`24`) | yes — `tracing::warn!` |
+| `"65"` or higher | fallback (`24`) | yes — `tracing::warn!` |
+| `"abc"`, empty, `"-1"`, `"3.5"` | fallback (`24`) | yes — `tracing::warn!` |
+
+The warning is emitted on the `simard::ooda_loop::types` target — the module
+where `env_u32_bounded` is defined, so `tracing`'s default target already
+matches at runtime with no custom `target:` override needed (mirroring the
+`simard::disk_pressure` precedent, whose target is likewise its own module).
+Operators can therefore see that a bad value was ignored:
+
+```
+WARN simard::ooda_loop::types: invalid value for SIMARD_OODA_MAX_CONCURRENT; using default 24 key="SIMARD_OODA_MAX_CONCURRENT" value="99" min=1 max=64 default=24
+```
+
+There are **no** `println!` / `eprintln!` calls in the parse path — all
+diagnostics go through `tracing`.
+
+> **Why cap the range at 64?** `64` is a documented absurd-value guard: well
+> above the 24 target, but below anything a real host would sustain. It exists
+> to reject typos and overflow attempts, not to express a resource limit — the
+> resource limit is enforced later, by the admission gates.
+
+### Examples
+
+```bash
+# Default: cover up to 24 independent goals per cycle.
+SIMARD_SCALING=auto simard ooda run
+
+# Widen further on a large host (still bounded by admission gates).
+SIMARD_OODA_MAX_CONCURRENT=48 SIMARD_SCALING=auto simard ooda run
+
+# Narrow on a constrained host.
+SIMARD_OODA_MAX_CONCURRENT=8 SIMARD_SCALING=auto simard ooda run
+
+# Legacy variable still works when the new one is unset.
+SIMARD_MAX_CONCURRENT_ACTIONS=16 SIMARD_SCALING=auto simard ooda run
+
+# Invalid value → warn + fall back to 24 (does not crash, does not use 99).
+SIMARD_OODA_MAX_CONCURRENT=99 SIMARD_SCALING=auto simard ooda run
+```
+
+## 24 is a ceiling, not a guarantee
+
+The parallelism ceiling caps how many goals coverage may **plan** per cycle. It
+does **not** override the gates that decide how many engineers actually
+**spawn**. Even at cap 24, an OODA cycle may spawn far fewer engineers — or
+none — when resources are tight or work overlaps.
+
+```
+                        per-cycle pipeline (Decide → Coverage → Act → spawn)
+
+  Decide  ──►  Coverage cap (≤ 24)  ──►  Act dispatch  ──►  per-goal spawn gates
+                    │                                         │
+     up to 24 distinct AdvanceGoal            each spawn still passes through:
+     actions planned this cycle                 • overlap/dependency dedup
+                                                 • resource-admission gate
+                                                   (disk / build-cache / load)
+                                                 • disk-ceiling hard rail
+```
+
+The gates run **after** the count cap and can independently `Defer`:
+
+- **Overlap / dependency gate.** Duplicate or overlapping goals are de-duplicated
+  so two engineers never work the same item. A cap of 24 does not admit 24
+  engineers onto 24 copies of the same work. See
+  [dependency-overlap-aware scheduling](../concepts/dependency-overlap-aware-scheduling.md).
+- **Resource-admission gate.** Before each spawn, Simard reasons over the host
+  resource picture (disk %, build-cache/worktree footprint, load average,
+  in-flight builds) and returns **admit**, **defer**, or **reclaim-first**; a
+  deterministic disk-ceiling rail (`SIMARD_DISK_ADMISSION_CEILING_PCT`) blocks
+  admission regardless of the reasoning. Under disk or memory pressure it
+  defers *even when the cap is 24*. See
+  [resource-aware engineer admission](../concepts/resource-aware-engineer-admission.md)
+  and the [resource-admission API](./resource-admission-api.md).
+- **AIMD back-off.** The scaler still halves `current_max()` under CPU/memory
+  pressure or 429 errors and recovers `+1` per low-pressure cycle, so the
+  *effective* cap drops below 24 while the host is loaded and climbs back to 24
+  as it drains. See the [adaptive scaling API](./adaptive-scaling-api.md).
+
+The invariant is: **raise the ceiling to allow up to ~24 genuinely-independent
+goals to be covered per cycle when resources allow — never bypass the gates
+that keep the host safe.**
+
+## Invariants
+
+- **Effective cap ≤ 24 by default.** `coverage_cap == scaler.current_max()`,
+  and the scaler ceiling equals the configured base (24 by default), so a cycle
+  never plans more than 24 coverage actions unless the operator raised the base.
+- **Config-driven, not code-driven.** The 24 default and the `1..=64` range live
+  in `OodaConfig::default`; there is no separate hard-coded `6`.
+- **Fail-closed override.** An invalid `SIMARD_OODA_MAX_CONCURRENT` (or legacy)
+  value warns and uses the default 24; it never crashes and never applies the
+  bad number.
+- **AIMD adaptivity preserved.** The scaler still backs off on pressure/429 and
+  recovers, now inside `[1, 24]` instead of `[1, 20]`.
+- **Gates are never bypassed.** The count cap runs *before* the overlap and
+  resource-admission gates, which still `Defer` at cap 24.
+
+## Related reading
+
+- [Maximum safe parallelism](./maximum-safe-parallelism.md) — how coverage, the
+  AIMD cap, and goal decomposition combine to fill spare machine capacity.
+- [Goal coverage allocation API](./goal-coverage-allocation.md) — the allocator
+  that consumes this cap.
+- [Adaptive scaling API](./adaptive-scaling-api.md) — the AIMD scaler that
+  supplies `current_max()`.
+- [Resource-admission API](./resource-admission-api.md) — the disk/load gate
+  that still bounds spawns at cap 24.
+- [How to configure adaptive scaling](../howto/configure-adaptive-scaling.md) —
+  operator guide for the ceiling and the `SIMARD_OODA_MAX_CONCURRENT` override.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -311,6 +311,7 @@ nav:
     - CI-Health Sweep: reference/ci-health-sweep.md
     - Simard Whisperer API: reference/simard-whisperer-api.md
     - Maximum Safe Parallelism: reference/maximum-safe-parallelism.md
+    - OODA Coverage Parallelism Ceiling: reference/ooda-coverage-parallelism-ceiling.md
     - Concurrent Engineer Dispatch: reference/concurrent-engineer-dispatch.md
     - Engineer-Admission API (overlap-aware scheduling): reference/engineer-admission-api.md
     - OODA Engineer-Admission Recipe & Prompt Schema: reference/ooda-engineer-admission-recipe.md

--- a/src/ooda_actions/advance_goal/admission.rs
+++ b/src/ooda_actions/advance_goal/admission.rs
@@ -551,6 +551,37 @@ mod tests {
         }
     }
 
+    // Issue #2935: raising the per-cycle count ceiling to 24 must NOT bypass the
+    // exact-path overlap rail. Even when the daemon may spawn up to 24 engineers,
+    // a candidate whose predicted scope is fully held by a live engineer (a
+    // duplicate/overlapping goal) is deterministically deferred — a brain that
+    // would Admit is overridden. The count cap and the overlap gate are
+    // independent axes; the higher cap only raises the number of *independent*
+    // goals that may run.
+    #[test]
+    fn count_cap_24_does_not_bypass_exact_path_rail() {
+        let c = ctx(
+            "cand",
+            &["src/shared.rs"],
+            vec![engineer("other", &["src/shared.rs", "src/other.rs"])],
+        );
+        let brain = stub(EngineerAdmissionDecision::Admit {
+            rationale: "count cap is 24 — plenty of room".into(),
+        });
+        let out = evaluate_admission(&c, "task", &brain).outcome;
+        match out {
+            AdmissionOutcome::Defer { detail } => {
+                assert!(
+                    detail.contains("other"),
+                    "names the blocking engineer: {detail}"
+                );
+            }
+            other => panic!(
+                "exact-path rail must still Defer a duplicate/overlapping goal at count cap 24, got {other:?}"
+            ),
+        }
+    }
+
     // T6 — brain Err ⇒ fail OPEN to Admit (never a silent stall).
     #[test]
     fn t6_brain_error_fails_open_to_admit() {

--- a/src/ooda_actions/advance_goal/resource_admission.rs
+++ b/src/ooda_actions/advance_goal/resource_admission.rs
@@ -658,6 +658,49 @@ mod tests {
         assert!(matches!(out, ResourceAdmissionOutcome::Defer { .. }));
     }
 
+    // ── Issue #2935: raising the count ceiling to 24 must NOT bypass gates ───
+
+    // Raising the per-cycle count ceiling to 24 is a COUNT axis; the disk-ceiling
+    // rail is an independent RESOURCE axis. Even when the daemon may spawn up to
+    // 24 engineers, a candidate that would push disk past the ceiling is still
+    // deterministically deferred — the ENOSPC guard is untouched by the higher cap.
+    #[test]
+    fn count_cap_24_does_not_bypass_disk_ceiling_rail() {
+        let e = eval(
+            &ctx(Some(95.0), 90.0),
+            &stub(admit("count cap is 24 — parallelize aggressively")),
+        );
+        match e.outcome {
+            ResourceAdmissionOutcome::Defer { detail } => {
+                assert!(detail.contains("disk-ceiling"), "names the rail: {detail}");
+            }
+            other => panic!(
+                "disk-ceiling rail must still Defer a spawn past the ceiling at count cap 24, got {other:?}"
+            ),
+        }
+    }
+
+    // Memory pressure is a SOFT signal the brain reasons about. Even at count cap
+    // 24, when the reasoner Defers under memory pressure the seam yields a benign
+    // skip: the raised count ceiling never forces a spawn under pressure.
+    #[test]
+    fn count_cap_24_still_defers_under_memory_pressure() {
+        let out = eval(
+            &ctx(Some(50.0), 90.0),
+            &stub(defer("memory pressure: MemAvailable critically low")),
+        )
+        .outcome;
+        match out {
+            ResourceAdmissionOutcome::Defer { detail } => {
+                assert!(
+                    detail.contains("memory pressure"),
+                    "carries the reason: {detail}"
+                );
+            }
+            other => panic!("expected Defer under memory pressure at count cap 24, got {other:?}"),
+        }
+    }
+
     #[test]
     fn unknown_disk_admits_on_reasoning() {
         // total=0 ⇒ used_pct None ⇒ rail inert ⇒ brain Admit honored.

--- a/src/ooda_loop/adaptive_scaling.rs
+++ b/src/ooda_loop/adaptive_scaling.rs
@@ -412,4 +412,36 @@ mod tests {
             "non-AdapterInvocationFailed errors must not affect scaler"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Issue #2935: AIMD adaptivity is preserved at the raised ceiling of 24.
+    // The algorithm is unchanged; only the ceiling rises. A scaler that starts
+    // at the raised ceiling still halves on a 429 (back-off) and additively
+    // recovers back up to — but never beyond — 24.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn backs_off_and_recovers_within_raised_ceiling_of_24() {
+        let s = AdaptiveScaler::new(24, 1, 24);
+        assert_eq!(s.current_max(), 24, "starts at the raised ceiling of 24");
+
+        // High system pressure halves the limit (multiplicative back-off). Uses
+        // a fresh per-cycle pressure sample rather than a 429 so recovery is not
+        // blocked by the sticky 300s error window.
+        let after_pressure = s.adjust_with_samples(Some(0.95), None);
+        assert_eq!(
+            after_pressure, 12,
+            "high pressure must still halve even at the raised ceiling (24 → 12)"
+        );
+
+        // With pressure relieved, additive +1 per cycle recovers back toward the
+        // ceiling, clamped at 24 — never beyond.
+        for _ in 0..20 {
+            s.adjust_with_samples(None, None);
+        }
+        assert_eq!(
+            s.current_max(),
+            24,
+            "additive recovery must climb back to but never exceed the 24 ceiling"
+        );
+    }
 }

--- a/src/ooda_loop/coverage.rs
+++ b/src/ooda_loop/coverage.rs
@@ -494,4 +494,58 @@ mod tests {
             "covered 3/3 incomplete goals, deferred 0 due to cap"
         );
     }
+
+    // ── Issue #2935: raised per-cycle coverage ceiling (up to 24) ───────────
+
+    #[test]
+    fn covers_up_to_24_uncovered_incomplete_goals_at_cap_24() {
+        // With the raised ceiling and no resource pressure / no overlap, a full
+        // cycle must cover up to 24 genuinely-independent uncovered goals — the
+        // headline behavior the ceiling raise unlocks (was effectively ~6).
+        let goals: Vec<ActiveGoal> = (0..24)
+            .map(|i| goal(&format!("g{i:02}"), i, GoalProgress::NotStarted, None))
+            .collect();
+        let state = state_with(goals);
+        let mut planned: Vec<PlannedAction> = vec![];
+
+        let report = ensure_goal_coverage(&state, &mut planned, 24);
+
+        assert_eq!(
+            advance_goal_ids(&planned).len(),
+            24,
+            "all 24 uncovered incomplete goals must be covered when cap == 24"
+        );
+        assert!(planned.len() <= 24, "cap is a hard ceiling");
+        assert_eq!(report.incomplete, 24);
+        assert_eq!(report.covered, 24);
+        assert_eq!(
+            report.deferred, 0,
+            "nothing is deferred when the cap fits every goal"
+        );
+    }
+
+    #[test]
+    fn clamps_to_cap_24_when_more_than_24_goals_await_coverage() {
+        // 24 is a CEILING, not a guarantee: with 30 uncovered goals, exactly 24
+        // are covered this cycle and the 6 lowest-priority spill to the next.
+        let goals: Vec<ActiveGoal> = (0..30)
+            .map(|i| goal(&format!("g{i:02}"), i, GoalProgress::NotStarted, None))
+            .collect();
+        let state = state_with(goals);
+        let mut planned: Vec<PlannedAction> = vec![];
+
+        let report = ensure_goal_coverage(&state, &mut planned, 24);
+
+        assert_eq!(
+            planned.len(),
+            24,
+            "cap 24 is a hard ceiling on planned actions"
+        );
+        assert_eq!(report.incomplete, 30);
+        assert_eq!(report.covered, 24);
+        assert_eq!(
+            report.deferred, 6,
+            "the 6 lowest-priority goals spill to the next cycle"
+        );
+    }
 }

--- a/src/ooda_loop/tests_types.rs
+++ b/src/ooda_loop/tests_types.rs
@@ -247,7 +247,10 @@ fn action_kind_equality() {
 #[test]
 fn ooda_config_default_values() {
     let config = OodaConfig::default();
-    assert_eq!(config.max_concurrent_actions, 5);
+    // Issue #2935: the per-OODA-cycle goal-coverage parallelism ceiling was
+    // raised from the arbitrary low default of 5 to 24 (env-configurable via
+    // SIMARD_OODA_MAX_CONCURRENT).
+    assert_eq!(config.max_concurrent_actions, 24);
     assert!((config.improvement_threshold - 0.02).abs() < f64::EPSILON);
     assert_eq!(config.gym_suite_id, "progressive");
 }

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -285,10 +285,36 @@ fn default_lesson_recurrence_threshold() -> u32 {
 
 impl Default for OodaConfig {
     fn default() -> Self {
-        let max_concurrent_actions = env_u32("SIMARD_MAX_CONCURRENT_ACTIONS", 5);
+        // Issue #2935: per-OODA-cycle goal-coverage parallelism ceiling.
+        // Precedence: SIMARD_OODA_MAX_CONCURRENT (preferred) > legacy
+        // SIMARD_MAX_CONCURRENT_ACTIONS > default 24. Each source is fail-closed
+        // INDEPENDENTLY: a present-but-invalid value uses the default 24 and does
+        // NOT fall through to a lower-precedence source, so a typo in the
+        // preferred variable can never silently resurrect a stale legacy value.
+        // Both are bounds-validated to [MAX_CONCURRENT_MIN, MAX_CONCURRENT_MAX].
+        let max_concurrent_actions = if std::env::var("SIMARD_OODA_MAX_CONCURRENT").is_ok() {
+            env_u32_bounded(
+                "SIMARD_OODA_MAX_CONCURRENT",
+                DEFAULT_MAX_CONCURRENT_ACTIONS,
+                MAX_CONCURRENT_MIN,
+                MAX_CONCURRENT_MAX,
+            )
+        } else {
+            env_u32_bounded(
+                "SIMARD_MAX_CONCURRENT_ACTIONS",
+                DEFAULT_MAX_CONCURRENT_ACTIONS,
+                MAX_CONCURRENT_MIN,
+                MAX_CONCURRENT_MAX,
+            )
+        };
         let scaler = match std::env::var("SIMARD_SCALING").as_deref() {
             Ok("auto") => {
-                let ceiling = max_concurrent_actions.saturating_mul(4).max(1);
+                // Issue #2935: the AIMD ceiling IS the configured max (was 4×).
+                // This makes the configured value a TRUE per-cycle ceiling — 24
+                // means at most 24, not 96 — while the scaler still backs off on
+                // pressure and additively recovers up to, never beyond, the
+                // ceiling. It starts at the max so the cap is reached at once.
+                let ceiling = max_concurrent_actions.max(MAX_CONCURRENT_MIN);
                 Some(std::sync::Arc::new(
                     super::adaptive_scaling::AdaptiveScaler::new(
                         max_concurrent_actions,
@@ -334,6 +360,52 @@ fn env_u32(key: &str, default: u32) -> u32 {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(default)
+}
+
+/// Default per-OODA-cycle goal-coverage parallelism ceiling (issue #2935).
+///
+/// Raised from the arbitrary historical value of 5 to 24 so that, when
+/// resources allow and goals are genuinely independent, a single cycle can
+/// cover up to 24 uncovered incomplete goals instead of the ~6 previously
+/// observed live. This is a CEILING, not a guarantee: the resource-aware
+/// admission gate and the overlap/dependency gate still bound actual spawns.
+pub const DEFAULT_MAX_CONCURRENT_ACTIONS: u32 = 24;
+
+/// Lower bound for a validated concurrency override. Zero would stall the
+/// daemon (no action could ever dispatch), so 1 is the minimum sane value.
+pub const MAX_CONCURRENT_MIN: u32 = 1;
+
+/// Upper bound for a validated concurrency override. Well above the 24 target
+/// yet below anything resource-realistic; values beyond this are treated as an
+/// operator misconfiguration and rejected (fail closed).
+pub const MAX_CONCURRENT_MAX: u32 = 64;
+
+/// Parses an unsigned-integer env var with fail-closed bounds validation.
+///
+/// - Absent key → returns `default` silently (an unset var is not a
+///   misconfiguration, so it does not warrant a warning).
+/// - Present but non-numeric, or numeric yet outside `[min, max]` → logs a
+///   `tracing::warn!` and returns `default`. Failing closed means a bad
+///   operator value can never silently escalate concurrency or stall the
+///   daemon; the effective value is always the known-safe fallback.
+fn env_u32_bounded(key: &str, default: u32, min: u32, max: u32) -> u32 {
+    match std::env::var(key) {
+        Err(_) => default,
+        Ok(raw) => match raw.trim().parse::<u32>() {
+            Ok(v) if v >= min && v <= max => v,
+            _ => {
+                tracing::warn!(
+                    key,
+                    value = %raw,
+                    min,
+                    max,
+                    default,
+                    "invalid value for {key}; using default {default}"
+                );
+                default
+            }
+        },
+    }
 }
 
 /// Serializable view of [`OodaState`] suitable for round-tripping through
@@ -509,7 +581,9 @@ mod tests_ooda_config {
     #[serial_test::serial(cognitive_memory)]
     #[test]
     fn ooda_config_creates_scaler_when_scaling_auto() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         unsafe { std::env::set_var("SIMARD_SCALING", "auto") };
         let config = OodaConfig::default();
         unsafe { std::env::remove_var("SIMARD_SCALING") };
@@ -522,7 +596,9 @@ mod tests_ooda_config {
     #[serial_test::serial(cognitive_memory)]
     #[test]
     fn ooda_config_no_scaler_when_scaling_fixed() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         unsafe { std::env::set_var("SIMARD_SCALING", "fixed") };
         let config = OodaConfig::default();
         unsafe { std::env::remove_var("SIMARD_SCALING") };
@@ -535,7 +611,9 @@ mod tests_ooda_config {
     #[serial_test::serial(cognitive_memory)]
     #[test]
     fn ooda_config_no_scaler_when_scaling_unset() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         unsafe { std::env::remove_var("SIMARD_SCALING") };
         let config = OodaConfig::default();
         assert!(
@@ -550,7 +628,9 @@ mod tests_ooda_config {
     #[serial_test::serial(cognitive_memory)]
     #[test]
     fn ooda_config_default_distill_thresholds() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         unsafe { std::env::remove_var("SIMARD_DISTILL_MIN_EPISODES") };
         unsafe { std::env::remove_var("SIMARD_DISTILL_INTERVAL_CYCLES") };
         let config = OodaConfig::default();
@@ -569,7 +649,9 @@ mod tests_ooda_config {
     #[serial_test::serial(cognitive_memory)]
     #[test]
     fn ooda_config_default_lesson_recurrence_threshold() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         unsafe { std::env::remove_var("SIMARD_LESSON_RECURRENCE_THRESHOLD") };
         let config = OodaConfig::default();
         assert_eq!(
@@ -578,27 +660,45 @@ mod tests_ooda_config {
         );
     }
 
+    // Issue #2935: the AIMD ceiling is now the *configured max* itself (was
+    // `4 × max`). This makes the configured value a TRUE per-cycle ceiling —
+    // e.g. 24 means at most 24, not 96 — while the scaler still backs off on
+    // pressure and recovers back up to the ceiling. The scaler therefore also
+    // starts AT the configured max, so the per-cycle cap reaches it immediately.
     #[serial_test::serial(cognitive_memory)]
     #[test]
-    fn ooda_config_auto_scaler_ceiling_is_4x_max() {
-        let _lock = ENV_LOCK.lock().unwrap();
+    fn ooda_config_auto_scaler_ceiling_equals_configured_max() {
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        clear_concurrency_env();
         unsafe { std::env::set_var("SIMARD_SCALING", "auto") };
-        unsafe { std::env::set_var("SIMARD_MAX_CONCURRENT_ACTIONS", "3") };
+        unsafe { std::env::set_var("SIMARD_OODA_MAX_CONCURRENT", "8") };
         let config = OodaConfig::default();
-        unsafe { std::env::remove_var("SIMARD_SCALING") };
-        unsafe { std::env::remove_var("SIMARD_MAX_CONCURRENT_ACTIONS") };
+        clear_concurrency_env();
         let scaler = config.scaler.expect("scaler must be Some under auto");
         assert_eq!(
             scaler.ceiling(),
-            12,
-            "ceiling must be 4 × max_concurrent_actions=3"
+            8,
+            "AIMD ceiling must equal the configured max (issue #2935), not a 4x multiple"
+        );
+        assert_eq!(
+            config.max_concurrent_actions, 8,
+            "SIMARD_OODA_MAX_CONCURRENT must seed max_concurrent_actions"
+        );
+        assert_eq!(
+            scaler.current_max(),
+            8,
+            "the scaler starts at the configured max so the per-cycle cap reaches it immediately"
         );
     }
 
     #[serial_test::serial(cognitive_memory)]
     #[test]
     fn ooda_config_auto_scaler_adjust_returns_within_bounds() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         unsafe { std::env::set_var("SIMARD_SCALING", "auto") };
         unsafe { std::env::set_var("SIMARD_MAX_CONCURRENT_ACTIONS", "5") };
         let config = OodaConfig::default();
@@ -617,7 +717,9 @@ mod tests_ooda_config {
     #[serial_test::serial(cognitive_memory)]
     #[test]
     fn ooda_config_scaler_skipped_on_serde_roundtrip() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         unsafe { std::env::set_var("SIMARD_SCALING", "auto") };
         let config = OodaConfig::default();
         unsafe { std::env::remove_var("SIMARD_SCALING") };
@@ -628,6 +730,223 @@ mod tests_ooda_config {
         assert!(
             deserialized.scaler.is_none(),
             "scaler must be None after serde round-trip (#[serde(skip)])"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #2935: SIMARD_OODA_MAX_CONCURRENT parsing, precedence, and
+    // fail-closed validation. The per-OODA-cycle goal-coverage parallelism
+    // ceiling is raised from the arbitrary 5 to 24 and made env-configurable.
+    //
+    // All assertions go through the public `OodaConfig::default()` contract
+    // (not the private parser) so the crate keeps compiling in the red phase
+    // and the tests exercise the real end-to-end wiring.
+    // -----------------------------------------------------------------------
+
+    /// Remove every env var that influences the per-cycle concurrency ceiling so
+    /// each test starts from a known-clean baseline (order-independent, no leakage).
+    fn clear_concurrency_env() {
+        unsafe { std::env::remove_var("SIMARD_OODA_MAX_CONCURRENT") };
+        unsafe { std::env::remove_var("SIMARD_MAX_CONCURRENT_ACTIONS") };
+        unsafe { std::env::remove_var("SIMARD_SCALING") };
+    }
+
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn max_concurrent_defaults_to_24_when_unset() {
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        clear_concurrency_env();
+        let config = OodaConfig::default();
+        assert_eq!(
+            config.max_concurrent_actions, 24,
+            "with no override, the per-cycle concurrency default must be 24 (issue #2935)"
+        );
+    }
+
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn simard_ooda_max_concurrent_overrides_default() {
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        clear_concurrency_env();
+        unsafe { std::env::set_var("SIMARD_OODA_MAX_CONCURRENT", "30") };
+        let config = OodaConfig::default();
+        clear_concurrency_env();
+        assert_eq!(
+            config.max_concurrent_actions, 30,
+            "a valid SIMARD_OODA_MAX_CONCURRENT must override the default"
+        );
+    }
+
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn legacy_simard_max_concurrent_actions_still_honored() {
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        clear_concurrency_env();
+        unsafe { std::env::set_var("SIMARD_MAX_CONCURRENT_ACTIONS", "10") };
+        let config = OodaConfig::default();
+        clear_concurrency_env();
+        assert_eq!(
+            config.max_concurrent_actions, 10,
+            "the legacy var remains functional when the new var is unset (additive change)"
+        );
+    }
+
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn new_var_takes_precedence_over_legacy_var() {
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        clear_concurrency_env();
+        unsafe { std::env::set_var("SIMARD_OODA_MAX_CONCURRENT", "30") };
+        unsafe { std::env::set_var("SIMARD_MAX_CONCURRENT_ACTIONS", "10") };
+        let config = OodaConfig::default();
+        clear_concurrency_env();
+        assert_eq!(
+            config.max_concurrent_actions, 30,
+            "SIMARD_OODA_MAX_CONCURRENT must take precedence over the legacy var"
+        );
+    }
+
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn non_numeric_override_fails_closed_to_default_24() {
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        clear_concurrency_env();
+        unsafe { std::env::set_var("SIMARD_OODA_MAX_CONCURRENT", "not-a-number") };
+        let config = OodaConfig::default();
+        clear_concurrency_env();
+        assert_eq!(
+            config.max_concurrent_actions, 24,
+            "a non-numeric override must fail closed to the default 24 (and log a warning)"
+        );
+    }
+
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn invalid_preferred_var_does_not_fall_through_to_legacy() {
+        // Documented fail-closed-INDEPENDENT contract (issue #2935): when the
+        // preferred var is PRESENT but invalid, resolution fails closed to the
+        // default 24 and must NOT resurrect an otherwise-valid legacy value — a
+        // typo in SIMARD_OODA_MAX_CONCURRENT should not silently apply stale
+        // SIMARD_MAX_CONCURRENT_ACTIONS config.
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        clear_concurrency_env();
+        unsafe { std::env::set_var("SIMARD_OODA_MAX_CONCURRENT", "not-a-number") };
+        unsafe { std::env::set_var("SIMARD_MAX_CONCURRENT_ACTIONS", "10") };
+        let config = OodaConfig::default();
+        clear_concurrency_env();
+        assert_eq!(
+            config.max_concurrent_actions, 24,
+            "an invalid PRESENT preferred var must fail closed to 24, not fall through to the legacy 10"
+        );
+    }
+
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn zero_override_is_rejected_and_fails_closed_to_24() {
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        clear_concurrency_env();
+        unsafe { std::env::set_var("SIMARD_OODA_MAX_CONCURRENT", "0") };
+        let config = OodaConfig::default();
+        clear_concurrency_env();
+        assert_eq!(
+            config.max_concurrent_actions, 24,
+            "0 is below the minimum of 1; fail closed to 24 (a zero cap would stall the daemon)"
+        );
+    }
+
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn over_max_override_is_rejected_and_fails_closed_to_24() {
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        clear_concurrency_env();
+        unsafe { std::env::set_var("SIMARD_OODA_MAX_CONCURRENT", "9999") };
+        let config = OodaConfig::default();
+        clear_concurrency_env();
+        assert_eq!(
+            config.max_concurrent_actions, 24,
+            "a value above the sane maximum (64) must fail closed to 24"
+        );
+    }
+
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn boundary_values_1_and_64_are_accepted() {
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        clear_concurrency_env();
+        unsafe { std::env::set_var("SIMARD_OODA_MAX_CONCURRENT", "1") };
+        let low = OodaConfig::default();
+        assert_eq!(
+            low.max_concurrent_actions, 1,
+            "the minimum boundary (1) must be accepted"
+        );
+        unsafe { std::env::set_var("SIMARD_OODA_MAX_CONCURRENT", "64") };
+        let high = OodaConfig::default();
+        clear_concurrency_env();
+        assert_eq!(
+            high.max_concurrent_actions, 64,
+            "the maximum boundary (64) must be accepted"
+        );
+    }
+
+    // ── The per-cycle coverage cap actually reaches 24 (cycle.rs:316) ───────
+
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn default_coverage_cap_reaches_24_under_auto_scaling() {
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        clear_concurrency_env();
+        unsafe { std::env::set_var("SIMARD_SCALING", "auto") };
+        let config = OodaConfig::default();
+        clear_concurrency_env();
+        // Mirror the per-cycle coverage-cap derivation in cycle.rs (issue #2935
+        // target site): the AIMD scaler's current_max, else max_concurrent_actions.
+        let cap = config
+            .scaler
+            .as_ref()
+            .map(|s| s.current_max() as usize)
+            .unwrap_or(config.max_concurrent_actions as usize);
+        assert_eq!(
+            cap, 24,
+            "with the raised ceiling, the AIMD per-cycle coverage cap must reach 24"
+        );
+    }
+
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn default_coverage_cap_reaches_24_under_fixed_scaling() {
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        clear_concurrency_env(); // SIMARD_SCALING unset ⇒ scaler is None
+        let config = OodaConfig::default();
+        let cap = config
+            .scaler
+            .as_ref()
+            .map(|s| s.current_max() as usize)
+            .unwrap_or(config.max_concurrent_actions as usize);
+        assert_eq!(
+            cap, 24,
+            "with fixed scaling the cap is max_concurrent_actions, which now defaults to 24"
         );
     }
 }

--- a/src/operator_commands_ooda/tests/report_tests.rs
+++ b/src/operator_commands_ooda/tests/report_tests.rs
@@ -7,7 +7,8 @@ use crate::{CognitiveStatistics, GoalProgress};
 #[test]
 fn ooda_config_default_values() {
     let config = OodaConfig::default();
-    assert_eq!(config.max_concurrent_actions, 5);
+    // Issue #2935: raised from 5 to 24 (env-configurable via SIMARD_OODA_MAX_CONCURRENT).
+    assert_eq!(config.max_concurrent_actions, 24);
     assert!(
         (config.improvement_threshold - 0.02).abs() < f64::EPSILON,
         "improvement_threshold should be 0.02"
@@ -163,9 +164,10 @@ fn ooda_config_gym_suite_id_is_progressive() {
 }
 
 #[test]
-fn ooda_config_max_concurrent_is_three() {
+fn ooda_config_max_concurrent_defaults_to_24() {
     let config = OodaConfig::default();
-    assert_eq!(config.max_concurrent_actions, 5);
+    // Issue #2935: raised from 5 to 24 (env-configurable via SIMARD_OODA_MAX_CONCURRENT).
+    assert_eq!(config.max_concurrent_actions, 24);
 }
 
 // --- report field accessors ---


### PR DESCRIPTION
## Summary

Raises Simard's per-OODA-cycle goal-coverage parallelism ceiling from the arbitrary ~6 observed live to **24**, and makes it environment-configurable. Closes #2935.

### Root cause
`OodaConfig.max_concurrent_actions` defaulted to **5**. Under `SIMARD_SCALING=auto` the AIMD scaler *started at that base* and climbed `+1`/cycle under a `base × 4` ceiling, so the effective coverage cap sat near **6** early in a run:

```
[simard] OODA cycle: coverage — covered 6/12 incomplete goals, deferred 6 due to cap (cap 6)
```

Raising only the ceiling would not have helped — the **base** had to rise too.

## Changes (additive)

- **`OodaConfig::default`** now resolves `max_concurrent_actions` from `SIMARD_OODA_MAX_CONCURRENT` (preferred) > legacy `SIMARD_MAX_CONCURRENT_ACTIONS` > default **24**.
- New **fail-closed bounded parser** `env_u32_bounded` (range `1..=64`). Each source is fail-closed **independently**: a present-but-invalid preferred value logs `tracing::warn!` and uses **24** rather than resurrecting a stale legacy value. Absent keys are silent.
- **AIMD ceiling now equals the configured max** (was `base × 4`), making the configured value a *true* per-cycle ceiling. AIMD back-off/recovery is unchanged and operates inside `[1, max]`.

## Safety: 24 is a ceiling, not a guarantee

The resource-aware admission gate (disk / memory / load) and the overlap/dependency gate are **untouched** and still bound actual spawns. The higher cap only *allows* up to ~24 genuinely-independent goals to be covered per cycle when resources permit. New tests prove both gates still `Defer` at cap 24 under pressure/overlap.

## Tests

- Env precedence, bounds-checking, and fail-closed validation (incl. "invalid preferred var does not fall through to legacy").
- Per-cycle coverage cap reaches 24 under both `auto` and `fixed` scaling.
- `ensure_goal_coverage` covers up to 24 independent goals and clamps at 24.
- AIMD backs off and recovers within the raised 24 ceiling.
- Admission + overlap gates still defer at cap 24 under simulated disk/memory pressure and duplicate goals.

## Docs

- New `docs/reference/ooda-coverage-parallelism-ceiling.md`.
- Updated adaptive-scaling concept/how-to/API docs, `maximum-safe-parallelism.md`, README env-var table, and mkdocs nav.

## Verification

- `cargo fmt --check` ✓
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓
- `cargo test --lib --all-features` → 7991 passed, 0 failed ✓
- OODA integration test binaries (`ooda`, `adaptive_scaling`, `recipe_ooda_step_parity`, `ooda_daemon`) ✓
- `mkdocs build --strict` ✓
- All pre-commit + pre-push hooks passed (no `--no-verify`/`--admin`).