### PR TITLE
fix(dashboard): live goal-board read unions snapshot + goal-store overlay (#2922)

### DIFF
--- a/docs/reference/dashboard-live-goal-board-read.md
+++ b/docs/reference/dashboard-live-goal-board-read.md
@@ -1,0 +1,373 @@
+---
+title: Dashboard live goal-board read
+description: >
+  How the dashboard Goals tab and the Memory tab's "Goal Records" tile read the
+  LIVE goal state instead of the periodically-rewritten `goal-board:snapshot`
+  fact. Documents the root cause (a snapshot the daemon rewrites only ~once per
+  OODA cycle, so creative-idea Proposed goals and other cognitive-memory goal
+  records lag up to ~5 minutes), the shipped fix — a single fail-closed live
+  builder `dashboard_live_goal_board` that unions the snapshot-fact board with a
+  live `CognitiveMemoryGoalStore::list()` overlay, deduped by slug (board wins) —
+  the new reverse adapter `record_as_active_goal`, the repointed `GET /api/goals`
+  and `GET /api/memory` read paths, the fail-closed contract (no silent fallback
+  to stale data), the preserved `{active, backlog, active_count, backlog_count}`
+  shape, the TUI parity, and the regression tests. Fixes issue #2922.
+last_updated: 2026-07-07
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+status: current — shipped; the read path is live, the per-cycle snapshot WRITE is
+  retained for history/other consumers
+related:
+  - ./goal-board-api.md
+  - ./dashboard-goal-lifecycle-status.md
+  - ./dashboard-goal-hierarchy-priority.md
+  - ./creative-ideas-trigger-scoped-read.md
+  - ./creative-ideas-goal-routing-fail-closed.md
+  - ./cognitive-memory-goal-store.md
+  - ../dashboard.md
+---
+
+# Dashboard live goal-board read
+
+The dashboard **Goals** tab renders the goal register: active top-N goals with
+priority, status, and current activity, plus the proposed backlog. On a **live**
+brain, promoting a creative idea (or unblocking a goal, or any mutation that
+persists a goal record) **did not show up on the board until the next OODA cycle**
+— a lag of up to ~5 minutes. The `POST /api/creative-ideas/{id}/promote` call
+returned the newly-persisted **Proposed** goal, yet `GET /api/goals`
+(`active` / `backlog`) and the Memory tab's **Goal Records** count stayed
+unchanged until the daemon happened to rewrite its snapshot.
+
+This page documents the shipped fix. The board **read** is now **live**: both
+`GET /api/goals` and the `goal_records` tile in `GET /api/memory` read a union of
+the authoritative snapshot-fact board **and** a live `CognitiveMemoryGoalStore`
+overlay, so a goal record appears the instant it is persisted — no snapshot cycle
+required. The per-cycle snapshot **write** is unchanged (it is still useful as a
+durable history/summary artifact); only the READ moved off the stale fact.
+
+!!! note "Status — shipped; fail-closed (#2922)"
+    The fix is implemented and green in CI: the live builder
+    `dashboard_live_goal_board`, the reverse adapter `record_as_active_goal`,
+    the repointed `goals_at` / `memory_metrics` read paths, and the regression
+    tests all land against the real code seams. The read is **fail-closed**:
+    there is no fallback to the stale snapshot that could mask a live-read
+    failure — any leg error surfaces as an explicit error payload, never as
+    silently-stale or partial data. Additive only (no response-shape change). No
+    type or method contains the word `Bridge` (operator preference); no stray
+    `println!` / `eprintln!` (tracing only).
+
+---
+
+## Root cause — the read was pinned to a periodically-written cache
+
+Two goal-writing paths exist, and they land in **different** places:
+
+| Writer | Persists to | Freshness on the board (before #2922) |
+|---|---|---|
+| OODA daemon `commit_cycle`, and every dashboard/CLI operator mutation (add / promote / unblock / remove) via `dashboard_save_goal_board*` | the `goal-board:snapshot` fact (`load_goal_board` / `save_goal_board`) | operator mutations were read-your-writes through the snapshot; **daemon-authored** changes refreshed only when the cycle rewrote the fact (~once / ~5 min) |
+| Creative-ideas promote, meeting-derived goals, runtime sessions, seed | a `goal-store:record` fact via `CognitiveMemoryGoalStore::put` (see [Cognitive-Memory Goal Store](./cognitive-memory-goal-store.md)) | **never** on the board until the daemon's next OODA cycle folded the record into the board and rewrote the snapshot |
+
+The dashboard read used only the first source:
+
+```
+READ PATH (before #2922) — snapshot-only, stale for goal-store records
+----------------------------------------------------------------------
+GET /api/goals
+  goals_at(state_root)
+    dashboard_goal_board_snapshot(state_root).unwrap_or_default()
+      open_reader_client(state_root) -> load_goal_board(reader.ops())
+        read_latest_snapshot("goal-board:snapshot")   <-- rewritten ~1×/cycle
+
+GET /api/memory  (goal_records tile)
+  memory_metrics()
+    dashboard_goal_board_snapshot(state_root).ok()
+      => goal_count = board.active.len() + board.backlog.len()
+```
+
+A creative-idea promote writes a **Proposed** `goal-store:record`, which the
+snapshot fact does not contain, so `goals_at` and the `goal_records` count could
+not see it until the next cycle. Two further defects compounded the staleness:
+
+* **`unwrap_or_default()` masked failures.** A live-read error degraded silently
+  to an empty board (`GoalBoard::default()`), so an outage looked like "no
+  goals" rather than an error — a fail-open behavior #2922 removes.
+* **Raising the snapshot cadence is not a fix.** It only shortens the lag window
+  and cannot make creative-idea `put`s appear immediately; those records are not
+  in the snapshot at all.
+
+## The fix — one fail-closed live builder, union of two live sources
+
+The read path now goes through a single helper, `dashboard_live_goal_board`,
+that builds the board from **two live sources** and dedupes them:
+
+```
+READ PATH (after #2922) — live union, fail-closed
+-------------------------------------------------
+GET /api/goals / GET /api/memory
+  dashboard_live_goal_board(state_root)  -> SimardResult<GoalBoard>
+    base    = dashboard_goal_board_snapshot(state_root)?        // snapshot-fact board (operator RYOW)
+    overlay = CognitiveMemoryGoalStore::new(state_root)?.list()? // LIVE goal-store records (#2896 fail-closed)
+    union:  base.active/base.backlog
+            + record_as_active_goal(record) for each overlay record
+              whose slug is NOT already present in base   // board wins on conflict
+```
+
+* **Base** — the authoritative snapshot-fact board via
+  `dashboard_goal_board_snapshot`. This already gives operator dashboard/CLI
+  mutations read-your-writes (they persist the snapshot synchronously) and
+  carries the daemon-OODA active/backlog goals with their rich fields
+  (`current_activity`, `wip_refs`, `repo`, `parent_goal_id`,
+  `priority_explicit`, `labels`).
+* **Overlay** — the **live** `CognitiveMemoryGoalStore::list()` records. This is
+  the same shared live store the creative-ideas / meeting / runtime / seed
+  writers `put` into, read through the same reader tiers the daemon writer
+  serves. `list()` is already **fail-closed** (issue #2896 —
+  `list_via_reader` propagates a transport fault as `Err`, never a masked empty),
+  so the overlay never coerces an outage into "no goals".
+* **Dedup by slug, board wins.** A record whose `slug` already appears in the
+  base board (active or backlog) is dropped — the base carries the richer,
+  authoritative fields. The base slug set is built with `goal_slug(active.id)` /
+  `goal_slug(item.id)` — the **same** slug function the forward
+  `active_goals_as_records` adapter uses — because an `ActiveGoal.id` is not
+  guaranteed to already be a slug; comparing raw ids would let a slugged overlay
+  record slip past dedup and double-render. Only records *absent* from the base
+  (e.g. a freshly promoted creative-idea Proposed goal) are added. Single-pass
+  `O(n)` over the pre-built slug set; the base board's flock/read is released
+  before the overlay read.
+
+Because the overlay is read live on every request, a promoted creative-idea
+Proposed goal, an unblock, or any other `goal-store:record` write appears on the
+board **immediately**, with no dependence on the snapshot cadence.
+
+### New reverse adapter — `record_as_active_goal`
+
+Module `simard::goal_curation` (`src/goal_curation/operations.rs`). It is the
+inverse of the existing `active_goals_as_records` (which maps board → records);
+`record_as_active_goal` maps a persisted `GoalRecord` back into the board's
+`ActiveGoal` / `BacklogItem` shapes so overlay records render identically to
+snapshot goals. Pure struct-mapping — panic-free on arbitrary record text, and
+it synthesizes absent rich fields as `None` / `[]` so the JSON stays byte-stable.
+
+Status routing (mirrors the board's own active/backlog split and the lifecycle
+in [Dashboard Goal Lifecycle-Status Badges](./dashboard-goal-lifecycle-status.md)):
+
+| `GoalRecord.status` (`GoalStatus`) | Placement | Rendered `GoalProgress` |
+|---|---|---|
+| `Active` | `active[]` | `InProgress { percent: 0 }` |
+| `Proposed` | `backlog[]` | — (Proposed record → backlog item) |
+| `Paused` | `backlog[]` | — |
+| `Completed` | **skipped** | terminal; not surfaced on the live board |
+
+Field synthesis when mapping a record into an `ActiveGoal`:
+
+| `ActiveGoal` field | From `GoalRecord` |
+|---|---|
+| `id` | `record.slug` |
+| `description` | `record.title` |
+| `priority` | `record.priority as u32` |
+| `status` | per the status table above |
+| `assigned_to` | `Some(record.owner_identity)` (`None` when `"unassigned"`) |
+| `labels` | `record.labels` (carries `source:creative-ideas` etc.) |
+| `repo`, `current_activity`, `parent_goal_id` | `None` |
+| `wip_refs` | `[]` |
+| `priority_explicit` | `false` |
+
+When mapping a Proposed/Paused record into a `BacklogItem`: `id = record.slug`,
+`description = record.title`, `source` is a plain-English provenance label
+derived from the record's `source:*` label (e.g. `"From creative ideas"`), and
+`score` is synthesized deterministically from `record.priority` (higher priority
+→ higher score) so backlog ordering is stable.
+
+The primary #2922 case — a promoted creative idea — persists a **Proposed**
+`goal-store:record`, so it lands in `backlog[]` and shows up on the Goals tab's
+proposed backlog the instant the promote returns.
+
+#### Round-trip fidelity (inherent, not a regression)
+
+A `GoalRecord` persists only the four `GoalStatus` values and a small field set,
+so mapping a record **back** into an `ActiveGoal` cannot recover the finer state
+a snapshot-authored goal carries. Because the forward `active_goals_as_records`
+already collapses `GoalProgress::InProgress` / `NotStarted` / `Blocked` →
+`GoalStatus::Active` and does not persist `percent` or `current_activity`, an
+`Active` overlay record renders as `InProgress { percent: 0 }` with
+`current_activity = None`; likewise `title` is the record's ≤120-char first line
+and `rationale` is not restored. This loss is confined to overlay records that
+are **not** already on the base board — snapshot goals keep their rich fields
+because the base wins on dedup. The lossiness is inherent to the record schema,
+so no code change removes it; it is documented here for accuracy.
+
+## Dashboard HTTP contract (unchanged shape)
+
+### `GET /api/goals`
+
+Shape is **byte-identical** to before #2922 — the meeting-fact backlog
+enrichment and the priority-ASC active ordering (p1 highest first, id tiebreak)
+are preserved; only the data is now live:
+
+```json
+{
+  "active": [
+    {
+      "id": "…",
+      "description": "…",
+      "priority": 2,
+      "parent_goal_id": null,
+      "priority_explicit": false,
+      "status": "active",
+      "status_progress": { "InProgress": { "percent": 40 } },
+      "assigned_to": "…",
+      "repo": null,
+      "current_activity": "…",
+      "status_chip": "…",
+      "detail": "…",
+      "detail_full": "…",
+      "wip_refs": []
+    }
+  ],
+  "backlog": [
+    { "id": "improve-recall-precision", "description": "Improve recall precision", "source": "From creative ideas", "score": 0.8 }
+  ],
+  "active_count": 1,
+  "backlog_count": 1
+}
+```
+
+`active_count` / `backlog_count` reflect the **live union**, so a newly promoted
+Proposed goal both appears in `backlog` and increments `backlog_count` on the
+very next poll.
+
+### `GET /api/memory` — `goal_records` tile
+
+The `goal_records` count is derived from the same live union (active + backlog),
+and the `source` label is relabeled off the snapshot to reflect the live read.
+An additive `error` field surfaces a live-read failure; on error the count is
+**excluded** from `total_facts` rather than contributing a stale or zero value:
+
+```json
+{
+  "goal_records": {
+    "source": "cognitive-memory:live-goal-board",
+    "count": 7
+  }
+}
+```
+
+```json
+{
+  "goal_records": {
+    "source": "cognitive-memory:live-goal-board",
+    "count": 0,
+    "error": "goal-board read failed"
+  }
+}
+```
+
+## Fail-closed contract
+
+The read path is **additive and fail-closed** — there is no fallback to the
+stale snapshot and no path that silently serves empty/partial data on failure:
+
+* `goals_at` and `memory_metrics` no longer call `unwrap_or_default()` on the
+  board read. Either leg failing (snapshot base read **or** goal-store overlay
+  `list()`) is surfaced, not swallowed.
+* On failure, `GET /api/goals` returns an explicit fail-closed payload with
+  zeroed counts and an `error` field — never a snapshot/stale board:
+
+  ```json
+  { "active": [], "backlog": [], "active_count": 0, "backlog_count": 0, "error": "goal-board read failed" }
+  ```
+
+  The error message is **generic**; the underlying error chain (paths, env) is
+  logged server-side via `tracing` only, never returned to the client and never
+  emitted via `println!` / `eprintln!`.
+* **The Goals tab renders the `error` field as an explicit failure state.** An
+  empty `active`/`backlog` *with* `error` set means the live read failed — it is
+  not "no goals". The frontend surfaces it distinctly (banner/toast) so a
+  fail-closed outage is never visually indistinguishable from a legitimately
+  empty board; otherwise the client would fail-open at the UI layer even though
+  the handler failed closed.
+* The overlay uses `CognitiveMemoryGoalStore::list()`, which is already
+  fail-closed (#2896): a reader-open or `search_facts` transport fault
+  propagates as `Err`. The dashboard **must not** substitute the snapshot to
+  paper over such a fault — that would reintroduce exactly the silent staleness
+  #2922 removes.
+* The per-cycle snapshot **write** (`overwrite_memory_cache` on the daemon) is
+  **retained** as a durable history/summary artifact. It is no longer on any
+  dashboard READ path.
+
+## Terminal UI parity
+
+The TUI Goals view (`src/bin/simard_tui/goals.rs`, `read_goal_board`) applies the
+same live union so the terminal board matches the web dashboard — a promoted
+creative-idea Proposed goal appears in `monitor-simard-with-tui` without waiting
+for a snapshot cycle. This TUI parity is the **secondary, separately-shippable**
+slice of #2922: it may land in a follow-up behind an explicit flag without
+holding up the web-dashboard read fix, which is the primary deliverable. (Today
+`read_goal_board` still calls `unwrap_or_default()`; the live union replaces it
+when this slice ships.) See [simard-tui Dashboard](./simard-tui.md).
+
+## Regression tests
+
+* **`src/operator_commands_dashboard/tests_goals_crud.rs`** — the existing goal
+  CRUD/route tests stay green (the response shape and operator round-trips are
+  unchanged).
+* **`src/operator_commands_dashboard/tests_goal_records_migration.rs`** — the
+  `goal_records` tile keeps working; the count now comes from the live union.
+* **`src/goal_curation/operations.rs` (adapter unit tests)** —
+  `record_as_active_goal` status mapping (Active → active, Proposed/Paused →
+  backlog, Completed → skipped), absent-field synthesis, and panic-free mapping
+  of arbitrary record text.
+* **Live-read test (the #2922 acceptance)** — using a real
+  `CognitiveMemoryGoalStore` + snapshot base: persist a **Proposed** goal record
+  (as a creative-idea promote does) and assert it appears in `goals_at(...)`
+  output **and** increments the `goal_records` count **without** writing a new
+  snapshot; then force a live-read failure and assert the handler surfaces an
+  explicit `error` payload rather than serving a stale/empty board.
+* **`tests/e2e-dashboard/specs/goals.spec.ts`** — the Playwright board rendering
+  stays green.
+
+## Operator verification (live)
+
+Verify the fix in the running system after a redeploy:
+
+1. Deploy the built binary (the read change ships in the daemon **and** the
+   dashboard process).
+2. Promote a creative idea — press **Promote** on the Creative Ideas tab
+   (`POST /api/creative-ideas/{id}/promote`), which persists a **Proposed**
+   goal record.
+3. **Immediately** (do not wait ~5 minutes) reload the Goals tab or `curl` the
+   endpoints:
+
+   ```console
+   $ curl -s http://127.0.0.1:PORT/api/goals   | jq '.backlog_count, (.backlog | map(.description))'
+   $ curl -s http://127.0.0.1:PORT/api/memory  | jq '.goal_records'
+   ```
+
+   The promoted goal is present in `backlog` and `backlog_count` /
+   `goal_records.count` reflect it on the first poll — no snapshot cycle
+   required. See also
+   [Diagnose lost Creative-Ideas goals](../howto/diagnose-lost-creative-ideas-goals.md).
+
+## Constraints honoured
+
+Additive (new builder + new reverse adapter; no signature churn on existing
+callers, no response-shape change) · fail-closed (no snapshot fallback on a
+live-read failure; no silent empty/partial data) · snapshot **write** unchanged
+· no `*Bridge` names · no `println!` / `eprintln!` (tracing only) · CI green ·
+never `--admin` / `--no-verify` · references **#2922**.
+
+## See also
+
+- [Goal-Board API reference](./goal-board-api.md) — the `GoalBoard` /
+  `ActiveGoal` / `BacklogItem` shapes and the snapshot persistence seam.
+- [Cognitive-Memory Goal Store](./cognitive-memory-goal-store.md) — the
+  `CognitiveMemoryGoalStore` overlay source (`goal-store:record` facts).
+- [Creative-Ideas Goal Routing — Fail-Closed Persistence](./creative-ideas-goal-routing-fail-closed.md)
+  — how a promoted idea persists its Proposed goal (#2896).
+- [Creative Ideas Trigger-Scoped Read](./creative-ideas-trigger-scoped-read.md)
+  — the sibling live-read fix on the Creative Ideas tab (#122).
+- [Dashboard Goal Lifecycle-Status Badges](./dashboard-goal-lifecycle-status.md)
+  and [Dashboard Goal Hierarchy & Priorities](./dashboard-goal-hierarchy-priority.md)
+  — how the Goals tab renders status and ordering.
+- [Dashboard](../dashboard.md) — the operator-facing dashboard overview.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -367,6 +367,7 @@ nav:
     - Dashboard Action-Detail Humanization: reference/dashboard-action-detail-humanization.md
     - Dashboard Goal Lifecycle-Status Badges: reference/dashboard-goal-lifecycle-status.md
     - Dashboard Goal Hierarchy & Priorities: reference/dashboard-goal-hierarchy-priority.md
+    - Dashboard Live Goal-Board Read: reference/dashboard-live-goal-board-read.md
     - Dashboard Thinking Cycle History: reference/dashboard-thinking-cycle-history.md
     - Dashboard Activity Cycle Reports: reference/dashboard-activity-cycle-reports.md
     - Dashboard Background Tab Prefetch: reference/dashboard-background-tab-prefetch.md

--- a/src/goal_curation/labels.rs
+++ b/src/goal_curation/labels.rs
@@ -153,6 +153,27 @@ pub fn source_for_backlog(backlog_source: &str) -> &'static str {
     }
 }
 
+/// Plain-English provenance label for a goal, derived from the first `source:*`
+/// tag in `labels` (issue #2922). Used when rendering a live overlay
+/// `goal-store:record` as a backlog `source`, so the raw `source:creative-ideas`
+/// token never leaks to the operator surface. Falls back to `"From goals"` when
+/// no recognized `source:*` tag is present (e.g. legacy/seed records).
+pub fn human_source_label(labels: &[String]) -> &'static str {
+    for label in labels {
+        match label.as_str() {
+            SOURCE_CREATIVE_IDEAS => return "From creative ideas",
+            SOURCE_OPERATOR => return "From an operator",
+            SOURCE_OODA => return "From the OODA loop",
+            SOURCE_OVERSEER => return "From the overseer",
+            SOURCE_MEETING => return "From a meeting",
+            SOURCE_SEED => return "From the seed board",
+            SOURCE_DECOMPOSITION => return "From goal decomposition",
+            _ => {}
+        }
+    }
+    "From goals"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/goal_curation/labels.rs
+++ b/src/goal_curation/labels.rs
@@ -158,7 +158,11 @@ pub fn source_for_backlog(backlog_source: &str) -> &'static str {
 /// `goal-store:record` as a backlog `source`, so the raw `source:creative-ideas`
 /// token never leaks to the operator surface. Falls back to `"From goals"` when
 /// no recognized `source:*` tag is present (e.g. legacy/seed records).
-pub fn human_source_label(labels: &[String]) -> &'static str {
+///
+/// Named to stay distinct from the unrelated
+/// `operator_commands_dashboard::goals::human_source_label`, which maps a
+/// cognitive-memory *concept* string (not a `source:*` provenance label).
+pub fn provenance_source_label(labels: &[String]) -> &'static str {
     for label in labels {
         match label.as_str() {
             SOURCE_CREATIVE_IDEAS => return "From creative ideas",

--- a/src/goal_curation/mod.rs
+++ b/src/goal_curation/mod.rs
@@ -26,12 +26,13 @@ mod prioritize;
 // Re-export all public items so `crate::goal_curation::X` still works.
 pub use operations::CarryoverVerification;
 pub use operations::{
-    DEFAULT_SEED_GOALS, DEFAULT_STEWARD_SCORE, active_goals_as_records, add_active_goal,
-    add_backlog_item, archive_completed, board_snapshot_hash, clear_goal_assignment,
-    enqueue_stewardship_issue, load_goal_board, overwrite_memory_cache, persist_board,
-    promote_to_active, read_latest_carryover, rollup_parent_progress, save_goal_board,
-    save_goal_board_with_removals, seed_default_board, simard_state_root, update_goal_progress,
-    update_goal_progress_with_evidence, verify_goal_carryover, write_goal_carryover,
+    BoardPlacement, DEFAULT_SEED_GOALS, DEFAULT_STEWARD_SCORE, active_goals_as_records,
+    add_active_goal, add_backlog_item, archive_completed, board_snapshot_hash,
+    clear_goal_assignment, enqueue_stewardship_issue, load_goal_board, overwrite_memory_cache,
+    persist_board, promote_to_active, read_latest_carryover, record_as_active_goal,
+    rollup_parent_progress, save_goal_board, save_goal_board_with_removals, seed_default_board,
+    simard_state_root, update_goal_progress, update_goal_progress_with_evidence,
+    verify_goal_carryover, write_goal_carryover,
 };
 pub use types::{
     ActiveGoal, BacklogItem, CARRYOVER_CONCEPT, GoalBoard, GoalCarryoverRecord, GoalEdge,
@@ -89,6 +90,8 @@ mod tests_no_progress_breaker;
 mod tests_no_progress_why;
 #[cfg(test)]
 mod tests_operations;
+#[cfg(test)]
+mod tests_reverse_adapter;
 #[cfg(test)]
 mod tests_save_with_removals;
 

--- a/src/goal_curation/operations.rs
+++ b/src/goal_curation/operations.rs
@@ -1428,3 +1428,91 @@ pub fn active_goals_as_records(board: &GoalBoard) -> Vec<crate::goals::GoalRecor
         })
         .collect()
 }
+
+// ---------------------------------------------------------------------------
+// GoalRecord -> board placement adapter (reverse of active_goals_as_records)
+// ---------------------------------------------------------------------------
+
+/// Where a persisted [`GoalRecord`] lands when mapped back onto the live board
+/// (issue #2922). The inverse of [`active_goals_as_records`]: it renders an
+/// overlay `goal-store:record` — a promoted creative-idea Proposed goal, a
+/// meeting goal, a seed/runtime goal — in the SAME `ActiveGoal` / `BacklogItem`
+/// shapes a snapshot goal uses, so the dashboard's live union renders overlay
+/// and snapshot goals identically.
+///
+/// `Skip` drops terminal (`Completed`) records: they are not surfaced on the
+/// live board in either bucket.
+#[derive(Debug)]
+// An `ActiveGoal` is materially larger than the other two variants; the doc
+// contract (#2922) is that this enum stays unboxed so callers can move the
+// payload out and `{:?}`-format it, so we accept the size disparity rather than
+// box the variant.
+#[allow(clippy::large_enum_variant)]
+pub enum BoardPlacement {
+    Active(ActiveGoal),
+    Backlog(BacklogItem),
+    Skip,
+}
+
+/// Map a persisted [`GoalRecord`] back into its live-board placement (issue
+/// #2922) — the inverse of [`active_goals_as_records`].
+///
+/// Status routing mirrors the board's own active/backlog split:
+///
+/// | `GoalStatus` | Placement | Rendered progress |
+/// |--------------|-----------|-------------------|
+/// | `Active`     | active    | `InProgress { percent: 0 }` |
+/// | `Proposed`   | backlog   | — |
+/// | `Paused`     | backlog   | — |
+/// | `Completed`  | skipped   | terminal |
+///
+/// A `GoalRecord` carries none of the snapshot-only rich fields, so they are
+/// synthesized as `None` / `[]` / `false`. Pure struct mapping — panic-free on
+/// arbitrary record text: overlay records carry untrusted, model-generated
+/// content and a panic here would 500 the dashboard read path.
+pub fn record_as_active_goal(record: &crate::goals::GoalRecord) -> BoardPlacement {
+    match record.status {
+        crate::goals::GoalStatus::Completed => BoardPlacement::Skip,
+        crate::goals::GoalStatus::Active => {
+            // The forward adapter writes the `"unassigned"` sentinel for a
+            // goal with no assignee; map it back to `None` so the round-trip
+            // is faithful.
+            let assigned_to = match record.owner_identity.as_str() {
+                "unassigned" => None,
+                owner => Some(owner.to_string()),
+            };
+            BoardPlacement::Active(ActiveGoal {
+                id: record.slug.clone(),
+                description: record.title.clone(),
+                priority: u32::from(record.priority),
+                status: GoalProgress::InProgress { percent: 0 },
+                assigned_to,
+                repo: None,
+                current_activity: None,
+                wip_refs: Vec::new(),
+                last_progress_update_at: None,
+                parent_goal_id: None,
+                priority_explicit: false,
+                labels: record.labels.clone(),
+            })
+        }
+        crate::goals::GoalStatus::Proposed | crate::goals::GoalStatus::Paused => {
+            BoardPlacement::Backlog(BacklogItem {
+                id: record.slug.clone(),
+                description: record.title.clone(),
+                source: super::labels::human_source_label(&record.labels).to_string(),
+                score: backlog_score_for_priority(record.priority),
+            })
+        }
+    }
+}
+
+/// Deterministic backlog score from a goal's priority so the proposed backlog
+/// orders stably (issue #2922). Higher priority — a LOWER number, p1 is most
+/// important — yields a higher score. The priority is clamped into `[1, 10]`
+/// and mapped to `(0, 1]` via `(11 - p) / 10`, so p1 -> 1.0, p3 -> 0.8, and
+/// p10+ -> 0.1. Always finite; never panics for any `u8`.
+fn backlog_score_for_priority(priority: u8) -> f64 {
+    let p = f64::from(priority.clamp(1, 10));
+    (11.0 - p) / 10.0
+}

--- a/src/goal_curation/operations.rs
+++ b/src/goal_curation/operations.rs
@@ -1500,7 +1500,7 @@ pub fn record_as_active_goal(record: &crate::goals::GoalRecord) -> BoardPlacemen
             BoardPlacement::Backlog(BacklogItem {
                 id: record.slug.clone(),
                 description: record.title.clone(),
-                source: super::labels::human_source_label(&record.labels).to_string(),
+                source: super::labels::provenance_source_label(&record.labels).to_string(),
                 score: backlog_score_for_priority(record.priority),
             })
         }

--- a/src/goal_curation/tests_reverse_adapter.rs
+++ b/src/goal_curation/tests_reverse_adapter.rs
@@ -1,0 +1,372 @@
+//! Failing TDD tests (issue #2922, Step 7) for the reverse goal adapter
+//! `record_as_active_goal` — the inverse of [`super::operations::active_goals_as_records`].
+//!
+//! The live goal-board read (`dashboard_live_goal_board`, #2922) unions the
+//! stale `goal-board:snapshot` board with a LIVE `CognitiveMemoryGoalStore`
+//! overlay of `goal-store:record` facts (creative-idea Proposed goals, meeting
+//! goals, …). To render an overlay record on the board it must be mapped BACK
+//! into the board's `ActiveGoal` / `BacklogItem` shapes. That mapping is
+//! `record_as_active_goal`, which places each record into one board bucket:
+//!
+//! ```ignore
+//! #[derive(Debug)]
+//! pub enum BoardPlacement { Active(ActiveGoal), Backlog(BacklogItem), Skip }
+//! pub fn record_as_active_goal(record: &GoalRecord) -> BoardPlacement;
+//! ```
+//!
+//! The enum is unboxed and derives `Debug` (these tests move the variant payload
+//! out and `{:?}`-format it). If clippy flags `large_enum_variant`, the
+//! implementation may add `#[allow(clippy::large_enum_variant)]` rather than
+//! boxing — boxing is not part of this contract.
+//!
+//! Status routing (mirrors the board's active/backlog split):
+//!
+//! | `GoalRecord.status` | Placement  | Rendered progress          |
+//! |---------------------|------------|----------------------------|
+//! | `Active`            | `active[]` | `InProgress { percent: 0 }`|
+//! | `Proposed`          | `backlog[]`| — (backlog item)           |
+//! | `Paused`            | `backlog[]`| —                          |
+//! | `Completed`         | **Skip**   | terminal; not surfaced     |
+//!
+//! These tests reference `record_as_active_goal` and `BoardPlacement`, which do
+//! not exist yet — that is the intended TDD red (compile-fail) state, exactly as
+//! the sibling `tests_adapter.rs` did for the forward adapter.
+
+use super::labels::SOURCE_CREATIVE_IDEAS;
+use super::operations::{BoardPlacement, record_as_active_goal};
+use super::types::{ActiveGoal, BacklogItem, GoalProgress};
+
+use crate::goals::{GoalRecord, GoalStatus, goal_slug};
+use crate::session::{SessionId, SessionPhase};
+
+/// Build a `GoalRecord` with the given status/priority/labels. `slug` is derived
+/// from `title` via `goal_slug`, mirroring how the creative-ideas router
+/// (`route_idea_to_goal`) constructs the record it `put`s.
+fn record(title: &str, status: GoalStatus, priority: u8, labels: Vec<String>) -> GoalRecord {
+    GoalRecord {
+        slug: goal_slug(title),
+        title: title.to_string(),
+        rationale: "why this goal matters".to_string(),
+        status,
+        priority,
+        owner_identity: "creative-ideas".to_string(),
+        source_session_id: SessionId::parse("session-018f1f7e-4c5d-7b2a-8f10-b5c0d4f7b123")
+            .expect("session id should parse"),
+        updated_in: SessionPhase::Planning,
+        evidence: Vec::new(),
+        labels,
+    }
+}
+
+/// Extract the `ActiveGoal` from an `Active` placement, or panic with context.
+fn expect_active(placement: BoardPlacement) -> ActiveGoal {
+    match placement {
+        BoardPlacement::Active(goal) => goal,
+        other => panic!("expected BoardPlacement::Active, got {other:?}"),
+    }
+}
+
+/// Extract the `BacklogItem` from a `Backlog` placement, or panic with context.
+fn expect_backlog(placement: BoardPlacement) -> BacklogItem {
+    match placement {
+        BoardPlacement::Backlog(item) => item,
+        other => panic!("expected BoardPlacement::Backlog, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Status routing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn active_record_routes_to_active_bucket() {
+    let placement = record_as_active_goal(&record(
+        "Drive amplihack-rs to feature parity",
+        GoalStatus::Active,
+        2,
+        Vec::new(),
+    ));
+    assert!(
+        matches!(placement, BoardPlacement::Active(_)),
+        "an Active goal-store record must render on the active board"
+    );
+}
+
+#[test]
+fn proposed_record_routes_to_backlog_bucket() {
+    // The primary #2922 case: a promoted creative idea persists a Proposed
+    // record, which must show up on the Goals tab's proposed backlog.
+    let placement = record_as_active_goal(&record(
+        "Improve recall precision",
+        GoalStatus::Proposed,
+        3,
+        vec![SOURCE_CREATIVE_IDEAS.to_string()],
+    ));
+    assert!(
+        matches!(placement, BoardPlacement::Backlog(_)),
+        "a Proposed goal-store record must render as a backlog item (issue #2922)"
+    );
+}
+
+#[test]
+fn paused_record_routes_to_backlog_bucket() {
+    let placement = record_as_active_goal(&record(
+        "Deferred cleanup pass",
+        GoalStatus::Paused,
+        4,
+        Vec::new(),
+    ));
+    assert!(
+        matches!(placement, BoardPlacement::Backlog(_)),
+        "a Paused goal-store record must render as a backlog item"
+    );
+}
+
+#[test]
+fn completed_record_is_skipped() {
+    let placement = record_as_active_goal(&record(
+        "Already shipped work",
+        GoalStatus::Completed,
+        1,
+        Vec::new(),
+    ));
+    assert!(
+        matches!(placement, BoardPlacement::Skip),
+        "a Completed record is terminal and must NOT be surfaced on the live board"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Active-bucket field synthesis
+// ---------------------------------------------------------------------------
+
+#[test]
+fn active_record_maps_id_description_and_priority() {
+    let rec = record(
+        "Ship the fail-closed live read",
+        GoalStatus::Active,
+        2,
+        Vec::new(),
+    );
+    let goal = expect_active(record_as_active_goal(&rec));
+
+    assert_eq!(goal.id, rec.slug, "ActiveGoal.id must be the record slug");
+    assert_eq!(
+        goal.description, rec.title,
+        "ActiveGoal.description must be the record title"
+    );
+    assert_eq!(
+        goal.priority, rec.priority as u32,
+        "record priority (u8) must widen to ActiveGoal.priority (u32)"
+    );
+}
+
+#[test]
+fn active_record_status_is_in_progress_zero_percent() {
+    let goal = expect_active(record_as_active_goal(&record(
+        "Live board goal",
+        GoalStatus::Active,
+        1,
+        Vec::new(),
+    )));
+    assert_eq!(
+        goal.status,
+        GoalProgress::InProgress { percent: 0 },
+        "an Active record has no persisted percent, so it renders as InProgress {{ percent: 0 }}"
+    );
+}
+
+#[test]
+fn active_record_owner_becomes_assigned_to() {
+    let mut rec = record("Owned goal", GoalStatus::Active, 1, Vec::new());
+    rec.owner_identity = "simard-engineer".to_string();
+    let goal = expect_active(record_as_active_goal(&rec));
+    assert_eq!(
+        goal.assigned_to.as_deref(),
+        Some("simard-engineer"),
+        "record.owner_identity must map to ActiveGoal.assigned_to"
+    );
+}
+
+#[test]
+fn active_record_unassigned_owner_maps_to_none() {
+    let mut rec = record("Unowned goal", GoalStatus::Active, 1, Vec::new());
+    rec.owner_identity = "unassigned".to_string();
+    let goal = expect_active(record_as_active_goal(&rec));
+    assert_eq!(
+        goal.assigned_to, None,
+        "the 'unassigned' sentinel owner must map back to assigned_to = None"
+    );
+}
+
+#[test]
+fn active_record_preserves_labels() {
+    let rec = record(
+        "Creative-idea goal",
+        GoalStatus::Active,
+        3,
+        vec![SOURCE_CREATIVE_IDEAS.to_string()],
+    );
+    let goal = expect_active(record_as_active_goal(&rec));
+    assert!(
+        goal.labels.contains(&SOURCE_CREATIVE_IDEAS.to_string()),
+        "provenance labels must carry through the reverse adapter; got {:?}",
+        goal.labels
+    );
+}
+
+#[test]
+fn active_record_synthesizes_absent_rich_fields() {
+    // A GoalRecord carries none of the snapshot-only rich fields, so the adapter
+    // must synthesize them so the JSON stays byte-stable.
+    let goal = expect_active(record_as_active_goal(&record(
+        "Minimal record",
+        GoalStatus::Active,
+        1,
+        Vec::new(),
+    )));
+    assert_eq!(goal.repo, None, "repo must be synthesized as None");
+    assert_eq!(
+        goal.current_activity, None,
+        "current_activity must be synthesized as None"
+    );
+    assert_eq!(
+        goal.parent_goal_id, None,
+        "parent_goal_id must be synthesized as None"
+    );
+    assert!(
+        goal.wip_refs.is_empty(),
+        "wip_refs must be synthesized as []"
+    );
+    assert!(
+        !goal.priority_explicit,
+        "priority_explicit must be synthesized as false (record has no such provenance)"
+    );
+    assert_eq!(
+        goal.last_progress_update_at, None,
+        "last_progress_update_at must be synthesized as None"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Backlog-bucket field synthesis
+// ---------------------------------------------------------------------------
+
+#[test]
+fn proposed_record_maps_id_and_description() {
+    let rec = record("Proposed backlog goal", GoalStatus::Proposed, 3, Vec::new());
+    let item = expect_backlog(record_as_active_goal(&rec));
+    assert_eq!(item.id, rec.slug, "BacklogItem.id must be the record slug");
+    assert_eq!(
+        item.description, rec.title,
+        "BacklogItem.description must be the record title"
+    );
+}
+
+#[test]
+fn proposed_creative_idea_record_has_plain_english_source() {
+    let rec = record(
+        "Proposed from a creative idea",
+        GoalStatus::Proposed,
+        3,
+        vec![SOURCE_CREATIVE_IDEAS.to_string()],
+    );
+    let item = expect_backlog(record_as_active_goal(&rec));
+    assert!(
+        item.source.to_lowercase().contains("creative"),
+        "a source:creative-ideas record must get a plain-English provenance label \
+         mentioning creative ideas, not the raw label; got {:?}",
+        item.source
+    );
+    assert!(
+        !item.source.contains("source:"),
+        "the raw `source:*` label must not leak into the backlog source; got {:?}",
+        item.source
+    );
+}
+
+#[test]
+fn backlog_score_is_finite_and_ranks_higher_priority_first() {
+    // "Higher priority" in this codebase means a LOWER priority number (p1 is
+    // most important). The doc mandates higher priority -> higher score so the
+    // proposed backlog orders deterministically.
+    let high = expect_backlog(record_as_active_goal(&record(
+        "Most important proposal",
+        GoalStatus::Proposed,
+        1,
+        Vec::new(),
+    )));
+    let low = expect_backlog(record_as_active_goal(&record(
+        "Least important proposal",
+        GoalStatus::Proposed,
+        9,
+        Vec::new(),
+    )));
+
+    assert!(
+        high.score.is_finite(),
+        "score must be finite, got {}",
+        high.score
+    );
+    assert!(
+        low.score.is_finite(),
+        "score must be finite, got {}",
+        low.score
+    );
+    assert!(
+        high.score > low.score,
+        "a higher-priority (p1) proposal must score above a lower-priority (p9) one \
+         so backlog ordering is stable; got p1={} vs p9={}",
+        high.score,
+        low.score
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Robustness — panic-free on arbitrary record text
+// ---------------------------------------------------------------------------
+
+#[test]
+fn adapter_is_panic_free_on_arbitrary_text() {
+    // Overlay records carry untrusted, model-generated text. The adapter is a
+    // pure struct mapping and must never panic (a panic in the read path would
+    // 500 / DoS the dashboard).
+    let weird_titles = [
+        "",
+        "   ",
+        "🦀 unicode goal with emoji 🚀 and\nnewlines\tand tabs",
+        &"x".repeat(10_000),
+        "slug/with:colons and spaces & Punctuation!!!",
+    ];
+    for title in weird_titles {
+        for status in [
+            GoalStatus::Active,
+            GoalStatus::Proposed,
+            GoalStatus::Paused,
+            GoalStatus::Completed,
+        ] {
+            let mut rec = record("placeholder", status, 1, Vec::new());
+            rec.title = title.to_string();
+            rec.slug = title.to_string();
+            rec.owner_identity = title.to_string();
+            // Must not panic for any (title, status) combination.
+            let _ = record_as_active_goal(&rec);
+        }
+    }
+}
+
+#[test]
+fn priority_at_u8_max_widens_without_panic() {
+    let rec = record(
+        "Max priority proposal",
+        GoalStatus::Active,
+        u8::MAX,
+        Vec::new(),
+    );
+    let goal = expect_active(record_as_active_goal(&rec));
+    assert_eq!(
+        goal.priority,
+        u32::from(u8::MAX),
+        "u8::MAX priority must widen cleanly to u32 without panic or truncation"
+    );
+}

--- a/src/goals/mod.rs
+++ b/src/goals/mod.rs
@@ -15,7 +15,9 @@ pub use cognitive_memory_store::CognitiveMemoryGoalStore;
 pub use cognitive_memory_store::InProcessGoalStore;
 pub use cognitive_memory_store::migrate_file_backed_goal_store_if_present;
 pub use cognitive_memory_store::reconcile_board_prospectives;
-pub(crate) use cognitive_memory_store::{GOAL_STORE_FACT_CONCEPT, GOAL_STORE_LIST_LIMIT};
+pub(crate) use cognitive_memory_store::{
+    GOAL_STORE_FACT_CONCEPT, GOAL_STORE_LIST_LIMIT, list_via_ops,
+};
 pub use seed::seed_default_goals;
 pub use store::{FileBackedGoalStore, GoalStore, InMemoryGoalStore};
 pub use types::{GOAL_SLUG_MAX_LEN, GoalRecord, GoalStatus, GoalUpdate, goal_slug};

--- a/src/operator_commands_dashboard/goals.rs
+++ b/src/operator_commands_dashboard/goals.rs
@@ -7,7 +7,7 @@ use serde_json::{Value, json};
 use super::goals_status::render_status_and_detail;
 use super::routes::resolve_state_root;
 use super::{
-    dashboard_goal_board_snapshot, dashboard_save_goal_board,
+    dashboard_goal_board_snapshot, dashboard_live_goal_board, dashboard_save_goal_board,
     dashboard_save_goal_board_with_removals,
 };
 use crate::goal_curation::{ActiveGoal, BacklogItem, GoalBoard, GoalProgress, MAX_ACTIVE_GOALS};
@@ -91,7 +91,28 @@ pub(crate) async fn goals() -> Json<Value> {
 /// (#2408 / #2384). See [`load_board_or_empty_at`] for the trusted-internal
 /// `state_root` invariant.
 pub(crate) async fn goals_at(state_root: &std::path::Path) -> Json<Value> {
-    let board = dashboard_goal_board_snapshot(state_root).unwrap_or_default();
+    // Issue #2922: read the LIVE goal board (snapshot base unioned with the live
+    // `CognitiveMemoryGoalStore` overlay), fail-closed. A live-read failure
+    // surfaces an explicit error payload with zeroed counts and empty lists —
+    // NEVER a silently-empty or stale board that a client could not distinguish
+    // from "no goals". The underlying error chain is logged server-side only
+    // (tracing), never returned to the client.
+    let board = match dashboard_live_goal_board(state_root) {
+        Ok(board) => board,
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                "dashboard live goal-board read failed; serving fail-closed error payload"
+            );
+            return Json(json!({
+                "active": [],
+                "backlog": [],
+                "active_count": 0,
+                "backlog_count": 0,
+                "error": "goal-board read failed",
+            }));
+        }
+    };
 
     // Issue #2695 follow-up: emit active goals ordered by priority ASCENDING
     // (p1 = highest first) with a stable id tiebreak, so the Goals tab renders a

--- a/src/operator_commands_dashboard/metrics.rs
+++ b/src/operator_commands_dashboard/metrics.rs
@@ -4,7 +4,7 @@ use axum::http::StatusCode;
 use serde_json::{Value, json};
 use std::path::Path;
 
-use super::dashboard_goal_board_snapshot;
+use super::dashboard_live_goal_board;
 use super::routes::resolve_state_root;
 use super::subagent::{count_json_records, file_metrics};
 use crate::cognitive_memory::metrics::RECALL_PRECISION_METRIC;
@@ -31,14 +31,25 @@ pub(crate) async fn memory_metrics() -> Json<Value> {
     let fact_count = count_json_records(&memory_path);
     let evidence_count = count_json_records(&evidence_path);
 
-    // Goal records now live in cognitive memory (issue #1590); render a
-    // metadata-only panel so the dashboard's "Goal Records" tile keeps
-    // working without any disk file.
-    let goal_board = dashboard_goal_board_snapshot(&state_root).ok();
-    let goal_count = goal_board
+    // Goal records now come from the LIVE goal board (issue #2922): the
+    // snapshot base unioned with the live `CognitiveMemoryGoalStore` overlay, so
+    // a freshly-persisted goal record (e.g. a promoted creative idea) is counted
+    // on the very next poll instead of lagging a ~5-min snapshot cycle. Reads
+    // fail-closed: a live-read failure surfaces an explicit `error` on the tile
+    // and is EXCLUDED from `total_facts` (never a stale or fabricated count),
+    // with the error chain logged server-side only.
+    let live_board = dashboard_live_goal_board(&state_root);
+    let goal_records_error = live_board.as_ref().err().map(|err| {
+        tracing::warn!(
+            error = %err,
+            "dashboard live goal-board read failed for the goal_records tile"
+        );
+        "goal-board read failed"
+    });
+    let goal_count = live_board
         .as_ref()
-        .map(|b| (b.active.len() + b.backlog.len()) as u64)
-        .unwrap_or(0);
+        .ok()
+        .map(|b| (b.active.len() + b.backlog.len()) as u64);
 
     // Query the library-backed cognitive memory for live statistics (#419),
     // routed through `open_reader_client` so the daemon's IPC writer serves the
@@ -61,15 +72,29 @@ pub(crate) async fn memory_metrics() -> Json<Value> {
     let (consolidation_count, last_consolidation) = recent_consolidation_activity(&state_root);
     let recent_last = last_consolidation.clone();
 
-    // Use LadybugDB counts when available; JSON file counts are the legacy source.
+    // Use LadybugDB counts when available; JSON file counts are the legacy
+    // source. On a goal-board live-read failure `goal_count` is `None`, so the
+    // fallback total EXCLUDES goal records rather than counting a stale/zero
+    // value (issue #2922 fail-closed).
     let total = native_stats
         .as_ref()
         .map(|s| s.total())
-        .unwrap_or(fact_count + evidence_count + goal_count);
+        .unwrap_or(fact_count + evidence_count + goal_count.unwrap_or(0));
 
     // De-fork Phase 2b (#2307): the library backend persists at
     // `<state_root>/cognitive`, replacing the native `cognitive_memory.ladybug`.
     let db_path = state_root.join("cognitive");
+
+    // Issue #2922: additively surface a goal-board live-read failure on the tile
+    // (never returned as a silently-zero count). Omitted on success so the shape
+    // is byte-identical for the healthy case.
+    let mut goal_records = json!({
+        "source": "cognitive-memory:live-goal-board",
+        "count": goal_count.unwrap_or(0),
+    });
+    if let Some(err) = goal_records_error {
+        goal_records["error"] = json!(err);
+    }
 
     Json(json!({
         "state_root": state_root.to_string_lossy(),
@@ -85,10 +110,7 @@ pub(crate) async fn memory_metrics() -> Json<Value> {
             "size_bytes": evidence_info.0,
             "modified": evidence_info.1,
         },
-        "goal_records": {
-            "source": "cognitive-memory:goal-board:snapshot",
-            "count": goal_count,
-        },
+        "goal_records": goal_records,
         "handoff": {
             "path": handoff_path.to_string_lossy().to_string(),
             "size_bytes": handoff_info.0,

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -53,6 +53,13 @@ mod tests_goals_crud;
 // silently return.
 #[cfg(test)]
 mod tests_memory_recent_last_hour;
+// Issue #2922: the dashboard goal-board READ is live — `dashboard_live_goal_board`
+// unions the `goal-board:snapshot` base with a live `CognitiveMemoryGoalStore`
+// overlay (deduped by slug, board wins), so a promoted creative-idea Proposed
+// goal appears immediately instead of lagging a ~5-min snapshot cycle; the read
+// is fail-closed (no silent fallback to the stale snapshot).
+#[cfg(test)]
+mod tests_live_goal_board;
 #[cfg(test)]
 mod tests_ooda_cycles_history;
 // Issue #26: the Logs tab's "Cycle Reports" card (#cycle-reports) must show the
@@ -87,8 +94,10 @@ use std::path::Path;
 
 use crate::error::SimardResult;
 use crate::goal_curation::{
-    GoalBoard, load_goal_board, save_goal_board, save_goal_board_with_removals,
+    BoardPlacement, GoalBoard, load_goal_board, record_as_active_goal, save_goal_board,
+    save_goal_board_with_removals,
 };
+use crate::goals::{CognitiveMemoryGoalStore, GoalStore, goal_slug};
 use crate::memory_ipc::{launch_writer_client, open_reader_client};
 
 /// Read the cognitive-memory `goal-board:snapshot` for the dashboard.
@@ -131,6 +140,67 @@ pub(crate) fn dashboard_save_goal_board_with_removals(
 ) -> SimardResult<()> {
     let writer = launch_writer_client(state_root)?;
     save_goal_board_with_removals(board, force_remove_ids, writer.ops())
+}
+
+/// Build the dashboard's **live** goal board (issue #2922): the authoritative
+/// `goal-board:snapshot` board unioned with a LIVE `CognitiveMemoryGoalStore`
+/// overlay, so a freshly-persisted `goal-store:record` (a promoted creative-idea
+/// Proposed goal, a meeting goal, an unblocked goal, …) appears immediately
+/// instead of lagging up to a ~5-min snapshot cycle.
+///
+/// Two live sources, deduped by slug with the **base winning**:
+/// - **Base** — [`dashboard_goal_board_snapshot`], the operator read-your-writes
+///   snapshot board carrying the daemon-OODA active/backlog goals with their
+///   rich fields (`current_activity`, `wip_refs`, `repo`, …).
+/// - **Overlay** — [`CognitiveMemoryGoalStore::list`], the same shared live
+///   store the creative-ideas / meeting / runtime / seed writers `put` into. A
+///   record whose slug is already on the base board is dropped (the base carries
+///   the richer, authoritative fields); only records *absent* from the base are
+///   mapped in via [`record_as_active_goal`].
+///
+/// **Fail-closed** (issues #2922 / #2896): either leg failing — the snapshot
+/// base read or the overlay `list()` — propagates as `Err`. There is no fallback
+/// to the stale snapshot and no coercion of a transport fault into a phantom
+/// empty board; the caller surfaces the error rather than serving silently-stale
+/// or partial data.
+pub(crate) fn dashboard_live_goal_board(state_root: &Path) -> SimardResult<GoalBoard> {
+    // Base: authoritative snapshot board. Fail-closed — never unwrap_or_default.
+    let mut board = dashboard_goal_board_snapshot(state_root)?;
+
+    // Index the base by slug so the overlay dedup is O(overlay). Slugs are
+    // derived with `goal_slug` (the SAME function the forward adapter uses),
+    // because an `ActiveGoal.id` is not guaranteed to already be a slug —
+    // comparing raw ids would let a slugged overlay record slip past dedup and
+    // double-render.
+    let mut seen: std::collections::HashSet<String> = board
+        .active
+        .iter()
+        .map(|g| goal_slug(&g.id))
+        .chain(board.backlog.iter().map(|b| goal_slug(&b.id)))
+        .collect();
+
+    // Overlay: LIVE goal-store records. `list()` is fail-closed (#2896); a
+    // reader-open or `search_facts` transport fault propagates as `Err`.
+    let overlay = CognitiveMemoryGoalStore::new(state_root.to_path_buf())?.list()?;
+    for record in overlay {
+        if seen.contains(&record.slug) {
+            continue;
+        }
+        match record_as_active_goal(&record) {
+            BoardPlacement::Active(goal) => {
+                seen.insert(record.slug);
+                board.active.push(goal);
+            }
+            BoardPlacement::Backlog(item) => {
+                seen.insert(record.slug);
+                board.backlog.push(item);
+            }
+            // Terminal (`Completed`) records are not surfaced on the live board.
+            BoardPlacement::Skip => {}
+        }
+    }
+
+    Ok(board)
 }
 
 /// Initialize dashboard auth and print the login code to stderr.

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -97,7 +97,7 @@ use crate::goal_curation::{
     BoardPlacement, GoalBoard, load_goal_board, record_as_active_goal, save_goal_board,
     save_goal_board_with_removals,
 };
-use crate::goals::{CognitiveMemoryGoalStore, GoalStore, goal_slug};
+use crate::goals::{goal_slug, list_via_ops};
 use crate::memory_ipc::{launch_writer_client, open_reader_client};
 
 /// Read the cognitive-memory `goal-board:snapshot` for the dashboard.
@@ -148,15 +148,17 @@ pub(crate) fn dashboard_save_goal_board_with_removals(
 /// Proposed goal, a meeting goal, an unblocked goal, …) appears immediately
 /// instead of lagging up to a ~5-min snapshot cycle.
 ///
-/// Two live sources, deduped by slug with the **base winning**:
-/// - **Base** — [`dashboard_goal_board_snapshot`], the operator read-your-writes
-///   snapshot board carrying the daemon-OODA active/backlog goals with their
-///   rich fields (`current_activity`, `wip_refs`, `repo`, …).
-/// - **Overlay** — [`CognitiveMemoryGoalStore::list`], the same shared live
-///   store the creative-ideas / meeting / runtime / seed writers `put` into. A
-///   record whose slug is already on the base board is dropped (the base carries
-///   the richer, authoritative fields); only records *absent* from the base are
-///   mapped in via [`record_as_active_goal`].
+/// Two live sources — both read off a SINGLE shared reader bridge (issue #2922
+/// perf) and deduped by slug with the **base winning**:
+/// - **Base** — [`load_goal_board`], the operator read-your-writes snapshot
+///   board (identical to [`dashboard_goal_board_snapshot`]) carrying the
+///   daemon-OODA active/backlog goals with their rich fields (`current_activity`,
+///   `wip_refs`, `repo`, …).
+/// - **Overlay** — [`list_via_ops`] over the same reader, the shared live
+///   goal-store the creative-ideas / meeting / runtime / seed writers `put`
+///   into. A record whose slug is already on the base board is dropped (the base
+///   carries the richer, authoritative fields); only records *absent* from the
+///   base are mapped in via [`record_as_active_goal`].
 ///
 /// **Fail-closed** (issues #2922 / #2896): either leg failing — the snapshot
 /// base read or the overlay `list()` — propagates as `Err`. There is no fallback
@@ -164,8 +166,19 @@ pub(crate) fn dashboard_save_goal_board_with_removals(
 /// empty board; the caller surfaces the error rather than serving silently-stale
 /// or partial data.
 pub(crate) fn dashboard_live_goal_board(state_root: &Path) -> SimardResult<GoalBoard> {
+    // Issue #2922 perf: open the reader bridge ONCE and serve BOTH live legs
+    // (the snapshot base and the goal-store overlay) from the same handle. Both
+    // legs already resolve to the same `state_root` reader, so a single open is
+    // behaviorally identical — but in the standalone-dashboard tier each open is
+    // a fresh Unix-socket connect plus a synchronous Ping/Pong handshake, so
+    // collapsing two opens into one removes a full round-trip from every Goals /
+    // Memory poll. Fail-closed: a reader-open or transport fault on either leg
+    // still propagates as `Err`, never a stale or partial board.
+    let reader = open_reader_client(state_root)?;
+    let ops = reader.ops();
+
     // Base: authoritative snapshot board. Fail-closed — never unwrap_or_default.
-    let mut board = dashboard_goal_board_snapshot(state_root)?;
+    let mut board = load_goal_board(ops)?;
 
     // Index the base by slug so the overlay dedup is O(overlay). Slugs are
     // derived with `goal_slug` (the SAME function the forward adapter uses),
@@ -179,9 +192,9 @@ pub(crate) fn dashboard_live_goal_board(state_root: &Path) -> SimardResult<GoalB
         .chain(board.backlog.iter().map(|b| goal_slug(&b.id)))
         .collect();
 
-    // Overlay: LIVE goal-store records. `list()` is fail-closed (#2896); a
-    // reader-open or `search_facts` transport fault propagates as `Err`.
-    let overlay = CognitiveMemoryGoalStore::new(state_root.to_path_buf())?.list()?;
+    // Overlay: LIVE goal-store records off the SAME reader handle. The read is
+    // fail-closed (#2896); a `search_facts` transport fault propagates as `Err`.
+    let overlay = list_via_ops(ops)?;
     for record in overlay {
         if seen.contains(&record.slug) {
             continue;

--- a/src/operator_commands_dashboard/tests_live_goal_board.rs
+++ b/src/operator_commands_dashboard/tests_live_goal_board.rs
@@ -468,3 +468,157 @@ async fn memory_metrics_goal_count_reflects_live_union_and_relabels_source() {
     );
     drop(mem);
 }
+
+// ---------------------------------------------------------------------------
+// Outside-in end-to-end (Step 13): drive the REAL dashboard router over raw
+// HTTP/1.1 on an ephemeral loopback port, exactly as the browser Goals tab
+// does. Unlike the handler-fn tests above, this exercises the FULL consumer
+// path — route registration, the `require_auth` layer, `resolve_state_root`,
+// the live in-process goal store, and JSON serialization — proving that a
+// freshly-persisted Proposed goal is visible over HTTP WITHOUT a snapshot
+// cycle (issue #2922). Auth uses the deterministic `SIMARD_DASHBOARD_TOKEN`
+// bearer, independent of the process `LOGIN_CODE`.
+// ---------------------------------------------------------------------------
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+const ITEST_TOKEN: &str = "itest-live-goal-board";
+
+/// One-shot HTTP/1.1 request over a raw socket → `(status_code, body)`.
+/// `Connection: close` lets the server delimit the body by EOF so
+/// `read_to_end` completes with no HTTP-client dependency.
+async fn http_request(addr: SocketAddr, path: &str, bearer: Option<&str>) -> (u16, String) {
+    let mut stream = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("connect to ephemeral dashboard server");
+    let mut req = format!("GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n");
+    if let Some(b) = bearer {
+        req.push_str(&format!("Authorization: Bearer {b}\r\n"));
+    }
+    req.push_str("\r\n");
+    stream
+        .write_all(req.as_bytes())
+        .await
+        .expect("write request");
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).await.expect("read response");
+    let text = String::from_utf8_lossy(&raw).into_owned();
+    let code = text
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|c| c.parse::<u16>().ok())
+        .unwrap_or(0);
+    let body = text
+        .split_once("\r\n\r\n")
+        .map(|(_, b)| b.to_string())
+        .unwrap_or_default();
+    (code, body)
+}
+
+/// [`http_request`] wrapped in a 30s timeout so a wiring bug can never hang the
+/// suite.
+async fn http(addr: SocketAddr, path: &str, bearer: Option<&str>) -> (u16, String) {
+    tokio::time::timeout(Duration::from_secs(30), http_request(addr, path, bearer))
+        .await
+        .unwrap_or_else(|_| panic!("GET {path} timed out"))
+}
+
+/// Boot the real [`build_router`](super::routes::build_router) on an ephemeral
+/// loopback port (auth initialized) and return its address.
+async fn spawn_dashboard() -> SocketAddr {
+    super::auth::init_login_code();
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("bind ephemeral loopback port");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, super::routes::build_router()).await;
+    });
+    addr
+}
+
+// SAFETY (both fns): env mutation is serialised by
+// `#[serial_test::serial(cognitive_memory)]`; the token is set before any
+// request that reads it and cleared only after all responses are received.
+fn set_dashboard_token() {
+    unsafe { std::env::set_var("SIMARD_DASHBOARD_TOKEN", ITEST_TOKEN) };
+}
+fn clear_dashboard_token() {
+    unsafe { std::env::remove_var("SIMARD_DASHBOARD_TOKEN") };
+}
+
+/// Outside-in acceptance (#2922): over the REAL router, a promoted creative-idea
+/// Proposed goal persisted to the LIVE store surfaces on `GET /api/goals`
+/// (backlog + count) and is counted by the `GET /api/memory` goal-records tile
+/// (relabeled off the stale snapshot) — all WITHOUT any snapshot write, and
+/// gated behind auth (unauthenticated ⇒ 401, so goal data never leaks).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial_test::serial(cognitive_memory)]
+async fn http_goals_board_surfaces_live_proposed_goal_without_snapshot() {
+    let state = HermeticState::new();
+    let root = state.state_root().to_path_buf();
+    let mem = SharedMem::register(&root);
+    // Base snapshot is EMPTY — the goal must arrive purely via the live overlay.
+    save_goal_board(&GoalBoard::new(), mem.ops()).expect("seed empty snapshot base");
+
+    let title = "Ship the live goal-board read over HTTP (2922 e2e)";
+    let store = CognitiveMemoryGoalStore::new(root.clone()).expect("construct goal store");
+    store
+        .put(proposed_record(title))
+        .expect("persist Proposed goal record via the live store");
+
+    let addr = spawn_dashboard().await;
+
+    // Auth-gated: no bearer ⇒ 401, so the board never leaks past the auth layer.
+    let (unauth, _) = http(addr, "/api/goals", None).await;
+    assert_eq!(unauth, 401, "the goal-board endpoint must sit behind auth");
+
+    set_dashboard_token();
+    // Deliberately NO snapshot write between the put and the HTTP read.
+    let (code, body) = http(addr, "/api/goals", Some(ITEST_TOKEN)).await;
+    let (mem_code, mem_body) = http(addr, "/api/memory", Some(ITEST_TOKEN)).await;
+    clear_dashboard_token();
+
+    assert_eq!(
+        code, 200,
+        "authenticated goal-board load must succeed; body={body:?}"
+    );
+    let v: serde_json::Value =
+        serde_json::from_str(&body).expect("/api/goals returns a JSON object");
+    let backlog = v["backlog"].as_array().expect("backlog must be an array");
+    assert!(
+        backlog.iter().any(|b| b["description"] == title),
+        "GET /api/goals must surface the freshly-promoted Proposed goal in backlog WITHOUT a \
+         snapshot cycle (issue #2922); got {v}"
+    );
+    assert!(
+        v["backlog_count"].as_u64().unwrap_or(0) >= 1,
+        "backlog_count must reflect the live union over HTTP; got {v}"
+    );
+    assert!(
+        v.get("error").map(|e| e.is_null()).unwrap_or(true),
+        "a successful live read must not carry an error field; got {v}"
+    );
+
+    // The Memory tab's Goal-Records tile counts the same live union, relabeled.
+    assert_eq!(
+        mem_code, 200,
+        "authenticated memory load must succeed; body={mem_body:?}"
+    );
+    let mv: serde_json::Value =
+        serde_json::from_str(&mem_body).expect("/api/memory returns a JSON object");
+    let gr = &mv["goal_records"];
+    assert_eq!(
+        gr["source"], "cognitive-memory:live-goal-board",
+        "goal_records.source must be relabeled off the snapshot over HTTP; got {gr}"
+    );
+    assert!(
+        gr["count"].as_u64().unwrap_or(0) >= 1,
+        "goal_records.count must include the live goal-store record over HTTP; got {gr}"
+    );
+    drop(mem);
+}

--- a/src/operator_commands_dashboard/tests_live_goal_board.rs
+++ b/src/operator_commands_dashboard/tests_live_goal_board.rs
@@ -1,0 +1,470 @@
+//! Failing TDD tests (issue #2922, Step 7) for the dashboard's LIVE goal-board
+//! read.
+//!
+//! Before #2922 the Goals tab (`GET /api/goals` → `goals_at`) and the Memory
+//! tab's Goal-Records tile (`GET /api/memory` → `memory_metrics`) read ONLY the
+//! `goal-board:snapshot` fact — a cache the daemon rewrites ~once per OODA cycle
+//! (~5 min). A promoted creative-idea Proposed goal persists a `goal-store:record`
+//! that the snapshot does not contain, so it did not appear on the board until
+//! the next cycle. This is the staleness #2922 fixes.
+//!
+//! The fix introduces a single fail-closed live builder that unions the snapshot
+//! base with a LIVE `CognitiveMemoryGoalStore` overlay:
+//!
+//! ```ignore
+//! pub(crate) fn dashboard_live_goal_board(state_root: &Path) -> SimardResult<GoalBoard>;
+//! ```
+//!
+//! and repoints `goals_at` / `memory_metrics` at it. These tests reference
+//! `dashboard_live_goal_board` (which does not exist yet) and assert the
+//! repointed, fail-closed behaviour of the handlers — the intended TDD red
+//! (compile-fail) state until the implementation lands.
+//!
+//! Hermetic: a shared in-process `LibraryCognitiveMemory` writer (tier 0) is
+//! registered for a `TempDir` state root so both the snapshot base read and the
+//! goal-store overlay resolve to the SAME live store, exactly like production.
+//! The fail-closed tests instead register a fault-injecting backend so a
+//! transport error surfaces. Registration mutates process-global state, so every
+//! test is `#[serial_test::serial(cognitive_memory)]` and clears on exit.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
+use crate::error::{SimardError, SimardResult};
+use crate::goal_curation::{ActiveGoal, GoalBoard, GoalProgress, save_goal_board};
+use crate::goals::{CognitiveMemoryGoalStore, GoalRecord, GoalStatus, GoalStore, goal_slug};
+use crate::memory_cognitive::{
+    CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
+    CognitiveWorkingSlot,
+};
+use crate::memory_ipc::{clear_in_process_writer, register_in_process_writer};
+use crate::session::{SessionId, SessionPhase};
+use crate::test_support::HermeticState;
+
+use super::dashboard_live_goal_board;
+use super::goals::goals_at;
+use super::metrics::memory_metrics;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/// Holds the single shared in-process cognitive-memory writer for a test and
+/// clears the global registration on drop (panic-safe). Mirrors the tier-0
+/// wiring the daemon / dashboard use in production.
+struct SharedMem {
+    writer: Arc<dyn CognitiveMemoryOps>,
+}
+
+impl SharedMem {
+    fn register(root: &Path) -> Self {
+        clear_in_process_writer();
+        let writer: Arc<dyn CognitiveMemoryOps> =
+            Arc::new(LibraryCognitiveMemory::open(root).expect("open shared cognitive memory"));
+        register_in_process_writer(root.to_path_buf(), Arc::clone(&writer));
+        Self { writer }
+    }
+
+    fn ops(&self) -> &dyn CognitiveMemoryOps {
+        self.writer.as_ref()
+    }
+}
+
+impl Drop for SharedMem {
+    fn drop(&mut self) {
+        clear_in_process_writer();
+    }
+}
+
+/// A cognitive-memory backend that simulates a memory-ipc transport failure on
+/// the read path, mirroring the real "bridge 'memory-ipc' transport error" the
+/// #2896 bug reports. Non-faulted operations return benign values.
+struct FaultyMemory {
+    fail_reads: bool,
+}
+
+impl FaultyMemory {
+    fn transport_err(op: &str) -> SimardError {
+        SimardError::RpcCallFailed {
+            bridge: "memory-ipc".to_string(),
+            method: op.to_string(),
+            reason: "write-len: Broken pipe (os error 32)".to_string(),
+        }
+    }
+}
+
+impl CognitiveMemoryOps for FaultyMemory {
+    fn record_sensory(&self, _m: &str, _r: &str, _t: u64) -> SimardResult<String> {
+        Ok("sensory".to_string())
+    }
+    fn prune_expired_sensory(&self) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn push_working(&self, _s: &str, _c: &str, _t: &str, _r: f64) -> SimardResult<String> {
+        Ok("working".to_string())
+    }
+    fn get_working(&self, _t: &str) -> SimardResult<Vec<CognitiveWorkingSlot>> {
+        Ok(vec![])
+    }
+    fn clear_working(&self, _t: &str) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn store_episode(
+        &self,
+        _c: &str,
+        _s: &str,
+        _m: Option<&serde_json::Value>,
+    ) -> SimardResult<String> {
+        Ok("episode".to_string())
+    }
+    fn consolidate_episodes(&self, _b: u32) -> SimardResult<Option<String>> {
+        Ok(None)
+    }
+    fn store_fact(
+        &self,
+        _c: &str,
+        _co: &str,
+        _cf: f64,
+        _t: &[String],
+        _s: &str,
+    ) -> SimardResult<String> {
+        Ok("fact".to_string())
+    }
+    fn store_fact_with_caller_key(
+        &self,
+        _caller_key: &str,
+        _concept: &str,
+        _content: &str,
+        _confidence: f64,
+        _tags: &[String],
+        _source_id: &str,
+    ) -> SimardResult<String> {
+        Ok("fact".to_string())
+    }
+    fn search_facts(&self, _q: &str, _l: u32, _m: f64) -> SimardResult<Vec<CognitiveFact>> {
+        if self.fail_reads {
+            return Err(Self::transport_err("search_facts"));
+        }
+        Ok(vec![])
+    }
+    fn store_procedure(&self, _n: &str, _s: &[String], _p: &[String]) -> SimardResult<String> {
+        Ok("procedure".to_string())
+    }
+    fn recall_procedure(&self, _q: &str, _l: u32) -> SimardResult<Vec<CognitiveProcedure>> {
+        Ok(vec![])
+    }
+    fn store_prospective(&self, _d: &str, _tc: &str, _a: &str, _p: i64) -> SimardResult<String> {
+        Ok("prospective".to_string())
+    }
+    fn check_triggers(&self, _c: &str) -> SimardResult<Vec<CognitiveProspective>> {
+        Ok(vec![])
+    }
+    fn get_statistics(&self) -> SimardResult<CognitiveStatistics> {
+        Ok(CognitiveStatistics::default())
+    }
+}
+
+/// A `TempDir` state root (never under `$HOME/.simard`) paired with a
+/// fault backend registered as the in-process writer.
+struct FaultFixture {
+    _dir: tempfile::TempDir,
+    root: std::path::PathBuf,
+    _mem: Arc<dyn CognitiveMemoryOps>,
+}
+
+impl FaultFixture {
+    fn register_failing_reads() -> Self {
+        clear_in_process_writer();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().to_path_buf();
+        let mem: Arc<dyn CognitiveMemoryOps> = Arc::new(FaultyMemory { fail_reads: true });
+        register_in_process_writer(root.clone(), Arc::clone(&mem));
+        Self {
+            _dir: dir,
+            root,
+            _mem: mem,
+        }
+    }
+}
+
+/// Build a Proposed `goal-store:record` exactly as the creative-ideas router
+/// (`route_idea_to_goal`) does when an operator promotes an idea.
+fn proposed_record(title: &str) -> GoalRecord {
+    GoalRecord {
+        slug: goal_slug(title),
+        title: title.to_string(),
+        rationale: "routed from a promoted creative idea".to_string(),
+        status: GoalStatus::Proposed,
+        priority: 3,
+        owner_identity: "creative-ideas".to_string(),
+        source_session_id: SessionId::parse("session-018f1f7e-4c5d-7b2a-8f10-b5c0d4f7b123")
+            .expect("session id should parse"),
+        updated_in: SessionPhase::Planning,
+        evidence: Vec::new(),
+        labels: vec![crate::goal_curation::labels::SOURCE_CREATIVE_IDEAS.to_string()],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// dashboard_live_goal_board — the live union builder
+// ---------------------------------------------------------------------------
+
+/// The #2922 core: a Proposed record persisted to the live goal store must show
+/// up in the live board WITHOUT any snapshot write in between.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn live_builder_surfaces_proposed_goal_store_record_immediately() {
+    let state = HermeticState::new();
+    let root = state.state_root().to_path_buf();
+    let mem = SharedMem::register(&root);
+    // Base snapshot is EMPTY — the record must arrive purely via the live overlay.
+    save_goal_board(&GoalBoard::new(), mem.ops()).expect("seed empty snapshot base");
+
+    let title = "Ship the live goal-board read for issue 2922";
+    let store = CognitiveMemoryGoalStore::new(root.clone()).expect("construct goal store");
+    store
+        .put(proposed_record(title))
+        .expect("persist Proposed goal record via the live store");
+
+    // No snapshot write happens here — this is the whole point of the fix.
+    let board = dashboard_live_goal_board(&root).expect("live board build must succeed");
+
+    let slug = goal_slug(title);
+    assert!(
+        board
+            .backlog
+            .iter()
+            .any(|b| b.id == slug || b.description == title),
+        "a freshly-persisted Proposed goal-store record must appear in the live board \
+         backlog without a snapshot cycle (issue #2922); got backlog {:?}",
+        board.backlog
+    );
+    // It is Proposed, so it belongs in backlog, not active.
+    assert!(
+        !board.active.iter().any(|g| g.id == slug),
+        "a Proposed record must not land in the active list"
+    );
+}
+
+/// Dedup contract: a goal-store record whose slug already exists on the
+/// authoritative snapshot base is dropped — the base wins and carries the richer
+/// fields.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn live_builder_dedups_by_slug_base_wins() {
+    let state = HermeticState::new();
+    let root = state.state_root().to_path_buf();
+    let mem = SharedMem::register(&root);
+
+    let mut base = GoalBoard::new();
+    base.active.push(ActiveGoal {
+        labels: Vec::new(),
+        parent_goal_id: None,
+        priority_explicit: false,
+        repo: Some("Simard".to_string()),
+        id: "shared-slug-goal".to_string(),
+        description: "BASE authoritative description".to_string(),
+        priority: 1,
+        status: GoalProgress::InProgress { percent: 70 },
+        assigned_to: Some("simard".to_string()),
+        current_activity: Some("advancing on the base goal".to_string()),
+        wip_refs: vec![],
+        last_progress_update_at: None,
+    });
+    save_goal_board(&base, mem.ops()).expect("seed base snapshot with the active goal");
+
+    // Overlay record colliding on the SAME slug, with losing content.
+    let store = CognitiveMemoryGoalStore::new(root.clone()).expect("construct goal store");
+    let mut rec = proposed_record("overlay title that must lose the dedup");
+    rec.slug = "shared-slug-goal".to_string();
+    store.put(rec).expect("persist colliding overlay record");
+
+    let board = dashboard_live_goal_board(&root).expect("live board build");
+
+    let matches: Vec<&ActiveGoal> = board
+        .active
+        .iter()
+        .filter(|g| g.id == "shared-slug-goal")
+        .collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "a slug collision must not double-render the goal; got active {:?}",
+        board.active
+    );
+    assert_eq!(
+        matches[0].description, "BASE authoritative description",
+        "the authoritative snapshot goal must win on a slug collision, keeping its rich fields"
+    );
+    assert!(
+        !board.backlog.iter().any(|b| b.id == "shared-slug-goal"),
+        "the colliding overlay record must be dropped, never added as a duplicate backlog item"
+    );
+}
+
+/// A Completed overlay record is terminal and must not be surfaced on the live
+/// board in either bucket.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn live_builder_skips_completed_overlay_records() {
+    let state = HermeticState::new();
+    let root = state.state_root().to_path_buf();
+    let mem = SharedMem::register(&root);
+    save_goal_board(&GoalBoard::new(), mem.ops()).expect("seed empty snapshot base");
+
+    let title = "A completed overlay goal that must not surface";
+    let store = CognitiveMemoryGoalStore::new(root.clone()).expect("construct goal store");
+    let mut rec = proposed_record(title);
+    rec.status = GoalStatus::Completed;
+    store.put(rec).expect("persist completed overlay record");
+
+    let board = dashboard_live_goal_board(&root).expect("live board build");
+
+    let slug = goal_slug(title);
+    assert!(
+        !board.active.iter().any(|g| g.id == slug),
+        "a Completed overlay record must not appear in active"
+    );
+    assert!(
+        !board.backlog.iter().any(|b| b.id == slug),
+        "a Completed overlay record must not appear in backlog"
+    );
+}
+
+/// Fail-closed: a transport fault on the live read must PROPAGATE as `Err`,
+/// never a masked empty board (that would reintroduce the exact silent staleness
+/// #2922 removes).
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn live_builder_surfaces_reader_transport_error() {
+    let fx = FaultFixture::register_failing_reads();
+
+    let result = dashboard_live_goal_board(&fx.root);
+
+    clear_in_process_writer();
+    assert!(
+        result.is_err(),
+        "a broken-pipe read on either leg (snapshot base or goal-store overlay) MUST \
+         propagate as Err, never a phantom empty board (issue #2922 fail-closed). Got: {result:?}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/goals — goals_at repointed at the live builder
+// ---------------------------------------------------------------------------
+
+/// End-to-end acceptance: promoting a creative idea persists a Proposed record;
+/// `goals_at` must surface it in `backlog` and increment `backlog_count` on the
+/// very next poll, with NO snapshot write.
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn goals_at_shows_proposed_record_without_snapshot_write() {
+    let state = HermeticState::new();
+    let root = state.state_root().to_path_buf();
+    let mem = SharedMem::register(&root);
+    save_goal_board(&GoalBoard::new(), mem.ops()).expect("seed empty snapshot base");
+
+    let title = "Promoted creative-idea goal (2922 acceptance)";
+    let store = CognitiveMemoryGoalStore::new(root.clone()).expect("construct goal store");
+    store
+        .put(proposed_record(title))
+        .expect("persist Proposed record via the live store");
+
+    // Deliberately NO snapshot write between the put and the read.
+    let result = goals_at(&root).await;
+    let val = &result.0;
+
+    let backlog = val["backlog"].as_array().expect("backlog must be an array");
+    assert!(
+        backlog.iter().any(|b| b["description"] == title),
+        "goals_at must surface the freshly-promoted Proposed goal in backlog WITHOUT a \
+         snapshot cycle (issue #2922); got {val}"
+    );
+    assert!(
+        val["backlog_count"].as_u64().unwrap_or(0) >= 1,
+        "backlog_count must reflect the live union; got {val}"
+    );
+    // Shape preserved and successful → no error field.
+    assert!(
+        val.get("error").map(|e| e.is_null()).unwrap_or(true),
+        "a successful live read must not carry an error field; got {val}"
+    );
+    drop(mem);
+}
+
+/// Fail-closed handler contract: on a live-read failure `goals_at` returns an
+/// explicit error payload with zeroed counts and empty lists — never a
+/// silently-empty board that would be indistinguishable from "no goals".
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn goals_at_fail_closed_surfaces_error_not_stale_board() {
+    let fx = FaultFixture::register_failing_reads();
+
+    let result = goals_at(&fx.root).await;
+
+    clear_in_process_writer();
+    let val = &result.0;
+    assert!(
+        val.get("error").and_then(|e| e.as_str()).is_some(),
+        "a live-read failure MUST surface an explicit error field, never a silently-empty \
+         board (issue #2922 fail-closed); got {val}"
+    );
+    assert_eq!(
+        val["active_count"].as_u64().unwrap_or(u64::MAX),
+        0,
+        "fail-closed payload must zero active_count; got {val}"
+    );
+    assert_eq!(
+        val["backlog_count"].as_u64().unwrap_or(u64::MAX),
+        0,
+        "fail-closed payload must zero backlog_count; got {val}"
+    );
+    assert!(
+        val["active"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(false),
+        "fail-closed payload must carry an empty active array; got {val}"
+    );
+    assert!(
+        val["backlog"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(false),
+        "fail-closed payload must carry an empty backlog array; got {val}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/memory — goal_records tile from the live union
+// ---------------------------------------------------------------------------
+
+/// The Goal-Records tile count must come from the live union and its `source`
+/// label must be relabeled off the stale snapshot.
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn memory_metrics_goal_count_reflects_live_union_and_relabels_source() {
+    let state = HermeticState::new();
+    let root = state.state_root().to_path_buf();
+    let mem = SharedMem::register(&root);
+    save_goal_board(&GoalBoard::new(), mem.ops()).expect("seed empty snapshot base");
+
+    let store = CognitiveMemoryGoalStore::new(root.clone()).expect("construct goal store");
+    store
+        .put(proposed_record("Live-counted proposal (2922)"))
+        .expect("persist Proposed record via the live store");
+
+    let result = memory_metrics().await;
+    let gr = &result.0["goal_records"];
+
+    assert_eq!(
+        gr["source"], "cognitive-memory:live-goal-board",
+        "goal_records.source must be relabeled off the snapshot to reflect the live read; got {gr}"
+    );
+    assert!(
+        gr["count"].as_u64().unwrap_or(0) >= 1,
+        "goal_records.count must include the live goal-store record without a snapshot cycle; got {gr}"
+    );
+    drop(mem);
+}


### PR DESCRIPTION
Fixes #2922.

## Problem

The dashboard Goals tab (`GET /api/goals`) and the Memory tab's Goal-Records tile (`GET /api/memory`) read **only** the `goal-board:snapshot` fact — a cache the daemon rewrites just ~once per OODA cycle (~5 min). A promoted creative-idea **Proposed** goal persists a `goal-store:record` the snapshot does not contain, so it did not appear on the board (active/backlog or `goal_records` count) until the next cycle — a lag of up to ~5 minutes. Confirmed: promoting a creative idea returned the persisted Proposed goal from the API, yet the board stayed unchanged until the next snapshot.

## Fix — one fail-closed live builder, union of two live sources

The board **READ** is now **live**. Both handlers go through a single helper `dashboard_live_goal_board(state_root) -> SimardResult<GoalBoard>`:

- **Base** — the authoritative `goal-board:snapshot` board (`dashboard_goal_board_snapshot`), which already gives operator dashboard/CLI mutations read-your-writes and carries the daemon-OODA active/backlog goals with their rich fields (`current_activity`, `wip_refs`, `repo`, …).
- **Overlay** — the **live** `CognitiveMemoryGoalStore::list()` records (the same shared store creative-ideas / meeting / runtime / seed writers `put` into, already fail-closed per #2896).
- **Dedup by slug, base wins.** Overlay records whose slug is already on the base board are dropped; only absent records (e.g. a freshly promoted Proposed goal) are mapped in.

New reverse adapter `record_as_active_goal` + `BoardPlacement` (inverse of `active_goals_as_records`): `Active` → active (`InProgress{0}`), `Proposed`/`Paused` → backlog, `Completed` → skipped. Synthesizes absent rich fields; panic-free on arbitrary record text. Backlog `source` is a plain-English provenance label (`labels::provenance_source_label`); `score` is deterministic from priority (higher priority → higher score) so ordering is stable.

## Fail-closed (no silent fallback to stale data)

- `goals_at` and `memory_metrics` no longer `unwrap_or_default()` the board read.
- On a live-read failure `GET /api/goals` returns an explicit `{ active: [], backlog: [], active_count: 0, backlog_count: 0, error: "goal-board read failed" }` — never a stale/empty board indistinguishable from "no goals".
- The `goal_records` tile relabels `source` to `cognitive-memory:live-goal-board`, surfaces an additive `error` field on failure, and is **excluded** from `total_facts` on error.
- Error chains are logged server-side via `tracing` only.

The per-cycle snapshot **WRITE** is unchanged (retained as durable history); only the READ moved off the stale fact.

## Tests (real)

- `tests_live_goal_board.rs` — persist a **Proposed** `goal-store:record` (as a creative-idea promote does) with a shared in-process cognitive-memory writer and assert it appears in `goals_at(...)` backlog and increments the `goal_records` count **without** any snapshot write; slug-dedup (base wins); Completed skipped; and fail-closed: a broken-pipe read surfaces `Err` / an `error` payload, never a phantom board.
- `tests_reverse_adapter.rs` — status routing, field synthesis, plain-English source, stable score, panic-free mapping.
- Existing `tests_goals_crud`, `tests_goal_records_migration`, and `goal_curation`/`operator_commands_dashboard` suites stay green (947 module tests pass).

## Constraints honoured

Additive · fail-closed (no snapshot fallback on a live-read failure) · snapshot write unchanged · no `*Bridge` names · no stray `println!`/`eprintln!` (tracing only) · full CI green (fmt + release clippy `-D warnings` + pre-push test subset all pass) · never `--admin`/`--no-verify`.

> Note: TUI parity (`src/bin/simard_tui/goals.rs`) is intentionally scoped as a separately-shippable follow-up — it is an independent binary reading a different DB path via `lbug` with its own `GoalBoard` type and fail-open contract. See the "Terminal UI parity" section of `docs/reference/dashboard-live-goal-board-read.md`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>