### PR TITLE
perf(stewardship): single-pass signature normalization (drop redundant whitespace round-trip)

### DIFF
--- a/src/stewardship/dedup.rs
+++ b/src/stewardship/dedup.rs
@@ -51,7 +51,13 @@ fn is_iso_timestamp(s: &str) -> bool {
 }
 
 fn normalize_for_signature(msg: &str) -> String {
-    normalize(msg)
+    // `normalize()` strips ANSI then collapses whitespace into a full
+    // throwaway String that we would immediately re-split here.
+    // `split_whitespace()` already collapses runs and trims, so strip ANSI
+    // once and split once: identical tokens => byte-identical signature
+    // input, without the extra allocation and second whitespace pass.
+    let stripped = crate::recipe_output::strip_ansi(msg);
+    stripped
         .split_whitespace()
         .map(redact_token)
         .collect::<Vec<_>>()


### PR DESCRIPTION
## Summary

`normalize_for_signature()` in `src/stewardship/dedup.rs` called `normalize()` — which strips ANSI **and** collapses whitespace into a full throwaway `String` — then **immediately re-split that copy** on whitespace. Since `split_whitespace()` already collapses runs and trims, the collapse-then-resplit round-trip is wasted work.

This change strips ANSI **once** and splits **once**, eliminating one full-length `String` allocation and an extra whitespace pass per `failure_signature()` call. The cost scales with error-text size, and `failure_signature()` runs on every stewardship dedup lookup.

## Correctness (output-identical)

- **Original:** `strip_ansi(msg)` → `split_whitespace().join(" ")` (single-space tokens) → `split_whitespace()` (same tokens) → `redact_token` → `join(" ")`.
- **New:** `strip_ansi(msg)` → `split_whitespace()` (same tokens; runs collapsed + trimmed) → `redact_token` → `join(" ")`.

Same tokens ⇒ byte-identical signature input ⇒ identical signature.

## Verification

- ✅ All **118** stewardship tests pass, including the signature-stability contracts (`signature_stable_across_timestamps_paths_hashes_runids_linecols`, `signature_differs_on_kind_change`, `signature_differs_on_message_change`, `normalize_strips_ansi_and_collapses_whitespace`).
- ✅ `cargo fmt --check` clean.
- ✅ `cargo clippy --all-targets --all-features --locked -- -D warnings` clean.
- ✅ Pre-push gate (release race-subset tests + full clippy) passed.

## Context

Follow-through on a performance review of the stewardship dedup path (issue #2934 / PR #2949). The optimization was identified during that review but never landed — the original push was blocked by a tooling hook error and PR #2949 squash-merged without it. This PR lands the intended change against current `main`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>