### PR TITLE
fix(ci): harden verify against flaky packages.microsoft.com apt source (#2975)

### DIFF
--- a/.github/actions/rust-runner-prep/action.yml
+++ b/.github/actions/rust-runner-prep/action.yml
@@ -49,6 +49,15 @@ runs:
         sudo swapon /swapfile
         echo "Swap enabled: $(swapon --show)"
 
+    - name: Harden apt sources (drop flaky packages.microsoft.com repo, #2975)
+      shell: bash
+      # GitHub runners ship packages.microsoft.com apt sources that periodically
+      # serve an invalid InRelease ("NOSPLIT" / "no longer signed"), which makes
+      # the `apt-get update` below exit 100 and fails the job with a spurious red
+      # on the default branch. This job only needs Ubuntu-archive packages
+      # (mold), so strip the Microsoft sources first. Idempotent and non-fatal.
+      run: bash "$GITHUB_WORKSPACE/scripts/ci-harden-apt.sh"
+
     - name: Install mold linker
       shell: bash
       # mold is a drop-in replacement for ld/lld with 3-5x faster cold-link of

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -353,6 +353,15 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Harden apt sources (drop flaky packages.microsoft.com repo, #2975)
+        # `playwright install --with-deps` runs `apt-get update` to pull the
+        # browser OS dependencies. GitHub runners ship packages.microsoft.com
+        # apt sources that periodically serve an invalid InRelease ("NOSPLIT" /
+        # "no longer signed"), which makes that update exit 100 and fails the
+        # job with a spurious red. We only need Ubuntu-archive deps here, so
+        # strip the Microsoft sources first. Idempotent and non-fatal.
+        run: bash "$GITHUB_WORKSPACE/scripts/ci-harden-apt.sh"
+
       - name: Install Playwright (chromium)
         run: npx playwright install --with-deps chromium
 

--- a/scripts/ci-harden-apt.sh
+++ b/scripts/ci-harden-apt.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# ci-harden-apt.sh — drop the flaky packages.microsoft.com apt sources shipped
+# on GitHub-hosted runners BEFORE any `apt-get update` in CI.
+#
+# The runner image configures `packages.microsoft.com` apt repositories
+# (azure-cli, MS prod). These periodically serve an invalid `InRelease` file:
+#
+#   E: Failed to fetch https://packages.microsoft.com/.../InRelease
+#      Clearsigned file isn't valid, got 'NOSPLIT' (does the network require authentication?)
+#   E: The repository '... noble InRelease' is no longer signed.
+#
+# When that happens, every `apt-get update` exits 100 and fails the job —
+# producing spurious red on the default branch (see the verify workflow's
+# `pre-commit` and `e2e-dashboard` jobs). None of our CI jobs need those repos;
+# they only install Ubuntu-archive packages (mold, Playwright browser deps), so
+# removing the Microsoft sources makes apt immune to the recurring breakage.
+#
+# Idempotent and non-fatal: safe to run whether or not the sources are present,
+# and it never fails the build on its own (removing a source we don't need can
+# only help). Requires passwordless sudo (present on GitHub-hosted runners).
+#
+# Usage:
+#   scripts/ci-harden-apt.sh
+
+set -euo pipefail
+
+MS_HOST_RE='packages\.microsoft\.com'
+removed=0
+
+# Modern runner images keep third-party repos as individual files under
+# sources.list.d/ in either one-line (.list) or deb822 (.sources) format.
+# Match by content so both formats — and any filename — are covered.
+if [ -d /etc/apt/sources.list.d ]; then
+  shopt -s nullglob
+  for f in /etc/apt/sources.list.d/*; do
+    [ -f "$f" ] || continue
+    if sudo grep -qsE "$MS_HOST_RE" "$f"; then
+      echo "ci-harden-apt: removing Microsoft apt source: $f"
+      sudo rm -f "$f"
+      removed=1
+    fi
+  done
+  shopt -u nullglob
+fi
+
+# Some images embed the Microsoft repo in the monolithic sources.list instead.
+# Comment only the *active* Microsoft lines: skip lines that are already
+# commented (so the step is idempotent) and leave every non-Microsoft archive
+# line untouched (so the file stays usable).
+if [ -f /etc/apt/sources.list ] \
+   && sudo grep -qsE "^[[:space:]]*[^#[:space:]].*${MS_HOST_RE}" /etc/apt/sources.list; then
+  echo "ci-harden-apt: disabling Microsoft entries in /etc/apt/sources.list"
+  sudo sed -i.ci-harden-apt.bak -E "/^[[:space:]]*#/! { /${MS_HOST_RE}/ s|^|# disabled-by-ci: | }" /etc/apt/sources.list
+  removed=1
+fi
+
+if [ "$removed" -eq 0 ]; then
+  echo "ci-harden-apt: no Microsoft apt sources found (nothing to do)"
+else
+  echo "ci-harden-apt: Microsoft apt sources removed; apt is now Ubuntu-archive only"
+fi


### PR DESCRIPTION
Fixes #2975.

## Problem (grounded in run data, not assumed)
`verify` intermittently reds the **default branch** when the GitHub-hosted
runner's `packages.microsoft.com` apt repositories serve an invalid `InRelease`:

```
E: Failed to fetch https://packages.microsoft.com/.../InRelease  Clearsigned file isn't valid, got 'NOSPLIT' (does the network require authentication?)
E: The repository '... noble InRelease' is no longer signed.
```

Any `apt-get update` on the runner then exits 100 and fails the job. Two `main`
`verify` runs failed at 20:43 UTC 2026-07-07 from this **single** cause:

| Run | Job | Failing step | Failure |
|-----|-----|--------------|---------|
| [28897370109](https://github.com/rysweet/Simard/actions/runs/28897370109) | `pre-commit` | `rust-runner-prep` → `apt-get update -qq` | exit 100 (NOSPLIT) |
| [28897367724](https://github.com/rysweet/Simard/actions/runs/28897367724) | `e2e-dashboard` | `npx playwright install --with-deps` (internal `apt-get update`) | `Failed to install browsers`, exit 100 |

The next `main` run (21:00, `28898321760`) was green **only because** the
Microsoft repo happened to be valid again. This is a recurring, non-deterministic
source of spurious red — not a code regression that "self-recovered."

## Fix
None of the CI jobs need the Microsoft repos; they install `mold` and Playwright
browser deps from the **Ubuntu archive**. Add `scripts/ci-harden-apt.sh` to strip
any apt source referencing `packages.microsoft.com` before every `apt-get update`,
and wire it into both entry points:

- `.github/actions/rust-runner-prep/action.yml` — before `apt-get update -qq` (covers `pre-commit` **and** `install-real`)
- `.github/workflows/verify.yml` `e2e-dashboard` job — before `npx playwright install --with-deps`

The script is **idempotent** (safe to re-run; skips already-disabled lines) and
**non-fatal** (removing an unneeded source can only help). It handles both
`sources.list.d/*.list`/`*.sources` (deb822) files and the monolithic
`sources.list`.

## Evidence for merge-ready criteria

**1. Tests / behavioral validation.** This is a CI-infrastructure change with no
product runtime surface, so gadugi/qa-team scenarios do not apply. The script was
validated with a **sandboxed functional + idempotency test** (never touching the
host `/etc/apt`) asserting: MS `.list` and deb822 `.sources` files removed;
`google-chrome.list` and Ubuntu-archive lines preserved verbatim; active MS line
in `sources.list` disabled exactly once; pre-commented MS lines untouched; RUN 2
reports "nothing to do" (idempotent). **All assertions PASS.**

**2. Docs / changed surfaces.** Changed surfaces are **internal CI only**
(`.github/**` + `scripts/ci-harden-apt.sh`). No user-facing runtime, CLI, or API
surface changes — no end-user docs required. Rationale is documented inline in
each workflow step and the script header.

**3. Quality audit (SEEK → VALIDATE → FIX).**
- Cycle 1 — SEEK: static analysis. `bash -n`, `shellcheck` (clean), `actionlint` (clean), YAML parse (both files). VALIDATE: pass.
- Cycle 2 — SEEK: sandboxed functional test. FOUND a real **idempotency bug** — the `sources.list` branch re-commented already-disabled MS lines, stacking `# disabled-by-ci:` prefixes. FIX: restrict the condition + `sed` to *active* (non-comment) MS lines only.
- Cycle 3 — VALIDATE: re-ran static + sandboxed functional + **idempotency** (double-run) tests → clean; RUN 2 = "nothing to do". Zero remaining findings.

**4. CI.** Full `verify` runs on this branch/PR; will confirm 100% green before
marking ready. (CI green here also proves the fix is safe: `mold` and Playwright
deps still install from the Ubuntu archive after the MS sources are removed.)

**6. Focused diff.** 3 files, +79/-0: one new script + two one-step wire-ins.
No unrelated edits.