### PR TITLE
fix(dashboard): load the live memory graph and fail LOUD on data-load errors (#2627)

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -747,6 +747,7 @@ The `SIMARD_DASHBOARD_URL` environment variable is honored by `conftest.py` (def
 - [Activity tab — Cycle Reports (live cycle number, accurate tree status, shared detail)](reference/dashboard-activity-cycle-reports.md)
 - [Overview Health & live memory-consolidation (Open PRs card removal, live Last Memory Compaction)](reference/dashboard-overview-health-and-live-memory.md)
 - [Memory tab — dedicated cognitive-memory graph (live nodes/edges, per-type filters)](reference/dashboard-memory-tab.md)
+- [Memory graph fail-loud data-load contract (visible error overlay, never a silent blank canvas)](reference/dashboard-memory-graph-fail-loud.md)
 - [Background tab prefetch and refresh (instant tab switches)](reference/dashboard-background-tab-prefetch.md)
 - [Header deployment datetime (build number + PST/PDT deploy time)](reference/dashboard-header-deployment-datetime.md)
 - [Creative Ideas tab — live view and operator controls (Run now / Promote / Prune)](operator-dashboard/creative-ideas-operator-controls.md)

--- a/docs/reference/dashboard-memory-graph-fail-loud.md
+++ b/docs/reference/dashboard-memory-graph-fail-loud.md
@@ -1,0 +1,358 @@
+---
+title: Dashboard — Memory graph fail-loud data-load contract
+description: Reference for the fail-LOUD behaviour of the dashboard Memory tab's cognitive-memory graph (GET /api/memory/graph). The graph never silently blanks: a data-load failure (cognitive reader unreachable, a per-type enumeration/statistics error, or a stats-vs-nodes discrepancy) is surfaced as a sanitized, path-free `error` field and painted as a visible on-canvas error overlay (#mem-graph-error / mgError) rather than an empty canvas. A genuinely empty store is a distinct, non-error state (six type hubs, no item nodes, available:true) with a neutral "empty" message. This closes the regression where the restored Memory tab (issue #2627, PR #2895) fetched the graph but rendered a blank canvas with no signal on any load error.
+last_updated: 2026-07-07
+owner: simard
+doc_type: reference
+related:
+  - ./dashboard-memory-tab.md
+  - ../dashboard.md
+  - ../memory.md
+  - ./cognitive-memory-client-helpers.md
+  - ./dashboard-overview-health-and-live-memory.md
+  - ./dashboard-e2e-tests.md
+---
+
+# Dashboard — Memory graph fail-loud data-load contract
+
+The dashboard **Memory** tab renders Simard's live cognitive-memory graph
+(facts, events, procedures, plans, plus working-memory and sensory-buffer hubs)
+from `GET /api/memory/graph` — see
+[dedicated Memory tab](./dashboard-memory-tab.md) for the graph itself.
+
+This page documents one specific guarantee layered on top of that graph: **it
+fails LOUD.** When the graph data cannot be loaded, the operator sees a visible
+error — never a blank canvas that is indistinguishable from "memory is empty".
+
+> **What this fixes.** The Memory tab was restored in
+> [#2627](https://github.com/rysweet/Simard/issues/2627) /
+> [PR #2895](https://github.com/rysweet/Simard/pull/2895) with a graph canvas and
+> a background loader. But the loader treated every failure the same way it
+> treated an empty store. The front-end had only a low-visibility fallback — a
+> one-line `#mem-graph-stats` note (`Error: …` / `Load failed`) that `return`ed
+> without touching the canvas — and, crucially, the backend **never emitted
+> `error` at all**, so even that branch was effectively dead: on any data-load
+> error the canvas stayed blank while a store holding thousands of facts appeared
+> empty. The backend also swallowed read errors
+> (`get_statistics().unwrap_or_default()`, `if let Ok(...)` per type) and the
+> reader-unavailable branch returned a silent `available:false` payload with only
+> a small `note`. This change removes those silent fallbacks end-to-end: the
+> backend surfaces load failures as a structured `error`, and the front-end
+> paints a visible overlay.
+
+## Three outcomes, one signal
+
+`GET /api/memory/graph` resolves to exactly one of three states. The client
+renders each distinctly; **there is no fourth "silent blank" state.**
+
+| Outcome | Backend response | What the operator sees |
+|---------|------------------|------------------------|
+| **Live data** | `error` absent; `nodes`/`edges` populated; `available:true`; live `stats`. | The force-directed graph, drawn from the live store. |
+| **Genuinely empty store** | `error` absent; `nodes` = the six type hubs only, no item nodes; `edges` empty; `available:true`. The four enumerable-type `stats` (`semantic`/`episodic`/`procedural`/`prospective`) are `0`; the transient `working`/`sensory` counts may be non-zero — those two types are hub-only, so a transient-only store still renders as hubs with no item nodes. | The six hubs plus a neutral *"Memory graph is empty"* message. **Not** an error. |
+| **Data-load failure** | `error` present (sanitized, path-free string). Reader-unavailable → `nodes:[]`, `available:false`; an in-build failure (per-type read `Err` or discrepancy) → the six hubs, `available:true`. See [Response shape by failure class](#response-shape-by-failure-class). | A visible on-canvas **error overlay** (`#mem-graph-error`) with the message; the (possibly partial) node set is suppressed; never a blank canvas. |
+
+The single machine-readable signal is the top-level **`error`** field. Its
+presence — and only its presence — puts the client into the error state.
+
+## Fail-loud triggers (backend)
+
+The `error` field is set whenever the graph cannot be assembled faithfully from
+the live store. Three failure classes are surfaced, all in
+`operator_commands_dashboard/memory.rs`:
+
+1. **Reader unreachable.** `open_reader_client(state_root)` returns `Err` — the
+   cognitive-memory reader (in-process, IPC/daemon socket, or direct library
+   tier) could not be opened. The handler returns:
+
+   ```jsonc
+   {
+     "error": "Cognitive memory reader is unavailable.",
+     "nodes": [], "edges": [],
+     "available": false,
+     "stats": { "working": 0, "semantic": 0, "episodic": 0,
+                "procedural": 0, "prospective": 0, "sensory": 0 }
+   }
+   ```
+
+   This branch replaces the previous silent `available:false` + `note` payload.
+   **Invariant:** on the reader-unavailable branch, `error` is present **iff**
+   `nodes == []` **and** `available == false`.
+
+2. **Per-type read error.** A statistics or enumeration read returns `Err`
+   (`get_statistics()`, `search_facts`, `list_all_episodes`,
+   `recall_procedure`, `list_all_prospective`). The builder no longer drops the
+   error via `unwrap_or_default()` / `if let Ok(...)`; it sets `error`
+   identifying which read failed. Any hubs already assembled may still be
+   present, but the presence of `error` forces the client into the error state
+   rather than presenting a partial graph as complete.
+
+3. **Stats-vs-nodes discrepancy.** The reads *succeeded* but are internally
+   inconsistent: an **enumerable** type reports `stats.<type> > 0` while it
+   produced **zero** item nodes. That means the graph would misrepresent a
+   populated store as hub-only, so the builder sets `error` describing the
+   discrepancy instead of silently degrading. The guard is scoped **strictly to
+   the four enumerable types** — `semantic` (facts), `episodic`, `procedural`,
+   `prospective` — because working memory and the sensory buffer are transient
+   and legitimately hub-only (they have no per-item enumerator), so counting
+   them here would produce false positives.
+
+Everything else (a truly empty store, working/sensory hubs with no items) is a
+valid, non-error state.
+
+### Response shape by failure class
+
+The three triggers do **not** produce the same JSON. Only the reader-unavailable
+branch is empty; the two in-build failures keep the already-assembled hubs so the
+legend and six filters stay meaningful, and `available` stays `true` because the
+reader *was* reachable:
+
+| Trigger | `error` | `available` | `nodes` |
+|---------|---------|-------------|---------|
+| Reader unreachable | present | `false` | `[]` (empty) |
+| Per-type read `Err` | present | `true` | six hubs (partial) |
+| Stats-vs-nodes discrepancy | present | `true` | six hubs (partial) |
+
+So the strict invariant *`error` present ⇔ `nodes == []` && `available == false`*
+holds **only** on the reader-unavailable branch. For the two in-build failures
+`error` coexists with the six hub nodes and `available: true`; the client keys off
+`error` alone (see [front-end overlay](#front-end-error-overlay)), so it never
+presents a partial graph as complete.
+
+`error` is serialized as `Option<String>` with
+`#[serde(skip_serializing_if = "Option::is_none")]` — it is **omitted** (not
+`null`) on the live-data and genuinely-empty paths. The `"error": null` shown in
+the `jq` examples below is `jq` filling a missing key in its projection, not a
+literal field in the response.
+
+### What is *not* an error
+
+- **An empty store.** Zero facts/episodes/procedures/plans returns the six hubs,
+  no item nodes, `available:true`, **no** `error`. The client shows the neutral
+  empty message.
+- **Working memory / sensory buffer being hub-only.** These two types are
+  transient and expose no enumerator; their magnitude shows only via `stats`.
+  They are exempt from the discrepancy guard above.
+
+## Response shape
+
+The successful/empty payload is unchanged from the
+[Memory tab reference](./dashboard-memory-tab.md#response-shape) except that the
+degraded path now carries `error` instead of `note`:
+
+```jsonc
+{
+  "available": true,
+  "nodes": [ /* six hubs + capped per-item nodes */ ],
+  "edges": [ /* item -> hub edges, no dangling endpoints */ ],
+  "stats": { "working": 3, "semantic": 42, "episodic": 17,
+             "procedural": 9, "prospective": 4, "sensory": 1 },
+  "timestamp": "2026-07-07T20:00:00Z"
+}
+```
+
+### Field contract (fail-loud fields)
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `error` | `string` (optional) | **Present only on a data-load failure.** Sanitized and **path-free** — never contains `state_root`, `$HOME`, or a backtrace. Its presence is the sole trigger for the client error overlay. Omitted (not `null`) on both the live-data and genuinely-empty paths. On an in-build failure it coexists with the six hub nodes — see [Response shape by failure class](#response-shape-by-failure-class). |
+| `available` | `bool` | `true` when the reader was reachable (including an empty store). `false` only on the reader-unavailable branch, where `error` is present and `nodes`/`edges` are empty. |
+| `nodes` / `edges` / `stats` / `timestamp` | — | Unchanged; see [dedicated Memory tab](./dashboard-memory-tab.md#field-contract). |
+
+> **`note` is removed.** The pre-fix reader-unavailable payload carried a
+> free-text `note`. That field is gone; failures are now reported through
+> `error`. Clients that read `note` should read `error`.
+
+### Examples
+
+Reader reachable, populated store (happy path):
+
+```bash
+curl -s --cookie "simard_session=<token>" \
+  http://localhost:8080/api/memory/graph \
+  | jq '{error, available, nodes: (.nodes|length), edges: (.edges|length), stats}'
+```
+
+```json
+{ "error": null, "available": true, "nodes": 78, "edges": 72,
+  "stats": { "working": 3, "semantic": 42, "episodic": 17,
+             "procedural": 9, "prospective": 4, "sensory": 1 } }
+```
+
+Reader unavailable (fail-loud):
+
+```json
+{ "error": "Cognitive memory reader is unavailable.",
+  "available": false, "nodes": 0, "edges": 0,
+  "stats": { "working": 0, "semantic": 0, "episodic": 0,
+             "procedural": 0, "prospective": 0, "sensory": 0 } }
+```
+
+Empty store (valid, non-error):
+
+```json
+{ "error": null, "available": true, "nodes": 6, "edges": 0,
+  "stats": { "working": 0, "semantic": 0, "episodic": 0,
+             "procedural": 0, "prospective": 0, "sensory": 0 } }
+```
+
+## Front-end error overlay
+
+The Memory tab panel (`index_html/part_00.rs`) gains a dedicated overlay element
+positioned over the graph canvas:
+
+```html
+<div id="mem-graph-error" role="alert" style="display:none"></div>
+```
+
+The graph engine (`index_html/part_03.rs`) tracks a single error string,
+`mgError` (`string | null`):
+
+- **`fetchMemoryGraph()`** sets `mgError` when any of the following is true, and
+  clears it (`null`) on a clean load:
+  - the payload has a truthy `d.error`;
+  - the `apiFetch('/api/memory/graph')` call throws (network / non-JSON / HTTP
+    error);
+  - a client-side discrepancy is detected (e.g. `d.stats` shows a populated
+    enumerable type but `d.nodes` carries no item nodes for it) — a defence in
+    depth mirroring the backend guard.
+
+  On a clean load it also updates the `#mem-graph-stats` line and runs the
+  normal `mgInitLayout()` → `mgApplyFilters()` → `mgSimulate()` render pipeline.
+
+  This **replaces** the pre-fix handling in `fetchMemoryGraph`, which wrote
+  `Error: …` / `Load failed` to the low-visibility `#mem-graph-stats` line and
+  `return`ed, leaving the canvas untouched. That stats-line error branch is
+  removed in favour of `mgError` + the `#mem-graph-error` overlay (a modify, not
+  an add — the implementer must delete the old `d.error`/`catch` stats-line
+  writes so there is a single error surface).
+
+- **`mgRender()`** is the single paint path and it honours `mgError`:
+  - when `mgError` is set, it shows `#mem-graph-error` with the message and does
+    **not** draw the (possibly partial) node set beneath it — so a hub-only
+    partial payload from an in-build failure is never shown as if it were the
+    whole graph, and the canvas is never a silent blank;
+  - when the graph is genuinely empty (no item nodes, no error) it shows the
+    neutral *"Memory graph is empty"* message;
+  - otherwise it draws the graph as before.
+
+All overlay text is written with `textContent` / the shared `esc()` helper —
+**never** unescaped `innerHTML` — so agent-authored memory content in an error
+message cannot inject markup (stored-XSS safe).
+
+The **"Refresh Graph"** button and the 120 s background loader
+(`TAB_LOADERS['memory']` in `index_html/part_05.rs`, path
+`/api/memory/graph`) are unchanged; a later refresh that succeeds clears the
+overlay automatically.
+
+## Configuration
+
+No new configuration is introduced. The fail-loud path preserves the existing
+graph bounds (a large store must not stream unbounded nodes into an error-free
+render, and truncation must survive the switch to fail-loud):
+
+| Constant (`memory.rs`) | Value | Purpose |
+|------------------------|-------|---------|
+| `GRAPH_MAX_PER_TYPE` | `200` | Max item nodes emitted per enumerable type. |
+| `GRAPH_NODE_CONTENT_MAX` | `2048` | Max per-node `content` bytes; truncated on a UTF-8 char boundary. |
+
+The Memory tab refreshes on the standard 120 s dashboard cadence and via the
+manual **Refresh Graph** button.
+
+## Security
+
+| Ref | Guarantee |
+|-----|-----------|
+| SR-AUTH-1 | `GET /api/memory/graph` stays **above** the `require_auth` layer in `routes.rs` (route registered before `.layer(middleware::from_fn(require_auth))`), so it is auth-gated and returns `401` when unauthenticated. A scope-guard test asserts the route is inside the authenticated router. |
+| SR-AUTH-3 | The dashkey (`~/.simard/.dashkey`) is never read, logged, or returned by this endpoint, and stays decoupled from `resolve_state_root()`. |
+| SR-VAL-2 | The endpoint takes **no** request parameters; no request-controlled path is ever routed into `open_reader_client` (no path traversal). |
+| SR-DATA-1 | The `error` string returned to the client is **path-free and sanitized** — no `state_root`, `$HOME`, or backtrace. Full failure detail is emitted only server-side via `tracing::warn!(target: "simard::dashboard", ...)`; there are **no** stray `println!` / `eprintln!`. |
+| SR-DATA-2 | The error / empty overlay is rendered with `textContent` / `esc()`, never unescaped `innerHTML`. |
+| SR-DATA-3 | `GRAPH_MAX_PER_TYPE` (200) and `GRAPH_NODE_CONTENT_MAX` (2048) caps are preserved on the fail-loud path (no DoS / payload-bloat regression). |
+
+Net new attack surface: **none** — the endpoint stays read-only, parameter-free,
+and auth-gated.
+
+## Tests
+
+The fail-loud contract is locked in at three layers:
+
+1. **Backend unit tests** (`mod tests_memory_graph`,
+   `operator_commands_dashboard/memory.rs`), using a fault-injecting
+   `CognitiveMemoryOps` double plus the existing populated-store harness:
+   - reader-open failure → response has `error`, empty `nodes`/`edges`,
+     `available:false`;
+   - a per-type enumeration / statistics `Err` → response has `error` (not a
+     silently dropped result);
+   - stats show a populated enumerable type but zero item nodes → response has
+     `error` (discrepancy guard), scoped to the four enumerable types;
+   - a genuinely empty store → **no** `error`, six hubs, `available:true`;
+   - a populated store → non-empty structured `nodes`/`edges`, **no** `error`;
+   - the returned `error` string is path-free (contains no `state_root` / home
+     path).
+
+2. **Rendered-HTML contract tests**
+   (`index_html/tests_memory_tab.rs`): assert the emitted dashboard HTML/JS
+   wires the error path — `fetchMemoryGraph` branches on `d.error` / a fetch
+   exception, the `#mem-graph-error` overlay element exists, and `mgRender`
+   references `mgError` so the overlay is actually painted.
+
+3. **E2E behavioural tests** (`tests/e2e-dashboard/specs/memory-tab.spec.ts`):
+   - **mocked error state:** route `/api/memory/graph` to `{ "error": "..." }`
+     and assert the Memory tab shows the visible `#mem-graph-error` overlay (not
+     a blank canvas);
+   - **mocked empty state:** hubs-only, no `error` → neutral empty message, no
+     error overlay;
+   - **live authenticated path:** read `~/.simard/.dashkey` (or
+     `SIMARD_DASHKEY`), `POST /api/login`, then `GET /api/memory/graph`; against
+     a store with content assert the response has **non-empty** `nodes`/`edges`
+     and no `error`, and the canvas renders non-blank. This live test gates on
+     the presence of a dashkey / live store and skips cleanly in CI when neither
+     is available (no flake). See
+     [Dashboard E2E tests](./dashboard-e2e-tests.md) and the outside-in check
+     `tests/gadugi/dashboard-memory-fidelity.sh` for the login → curl pattern.
+
+## Live acceptance gate
+
+The fix is accepted when, against a live daemon whose store holds content
+(≈7,700 facts at time of writing):
+
+```bash
+KEY="$(cat ~/.simard/.dashkey)"
+CJ="$(mktemp)"
+curl -s -c "$CJ" -X POST -H 'Content-Type: application/json' \
+     -d "{\"code\":\"$KEY\"}" http://localhost:8080/api/login >/dev/null
+curl -s -b "$CJ" http://localhost:8080/api/memory/graph \
+  | jq '{error, nodes: (.nodes|length), edges: (.edges|length), stats}'
+```
+
+returns non-empty `nodes` and `edges` with `error: null`, **and** the served
+Memory-tab HTML/JS renders that graph on the canvas — while an induced load
+failure surfaces the visible `#mem-graph-error` overlay instead of a blank
+canvas.
+
+## Constraints honoured
+
+- **Additive.** No endpoint, response field (beyond adding `error`), or route is
+  removed; `note` is the only field dropped and it belonged to a
+  never-user-facing degraded payload. `/api/memory/graph` keeps its shape on the
+  success and empty paths.
+- **Fail-loud.** No silent blank/empty fallback on a data-load error — every
+  failure class surfaces a visible signal.
+- **No `*Bridge` identifiers.** The reader is `open_reader_client` →
+  `ReaderClient`; no new bridge-named symbol (any casing) is introduced.
+- **No stray diagnostics.** Failure detail goes to `tracing::warn!` only; no new
+  `println!` / `eprintln!` outside the `[simard]` / tracing convention.
+- **Never `--admin` / `--no-verify`;** full CI green; PR against
+  `rysweet/Simard` `main`.
+
+## Related
+
+- [Dashboard — dedicated Memory tab](./dashboard-memory-tab.md) — the graph, its
+  live read path, and reader tiers this contract builds on.
+- [Dashboard](../dashboard.md) — full tab catalogue.
+- [Memory architecture](../memory.md) — the cognitive memory model behind the graph.
+- [Cognitive-memory client helpers](./cognitive-memory-client-helpers.md) —
+  `open_reader_client` and the live read path.
+- [Overview Health & live memory-consolidation](./dashboard-overview-health-and-live-memory.md)
+  — sibling live-read / fail-loud display work.
+- [Dashboard E2E tests](./dashboard-e2e-tests.md) — the authenticated E2E harness.

--- a/docs/reference/dashboard-memory-tab.md
+++ b/docs/reference/dashboard-memory-tab.md
@@ -124,11 +124,11 @@ statistics.
 
 | Field | Type | Meaning |
 |-------|------|---------|
-| `available` | `bool` | `true` whenever the reader was reachable — **including when the store is empty** (an empty store returns the six hubs, no item nodes, `available:true`) and **including partial degradation** (reader reachable but one type could not enumerate — that type falls back to hub-only and `available` stays `true`; see [Partial degradation](#partial-degradation-reachable-but-a-type-cant-enumerate)). |
+| `available` | `bool` | `true` whenever the reader was reachable — **including when the store is empty** (an empty store returns the six hubs, no item nodes, `available:true`). `false` only on the reader-unavailable failure path, where `error` is present and `nodes`/`edges` are empty (see [Fail-loud data-load contract](./dashboard-memory-graph-fail-loud.md)). |
 | `nodes[]` | array | One object per node. Fields consumed by the renderer: `id` (unique), `type` (one of the six type literals above), `label` (short display text), `content` (detail/tooltip text, UTF-8-safe truncated). |
 | `edges[]` | array | `{ source, target }` node-id pairs. Every item node has exactly one edge to its type hub; there are **no dangling edges** (every endpoint id exists in `nodes`). |
 | `stats` | object | Live per-type counts mirroring `CognitiveMemoryOps::get_statistics()`: `working, semantic, episodic, procedural, prospective, sensory`. |
-| `note` | `string` (optional) | Present only on the degraded path when the reader could not be opened. It is **path-free** (no filesystem paths) and human-readable; `available` is `false` and `nodes`/`edges` are empty. |
+| `error` | `string` (optional) | Present **only on a data-load failure** (reader unreachable, a per-type read error, or a stats-vs-nodes discrepancy). It is **path-free** (no filesystem paths, no backtrace) and human-readable; its presence is what puts the client into the visible error-overlay state. See [Fail-loud data-load contract](./dashboard-memory-graph-fail-loud.md). |
 
 ### Example
 
@@ -238,32 +238,37 @@ Two constants keep the payload bounded without dropping live fidelity:
 | `GRAPH_MAX_PER_TYPE` | `200` | Maximum item nodes emitted per enumerable type. |
 | `GRAPH_NODE_CONTENT_MAX` | `2048` | Maximum `content` length in bytes; longer content is truncated by `truncate_graph_content`, which cuts on a UTF-8 char boundary (never mid-codepoint). |
 
-### Degraded path
+### Fail-loud data-load path
 
-If `open_reader_client` fails (reader unreachable), the handler returns
-`available:false`, empty `nodes`/`edges`, the `stats` it could obtain (zeros if
-none), and a short, **path-free** `note`. This is a real fallback, not a
-placeholder for the normal path: when the reader is reachable the endpoint
-always returns live data, even if the store happens to be empty.
+The graph **fails LOUD** — it never silently renders a blank canvas on a
+data-load error. If `open_reader_client` fails (reader unreachable), the handler
+returns a sanitized, **path-free** `error`, empty `nodes`/`edges`,
+`available:false`, and zeroed `stats`. Two further failure classes also set
+`error`: a per-type statistics/enumeration read returning `Err` (surfaced, not
+dropped via `unwrap_or_default()` / `if let Ok`), and a stats-vs-nodes
+discrepancy (an enumerable type reports a non-zero count but produced zero item
+nodes). Whenever `error` is present the client shows a visible error overlay.
 
-### Partial degradation (reachable but a type can't enumerate)
+A **genuinely empty store** is distinct and is **not** an error: it returns the
+six hubs, no item nodes, `available:true`, and no `error`, and the client shows
+a neutral "empty" message. When the reader is reachable and the store has
+content, the endpoint always returns live nodes/edges.
 
-The degraded path above is for a reader that cannot be opened at all. A
-distinct, softer case is a reader that **is** reachable but cannot enumerate one
-specific type — for example a version-skewed daemon that predates the
-`ListAllEpisodes` / `ListAllProspective` IPC arms, or a per-type read error. In
-that case the builder does **not** fail the whole request: the affected type
-falls back to **hub-only** (its magnitude still shown from `stats`), the other
-types still enumerate, and `available` stays `true`. This keeps the graph
-resilient to a mismatched daemon while never fabricating item nodes it could not
-read. It is a defence-in-depth backstop — with the IPC arms in place (above) the
-normal daemon topology enumerates all four long-term types fully.
+The discrepancy guard is scoped strictly to the four enumerable long-term types
+(facts, episodes, procedures, prospective); working memory and the sensory
+buffer are transient and legitimately hub-only, so they are exempt and never
+trigger a false-positive error.
+
+See [Memory graph fail-loud data-load contract](./dashboard-memory-graph-fail-loud.md)
+for the full contract, the front-end `#mem-graph-error` / `mgError` overlay, and
+the tests.
 
 ### No stray diagnostics
 
 The read path emits **no** `println!` / `eprintln!` — errors are surfaced
-through the `note` field and normal `Result` handling, keeping production
-output clean.
+through the `error` field (see [Fail-loud data-load contract](./dashboard-memory-graph-fail-loud.md))
+and normal `Result` handling, with full detail only via `tracing::warn!`,
+keeping production output clean.
 
 ## Registration and wiring
 
@@ -352,9 +357,10 @@ pre-existing tooltip guard:
 - **Additive IPC protocol.** The two new memory-IPC request variants
   (`ListAllEpisodes`, `ListAllProspective`) are appended to `MemoryRequest` and
   reuse the existing `MemoryResponse::Episodes` / `Prospectives` variants; no
-  existing variant or its wire encoding changes, and a reader still degrades
-  gracefully (hub-only for that type) against a daemon that predates them — see
-  [Partial degradation](#partial-degradation-reachable-but-a-type-cant-enumerate).
+  existing variant or its wire encoding changes, and a stats-vs-nodes
+  discrepancy against a daemon that predates them **fails loud** rather than
+  silently degrading — see
+  [Fail-loud data-load contract](./dashboard-memory-graph-fail-loud.md).
 - **Live data only.** The graph renders real nodes/edges read from the live
   cognitive store; there is no stale snapshot or placeholder on the normal path.
 - **No new `println!` / `eprintln!`** in the production read path.
@@ -365,6 +371,7 @@ pre-existing tooltip guard:
 ## Related
 
 - [Dashboard](../dashboard.md) — full tab catalogue and the Tab Identity Contract.
+- [Memory graph fail-loud data-load contract](./dashboard-memory-graph-fail-loud.md) — how the graph surfaces data-load errors instead of a silent blank canvas.
 - [Memory architecture](../memory.md) — the cognitive memory model behind the graph.
 - [Background tab prefetch and refresh](./dashboard-background-tab-prefetch.md) — how the Memory tab is pre-warmed and refreshed.
 - [Cognitive-memory client helpers](./cognitive-memory-client-helpers.md) — `open_reader_client` and the read path.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -242,6 +242,7 @@ nav:
     - simard-engineer-step CLI: reference/simard-engineer-step.md
     - simard-tui Dashboard: reference/simard-tui.md
     - Dashboard Memory Tab: reference/dashboard-memory-tab.md
+    - Dashboard Memory Graph Fail-Loud: reference/dashboard-memory-graph-fail-loud.md
     - Dashboard Memory Last-Hour Count: reference/dashboard-memory-recent-last-hour-count.md
     - Journal API: reference/journal-api.md
     - Journal Narrative Result Channel: reference/journal-narrative-result-channel.md

--- a/src/operator_commands_dashboard/index_html/part_00.rs
+++ b/src/operator_commands_dashboard/index_html/part_00.rs
@@ -424,6 +424,7 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
       <div style="display:flex;gap:1rem">
         <div class="card" style="flex:1;padding:0;position:relative;min-height:60vh">
           <canvas id="mem-graph-canvas" style="width:100%;height:60vh;display:block;cursor:grab"></canvas>
+          <div id="mem-graph-error" role="alert" style="display:none;position:absolute;top:0;left:0;right:0;bottom:0;align-items:center;justify-content:center;text-align:center;padding:1.5rem;background:rgba(13,17,23,0.82);z-index:20"></div>
           <div id="mem-graph-tooltip" style="display:none;position:absolute;background:#161b22;border:1px solid #30363d;border-radius:6px;padding:.5rem .75rem;font-size:.8rem;max-width:320px;pointer-events:none;z-index:10;word-break:break-word"></div>
         </div>
         <div id="mem-graph-detail" class="card" style="width:280px;display:none">

--- a/src/operator_commands_dashboard/index_html/part_03.rs
+++ b/src/operator_commands_dashboard/index_html/part_03.rs
@@ -448,6 +448,10 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
     let mgNodes=[],mgEdges=[],mgFiltered=[],mgFilteredEdges=[];
     let mgDrag=null,mgPinned=null;
     let mgOffX=0,mgOffY=0,mgScale=1,mgPanX=0,mgPanY=0;
+    // Fail-LOUD state (issue #2627): non-empty => a data-load failure the single
+    // paint path (mgRender) must surface on the #mem-graph-error overlay, never a
+    // silent blank canvas. Empty string => no error.
+    let mgError='';
     const mgColors={WorkingMemory:'#f0883e',SemanticFact:'#58a6ff',EpisodicMemory:'#3fb950',ProceduralMemory:'#a371f7',ProspectiveMemory:'#d29922',SensoryBuffer:'#8b949e'};
 
     function mgApplyFilters(){
@@ -468,13 +472,40 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
     async function fetchMemoryGraph(){
       try{
         const d=await apiFetch('/api/memory/graph');
-        if(d.error){document.getElementById('mem-graph-stats').textContent='Error: '+d.error;return;}
         const s=d.stats||{};
-        document.getElementById('mem-graph-stats').textContent=
-          'Thinking:'+(s.working||0)+' Facts:'+(s.semantic||0)+' Events:'+(s.episodic||0)+' Procedures:'+(s.procedural||0)+' Planned:'+(s.prospective||0)+' Observed:'+(s.sensory||0);
+        // Fail-LOUD: a server-side error (reader unreachable, a per-type read
+        // failure, or a stats-vs-nodes discrepancy) is surfaced on the visible
+        // #mem-graph-error overlay via mgError — NOT hidden in the stats line.
         mgNodes=(d.nodes||[]);mgEdges=(d.edges||[]);
+        // Defence in depth: mirror the backend stats-vs-nodes discrepancy guard.
+        // If stats claim an enumerable type holds content but no item node of
+        // that type came back, treat it as a load failure rather than drawing a
+        // misleadingly hub-only graph.
+        const mgEnumTypes={semantic:'SemanticFact',episodic:'EpisodicMemory',procedural:'ProceduralMemory',prospective:'ProspectiveMemory'};
+        let mgDisc='';
+        for(const k in mgEnumTypes){
+          if((s[k]||0)>0 && !mgNodes.some(n=>!n.hub&&n.type===mgEnumTypes[k])){
+            mgDisc='Memory statistics report '+(s[k])+' '+k+' item(s) but none were returned (stats-vs-nodes discrepancy).';
+            break;
+          }
+        }
+        if(d.error||mgDisc){
+          mgError=d.error||mgDisc;
+          document.getElementById('mem-graph-stats').textContent='';
+        }else{
+          mgError='';
+          document.getElementById('mem-graph-stats').textContent=
+            'Thinking:'+(s.working||0)+' Facts:'+(s.semantic||0)+' Events:'+(s.episodic||0)+' Procedures:'+(s.procedural||0)+' Planned:'+(s.prospective||0)+' Observed:'+(s.sensory||0);
+        }
         mgInitLayout();mgApplyFilters();mgSimulate();
-      }catch(e){document.getElementById('mem-graph-stats').textContent='Load failed';}
+      }catch(e){
+        // A fetch throw must also fail loud on the overlay, not vanish into a
+        // blank canvas.
+        mgError='Failed to load memory graph: '+(e&&e.message?e.message:e);
+        mgNodes=[];mgEdges=[];
+        document.getElementById('mem-graph-stats').textContent='';
+        mgApplyFilters();mgRender();
+      }
     }
 
     function mgInitLayout(){
@@ -531,12 +562,32 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
     function mgRender(){
       const canvas=document.getElementById('mem-graph-canvas');
       if(!canvas)return;
+      // Single paint path owns the fail-loud overlay: show #mem-graph-error
+      // whenever mgError is set (a load failure is NEVER a silent blank), hide
+      // it otherwise.
+      const errEl=document.getElementById('mem-graph-error');
+      if(errEl){
+        if(mgError){
+          errEl.innerHTML='<div style="max-width:520px"><div style="color:#f85149;font-weight:600;margin-bottom:.35rem">Memory graph failed to load</div><div style="color:#c9d1d9;font-size:.85rem;white-space:pre-wrap">'+esc(mgError)+'</div></div>';
+          errEl.style.display='flex';
+        }else{
+          errEl.textContent='';errEl.style.display='none';
+        }
+      }
       canvas.width=canvas.clientWidth*(window.devicePixelRatio||1);
       canvas.height=canvas.clientHeight*(window.devicePixelRatio||1);
       const ctx=canvas.getContext('2d');
       const dpr=window.devicePixelRatio||1;
       ctx.scale(dpr,dpr);
       ctx.clearRect(0,0,canvas.clientWidth,canvas.clientHeight);
+      // Neutral empty state (distinct from the error overlay): a genuinely-empty
+      // store renders only the six type hubs and no item nodes — tell the
+      // operator so, rather than presenting an ambiguous near-blank canvas.
+      const hasItems=mgNodes.some(n=>!n.hub);
+      if(!mgError && !hasItems){
+        ctx.fillStyle='#8b949e';ctx.font='14px sans-serif';ctx.textAlign='center';
+        ctx.fillText('Memory graph is empty — nothing remembered yet',canvas.clientWidth/2,24);
+      }
       ctx.save();ctx.translate(mgPanX,mgPanY);ctx.scale(mgScale,mgScale);
       const nodeMap={};mgFiltered.forEach(n=>{nodeMap[n.id]=n;});
       mgFilteredEdges.forEach(e=>{

--- a/src/operator_commands_dashboard/index_html/tests_memory_tab.rs
+++ b/src/operator_commands_dashboard/index_html/tests_memory_tab.rs
@@ -199,3 +199,112 @@ fn memory_deeplink_alias_to_resources_removed() {
          Memory is a canonical tab (#2627)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Fail-LOUD front-end contract (issue #2627): the graph must never silently
+// blank. A data-load failure is surfaced as a VISIBLE on-canvas error overlay
+// (`#mem-graph-error`, driven by the `mgError` state and painted by `mgRender`),
+// and a genuinely-empty store shows a neutral "empty" message — not a blank
+// canvas. See docs/reference/dashboard-memory-graph-fail-loud.md.
+//
+// TDD note (Step 7 / red): these FAIL against the current renderer — there is no
+// `#mem-graph-error` overlay and no `mgError`; `fetchMemoryGraph` writes errors
+// to the low-visibility `#mem-graph-stats` line (`Error: …` / `Load failed`) and
+// `return`s, leaving the canvas untouched (the silent blank). They pass once the
+// overlay + `mgError` render path replace those stats-line writes.
+// ---------------------------------------------------------------------------
+
+/// Return the body of a JS `function <name>(...)` from the rendered HTML: from
+/// the declaration up to the next top-level `function ` declaration. Sufficient
+/// for the flat helpers in the Memory-graph script. Panics if the function is
+/// absent so a missing/renamed function fails loudly.
+fn js_function<'h>(html: &'h str, name: &str) -> &'h str {
+    let marker = format!("function {name}(");
+    let start = html.find(&marker).unwrap_or_else(|| {
+        panic!("expected a JS `{marker}...` declaration in the rendered dashboard")
+    });
+    let rest = &html[start + marker.len()..];
+    let end = rest.find("function ").unwrap_or(rest.len());
+    &rest[..end]
+}
+
+/// The Memory panel must own a dedicated, visible error-overlay element so a
+/// data-load failure is announced on the canvas, not swallowed into a tiny stats
+/// line. `role="alert"` makes it announce to assistive tech.
+#[test]
+fn memory_panel_has_visible_error_overlay_element() {
+    let html: &str = &INDEX_HTML;
+    let panel = tab_panel(html, "memory");
+    assert!(
+        panel.contains(r#"id="mem-graph-error""#),
+        "the Memory panel must render a dedicated #mem-graph-error overlay so a \
+         data-load failure is visible on the canvas (never a silent blank)"
+    );
+    assert!(
+        panel.contains(r#"role="alert""#),
+        "the #mem-graph-error overlay must carry role=\"alert\" so the failure is \
+         announced to assistive tech"
+    );
+}
+
+/// The renderer must track a single `mgError` state: `fetchMemoryGraph` sets it
+/// (on `d.error`, a fetch throw, or a client-side discrepancy) and the single
+/// paint path `mgRender` honours it by showing the `#mem-graph-error` overlay.
+#[test]
+fn memory_graph_fetch_and_render_wire_the_mg_error_overlay() {
+    let html: &str = &INDEX_HTML;
+    assert!(
+        html.contains("mgError"),
+        "the Memory-graph script must track an `mgError` state string driving the \
+         error overlay"
+    );
+
+    let fetch_body = js_function(html, "fetchMemoryGraph");
+    assert!(
+        fetch_body.contains("mgError"),
+        "fetchMemoryGraph must set/clear `mgError` (fail-loud on d.error / fetch \
+         throw / discrepancy), not just write the low-visibility stats line; body: {fetch_body}"
+    );
+
+    let render_body = js_function(html, "mgRender");
+    assert!(
+        render_body.contains("mgError"),
+        "mgRender (the single paint path) must honour `mgError`; body: {render_body}"
+    );
+    assert!(
+        render_body.contains("mem-graph-error"),
+        "mgRender must show the #mem-graph-error overlay when `mgError` is set so a \
+         partial/failed load is never presented as a blank canvas; body: {render_body}"
+    );
+}
+
+/// The retired silent branches must be gone: the pre-fix `fetchMemoryGraph` wrote
+/// `Error: …` / `Load failed` to the low-visibility `#mem-graph-stats` line and
+/// `return`ed, leaving the canvas a silent blank. There must be a SINGLE error
+/// surface (the overlay), so those stats-line error writes are removed.
+#[test]
+fn memory_graph_error_is_not_hidden_in_the_stats_line() {
+    let html: &str = &INDEX_HTML;
+    assert!(
+        !html.contains("Error: '+d.error"),
+        "the silent stats-line error branch (`#mem-graph-stats` = 'Error: '+d.error) \
+         must be replaced by the visible #mem-graph-error overlay (single error surface)"
+    );
+    assert!(
+        !html.contains("'Load failed'"),
+        "the silent stats-line 'Load failed' catch branch must be replaced by the \
+         visible #mem-graph-error overlay (never a silent blank)"
+    );
+}
+
+/// A genuinely-empty store is a distinct, non-error state: the renderer shows a
+/// neutral "empty" message (not the error overlay, not a blank canvas).
+#[test]
+fn memory_graph_has_neutral_empty_state_message() {
+    let html: &str = &INDEX_HTML;
+    assert!(
+        html.contains("Memory graph is empty"),
+        "the renderer must show a neutral \"Memory graph is empty\" message for a \
+         genuinely-empty store (distinct from the error overlay)"
+    );
+}

--- a/src/operator_commands_dashboard/memory.rs
+++ b/src/operator_commands_dashboard/memory.rs
@@ -533,13 +533,18 @@ pub(crate) fn build_live_memory_graph(
     ops: &dyn crate::cognitive_memory::CognitiveMemoryOps,
 ) -> Value {
     let cap = GRAPH_MAX_PER_TYPE as u32;
-    let stats = ops.get_statistics().unwrap_or_default();
 
     let mut nodes: Vec<Value> = Vec::new();
     let mut edges: Vec<Value> = Vec::new();
+    // Fail-LOUD accumulator (issue #2627): a read `Err` or a stats-vs-nodes
+    // discrepancy is recorded here and surfaced as a top-level `error` rather
+    // than swallowed into a phantom empty/partial graph. A genuinely empty
+    // store leaves this empty and OMITS the `error` key.
+    let mut errors: Vec<String> = Vec::new();
 
     // Six type hubs — always present so the legend + all six filters are
-    // meaningful even when a type currently holds no items.
+    // meaningful even when a type currently holds no items (and so an in-build
+    // failure still renders a legend-complete graph behind the error overlay).
     for (ty, label) in MEMORY_TYPE_HUBS {
         nodes.push(json!({
             "id": format!("hub:{ty}"),
@@ -550,88 +555,188 @@ pub(crate) fn build_live_memory_graph(
         }));
     }
 
-    // Semantic facts — wildcard enumeration (confidence-desc), capped.
-    if let Ok(facts) = ops.search_facts("*", cap, 0.0) {
-        for f in facts {
-            let id = graph_node_id("fact", &f.node_id);
-            nodes.push(json!({
-                "id": id.clone(),
-                "type": "SemanticFact",
-                "label": graph_label(&f.concept),
-                "content": truncate_graph_content(&f.content),
-                "confidence": f.confidence,
-                "tags": f.tags,
-            }));
-            edges.push(json!({"source": id, "target": "hub:SemanticFact"}));
+    // Live statistics. A read failure must NOT be swallowed into an all-zeros
+    // phantom (the retired `unwrap_or_default()`): record it and drop the
+    // discrepancy guard (we have no trustworthy counts to compare against).
+    let stats = match ops.get_statistics() {
+        Ok(s) => Some(s),
+        Err(e) => {
+            errors.push(format!("statistics read failed: {e}"));
+            None
         }
-    }
+    };
+
+    // Each enumerator yields `Some(item_node_count)` on success (0 = read OK but
+    // empty) or `None` when the read itself failed (already recorded in
+    // `errors`). The count feeds the stats-vs-nodes discrepancy guard below.
+
+    // Semantic facts — wildcard enumeration (confidence-desc), capped.
+    let semantic_items = match ops.search_facts("*", cap, 0.0) {
+        Ok(facts) => {
+            let mut count = 0usize;
+            for f in facts {
+                let id = graph_node_id("fact", &f.node_id);
+                nodes.push(json!({
+                    "id": id.clone(),
+                    "type": "SemanticFact",
+                    "label": graph_label(&f.concept),
+                    "content": truncate_graph_content(&f.content),
+                    "confidence": f.confidence,
+                    "tags": f.tags,
+                }));
+                edges.push(json!({"source": id, "target": "hub:SemanticFact"}));
+                count += 1;
+            }
+            Some(count)
+        }
+        Err(e) => {
+            errors.push(format!("semantic-fact read failed: {e}"));
+            None
+        }
+    };
 
     // Episodes — unfiltered enumeration, newest-first, capped.
-    if let Ok(episodes) = ops.list_all_episodes(cap) {
-        for e in episodes {
-            let id = graph_node_id("episode", &e.node_id);
-            nodes.push(json!({
-                "id": id.clone(),
-                "type": "EpisodicMemory",
-                "label": graph_label(&e.content),
-                "content": truncate_graph_content(&e.content),
-                "source": e.source_label,
-            }));
-            edges.push(json!({"source": id, "target": "hub:EpisodicMemory"}));
+    let episodic_items = match ops.list_all_episodes(cap) {
+        Ok(episodes) => {
+            let mut count = 0usize;
+            for e in episodes {
+                let id = graph_node_id("episode", &e.node_id);
+                nodes.push(json!({
+                    "id": id.clone(),
+                    "type": "EpisodicMemory",
+                    "label": graph_label(&e.content),
+                    "content": truncate_graph_content(&e.content),
+                    "source": e.source_label,
+                }));
+                edges.push(json!({"source": id, "target": "hub:EpisodicMemory"}));
+                count += 1;
+            }
+            Some(count)
         }
-    }
+        Err(e) => {
+            errors.push(format!("episodic-memory read failed: {e}"));
+            None
+        }
+    };
 
     // Procedures — wildcard enumeration (usage-desc), capped.
-    if let Ok(procedures) = ops.recall_procedure("*", cap) {
-        for p in procedures {
-            let id = graph_node_id("procedure", &p.node_id);
-            let body = truncate_graph_content(&p.steps.join("\n"));
-            nodes.push(json!({
-                "id": id.clone(),
-                "type": "ProceduralMemory",
-                "label": graph_label(&p.name),
-                "content": body,
-                "steps": p.steps.len(),
-                "usage_count": p.usage_count,
-            }));
-            edges.push(json!({"source": id, "target": "hub:ProceduralMemory"}));
+    let procedural_items = match ops.recall_procedure("*", cap) {
+        Ok(procedures) => {
+            let mut count = 0usize;
+            for p in procedures {
+                let id = graph_node_id("procedure", &p.node_id);
+                let body = truncate_graph_content(&p.steps.join("\n"));
+                nodes.push(json!({
+                    "id": id.clone(),
+                    "type": "ProceduralMemory",
+                    "label": graph_label(&p.name),
+                    "content": body,
+                    "steps": p.steps.len(),
+                    "usage_count": p.usage_count,
+                }));
+                edges.push(json!({"source": id, "target": "hub:ProceduralMemory"}));
+                count += 1;
+            }
+            Some(count)
         }
-    }
+        Err(e) => {
+            errors.push(format!("procedural-memory read failed: {e}"));
+            None
+        }
+    };
 
     // Prospective memories — every status, priority-ordered, capped.
-    if let Ok(prospective) = ops.list_all_prospective(cap) {
-        for pr in prospective {
-            let id = graph_node_id("prospective", &pr.node_id);
-            let body = truncate_graph_content(&format!(
-                "when: {}\n→ {}",
-                pr.trigger_condition, pr.action_on_trigger
-            ));
-            nodes.push(json!({
-                "id": id.clone(),
-                "type": "ProspectiveMemory",
-                "label": graph_label(&pr.description),
-                "content": body,
-                "status": pr.status,
-                "priority": pr.priority,
-            }));
-            edges.push(json!({"source": id, "target": "hub:ProspectiveMemory"}));
+    let prospective_items = match ops.list_all_prospective(cap) {
+        Ok(prospective) => {
+            let mut count = 0usize;
+            for pr in prospective {
+                let id = graph_node_id("prospective", &pr.node_id);
+                let body = truncate_graph_content(&format!(
+                    "when: {}\n→ {}",
+                    pr.trigger_condition, pr.action_on_trigger
+                ));
+                nodes.push(json!({
+                    "id": id.clone(),
+                    "type": "ProspectiveMemory",
+                    "label": graph_label(&pr.description),
+                    "content": body,
+                    "status": pr.status,
+                    "priority": pr.priority,
+                }));
+                edges.push(json!({"source": id, "target": "hub:ProspectiveMemory"}));
+                count += 1;
+            }
+            Some(count)
+        }
+        Err(e) => {
+            errors.push(format!("prospective-memory read failed: {e}"));
+            None
+        }
+    };
+
+    // Stats-vs-nodes discrepancy guard (issue #2627): if statistics claim an
+    // ENUMERABLE type holds content while its enumerator read OK yet yielded no
+    // item nodes, the store would be misrepresented as hub-only. Fail loud.
+    // Scoped strictly to the four enumerable types — working memory and the
+    // sensory buffer are transient and hub-only (no per-item enumerator), so
+    // non-zero working/sensory counts with zero item nodes is a VALID state.
+    // `emitted.is_some()` skips types whose read already failed (double-flag),
+    // and a capped read always emits `cap > 0` items so capping never trips it.
+    if let Some(s) = &stats {
+        let checks: [(&str, u64, Option<usize>); 4] = [
+            ("semantic fact", s.semantic_count, semantic_items),
+            ("episodic memory", s.episodic_count, episodic_items),
+            ("procedural memory", s.procedural_count, procedural_items),
+            ("prospective memory", s.prospective_count, prospective_items),
+        ];
+        for (name, stat, emitted) in checks {
+            if let Some(0) = emitted
+                && stat > 0
+            {
+                errors.push(format!(
+                    "{name} statistics report {stat} item(s) but the live \
+                     enumerator returned none (stats-vs-nodes discrepancy)"
+                ));
+            }
         }
     }
 
-    json!({
+    let stats_block = match &stats {
+        Some(s) => json!({
+            "working": s.working_count,
+            "semantic": s.semantic_count,
+            "episodic": s.episodic_count,
+            "procedural": s.procedural_count,
+            "prospective": s.prospective_count,
+            "sensory": s.sensory_count,
+        }),
+        // Statistics could not be read — surface null, never a phantom all-zeros
+        // block (the `error` field carries the real cause).
+        None => Value::Null,
+    };
+
+    let mut payload = json!({
         "nodes": nodes,
         "edges": edges,
+        // The reader WAS reachable (this builder only runs against a live `ops`),
+        // so `available` stays true even for an in-build read failure — the
+        // handler owns the reader-unreachable `available:false` branch.
         "available": true,
-        "stats": {
-            "working": stats.working_count,
-            "semantic": stats.semantic_count,
-            "episodic": stats.episodic_count,
-            "procedural": stats.procedural_count,
-            "prospective": stats.prospective_count,
-            "sensory": stats.sensory_count,
-        },
+        "stats": stats_block,
         "timestamp": chrono::Utc::now().to_rfc3339(),
-    })
+    });
+
+    if !errors.is_empty() {
+        // Single, non-empty top-level error surface. OMITTED entirely (not null)
+        // on the success/empty paths so the client only shows the error overlay
+        // for a genuine failure.
+        payload["error"] = Value::String(format!(
+            "Memory graph loaded with errors: {}",
+            errors.join("; ")
+        ));
+    }
+
+    payload
 }
 
 /// `GET /api/memory/graph` — LIVE cognitive-memory graph visualization
@@ -642,8 +747,12 @@ pub(crate) fn build_live_memory_graph(
 /// via a single shared reader ([`open_reader_client`]) and renders it through
 /// [`build_live_memory_graph`]: six type hubs, live per-item nodes for the four
 /// enumerable memory types linked to their hubs, and `stats` mirroring
-/// `get_statistics()`. When the reader is unreachable the graph falls back to an
-/// empty, `available:false` payload with a path-free note rather than erroring.
+/// `get_statistics()`. When the reader is unreachable the handler fails LOUD
+/// (issue #2627): it returns a path-free top-level `error` with an empty graph
+/// (`available:false`), never a silent blank or a hidden `note` — so the Memory
+/// tab shows a visible error state instead of an empty canvas. The
+/// client-facing `error` is sanitized (no filesystem paths, SR-DATA-1); the
+/// underlying cause (which may embed the socket path) is logged server-side.
 pub(crate) async fn memory_graph() -> Json<Value> {
     let state_root = resolve_state_root();
     match open_reader_client(&state_root) {
@@ -652,14 +761,17 @@ pub(crate) async fn memory_graph() -> Json<Value> {
             tracing::warn!(
                 target: "simard::dashboard",
                 error = %e,
-                "memory_graph: cognitive reader unavailable; serving empty graph"
+                "memory_graph: cognitive reader unavailable; failing loud with an \
+                 empty graph + error"
             );
             Json(json!({
                 "nodes": [],
                 "edges": [],
                 "available": false,
-                "note": "Cognitive memory reader is currently unavailable; \
-                         showing an empty graph.",
+                // Fail-LOUD, PATH-FREE (SR-DATA-1): the detailed cause `e` may
+                // embed the socket/state-root path, so it is logged above rather
+                // than returned. The client shows this as a visible error state.
+                "error": "Cognitive memory reader is unavailable.",
                 "stats": {
                     "working": 0,
                     "semantic": 0,
@@ -1356,5 +1468,384 @@ mod tests_memory_graph {
             "EpisodicMemory nodes ({episodic}) must be capped near GRAPH_MAX_PER_TYPE \
              (~200, +1 hub) — an uncapped per-type dump is a DoS vector on large stores"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Fail-LOUD contract (issue #2627): the memory graph must NEVER silently
+    // blank. A data-load failure — reader unreachable, a per-type
+    // statistics/enumeration read `Err`, or a stats-vs-nodes discrepancy — must
+    // surface a top-level `error` string; a genuinely empty store is a distinct,
+    // VALID non-error state. See
+    // docs/reference/dashboard-memory-graph-fail-loud.md.
+    //
+    // TDD note (Step 7 / red): these FAIL against the current builder, which
+    // swallows every read error via `unwrap_or_default()` / `if let Ok(...)` and
+    // never emits `error`, and whose handler returns a silent `available:false`
+    // + `note` payload on reader failure. They pass once the builder/handler are
+    // rewired to fail loud.
+    // -----------------------------------------------------------------------
+
+    use crate::error::{SimardError, SimardResult};
+    use crate::memory_cognitive::{
+        CognitiveEpisode, CognitiveFact, CognitiveProcedure, CognitiveProspective,
+        CognitiveWorkingSlot,
+    };
+
+    /// True iff the payload carries a top-level `error` key that is a non-empty
+    /// string. The contract OMITS `error` entirely (not `null`) on the
+    /// success/empty paths, so a present-but-null key is treated as absent.
+    fn error_string(v: &Value) -> Option<String> {
+        v.as_object()
+            .and_then(|m| m.get("error"))
+            .and_then(|e| e.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    }
+
+    /// Whether the top-level `error` key is present at all. On the non-error
+    /// paths the key must be OMITTED (not serialized as `null`).
+    fn has_error_key(v: &Value) -> bool {
+        v.as_object().is_some_and(|m| m.contains_key("error"))
+    }
+
+    /// The set of `type` literals carried by the always-present type-hub nodes
+    /// (`"hub": true`).
+    fn hub_types(v: &Value) -> HashSet<String> {
+        nodes_of(v)
+            .iter()
+            .filter(|n| n.get("hub").and_then(Value::as_bool) == Some(true))
+            .filter_map(|n| n["type"].as_str().map(str::to_string))
+            .collect()
+    }
+
+    /// An in-build failure (per-type read `Err` or discrepancy) must still keep
+    /// the six type hubs so the legend and all six filters stay meaningful.
+    fn assert_six_hub_types(v: &Value) {
+        let hubs = hub_types(v);
+        for t in NODE_TYPE_ALLOWLIST {
+            assert!(
+                hubs.contains(t),
+                "an in-build failure must keep the six type hubs (legend/filters stay \
+                 meaningful); missing hub {t:?}. Nodes: {}",
+                &v["nodes"]
+            );
+        }
+    }
+
+    /// Configurable fault-injecting [`CognitiveMemoryOps`] double. Each read the
+    /// graph builder relies on can be flipped to return `Err` (the `*_err`
+    /// flags) or to yield a controlled value; `get_statistics` returns the
+    /// `stats` block verbatim. This exercises the fail-LOUD paths deterministically
+    /// without a live daemon — a read fault, or a store whose `stats` claim
+    /// content while the matching enumerator yields nothing (the stats-vs-nodes
+    /// discrepancy). Every write op is a benign `Ok` (never used by the builder).
+    #[derive(Default)]
+    struct GraphFaultOps {
+        stats: CognitiveStatistics,
+        stats_err: bool,
+        facts_err: bool,
+        episodes_err: bool,
+        procedures_err: bool,
+        prospective_err: bool,
+        facts: Vec<CognitiveFact>,
+        episodes: Vec<CognitiveEpisode>,
+        procedures: Vec<CognitiveProcedure>,
+        prospective: Vec<CognitiveProspective>,
+    }
+
+    impl GraphFaultOps {
+        fn boom(op: &str) -> SimardError {
+            SimardError::MemoryIntegrityError {
+                path: std::path::PathBuf::from("<graph-fault-double>"),
+                reason: format!("injected {op} read fault (fail-loud test double)"),
+            }
+        }
+    }
+
+    impl CognitiveMemoryOps for GraphFaultOps {
+        fn record_sensory(&self, _m: &str, _r: &str, _t: u64) -> SimardResult<String> {
+            Ok(String::new())
+        }
+        fn prune_expired_sensory(&self) -> SimardResult<usize> {
+            Ok(0)
+        }
+        fn push_working(&self, _s: &str, _c: &str, _t: &str, _r: f64) -> SimardResult<String> {
+            Ok(String::new())
+        }
+        fn get_working(&self, _t: &str) -> SimardResult<Vec<CognitiveWorkingSlot>> {
+            Ok(vec![])
+        }
+        fn clear_working(&self, _t: &str) -> SimardResult<usize> {
+            Ok(0)
+        }
+        fn store_episode(
+            &self,
+            _c: &str,
+            _s: &str,
+            _m: Option<&serde_json::Value>,
+        ) -> SimardResult<String> {
+            Ok(String::new())
+        }
+        fn consolidate_episodes(&self, _b: u32) -> SimardResult<Option<String>> {
+            Ok(None)
+        }
+        fn store_fact(
+            &self,
+            _c: &str,
+            _co: &str,
+            _cf: f64,
+            _t: &[String],
+            _s: &str,
+        ) -> SimardResult<String> {
+            Ok(String::new())
+        }
+        fn search_facts(&self, _q: &str, _l: u32, _m: f64) -> SimardResult<Vec<CognitiveFact>> {
+            if self.facts_err {
+                return Err(Self::boom("search_facts"));
+            }
+            Ok(self.facts.clone())
+        }
+        fn store_procedure(&self, _n: &str, _s: &[String], _p: &[String]) -> SimardResult<String> {
+            Ok(String::new())
+        }
+        fn recall_procedure(&self, _q: &str, _l: u32) -> SimardResult<Vec<CognitiveProcedure>> {
+            if self.procedures_err {
+                return Err(Self::boom("recall_procedure"));
+            }
+            Ok(self.procedures.clone())
+        }
+        fn store_prospective(
+            &self,
+            _d: &str,
+            _tc: &str,
+            _a: &str,
+            _p: i64,
+        ) -> SimardResult<String> {
+            Ok(String::new())
+        }
+        fn check_triggers(&self, _c: &str) -> SimardResult<Vec<CognitiveProspective>> {
+            Ok(vec![])
+        }
+        fn list_all_episodes(&self, _limit: u32) -> SimardResult<Vec<CognitiveEpisode>> {
+            if self.episodes_err {
+                return Err(Self::boom("list_all_episodes"));
+            }
+            Ok(self.episodes.clone())
+        }
+        fn list_all_prospective(&self, _limit: u32) -> SimardResult<Vec<CognitiveProspective>> {
+            if self.prospective_err {
+                return Err(Self::boom("list_all_prospective"));
+            }
+            Ok(self.prospective.clone())
+        }
+        fn get_statistics(&self) -> SimardResult<CognitiveStatistics> {
+            if self.stats_err {
+                return Err(Self::boom("get_statistics"));
+            }
+            Ok(self.stats.clone())
+        }
+    }
+
+    #[test]
+    fn build_live_memory_graph_surfaces_statistics_read_error() {
+        // Trigger #2 (per-type read Err): a failing get_statistics() must NOT be
+        // swallowed by `unwrap_or_default()` into a phantom all-zeros graph.
+        let ops = GraphFaultOps {
+            stats_err: true,
+            ..Default::default()
+        };
+        let v = build_live_memory_graph(&ops);
+        assert!(
+            error_string(&v).is_some(),
+            "a get_statistics() read error must surface as a non-empty `error` field \
+             (fail-loud), not be swallowed by unwrap_or_default(); got {v}"
+        );
+        assert_eq!(
+            v["available"],
+            Value::Bool(true),
+            "an in-build read failure keeps available:true (the reader WAS reachable); got {v}"
+        );
+        assert_six_hub_types(&v);
+    }
+
+    #[test]
+    fn build_live_memory_graph_surfaces_each_enumerator_read_error() {
+        // Trigger #2 for every per-item enumerator: a read Err from any of the four
+        // trait enumerators must surface as `error`, not be dropped by the old
+        // `if let Ok(...)` swallow that silently produced a partial graph.
+        type FaultSetter = fn(&mut GraphFaultOps);
+        let cases: [(&str, FaultSetter); 4] = [
+            ("search_facts", |o| o.facts_err = true),
+            ("list_all_episodes", |o| o.episodes_err = true),
+            ("recall_procedure", |o| o.procedures_err = true),
+            ("list_all_prospective", |o| o.prospective_err = true),
+        ];
+        for (name, set) in cases {
+            let mut ops = GraphFaultOps::default();
+            set(&mut ops);
+            let v = build_live_memory_graph(&ops);
+            assert!(
+                error_string(&v).is_some(),
+                "a {name}() read error must surface as a non-empty `error` field \
+                 (fail-loud), not be swallowed into a partial graph; got {v}"
+            );
+            assert_eq!(
+                v["available"],
+                Value::Bool(true),
+                "an in-build enumerator failure keeps available:true; got {v}"
+            );
+            assert_six_hub_types(&v);
+        }
+    }
+
+    #[test]
+    fn build_live_memory_graph_flags_stats_vs_nodes_discrepancy_per_enumerable_type() {
+        // Trigger #3: a store whose stats claim an ENUMERABLE type holds content
+        // while its enumerator yields zero item nodes would misrepresent a populated
+        // store as hub-only. The builder must fail loud rather than silently degrade.
+        for ty in ["semantic", "episodic", "procedural", "prospective"] {
+            let mut ops = GraphFaultOps::default();
+            match ty {
+                "semantic" => ops.stats.semantic_count = 5,
+                "episodic" => ops.stats.episodic_count = 5,
+                "procedural" => ops.stats.procedural_count = 5,
+                "prospective" => ops.stats.prospective_count = 5,
+                _ => unreachable!(),
+            }
+            let v = build_live_memory_graph(&ops);
+            assert!(
+                error_string(&v).is_some(),
+                "stats.{ty} = 5 but 0 item nodes for it must surface a discrepancy \
+                 `error` (fail-loud), not present a populated store as hub-only; got {v}"
+            );
+            assert_eq!(
+                v["available"],
+                Value::Bool(true),
+                "a discrepancy is an in-build failure — available stays true; got {v}"
+            );
+            assert_six_hub_types(&v);
+        }
+    }
+
+    #[test]
+    fn build_live_memory_graph_discrepancy_guard_exempts_transient_types() {
+        // False-positive guard: working memory + the sensory buffer are transient
+        // and hub-only (no per-item enumerator), so non-zero working/sensory counts
+        // with zero item nodes is a VALID state — it must NOT trip the discrepancy
+        // error. The guard is scoped strictly to the four enumerable types.
+        let mut ops = GraphFaultOps::default();
+        ops.stats.working_count = 9;
+        ops.stats.sensory_count = 9;
+        let v = build_live_memory_graph(&ops);
+        assert!(
+            !has_error_key(&v),
+            "non-zero working/sensory counts with hub-only rendering is valid and must \
+             NOT be flagged as an error (discrepancy guard is scoped to the four \
+             enumerable types); got {v}"
+        );
+        assert_eq!(v["available"], Value::Bool(true));
+        assert_six_hub_types(&v);
+    }
+
+    #[test]
+    fn build_live_memory_graph_genuine_empty_is_not_an_error() {
+        // A truly empty store (all enumerable stats 0, every read Ok+empty) is a
+        // distinct, VALID state: six hubs, no item nodes, no edges, available:true,
+        // and `error` OMITTED (not null) so the client shows the neutral empty
+        // message rather than the error overlay.
+        let ops = GraphFaultOps::default();
+        let v = build_live_memory_graph(&ops);
+        assert!(
+            !has_error_key(&v),
+            "a genuinely empty store must OMIT the `error` key entirely (not null); got {v}"
+        );
+        assert_eq!(v["available"], Value::Bool(true));
+        assert_six_hub_types(&v);
+        let item_nodes = nodes_of(&v)
+            .iter()
+            .filter(|n| n.get("hub").and_then(Value::as_bool) != Some(true))
+            .count();
+        assert_eq!(
+            item_nodes, 0,
+            "an empty store must render hubs only, no item nodes; got {v}"
+        );
+        assert!(
+            edges_of(&v).is_empty(),
+            "an empty store has no edges; got {v}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(cognitive_memory)]
+    async fn memory_graph_handler_reader_unavailable_surfaces_path_free_error() {
+        // Fail-LOUD trigger #1 (reader unreachable): when open_reader_client() fails
+        // closed (socket present but unconnectable), the handler must return a
+        // sanitized `error` — NOT the retired silent `available:false` + `note`
+        // payload — and the error must be PATH-FREE (SR-DATA-1): no state_root,
+        // $HOME, or temp-dir path may leak to the client. Invariant on this branch:
+        // `error` present <=> nodes == [] && available == false.
+        use crate::memory_ipc::{
+            clear_in_process_writer, clear_tier2_store_cache, socket_path_for,
+        };
+
+        clear_in_process_writer();
+        clear_tier2_store_cache();
+        let state = HermeticState::new();
+        let root = state.state_root().to_path_buf();
+
+        // Occupy the socket path with a plain file: `sock.exists()` is true but the
+        // connect fails, so open_reader_client() must fail closed (no divergent
+        // tier-2 fallback). This is the deterministic way to force the
+        // reader-unavailable branch without a live daemon (mirrors
+        // memory_ipc::tests_launcher_fail_closed_2896).
+        let sock = socket_path_for(&root);
+        if let Some(parent) = sock.parent() {
+            std::fs::create_dir_all(parent).expect("create socket parent dir");
+        }
+        std::fs::write(&sock, b"not a socket").expect("occupy socket path");
+
+        let out = memory_graph().await;
+        let v = &out.0;
+
+        clear_tier2_store_cache();
+
+        let err = error_string(v).unwrap_or_else(|| {
+            panic!(
+                "reader-unavailable must surface a non-empty `error` (fail-loud), \
+                 replacing the retired silent available:false + note payload; got {v}"
+            )
+        });
+        assert_eq!(
+            nodes_of(v).len(),
+            0,
+            "reader-unavailable invariant: nodes must be [] when error is present; got {v}"
+        );
+        assert_eq!(
+            v["available"],
+            Value::Bool(false),
+            "reader-unavailable invariant: available must be false; got {v}"
+        );
+        assert!(
+            v.as_object().is_some_and(|m| !m.contains_key("note")),
+            "the retired silent `note` fallback must be replaced by `error` (single \
+             error surface); got {v}"
+        );
+
+        // SR-DATA-1: no filesystem path may leak into the client-facing error string.
+        let root_str = root.to_string_lossy();
+        assert!(
+            !err.contains(root_str.as_ref()),
+            "the client-facing `error` must be PATH-FREE (SR-DATA-1) — it leaked the \
+             state_root path {root_str:?}: {err:?}"
+        );
+        if let Some(home) = std::env::var_os("HOME") {
+            let home = home.to_string_lossy().to_string();
+            if !home.is_empty() {
+                assert!(
+                    !err.contains(&home),
+                    "the client-facing `error` leaked $HOME {home:?}: {err:?}"
+                );
+            }
+        }
     }
 }

--- a/tests/e2e-dashboard/specs/memory-tab.spec.ts
+++ b/tests/e2e-dashboard/specs/memory-tab.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from '../fixtures/simard-dashboard';
 import type { Page } from '@playwright/test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 /*
  * Dedicated "Memory" tab contract (issue #2627).
@@ -129,5 +132,121 @@ test.describe('Dedicated Memory tab @structural', () => {
     await authenticatedPage.goto('/');
     // Moved, not copied: exactly one canvas in the whole document.
     await expect(authenticatedPage.locator('#mem-graph-canvas')).toHaveCount(1);
+  });
+});
+
+/*
+ * Fail-LOUD contract (issue #2627): the memory graph must never silently blank.
+ * A data-load failure surfaces a VISIBLE on-canvas #mem-graph-error overlay (not
+ * a tiny stats-line note, not a blank canvas). See
+ * docs/reference/dashboard-memory-graph-fail-loud.md.
+ *
+ * TDD note: RED against the current renderer — there is no #mem-graph-error
+ * overlay; fetchMemoryGraph writes `Error: …` to the low-visibility
+ * #mem-graph-stats line and returns, leaving the canvas untouched. Passes once
+ * the overlay + mgError render path land.
+ */
+test.describe('Memory tab fail-loud error state @structural', () => {
+  const ERROR_GRAPH = {
+    error: 'Cognitive memory reader is unavailable.',
+    available: false,
+    nodes: [],
+    edges: [],
+    stats: { working: 0, semantic: 0, episodic: 0, procedural: 0, prospective: 0, sensory: 0 },
+  };
+
+  function installErrorRoutes(page: Page): void {
+    page.route('**/api/**', async (route) => {
+      const pathname = new URL(route.request().url()).pathname;
+      const body =
+        pathname === '/api/memory/graph'
+          ? ERROR_GRAPH
+          : pathname in BODIES
+            ? BODIES[pathname]
+            : {};
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(body),
+      });
+    });
+  }
+
+  test('a data-load error paints the visible #mem-graph-error overlay, not a silent blank', async ({
+    authenticatedPage,
+  }) => {
+    installErrorRoutes(authenticatedPage);
+    await authenticatedPage.goto('/');
+    await authenticatedPage.locator('.tab[data-tab="memory"]').click();
+
+    const overlay = authenticatedPage.locator('#tab-memory #mem-graph-error');
+    await expect(
+      overlay,
+      'a graph-load error must surface a VISIBLE #mem-graph-error overlay (fail-loud, never a silent blank)',
+    ).toBeVisible();
+    await expect(
+      overlay,
+      'the overlay must show the sanitized error message from the payload',
+    ).toContainText('Cognitive memory reader is unavailable.');
+  });
+});
+
+/*
+ * Live acceptance gate (issue #2627): against the REAL dashboard (webServer runs
+ * `dashboard serve`), an authenticated GET /api/memory/graph must return a
+ * non-empty graph when the live cognitive store has content — the end-to-end
+ * proof the Memory tab shows Simard's live memory, not a stale/empty stub.
+ *
+ * Gated + skipped cleanly when there is no dashkey or the live store is empty, so
+ * it never flakes in CI without a live daemon (per the design's live-path risk).
+ */
+function readDashkeyOrEmpty(): string {
+  if (process.env.SIMARD_DASHKEY) return process.env.SIMARD_DASHKEY;
+  try {
+    return fs.readFileSync(path.join(os.homedir(), '.simard', '.dashkey'), 'utf-8').trim();
+  } catch {
+    return '';
+  }
+}
+
+test.describe('Memory tab live acceptance @smoke', () => {
+  test('authenticated GET /api/memory/graph returns a non-empty graph when the live store has content', async ({
+    page,
+    baseURL,
+  }) => {
+    const code = readDashkeyOrEmpty();
+    test.skip(!code, 'no ~/.simard/.dashkey or SIMARD_DASHKEY — live cognitive store unavailable');
+
+    const login = await page.request.post(`${baseURL}/api/login`, { data: { code } });
+    test.skip(login.status() !== 200, 'dashkey did not authenticate against the live dashboard');
+
+    const resp = await page.request.get(`${baseURL}/api/memory/graph`);
+    expect(resp.status(), 'the live graph endpoint must respond 200 to an authenticated GET').toBe(200);
+    const g = await resp.json();
+
+    // Fail-loud: a data-load error must be a non-empty string, never a silent blank.
+    if (g.error !== undefined && g.error !== null) {
+      expect(typeof g.error, 'a data-load `error` must be a string when present').toBe('string');
+      expect(String(g.error).length, 'a data-load `error` must be non-empty (fail-loud)').toBeGreaterThan(0);
+      test.skip(true, `live reader reported an error state (fail-loud, not asserting content): ${g.error}`);
+    }
+
+    const s = g.stats ?? {};
+    const enumerable = (s.semantic ?? 0) + (s.episodic ?? 0) + (s.procedural ?? 0) + (s.prospective ?? 0);
+    test.skip(enumerable === 0, 'live store holds no enumerable content (empty store) — nothing to render');
+
+    // ACCEPTANCE GATE: a populated live store must surface item nodes + edges,
+    // never a silent-empty / hub-only graph (the #2627 regression).
+    const nodes: Array<{ hub?: boolean }> = Array.isArray(g.nodes) ? g.nodes : [];
+    const edges: unknown[] = Array.isArray(g.edges) ? g.edges : [];
+    const itemNodes = nodes.filter((n) => !n.hub);
+    expect(
+      itemNodes.length,
+      'a populated live store (~7700 facts) must emit item nodes, not just the six type hubs',
+    ).toBeGreaterThan(0);
+    expect(
+      edges.length,
+      'live item nodes must be linked to their type hubs (non-empty edges)',
+    ).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #2627 — the dashboard **Memory** tab's graph visualization never loaded. The tab was restored (#2627 / PR #2895) with a canvas + background loader, but `GET /api/memory/graph` **swallowed every read error** and the front-end had **no visible error surface**, so on any load failure the canvas stayed blank — indistinguishable from an empty store while cognitive memory held thousands of facts (~7700).

## Root cause

- **Backend**: `build_live_memory_graph` read the live store through `get_statistics()` + the four enumerators but dropped failures via `get_statistics().unwrap_or_default()` and `if let Ok(...)` per type; the `memory_graph()` handler returned a silent `available:false` + free-text `note` when the reader was unreachable. No path ever emitted a machine-readable error.
- **Front-end**: `fetchMemoryGraph` wrote errors to the low-visibility `#mem-graph-stats` line (`Error: …` / `Load failed`) and `return`ed, leaving the canvas untouched — a silent blank.

## Fix (additive, fail-LOUD)

**Backend (`operator_commands_dashboard/memory.rs`)**
- No more swallowing: `get_statistics()` and `search_facts` / `list_all_episodes` / `recall_procedure` / `list_all_prospective` failures now surface a top-level, sanitized `error`.
- New **stats-vs-nodes discrepancy guard**: a populated enumerable type with zero item nodes fails loud, scoped to the four enumerable types (transient working/sensory never false-positive).
- Reader-unavailable → **path-free** `error` (full cause logged via `tracing`), replacing the retired silent `available:false` + `note`.
- A genuinely empty store stays a distinct, non-error state (six type hubs, `available:true`, `error` omitted).

**Front-end (`index_html`)**
- New `#mem-graph-error` overlay (`role="alert"`) painted by the single `mgRender` path via an `mgError` state; `fetchMemoryGraph` sets it on `d.error`, a fetch throw, or a client-side discrepancy (defence in depth). Retired stats-line error writes.
- Neutral **"Memory graph is empty"** message for a genuinely empty store.

## Verification (LIVE)

Against the live daemon (**7853 memories**: 1958 semantic / 3834 episodic / 268 procedural / 1751 prospective), authenticated `GET /api/memory/graph`:

```
available: true | error: absent
stats mirrors live counts
nodes: 806 (6 hubs + 800 capped item nodes) | edges: 800
item node types: SemanticFact 200, EpisodicMemory 200, ProceduralMemory 200, ProspectiveMemory 200
```

## Tests

- Backend fail-loud unit tests (fault-injecting `CognitiveMemoryOps` double + populated-store harness).
- Rendered-HTML contract tests (`index_html/tests_memory_tab.rs`).
- E2E: mocked-error overlay + **live acceptance** specs (`tests/e2e-dashboard/specs/memory-tab.spec.ts`).
- `cargo fmt`, `clippy --all-targets --all-features -- -D warnings`, and the memory + memory-tab suites all green. Full pre-commit + pre-push hooks passed.

Docs: `docs/reference/dashboard-memory-graph-fail-loud.md` (new) documents the three-outcome contract.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>