### PR TITLE
feat(coin-gym): wire the executor to the real coin evaluate/verify contract (#3001)

### DIFF
--- a/docs/howto/run-the-coin-gym-harness.md
+++ b/docs/howto/run-the-coin-gym-harness.md
@@ -1,7 +1,7 @@
 ---
 title: Run the LOCAL COIN Gym harness
 description: Operator guide for the coin-gym CLI — a local harness that runs the COIN benchmark shape, scores vs. the published leaderboard, and A/Bs a single-model baseline against a multi-agent team.
-last_updated: 2026-07-06
+last_updated: 2026-07-08
 review_schedule: as-needed
 owner: simard
 doc_type: howto
@@ -45,6 +45,7 @@ coin-gym run <model> [--strategy baseline|team] [--profile <name>] [--targets <p
 coin-gym score   <run-id> [--profile <name>]
 coin-gym compare <run-id> [--profile <name>]
 coin-gym improve <run-id> [--profile <name>]
+coin-gym contract [--dataset <repo>] [--revision <tag>] [--split a,b] [--project x,y] [--source rebuild|image]
 coin-gym profiles
 ```
 
@@ -118,6 +119,36 @@ Applying an accepted tactic, re-running on held-out **fresh** targets, and
 keeping it only if reach improves without a precision regression (else rolling
 back) requires live grading and is **Phase 5**.
 
+### `contract` — show the real `coin evaluate` / `coin verify` wiring
+
+```bash
+coin-gym contract
+coin-gym contract --dataset COIN-Bench/coin --revision v2026-07 \
+  --split codeql_only --project cups --source image
+```
+
+Prints — **without running anything** — exactly how the harness drives COIN's
+own oracle for a snapshot (issue #3001):
+
+```text
+LOCAL-ONLY: true (no external submission, no leaderboard entry, no VM provisioning)
+evaluate: coin evaluate --dataset COIN-Bench/coin --revision v2026-07 --source rebuild
+verify:   coin verify --experiment <experiment-id>
+submission-contract:
+  attempt:  /answer/blob.bin + /answer/blob.harness
+  abstain:  /answer/UNREACHABLE.md  (and NO blob.bin)
+verdict:  read `reached` from each result.json (never re-checked locally)
+```
+
+This is the **code-verified contract** from
+[`docs/reference/coin-benchmark.md`](../reference/coin-benchmark.md): the Gym
+never re-implements reach-checking — `coin verify` writes `reached` into each
+`result.json` and the harness only reads it. `--split` / `--project` narrow the
+target set (comma-separate to repeat), and `--source` picks rebuild-vs-image.
+The executor (`src/coin_gym/executor.rs`) builds this exact argv, writes the
+`/answer/` submission per the contract, and reads back `reached`; the live
+Docker invocation itself is gated behind Phase 3.
+
 ### `profiles` — list isolated per-model run state
 
 ```bash
@@ -148,11 +179,23 @@ cross-contaminate.
 The `oracle` and `script` sections drive the **offline** demo run only. A real
 run gets its oracle from `coin evaluate` and its candidates from a live model.
 
+> **Real COIN dataset schema.** The compact manifest above is the offline-demo
+> shape. The library also parses COIN's **published** dataset schema — rows with
+> `target_id` (`<project>:<harness>:<file>:<line_start>[-<line_end>]`),
+> `coin_version`, `project`, `harness`, `file`, `line_start`/`line_end`, and a
+> `split` (`codeql_only` → frontier, `gcs_reachable` → non-trivial-reachable) —
+> via `DatasetSource` in `src/coin_gym/target_loader.rs`, pinned by `revision`
+> and reserving a held-out fresh slice as the anti-overfit oracle.
+
 ## What is deferred
 
 | Phase | Work | Status |
 |-------|------|--------|
-| 3 | Provision an `azlin` VM + Docker host, pull a COIN snapshot, wire the real `coin evaluate` executor | follow-up (HIGH-RISK, operator-gated) |
-| 5 | Live self-improvement loop: apply tactic → verify on held-out fresh targets → keep-or-roll-back; durable tactic memory | follow-up |
+| 3 | Provision an `azlin` VM + Docker host and pull a COIN snapshot, then run the **already-wired** `coin evaluate` / `coin verify` executor live (see `contract`) | follow-up (HIGH-RISK, operator-gated; #2823) |
+| 5 | Live self-improvement loop: apply tactic → verify on held-out fresh targets → keep-or-roll-back; durable tactic memory | follow-up (#2825) |
 
-Both remain unchecked on issue #2713.
+Both remain unchecked on issue #2713. The **executor contract** itself — the
+`coin evaluate` / `coin verify` argv, the `/answer/blob.bin` +
+`/answer/blob.harness` (or `/answer/UNREACHABLE.md`) submission, and reading
+`reached` from each `result.json` — is implemented and unit-tested offline
+(issue #3001); only the live Docker invocation is gated behind Phase 3.

--- a/src/coin_gym/executor.rs
+++ b/src/coin_gym/executor.rs
@@ -1,18 +1,66 @@
-//! Harness executor (research doc Part 3.3, component 3).
+//! Harness executor — the wiring to COIN's real `coin evaluate` / `coin verify`
+//! contract (issue #3001).
 //!
-//! The executor is the **objective oracle**: it decides whether a submitted
-//! input actually reaches the target line. In production this delegates to
-//! `coin evaluate` (Docker + instrumented replay) and is **never
-//! re-implemented**. Real Docker wiring is gated behind Phase 3 (a provisioned
-//! VM). For offline development, tests, and CI, a [`MockHarnessExecutor`] returns
-//! deterministic verdicts from a ground-truth lookup table — a test double, not
+//! The executor is the **objective oracle**: whether a submitted input actually
+//! reaches the target line is decided by **executing the code** on a
+//! coverage-instrumented build. The Gym **never re-implements reach-checking**;
+//! it delegates to COIN's own pipeline and only *reads back* the `reached`
+//! verdict COIN's verifier wrote. See `docs/reference/coin-benchmark.md` for the
+//! code-verified contract this module implements.
+//!
+//! The real flow (LOCAL only — never submitted anywhere) is:
+//!
+//! 1. `coin evaluate --dataset <repo> --revision <tag> [--split ...]
+//!    [--project ...] [--source rebuild|image]` runs the agent-under-test in a
+//!    container; the agent writes its final answer to the bind-mounted
+//!    `/answer/` directory (`blob.bin` + `blob.harness`, or `UNREACHABLE.md` to
+//!    abstain). Evaluate mints an **experiment id**.
+//! 2. `coin verify --experiment <id>` replays each submission against the
+//!    project's coverage-instrumented build and writes `reached` (bool) into
+//!    each work item's `result.json`.
+//! 3. The Gym reads `reached` from each `result.json` to derive the per-target
+//!    outcome.
+//!
+//! Steps 1–2 require Docker + a pulled snapshot on a provisioned host, which is
+//! **Phase 3** (issue #2823). This module therefore keeps the *contract*
+//! (argv construction, the `/answer/` submission writer, and the `result.json`
+//! reader) fully unit-testable offline, while the live Docker delegate
+//! ([`CoinEvaluateExecutor::grade`]) surfaces a clear Phase-3 gate error rather
+//! than a fake verdict. For pure offline scaffold runs a [`MockHarnessExecutor`]
+//! returns deterministic verdicts from a ground-truth table — a test double, not
 //! a reachability engine.
+//!
+//! **LOCAL-ONLY guardrail.** Nothing in this module submits results externally,
+//! writes a leaderboard entry, or provisions infrastructure. The only `coin`
+//! subcommands it ever constructs are `evaluate` and `verify`; it never
+//! constructs `publish`/`--hf-repo`/`--registry`. See [`LOCAL_ONLY`].
 
 use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
 
 use super::types::{CoinGymError, CoinGymResult, OutcomeCode, Target};
 
-/// The oracle's verdict for a single submitted input.
+/// Compile-time assertion that this crate uses COIN as a **local** measurement
+/// substrate only: no external submission, no leaderboard entry, no external VM
+/// provisioning originates here. Kept as a `const` so it is greppable and can be
+/// asserted by tests and downstream callers.
+pub const LOCAL_ONLY: bool = true;
+
+/// The `coin` subcommands this crate is permitted to drive. Deliberately limited
+/// to the read/measure path — `publish` and any submission command are excluded
+/// by the LOCAL-ONLY guardrail.
+pub const ALLOWED_COIN_SUBCOMMANDS: &[&str] = &["evaluate", "verify"];
+
+/// The submission-contract file the agent writes with the raw input **bytes**.
+pub const ANSWER_BLOB_BIN: &str = "blob.bin";
+/// The submission-contract file naming the harness binary the blob feeds.
+pub const ANSWER_BLOB_HARNESS: &str = "blob.harness";
+/// The abstention marker: written **instead of** `blob.bin` to decline.
+pub const ANSWER_UNREACHABLE_MD: &str = "UNREACHABLE.md";
+
+/// The oracle's verdict for a single **submitted** input.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GradeResult {
     /// The input drove execution to the target line.
@@ -46,48 +94,307 @@ pub trait HarnessExecutor {
     /// # Errors
     /// Returns [`CoinGymError::Executor`] when grading cannot be performed at all
     /// (e.g. `coin evaluate` is unavailable because the Phase-3 VM is not
-    /// provisioned). A *reached/not-reached* verdict is returned as
-    /// `Ok(GradeResult)`, not an error.
+    /// provisioned, or a `result.json` is missing). A *reached/not-reached*
+    /// verdict is returned as `Ok(GradeResult)`, not an error.
     fn grade(&self, target: &Target, input: &str) -> CoinGymResult<GradeResult>;
 
-    /// Whether this executor is an offline scaffold (mock) rather than the real
-    /// `coin evaluate` oracle. Recorded on the [`crate::coin_gym::types::RunReport`]
-    /// so offline runs are never mistaken for graded results.
+    /// Whether this executor is an offline scaffold (mock) rather than a real
+    /// COIN grade. Recorded on the [`crate::coin_gym::types::RunReport`] so
+    /// offline runs are never mistaken for graded results. Executors that read
+    /// **real** `coin verify` output (e.g. [`CoinResultsExecutor`]) return
+    /// `false`.
     fn is_offline_scaffold(&self) -> bool {
         false
     }
 }
 
-// ── Real executor: delegates to `coin evaluate` (Phase 3 gated) ───────────────
+// ── The submission contract (`/answer/`) ─────────────────────────────────────
 
-/// Configuration for the real `coin evaluate` delegate.
-#[derive(Clone, Debug)]
-pub struct CoinEvaluateConfig {
-    /// Path/name of the `coin` binary (default `coin`).
-    pub binary: String,
-    /// Snapshot dataset reference (e.g. `you/coin@v1`).
-    pub dataset: String,
+/// The agent-under-test's final answer, per COIN's submission contract
+/// (`coin/stages/stage7/evaluate/prompt.py`). Either a concrete **attempt**
+/// (raw bytes + the harness they feed) or a precision-preserving **abstention**.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AgentAnswer {
+    /// A concrete attempt: `blob.bin` = raw input bytes; `blob.harness` = the
+    /// single harness-binary name (from the provided list) to feed it to.
+    Attempt {
+        /// Raw input bytes written to `blob.bin`.
+        blob: Vec<u8>,
+        /// Harness binary name written (as one line) to `blob.harness`.
+        harness: String,
+    },
+    /// Abstain: write **only** `UNREACHABLE.md` (with evidence) and NO
+    /// `blob.bin`. If `blob.bin` exists it is treated as a normal attempt and
+    /// `UNREACHABLE.md` is ignored, so [`write_answer`] removes any stale blob.
+    Abstain {
+        /// Evidence markdown written to `UNREACHABLE.md`.
+        unreachable_md: String,
+    },
 }
 
-impl CoinEvaluateConfig {
-    /// Build a config for a snapshot using the default `coin` binary.
-    #[must_use]
-    pub fn new(dataset: impl Into<String>) -> Self {
-        Self {
-            binary: "coin".to_string(),
-            dataset: dataset.into(),
+/// Write the agent's final answer into `answer_dir` per the COIN submission
+/// contract, keeping the directory unambiguous:
+///
+/// - **Attempt** ⇒ write `blob.bin` (bytes) + `blob.harness` (one line), and
+///   remove any stale `UNREACHABLE.md` so the attempt is honoured.
+/// - **Abstain** ⇒ write `UNREACHABLE.md`, and remove any stale `blob.bin` /
+///   `blob.harness` so the abstention is not silently overridden (COIN treats a
+///   present `blob.bin` as an attempt regardless of `UNREACHABLE.md`).
+///
+/// # Errors
+/// Returns [`CoinGymError::Usage`] if the harness name is empty or multi-line
+/// (the contract is *one line*), or [`CoinGymError::Io`] on a filesystem error.
+pub fn write_answer(answer_dir: &Path, answer: &AgentAnswer) -> CoinGymResult<()> {
+    std::fs::create_dir_all(answer_dir)
+        .map_err(|e| CoinGymError::Io(format!("create {}: {e}", answer_dir.display())))?;
+    let blob_bin = answer_dir.join(ANSWER_BLOB_BIN);
+    let blob_harness = answer_dir.join(ANSWER_BLOB_HARNESS);
+    let unreachable = answer_dir.join(ANSWER_UNREACHABLE_MD);
+    match answer {
+        AgentAnswer::Attempt { blob, harness } => {
+            if harness.trim().is_empty() {
+                return Err(CoinGymError::Usage(
+                    "blob.harness must name a harness binary (got empty)".to_string(),
+                ));
+            }
+            if harness.contains('\n') || harness.contains('\r') {
+                return Err(CoinGymError::Usage(
+                    "blob.harness must be a single line (the harness binary name)".to_string(),
+                ));
+            }
+            remove_if_present(&unreachable)?;
+            write_bytes(&blob_bin, blob)?;
+            write_bytes(&blob_harness, harness.as_bytes())?;
+        }
+        AgentAnswer::Abstain { unreachable_md } => {
+            remove_if_present(&blob_bin)?;
+            remove_if_present(&blob_harness)?;
+            write_bytes(&unreachable, unreachable_md.as_bytes())?;
+        }
+    }
+    Ok(())
+}
+
+fn write_bytes(path: &Path, bytes: &[u8]) -> CoinGymResult<()> {
+    std::fs::write(path, bytes)
+        .map_err(|e| CoinGymError::Io(format!("write {}: {e}", path.display())))
+}
+
+fn remove_if_present(path: &Path) -> CoinGymResult<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(CoinGymError::Io(format!("remove {}: {e}", path.display()))),
+    }
+}
+
+// ── Reading `reached` from a work item's `result.json` ───────────────────────
+
+/// The subset of a COIN work-item `result.json` the Gym reads. `coin verify`
+/// writes `reached` (bool); the evaluation phase records the submission
+/// disposition. All fields are optional so a partially-written or older
+/// `result.json` parses without error and maps to a conservative outcome.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+pub struct CoinResultJson {
+    /// The target this result is for (`<project>:<harness>:<file>:<lines>`).
+    #[serde(default)]
+    pub target_id: Option<String>,
+    /// The verified reach verdict written by `coin verify`. `None` means verify
+    /// has not (yet) run for this item.
+    #[serde(default)]
+    pub reached: Option<bool>,
+    /// The disposition recorded during evaluation, e.g. `submitted`, `abstained`
+    /// (`UNREACHABLE.md`), `no_submission`, `timeout`, `error`.
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Whether the agent submitted a `blob.bin` at all.
+    #[serde(default)]
+    pub submitted: Option<bool>,
+    /// The harness the blob was fed to (from `blob.harness`).
+    #[serde(default)]
+    pub harness: Option<String>,
+}
+
+impl CoinResultJson {
+    /// Parse a `result.json` payload.
+    ///
+    /// # Errors
+    /// Returns [`CoinGymError::Parse`] on malformed JSON.
+    pub fn parse(raw: &str) -> CoinGymResult<Self> {
+        serde_json::from_str(raw).map_err(|e| CoinGymError::Parse(format!("result.json: {e}")))
+    }
+}
+
+fn status_kind(status: Option<&str>) -> Option<OutcomeCode> {
+    let s = status?.trim().to_ascii_lowercase();
+    match s.as_str() {
+        "error" | "failed" | "crash" => Some(OutcomeCode::Error),
+        "timeout" | "timed_out" | "timed-out" => Some(OutcomeCode::TimedOut),
+        "abstained" | "abstain" | "unreachable" => Some(OutcomeCode::Abstained),
+        "no_submission" | "no-submission" | "none" | "missing" | "empty" => {
+            Some(OutcomeCode::NoSubmission)
+        }
+        _ => None,
+    }
+}
+
+/// Map a parsed `result.json` to a full per-target [`OutcomeCode`]
+/// (`R/W/A/T/N/E`). A decisive `status` (error/timeout/abstained/no-submission)
+/// wins; otherwise the verified `reached` bool decides Reached vs WrongInput.
+/// When neither is present the outcome is `Error` (verify did not produce a
+/// verdict — an honest failure, never a silent pass).
+#[must_use]
+pub fn outcome_from_result(result: &CoinResultJson) -> OutcomeCode {
+    if let Some(code) = status_kind(result.status.as_deref()) {
+        return code;
+    }
+    match result.reached {
+        Some(true) => OutcomeCode::Reached,
+        Some(false) => OutcomeCode::WrongInput,
+        None => {
+            if result.submitted == Some(false) {
+                OutcomeCode::NoSubmission
+            } else {
+                OutcomeCode::Error
+            }
         }
     }
 }
 
-/// Delegates grading to the COIN maintainer harness via `coin evaluate`.
+/// Map a parsed `result.json` to a [`GradeResult`] for a **submitted** input
+/// (the executor only grades submissions; abstain / no-submission are decided
+/// upstream). Abstain / no-submission dispositions collapse to `Error` here
+/// because they should never reach the grader.
+#[must_use]
+pub fn grade_from_result(result: &CoinResultJson) -> GradeResult {
+    match outcome_from_result(result) {
+        OutcomeCode::Reached => GradeResult::Reached,
+        OutcomeCode::WrongInput => GradeResult::WrongInput,
+        OutcomeCode::TimedOut => GradeResult::TimedOut,
+        OutcomeCode::Abstained | OutcomeCode::NoSubmission | OutcomeCode::Error => {
+            GradeResult::Error
+        }
+    }
+}
+
+// ── Real evaluate/verify delegate (Phase-3 gated) ────────────────────────────
+
+/// Which build the evaluator runs against: rebuild from the row's pins (default,
+/// gated on the functional precheck) or the digest-pinned prebuilt image.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
+pub enum EvaluateSource {
+    /// `--source rebuild` (default): rebuild from the dataset row's pins.
+    #[default]
+    Rebuild,
+    /// `--source image`: always pull the digest-pinned runtime image.
+    Image,
+}
+
+impl EvaluateSource {
+    /// The `--source` flag value.
+    #[must_use]
+    pub fn as_flag(self) -> &'static str {
+        match self {
+            Self::Rebuild => "rebuild",
+            Self::Image => "image",
+        }
+    }
+}
+
+/// Configuration for the real `coin evaluate` / `coin verify` delegate.
 ///
-/// This is the production oracle path. It is intentionally a thin shell around
-/// the external tool — the reachability judgement lives entirely in
-/// `coin evaluate`'s instrumented replay, never here. Actually invoking it
-/// requires Docker + a pulled snapshot (Phase 3); until then [`Self::grade`]
-/// surfaces a clear Phase-3 gate error while [`Self::build_argv`] (the exact
-/// delegation contract) stays unit-testable offline.
+/// Mirrors the snapshot-consumption path in the reference: `--dataset <repo>
+/// --revision <tag>` selects the pinned snapshot; `--split` / `--project` narrow
+/// the target set; `--source` picks rebuild-vs-image.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CoinEvaluateConfig {
+    /// Path/name of the `coin` binary (default `coin`).
+    pub binary: String,
+    /// Hugging Face dataset repo, e.g. `COIN-Bench/coin`.
+    pub dataset: String,
+    /// Snapshot revision tag, e.g. `v2026-07`.
+    pub revision: String,
+    /// Repeatable `--split` filters (empty ⇒ all splits).
+    pub splits: Vec<String>,
+    /// Repeatable `--project` filters (empty ⇒ all projects).
+    pub projects: Vec<String>,
+    /// The evaluation build source.
+    pub source: EvaluateSource,
+}
+
+impl CoinEvaluateConfig {
+    /// Build a config for `dataset` at `revision` using the default `coin`
+    /// binary, all splits/projects, and the default `rebuild` source.
+    #[must_use]
+    pub fn new(dataset: impl Into<String>, revision: impl Into<String>) -> Self {
+        Self {
+            binary: "coin".to_string(),
+            dataset: dataset.into(),
+            revision: revision.into(),
+            splits: Vec::new(),
+            projects: Vec::new(),
+            source: EvaluateSource::Rebuild,
+        }
+    }
+
+    /// Parse the `<repo>@<revision>` shorthand (e.g. `COIN-Bench/coin@v2026-07`)
+    /// into a config, matching the reference's `--dataset you/coin@v1` sugar.
+    ///
+    /// # Errors
+    /// Returns [`CoinGymError::Usage`] if the string has no `@<revision>` or
+    /// either side is empty.
+    pub fn from_dataset_ref(dataset_ref: &str) -> CoinGymResult<Self> {
+        let (repo, rev) = dataset_ref.rsplit_once('@').ok_or_else(|| {
+            CoinGymError::Usage(format!(
+                "dataset ref '{dataset_ref}' must be '<repo>@<revision>' (e.g. COIN-Bench/coin@v2026-07)"
+            ))
+        })?;
+        if repo.is_empty() || rev.is_empty() {
+            return Err(CoinGymError::Usage(format!(
+                "dataset ref '{dataset_ref}' must have a non-empty repo and revision"
+            )));
+        }
+        Ok(Self::new(repo, rev))
+    }
+
+    /// Override the `coin` binary path/name.
+    #[must_use]
+    pub fn with_binary(mut self, binary: impl Into<String>) -> Self {
+        self.binary = binary.into();
+        self
+    }
+
+    /// Add a repeatable `--split` filter.
+    #[must_use]
+    pub fn with_split(mut self, split: impl Into<String>) -> Self {
+        self.splits.push(split.into());
+        self
+    }
+
+    /// Add a repeatable `--project` filter.
+    #[must_use]
+    pub fn with_project(mut self, project: impl Into<String>) -> Self {
+        self.projects.push(project.into());
+        self
+    }
+
+    /// Set the evaluation build source.
+    #[must_use]
+    pub fn with_source(mut self, source: EvaluateSource) -> Self {
+        self.source = source;
+        self
+    }
+}
+
+/// Delegates grading to COIN's own oracle via `coin evaluate` + `coin verify`.
+///
+/// This is the production path. It is a thin shell around the external tool —
+/// the reachability judgement lives entirely in COIN's instrumented replay,
+/// never here. Actually invoking it requires Docker + a pulled snapshot
+/// (Phase 3, issue #2823); until then [`Self::grade`] surfaces a clear Phase-3
+/// gate error while the delegation contract ([`Self::build_evaluate_argv`],
+/// [`Self::build_verify_argv`]) and the `/answer/` + `result.json` wiring stay
+/// unit-testable offline.
 #[derive(Clone, Debug)]
 pub struct CoinEvaluateExecutor {
     config: CoinEvaluateConfig,
@@ -100,37 +407,193 @@ impl CoinEvaluateExecutor {
         Self { config }
     }
 
-    /// The argv this executor would pass to the `coin` binary to grade a target,
-    /// with the candidate input already staged at `input_path`.
-    ///
-    /// Exposed (and unit-tested) so the delegation contract is verified without a
-    /// Docker host. The reachability oracle remains `coin evaluate` itself.
+    /// The config this delegate drives.
     #[must_use]
-    pub fn build_argv(&self, target: &Target, input_path: &str) -> Vec<String> {
-        vec![
+    pub fn config(&self) -> &CoinEvaluateConfig {
+        &self.config
+    }
+
+    /// The argv for `coin evaluate` against the configured snapshot — the exact
+    /// contract from the reference:
+    /// `coin evaluate --dataset <repo> --revision <tag> [--split ...]
+    /// [--project ...] --source <rebuild|image>`.
+    #[must_use]
+    pub fn build_evaluate_argv(&self) -> Vec<String> {
+        let mut argv = vec![
             self.config.binary.clone(),
             "evaluate".to_string(),
             "--dataset".to_string(),
             self.config.dataset.clone(),
-            "--target".to_string(),
-            target.id.clone(),
-            "--input".to_string(),
-            input_path.to_string(),
-        ]
+            "--revision".to_string(),
+            self.config.revision.clone(),
+        ];
+        for split in &self.config.splits {
+            argv.push("--split".to_string());
+            argv.push(split.clone());
+        }
+        for project in &self.config.projects {
+            argv.push("--project".to_string());
+            argv.push(project.clone());
+        }
+        argv.push("--source".to_string());
+        argv.push(self.config.source.as_flag().to_string());
+        argv
     }
+
+    /// The argv for `coin verify` on the experiment `coin evaluate` minted:
+    /// `coin verify --experiment <id> [--max-concurrent <n>]`.
+    #[must_use]
+    pub fn build_verify_argv(
+        &self,
+        experiment_id: &str,
+        max_concurrent: Option<u32>,
+    ) -> Vec<String> {
+        let mut argv = vec![
+            self.config.binary.clone(),
+            "verify".to_string(),
+            "--experiment".to_string(),
+            experiment_id.to_string(),
+        ];
+        if let Some(n) = max_concurrent {
+            argv.push("--max-concurrent".to_string());
+            argv.push(n.to_string());
+        }
+        argv
+    }
+}
+
+/// Extract the experiment id `coin evaluate` mints from its output. Evaluate
+/// prints it (and creates `output/experiments/<id>/`); `coin verify` needs it.
+/// Recognises `experiment: <id>`, `experiment_id=<id>`, and
+/// `output/experiments/<id>/` forms. Returns the first match.
+#[must_use]
+pub fn parse_experiment_id(evaluate_output: &str) -> Option<String> {
+    for line in evaluate_output.lines() {
+        let line = line.trim();
+        if let Some(rest) = line
+            .strip_prefix("experiment:")
+            .or_else(|| line.strip_prefix("experiment_id="))
+            .or_else(|| line.strip_prefix("experiment_id:"))
+        {
+            // The id is the first whitespace-delimited token, unquoted, so a
+            // trailing note (`experiment: exp-1 (2 items)`) does not leak in.
+            if let Some(id) = rest.trim().trim_matches('"').split_whitespace().next()
+                && !id.is_empty()
+            {
+                return Some(id.to_string());
+            }
+        }
+        if let Some(idx) = line.find("output/experiments/") {
+            let after = &line[idx + "output/experiments/".len()..];
+            let id: String = after
+                .chars()
+                .take_while(|c| *c != '/' && !c.is_whitespace())
+                .collect();
+            if !id.is_empty() {
+                return Some(id);
+            }
+        }
+    }
+    None
 }
 
 impl HarnessExecutor for CoinEvaluateExecutor {
     fn grade(&self, _target: &Target, _input: &str) -> CoinGymResult<GradeResult> {
-        // Phase 3 gate: real grading needs `coin evaluate` on a Docker host with
-        // a pulled snapshot. Surfacing an explicit error (rather than a silent
-        // fake verdict) keeps the harness honest — an offline run must use
-        // MockHarnessExecutor and be flagged `offline_scaffold`.
+        // Phase 3 gate: real grading needs `coin evaluate` + `coin verify` on a
+        // Docker host with a pulled snapshot. Surfacing an explicit error
+        // (rather than a silent fake verdict) keeps the harness honest — an
+        // offline run must use MockHarnessExecutor (scaffold) or read real
+        // `coin verify` output via CoinResultsExecutor.
         Err(CoinGymError::Executor(format!(
-            "`{} evaluate` requires a Docker host + pulled snapshot (Phase 3, azlin VM); \
-             use the offline MockHarnessExecutor for local scaffold runs",
-            self.config.binary
+            "`{bin} evaluate`/`{bin} verify` require a Docker host + pulled snapshot \
+             ({dataset}@{rev}) — Phase 3 (azlin VM, issue #2823). Use MockHarnessExecutor for \
+             offline scaffold runs, or CoinResultsExecutor to read a completed run's result.json",
+            bin = self.config.binary,
+            dataset = self.config.dataset,
+            rev = self.config.revision,
         )))
+    }
+}
+
+// ── Results reader: read `reached` from a completed run's `result.json` ───────
+
+/// Reads the **real** grades `coin verify` wrote into per-work-item
+/// `result.json` files under an experiment results directory. This is the
+/// read-side of the real contract: it never re-implements reach-checking, it
+/// only parses the `reached` verdict COIN already computed by replaying the
+/// harness on the instrumented build.
+///
+/// Layout: `<results_dir>/<target-slug>/result.json`, where `target-slug` is the
+/// target id with path-unsafe characters replaced (so a `project:harness:file`
+/// id never escapes `results_dir`). Because these are real grades, this executor
+/// is **not** an offline scaffold.
+#[derive(Clone, Debug)]
+pub struct CoinResultsExecutor {
+    results_dir: PathBuf,
+}
+
+impl CoinResultsExecutor {
+    /// Create a reader over a completed experiment's results directory.
+    #[must_use]
+    pub fn new(results_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            results_dir: results_dir.into(),
+        }
+    }
+
+    /// The directory-safe slug for a target id used as a path component.
+    #[must_use]
+    pub fn target_slug(target_id: &str) -> String {
+        target_id
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+            .collect()
+    }
+
+    /// The `result.json` path for a target under the results directory.
+    #[must_use]
+    pub fn result_path(&self, target_id: &str) -> PathBuf {
+        self.results_dir
+            .join(Self::target_slug(target_id))
+            .join("result.json")
+    }
+
+    /// Read and parse the `result.json` for `target_id`.
+    ///
+    /// # Errors
+    /// Returns [`CoinGymError::Executor`] if the file is missing (the run did
+    /// not grade this target) or [`CoinGymError::Parse`] on malformed JSON.
+    pub fn read_result(&self, target_id: &str) -> CoinGymResult<CoinResultJson> {
+        let path = self.result_path(target_id);
+        let raw = std::fs::read_to_string(&path).map_err(|e| {
+            CoinGymError::Executor(format!(
+                "cannot read result.json for '{target_id}' at {}: {e}",
+                path.display()
+            ))
+        })?;
+        CoinResultJson::parse(&raw)
+    }
+
+    /// The full per-target outcome (`R/W/A/T/N/E`) for a target, read from its
+    /// `result.json`. Unlike [`HarnessExecutor::grade`] this can also report
+    /// `Abstained` / `NoSubmission`, so it is the honest reader for a whole run.
+    ///
+    /// # Errors
+    /// Propagates read/parse errors from [`Self::read_result`].
+    pub fn outcome(&self, target_id: &str) -> CoinGymResult<OutcomeCode> {
+        Ok(outcome_from_result(&self.read_result(target_id)?))
+    }
+}
+
+impl HarnessExecutor for CoinResultsExecutor {
+    fn grade(&self, target: &Target, _input: &str) -> CoinGymResult<GradeResult> {
+        // The input was already submitted to `/answer/` and replayed by
+        // `coin verify`; the verdict lives in result.json. We only read it.
+        Ok(grade_from_result(&self.read_result(&target.id)?))
+    }
+
+    fn is_offline_scaffold(&self) -> bool {
+        false
     }
 }
 
@@ -141,8 +604,8 @@ impl HarnessExecutor for CoinEvaluateExecutor {
 /// It does **not** compute reachability — it simply checks the submitted input
 /// against a known reaching input per target (and optional injected
 /// timeout/error sets). This lets the full pipeline run offline without a VM
-/// while keeping the real oracle (`coin evaluate`) the only thing that ever
-/// judges reachability for real.
+/// while keeping the real oracle (`coin evaluate` + `coin verify`) the only
+/// thing that ever judges reachability for real.
 #[derive(Clone, Debug, Default)]
 pub struct MockHarnessExecutor {
     reaching_input: HashMap<String, String>,

--- a/src/coin_gym/mod.rs
+++ b/src/coin_gym/mod.rs
@@ -50,7 +50,10 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use agent_runner::{AgentRunner, BaselineStrategy, FixtureReasoner, TeamStrategy};
-use executor::MockHarnessExecutor;
+use executor::{
+    ANSWER_BLOB_BIN, ANSWER_BLOB_HARNESS, ANSWER_UNREACHABLE_MD, CoinEvaluateConfig,
+    CoinEvaluateExecutor, EvaluateSource, LOCAL_ONLY, MockHarnessExecutor,
+};
 use improve::analyze_and_review;
 use leaderboard::compare_to_leaderboard;
 use profiles::{PersistedRun, default_home, ensure_profile, list_profiles, load_run, save_run};
@@ -68,11 +71,14 @@ pub fn coin_gym_usage() -> &'static str {
      \x20 score <run-id> [--profile <name>]\n\
      \x20 compare <run-id> [--profile <name>]\n\
      \x20 improve <run-id> [--profile <name>]\n\
+     \x20 contract [--dataset <repo>] [--revision <tag>] [--split a,b] [--project x,y] [--source rebuild|image]\n\
      \x20 profiles\n\
      \n\
      Offline scaffold (Phase 4): runs grade against a mock oracle. Live grading\n\
      needs `coin evaluate` on a Docker host (Phase 3); the self-improvement\n\
-     verify/rollback loop is Phase 5. See docs/howto/run-the-coin-gym-harness.md."
+     verify/rollback loop is Phase 5. `contract` prints the real coin\n\
+     evaluate/verify wiring without running anything (LOCAL-ONLY). See\n\
+     docs/howto/run-the-coin-gym-harness.md."
 }
 
 /// Dispatch the `coin-gym` CLI over an argument iterator (argv minus the
@@ -105,6 +111,7 @@ where
         "score" => cmd_score(home, rest),
         "compare" => cmd_compare(home, rest),
         "improve" => cmd_improve(home, rest),
+        "contract" => cmd_contract(rest),
         "profiles" => cmd_profiles(home, rest),
         other => Err(CoinGymError::Usage(format!(
             "unknown command '{other}'\n{}",
@@ -326,6 +333,79 @@ fn cmd_improve(home: &Path, rest: &[String]) -> CoinGymResult<()> {
         println!("        tactic: {}", reviewed.proposal.tactic);
     }
     println!("note: {}", report.note);
+    Ok(())
+}
+
+// ── contract ─────────────────────────────────────────────────────────────────
+
+/// Print the **real** `coin evaluate` / `coin verify` wiring the harness would
+/// drive for a snapshot — without running anything. Makes the Phase-4 executor
+/// wiring (issue #3001) observable and copy-pasteable, and states the LOCAL-ONLY
+/// guardrail explicitly. Defaults to the published `COIN-Bench/coin@v2026-07`.
+fn cmd_contract(rest: &[String]) -> CoinGymResult<()> {
+    let parsed = parse_args(
+        rest,
+        &[
+            "dataset",
+            "revision",
+            "split",
+            "project",
+            "source",
+            "experiment",
+        ],
+    )?;
+    let dataset = parsed
+        .flags
+        .get("dataset")
+        .cloned()
+        .unwrap_or_else(|| "COIN-Bench/coin".to_string());
+    let revision = parsed
+        .flags
+        .get("revision")
+        .cloned()
+        .unwrap_or_else(|| "v2026-07".to_string());
+    let mut config = CoinEvaluateConfig::new(dataset, revision);
+    if let Some(splits) = parsed.flags.get("split") {
+        for s in splits.split(',').filter(|s| !s.is_empty()) {
+            config = config.with_split(s);
+        }
+    }
+    if let Some(projects) = parsed.flags.get("project") {
+        for p in projects.split(',').filter(|s| !s.is_empty()) {
+            config = config.with_project(p);
+        }
+    }
+    if let Some(src) = parsed.flags.get("source") {
+        let source = match src.as_str() {
+            "rebuild" => EvaluateSource::Rebuild,
+            "image" => EvaluateSource::Image,
+            other => {
+                return Err(CoinGymError::Usage(format!(
+                    "unknown --source '{other}' (expected 'rebuild' or 'image')"
+                )));
+            }
+        };
+        config = config.with_source(source);
+    }
+    let experiment = parsed
+        .flags
+        .get("experiment")
+        .cloned()
+        .unwrap_or_else(|| "<experiment-id>".to_string());
+    let exec = CoinEvaluateExecutor::new(config);
+
+    println!(
+        "LOCAL-ONLY: {LOCAL_ONLY} (no external submission, no leaderboard entry, no VM provisioning)"
+    );
+    println!("evaluate: {}", exec.build_evaluate_argv().join(" "));
+    println!(
+        "verify:   {}",
+        exec.build_verify_argv(&experiment, None).join(" ")
+    );
+    println!("submission-contract:");
+    println!("  attempt:  /answer/{ANSWER_BLOB_BIN} + /answer/{ANSWER_BLOB_HARNESS}");
+    println!("  abstain:  /answer/{ANSWER_UNREACHABLE_MD}  (and NO {ANSWER_BLOB_BIN})");
+    println!("verdict:  read `reached` from each result.json (never re-checked locally)");
     Ok(())
 }
 

--- a/src/coin_gym/target_loader.rs
+++ b/src/coin_gym/target_loader.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use super::agent_runner::Candidate;
-use super::types::{CoinGymError, CoinGymResult, Target};
+use super::types::{CoinGymError, CoinGymResult, Target, TargetFamily};
 
 /// The bundled sample snapshot manifest, embedded at compile time so tests and
 /// the offline demo `run` never depend on a checked-out path.
@@ -206,5 +206,277 @@ impl DemoScenario {
         let raw = std::fs::read_to_string(path)
             .map_err(|e| CoinGymError::Io(format!("read {}: {e}", path.display())))?;
         Self::from_manifest(&raw)
+    }
+}
+
+// ── Real COIN dataset schema (Hugging Face rows) ─────────────────────────────
+//
+// The offline demo above uses the compact scaffold fixture shape. This section
+// parses COIN's **real** published dataset schema (one row per target, see
+// `docs/reference/coin-benchmark.md#dataset-schema`) so the loader is validated
+// against the actual contract, pinned by `revision`.
+
+/// The `<project>:<harness>:<file>:<line_start>[-<line_end>]` components decoded
+/// from a COIN `target_id`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParsedTargetId {
+    /// OSS-Fuzz project name.
+    pub project: String,
+    /// Primary reaching harness binary.
+    pub harness: String,
+    /// Canonical source path.
+    pub file: String,
+    /// 1-based start line.
+    pub line_start: u32,
+    /// 1-based end line (`None` for a single-line target).
+    pub line_end: Option<u32>,
+}
+
+/// Decode a COIN `target_id` of the form
+/// `<project>:<harness>:<file>:<line_start>[-<line_end>]`.
+///
+/// The line spec is the final `:`-separated segment, so a `file` containing no
+/// colon (the normal case for `/src/<project>/<rel>` paths) is preserved intact.
+///
+/// # Errors
+/// Returns [`CoinGymError::Parse`] if the id is missing components or the line
+/// spec is not a positive integer (optionally a `start-end` range).
+pub fn parse_target_id(target_id: &str) -> CoinGymResult<ParsedTargetId> {
+    let (rest, line_spec) = target_id.rsplit_once(':').ok_or_else(|| {
+        CoinGymError::Parse(format!(
+            "target_id '{target_id}' must be '<project>:<harness>:<file>:<line_start>[-<line_end>]'"
+        ))
+    })?;
+    let mut parts = rest.splitn(3, ':');
+    let project = parts.next().unwrap_or_default();
+    let harness = parts.next();
+    let file = parts.next();
+    let (Some(harness), Some(file)) = (harness, file) else {
+        return Err(CoinGymError::Parse(format!(
+            "target_id '{target_id}' must have project, harness, file, and line components"
+        )));
+    };
+    if project.is_empty() || harness.is_empty() || file.is_empty() {
+        return Err(CoinGymError::Parse(format!(
+            "target_id '{target_id}' has an empty project/harness/file component"
+        )));
+    }
+    let (line_start, line_end) = parse_line_spec(line_spec, target_id)?;
+    Ok(ParsedTargetId {
+        project: project.to_string(),
+        harness: harness.to_string(),
+        file: file.to_string(),
+        line_start,
+        line_end,
+    })
+}
+
+fn parse_line_spec(spec: &str, target_id: &str) -> CoinGymResult<(u32, Option<u32>)> {
+    let parse_u32 = |s: &str| -> CoinGymResult<u32> {
+        s.parse::<u32>().map_err(|_| {
+            CoinGymError::Parse(format!(
+                "target_id '{target_id}' has a non-numeric line component '{s}'"
+            ))
+        })
+    };
+    match spec.split_once('-') {
+        Some((start, end)) => {
+            let start = parse_u32(start)?;
+            let end = parse_u32(end)?;
+            if end < start {
+                return Err(CoinGymError::Parse(format!(
+                    "target_id '{target_id}' has line_end {end} < line_start {start}"
+                )));
+            }
+            Ok((start, if end == start { None } else { Some(end) }))
+        }
+        None => Ok((parse_u32(spec)?, None)),
+    }
+}
+
+/// Map a dataset `split` name to a target [`TargetFamily`].
+#[must_use]
+pub fn family_for_split(split: &str) -> Option<TargetFamily> {
+    match split {
+        "codeql_only" => Some(TargetFamily::Frontier),
+        "gcs_reachable" => Some(TargetFamily::NonTrivialReachable),
+        _ => None,
+    }
+}
+
+/// One row of the real COIN dataset (selected columns; the rest are ignored). A
+/// row is self-describing via `target_id` but may repeat the components as
+/// explicit columns; explicit columns win when present.
+#[derive(Clone, Debug, Deserialize)]
+pub struct CoinDatasetRow {
+    /// `<project>:<harness>:<file>:<line_start>[-<line_end>]`.
+    pub target_id: String,
+    /// Snapshot tag the row is pinned to (`coin_version`, e.g. `v2026-07`).
+    #[serde(default)]
+    pub coin_version: Option<String>,
+    /// OSS-Fuzz commit pinned for the snapshot (becomes [`Target::commit`]).
+    #[serde(default)]
+    pub oss_fuzz_commit: Option<String>,
+    /// COIN commit pinned for the snapshot (fallback for [`Target::commit`]).
+    #[serde(default)]
+    pub coin_commit: Option<String>,
+    /// Explicit project override.
+    #[serde(default)]
+    pub project: Option<String>,
+    /// Explicit harness override.
+    #[serde(default)]
+    pub harness: Option<String>,
+    /// Explicit source-file override.
+    #[serde(default)]
+    pub file: Option<String>,
+    /// Explicit start-line override.
+    #[serde(default)]
+    pub line_start: Option<u32>,
+    /// Explicit end-line override.
+    #[serde(default)]
+    pub line_end: Option<u32>,
+    /// Split the row belongs to (`codeql_only` / `gcs_reachable`), used to
+    /// derive the family when `family` is absent.
+    #[serde(default)]
+    pub split: Option<String>,
+    /// Explicit family override (wins over `split`).
+    #[serde(default)]
+    pub family: Option<TargetFamily>,
+}
+
+impl CoinDatasetRow {
+    /// Convert to a [`Target`], verifying the row is pinned to
+    /// `expected_revision` and deriving its family from `family`/`split`.
+    ///
+    /// # Errors
+    /// Returns [`CoinGymError::Parse`] if the row is pinned to a different
+    /// revision, its `target_id` is malformed, or its family cannot be resolved.
+    pub fn to_target(&self, expected_revision: &str) -> CoinGymResult<Target> {
+        if let Some(ver) = &self.coin_version
+            && ver != expected_revision
+        {
+            return Err(CoinGymError::Parse(format!(
+                "target '{}' is pinned to revision '{ver}', not the requested '{expected_revision}'",
+                self.target_id
+            )));
+        }
+        let parsed = parse_target_id(&self.target_id)?;
+        let family = self
+            .family
+            .or_else(|| self.split.as_deref().and_then(family_for_split))
+            .ok_or_else(|| {
+                CoinGymError::Parse(format!(
+                    "target '{}' has no family and no recognised split to derive one from",
+                    self.target_id
+                ))
+            })?;
+        let line = self.line_start.unwrap_or(parsed.line_start);
+        // An explicit `line_end` column must not contradict the start; a range
+        // that ends before it starts is malformed data, not a single-line target.
+        if let Some(end) = self.line_end
+            && end < line
+        {
+            return Err(CoinGymError::Parse(format!(
+                "target '{}' has line_end {end} < line_start {line}",
+                self.target_id
+            )));
+        }
+        let line_end = self.line_end.or(parsed.line_end).filter(|e| *e != line);
+        Ok(Target {
+            id: self.target_id.clone(),
+            project: self.project.clone().unwrap_or(parsed.project),
+            commit: self
+                .oss_fuzz_commit
+                .clone()
+                .or_else(|| self.coin_commit.clone())
+                .unwrap_or_default(),
+            harness: self.harness.clone().unwrap_or(parsed.harness),
+            file: self.file.clone().unwrap_or(parsed.file),
+            line,
+            line_end,
+            family,
+        })
+    }
+}
+
+/// A real-schema dataset snapshot: pinned evaluation rows plus a held-out fresh
+/// slice (the anti-overfit oracle, which may come from a newer revision).
+#[derive(Clone, Debug, Deserialize)]
+pub struct DatasetManifest {
+    /// Hugging Face dataset repo, e.g. `COIN-Bench/coin`.
+    pub dataset: String,
+    /// Pinned snapshot revision, e.g. `v2026-07`.
+    pub revision: String,
+    /// Revision of the held-out fresh slice (defaults to `revision`). A distinct
+    /// value models "reserve a *newer* snapshot slice as the overfit oracle".
+    #[serde(default)]
+    pub held_out_revision: Option<String>,
+    /// Pinned evaluation rows.
+    #[serde(default)]
+    pub pinned: Vec<CoinDatasetRow>,
+    /// Held-out fresh rows.
+    #[serde(default)]
+    pub held_out_fresh: Vec<CoinDatasetRow>,
+}
+
+/// Loads targets from the **real** COIN dataset schema, pinned by revision.
+#[derive(Clone, Debug)]
+pub struct DatasetSource {
+    manifest: DatasetManifest,
+}
+
+impl DatasetSource {
+    /// Create a source from an already-parsed manifest.
+    #[must_use]
+    pub fn new(manifest: DatasetManifest) -> Self {
+        Self { manifest }
+    }
+
+    /// Parse a dataset manifest (JSON) into a source.
+    ///
+    /// # Errors
+    /// Returns [`CoinGymError::Parse`] on malformed JSON.
+    pub fn from_manifest(raw: &str) -> CoinGymResult<Self> {
+        let manifest: DatasetManifest = serde_json::from_str(raw)
+            .map_err(|e| CoinGymError::Parse(format!("dataset manifest: {e}")))?;
+        Ok(Self::new(manifest))
+    }
+
+    /// Parse a dataset manifest from a file on disk.
+    ///
+    /// # Errors
+    /// Returns [`CoinGymError`] on read or parse failure.
+    pub fn from_path(path: &Path) -> CoinGymResult<Self> {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|e| CoinGymError::Io(format!("read {}: {e}", path.display())))?;
+        Self::from_manifest(&raw)
+    }
+}
+
+impl TargetSource for DatasetSource {
+    fn load(&self) -> CoinGymResult<TargetSet> {
+        let revision = &self.manifest.revision;
+        let held_out_rev = self
+            .manifest
+            .held_out_revision
+            .as_deref()
+            .unwrap_or(revision);
+        let pinned = self
+            .manifest
+            .pinned
+            .iter()
+            .map(|r| r.to_target(revision))
+            .collect::<CoinGymResult<Vec<_>>>()?;
+        let held_out_fresh = self
+            .manifest
+            .held_out_fresh
+            .iter()
+            .map(|r| r.to_target(held_out_rev))
+            .collect::<CoinGymResult<Vec<_>>>()?;
+        Ok(TargetSet {
+            snapshot: format!("{}@{}", self.manifest.dataset, revision),
+            pinned,
+            held_out_fresh,
+        })
     }
 }

--- a/src/coin_gym/tests_agent_runner.rs
+++ b/src/coin_gym/tests_agent_runner.rs
@@ -16,6 +16,7 @@ fn t(id: &str, family: TargetFamily) -> Target {
         harness: "h".to_string(),
         file: "src/x.c".to_string(),
         line: 10,
+        line_end: None,
         family,
     }
 }

--- a/src/coin_gym/tests_cli.rs
+++ b/src/coin_gym/tests_cli.rs
@@ -181,7 +181,7 @@ fn explicit_profile_name_is_sanitised() {
 #[test]
 fn usage_lists_all_subcommands() {
     let usage = coin_gym_usage();
-    for cmd in ["run", "score", "compare", "improve", "profiles"] {
+    for cmd in ["run", "score", "compare", "improve", "contract", "profiles"] {
         assert!(usage.contains(cmd), "usage should mention {cmd}");
     }
 }
@@ -246,4 +246,37 @@ fn run_rejects_manifest_with_disjoint_script_keys() {
     let err =
         dispatch_with_home(dir.path(), args(&["run", "m", "--targets", &manifest])).unwrap_err();
     assert!(err.to_string().contains("pinned target"));
+}
+
+#[test]
+fn contract_command_runs_with_defaults_and_flags() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // Default snapshot.
+    dispatch_with_home(home, args(&["contract"])).unwrap();
+    // Explicit snapshot + repeated split/project (comma-separated) + source.
+    dispatch_with_home(
+        home,
+        args(&[
+            "contract",
+            "--dataset",
+            "COIN-Bench/coin",
+            "--revision",
+            "v2026-07",
+            "--split",
+            "codeql_only,gcs_reachable",
+            "--project",
+            "cups,libraw",
+            "--source",
+            "image",
+        ]),
+    )
+    .unwrap();
+}
+
+#[test]
+fn contract_rejects_unknown_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let err = dispatch_with_home(dir.path(), args(&["contract", "--source", "magic"])).unwrap_err();
+    assert!(err.to_string().contains("unknown --source"));
 }

--- a/src/coin_gym/tests_executor.rs
+++ b/src/coin_gym/tests_executor.rs
@@ -1,5 +1,8 @@
 use super::executor::{
-    CoinEvaluateConfig, CoinEvaluateExecutor, GradeResult, HarnessExecutor, MockHarnessExecutor,
+    ALLOWED_COIN_SUBCOMMANDS, ANSWER_BLOB_BIN, ANSWER_BLOB_HARNESS, ANSWER_UNREACHABLE_MD,
+    AgentAnswer, CoinEvaluateConfig, CoinEvaluateExecutor, CoinResultJson, CoinResultsExecutor,
+    EvaluateSource, GradeResult, HarnessExecutor, LOCAL_ONLY, MockHarnessExecutor,
+    grade_from_result, outcome_from_result, parse_experiment_id, write_answer,
 };
 use super::types::{OutcomeCode, Target, TargetFamily};
 
@@ -11,6 +14,7 @@ fn target(id: &str) -> Target {
         harness: "libraw_raf_fuzzer".to_string(),
         file: "src/metadata/fuji.cpp".to_string(),
         line: 480,
+        line_end: None,
         family: TargetFamily::Frontier,
     }
 }
@@ -68,7 +72,7 @@ fn mock_is_flagged_offline_scaffold() {
 
 #[test]
 fn coin_evaluate_delegate_is_phase3_gated() {
-    let exec = CoinEvaluateExecutor::new(CoinEvaluateConfig::new("you/coin@v1"));
+    let exec = CoinEvaluateExecutor::new(CoinEvaluateConfig::new("COIN-Bench/coin", "v2026-07"));
     assert!(!exec.is_offline_scaffold());
     let err = exec.grade(&target("t1"), "bytes").unwrap_err();
     let msg = err.to_string();
@@ -77,22 +81,360 @@ fn coin_evaluate_delegate_is_phase3_gated() {
 }
 
 #[test]
-fn coin_evaluate_builds_delegation_argv() {
-    let exec = CoinEvaluateExecutor::new(CoinEvaluateConfig::new("you/coin@v1"));
-    let argv = exec.build_argv(&target("libraw-fuji-480"), "/tmp/input.bin");
+fn coin_evaluate_builds_snapshot_argv() {
+    // Real contract: --dataset/--revision, optional repeatable --split/--project,
+    // and --source; NO fictional --target/--input flags.
+    let exec = CoinEvaluateExecutor::new(
+        CoinEvaluateConfig::new("COIN-Bench/coin", "v2026-07")
+            .with_split("codeql_only")
+            .with_project("cups")
+            .with_source(EvaluateSource::Image),
+    );
+    let argv = exec.build_evaluate_argv();
     assert_eq!(
         argv,
         vec![
             "coin".to_string(),
             "evaluate".to_string(),
             "--dataset".to_string(),
-            "you/coin@v1".to_string(),
-            "--target".to_string(),
-            "libraw-fuji-480".to_string(),
-            "--input".to_string(),
-            "/tmp/input.bin".to_string(),
+            "COIN-Bench/coin".to_string(),
+            "--revision".to_string(),
+            "v2026-07".to_string(),
+            "--split".to_string(),
+            "codeql_only".to_string(),
+            "--project".to_string(),
+            "cups".to_string(),
+            "--source".to_string(),
+            "image".to_string(),
         ]
     );
+    // The evaluate argv must never re-introduce the fictional per-input flags.
+    assert!(!argv.iter().any(|a| a == "--target" || a == "--input"));
+}
+
+#[test]
+fn coin_evaluate_defaults_to_all_splits_and_rebuild() {
+    let exec = CoinEvaluateExecutor::new(CoinEvaluateConfig::new("COIN-Bench/coin", "v2026-07"));
+    let argv = exec.build_evaluate_argv();
+    assert_eq!(
+        argv,
+        vec![
+            "coin",
+            "evaluate",
+            "--dataset",
+            "COIN-Bench/coin",
+            "--revision",
+            "v2026-07",
+            "--source",
+            "rebuild",
+        ]
+    );
+}
+
+#[test]
+fn coin_evaluate_repeats_splits_and_projects() {
+    let exec = CoinEvaluateExecutor::new(
+        CoinEvaluateConfig::new("COIN-Bench/coin", "v2026-07")
+            .with_split("codeql_only")
+            .with_split("gcs_reachable")
+            .with_project("cups")
+            .with_project("libraw"),
+    );
+    let argv = exec.build_evaluate_argv();
+    assert_eq!(argv.iter().filter(|a| *a == "--split").count(), 2);
+    assert_eq!(argv.iter().filter(|a| *a == "--project").count(), 2);
+}
+
+#[test]
+fn dataset_ref_shorthand_parses_repo_and_revision() {
+    let cfg = CoinEvaluateConfig::from_dataset_ref("COIN-Bench/coin@v2026-07").unwrap();
+    assert_eq!(cfg.dataset, "COIN-Bench/coin");
+    assert_eq!(cfg.revision, "v2026-07");
+    assert_eq!(cfg.source, EvaluateSource::Rebuild);
+    // Missing '@revision' is a usage error, not a silent default.
+    assert!(CoinEvaluateConfig::from_dataset_ref("COIN-Bench/coin").is_err());
+    assert!(CoinEvaluateConfig::from_dataset_ref("COIN-Bench/coin@").is_err());
+    assert!(CoinEvaluateConfig::from_dataset_ref("@v1").is_err());
+}
+
+#[test]
+fn coin_verify_argv_targets_the_minted_experiment() {
+    let exec = CoinEvaluateExecutor::new(CoinEvaluateConfig::new("COIN-Bench/coin", "v2026-07"));
+    assert_eq!(
+        exec.build_verify_argv("exp-123", None),
+        vec!["coin", "verify", "--experiment", "exp-123"]
+    );
+    assert_eq!(
+        exec.build_verify_argv("exp-123", Some(4)),
+        vec![
+            "coin".to_string(),
+            "verify".to_string(),
+            "--experiment".to_string(),
+            "exp-123".to_string(),
+            "--max-concurrent".to_string(),
+            "4".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn experiment_id_is_parsed_from_evaluate_output() {
+    assert_eq!(
+        parse_experiment_id("running...\nexperiment: exp-2026-07-abc\ndone"),
+        Some("exp-2026-07-abc".to_string())
+    );
+    assert_eq!(
+        parse_experiment_id("wrote output/experiments/exp-xyz/results/"),
+        Some("exp-xyz".to_string())
+    );
+    // A trailing note after the id must not leak into the parsed value.
+    assert_eq!(
+        parse_experiment_id("experiment: exp-1 (70 items queued)"),
+        Some("exp-1".to_string())
+    );
+    assert_eq!(parse_experiment_id("no id here"), None);
+}
+
+#[test]
+fn local_only_guardrail_excludes_publish_and_submit() {
+    const { assert!(LOCAL_ONLY) };
+    // The crate only ever drives the read/measure subcommands.
+    assert_eq!(ALLOWED_COIN_SUBCOMMANDS, &["evaluate", "verify"]);
+    let exec = CoinEvaluateExecutor::new(CoinEvaluateConfig::new("COIN-Bench/coin", "v2026-07"));
+    let mut argv = exec.build_evaluate_argv();
+    argv.extend(exec.build_verify_argv("exp-1", Some(2)));
+    for forbidden in [
+        "publish",
+        "--hf-repo",
+        "--registry",
+        "submit",
+        "leaderboard",
+    ] {
+        assert!(
+            !argv.iter().any(|a| a.contains(forbidden)),
+            "LOCAL-ONLY: argv must never contain '{forbidden}'"
+        );
+    }
+}
+
+// ── Submission contract (`/answer/`) ─────────────────────────────────────────
+
+#[test]
+fn write_answer_attempt_writes_blob_and_harness() {
+    let dir = tempfile::tempdir().unwrap();
+    let answer = dir.path().join("answer");
+    write_answer(
+        &answer,
+        &AgentAnswer::Attempt {
+            blob: b"\x00magic-bytes".to_vec(),
+            harness: "libraw_raf_fuzzer".to_string(),
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        std::fs::read(answer.join(ANSWER_BLOB_BIN)).unwrap(),
+        b"\x00magic-bytes"
+    );
+    assert_eq!(
+        std::fs::read_to_string(answer.join(ANSWER_BLOB_HARNESS)).unwrap(),
+        "libraw_raf_fuzzer"
+    );
+    assert!(!answer.join(ANSWER_UNREACHABLE_MD).exists());
+}
+
+#[test]
+fn write_answer_attempt_removes_stale_unreachable_marker() {
+    let dir = tempfile::tempdir().unwrap();
+    let answer = dir.path().join("answer");
+    // A prior abstention left an UNREACHABLE.md behind.
+    write_answer(
+        &answer,
+        &AgentAnswer::Abstain {
+            unreachable_md: "unreachable: no path".to_string(),
+        },
+    )
+    .unwrap();
+    // A subsequent attempt must clear it so COIN grades the blob, not abstain.
+    write_answer(
+        &answer,
+        &AgentAnswer::Attempt {
+            blob: b"bytes".to_vec(),
+            harness: "h".to_string(),
+        },
+    )
+    .unwrap();
+    assert!(answer.join(ANSWER_BLOB_BIN).exists());
+    assert!(!answer.join(ANSWER_UNREACHABLE_MD).exists());
+}
+
+#[test]
+fn write_answer_abstain_removes_stale_blob() {
+    let dir = tempfile::tempdir().unwrap();
+    let answer = dir.path().join("answer");
+    write_answer(
+        &answer,
+        &AgentAnswer::Attempt {
+            blob: b"bytes".to_vec(),
+            harness: "h".to_string(),
+        },
+    )
+    .unwrap();
+    // Abstaining after an attempt must remove blob.bin (COIN treats a present
+    // blob.bin as an attempt and ignores UNREACHABLE.md otherwise).
+    write_answer(
+        &answer,
+        &AgentAnswer::Abstain {
+            unreachable_md: "unreachable: guarded by an unsatisfiable constant".to_string(),
+        },
+    )
+    .unwrap();
+    assert!(!answer.join(ANSWER_BLOB_BIN).exists());
+    assert!(!answer.join(ANSWER_BLOB_HARNESS).exists());
+    assert!(answer.join(ANSWER_UNREACHABLE_MD).exists());
+}
+
+#[test]
+fn write_answer_rejects_empty_or_multiline_harness() {
+    let dir = tempfile::tempdir().unwrap();
+    let answer = dir.path().join("answer");
+    let empty = write_answer(
+        &answer,
+        &AgentAnswer::Attempt {
+            blob: b"x".to_vec(),
+            harness: "  ".to_string(),
+        },
+    );
+    assert!(empty.is_err());
+    let multiline = write_answer(
+        &answer,
+        &AgentAnswer::Attempt {
+            blob: b"x".to_vec(),
+            harness: "a\nb".to_string(),
+        },
+    );
+    assert!(multiline.is_err());
+}
+
+// ── Reading `reached` from result.json ───────────────────────────────────────
+
+#[test]
+fn outcome_from_result_maps_reached_and_status() {
+    let reached = CoinResultJson {
+        reached: Some(true),
+        ..Default::default()
+    };
+    assert_eq!(outcome_from_result(&reached), OutcomeCode::Reached);
+    let wrong = CoinResultJson {
+        reached: Some(false),
+        ..Default::default()
+    };
+    assert_eq!(outcome_from_result(&wrong), OutcomeCode::WrongInput);
+    for (status, code) in [
+        ("timeout", OutcomeCode::TimedOut),
+        ("error", OutcomeCode::Error),
+        ("abstained", OutcomeCode::Abstained),
+        ("no_submission", OutcomeCode::NoSubmission),
+    ] {
+        let r = CoinResultJson {
+            status: Some(status.to_string()),
+            // A decisive status wins even if a stale reached bool is present.
+            reached: Some(true),
+            ..Default::default()
+        };
+        assert_eq!(outcome_from_result(&r), code, "status {status}");
+    }
+}
+
+#[test]
+fn outcome_from_result_without_verdict_is_error_or_no_submission() {
+    // verify never ran and nothing submitted → N.
+    let none_sub = CoinResultJson {
+        submitted: Some(false),
+        ..Default::default()
+    };
+    assert_eq!(outcome_from_result(&none_sub), OutcomeCode::NoSubmission);
+    // submitted but no verdict → honest Error (never a silent pass).
+    let no_verdict = CoinResultJson {
+        submitted: Some(true),
+        ..Default::default()
+    };
+    assert_eq!(outcome_from_result(&no_verdict), OutcomeCode::Error);
+}
+
+#[test]
+fn grade_from_result_collapses_non_submission_outcomes() {
+    assert_eq!(
+        grade_from_result(&CoinResultJson {
+            reached: Some(true),
+            ..Default::default()
+        }),
+        GradeResult::Reached
+    );
+    assert_eq!(
+        grade_from_result(&CoinResultJson {
+            status: Some("abstained".to_string()),
+            ..Default::default()
+        }),
+        GradeResult::Error
+    );
+}
+
+#[test]
+fn result_json_parses_the_reached_field() {
+    let r = CoinResultJson::parse(r#"{"target_id":"libraw:h:f:1","reached":true}"#).unwrap();
+    assert_eq!(r.reached, Some(true));
+    assert_eq!(r.target_id.as_deref(), Some("libraw:h:f:1"));
+    assert!(CoinResultJson::parse("{ not json").is_err());
+}
+
+// ── CoinResultsExecutor: read real grades from disk ──────────────────────────
+
+fn write_result_json(results_dir: &std::path::Path, target_id: &str, body: &str) {
+    let dir = results_dir.join(CoinResultsExecutor::target_slug(target_id));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("result.json"), body).unwrap();
+}
+
+#[test]
+fn results_executor_reads_reached_from_result_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let results = dir.path();
+    let t = target("libraw:libraw_raf_fuzzer:src/metadata/fuji.cpp:480");
+    write_result_json(results, &t.id, r#"{"reached":true}"#);
+    let exec = CoinResultsExecutor::new(results);
+    assert!(!exec.is_offline_scaffold(), "real grades are not scaffold");
+    assert_eq!(exec.grade(&t, "ignored").unwrap(), GradeResult::Reached);
+
+    write_result_json(results, &t.id, r#"{"reached":false}"#);
+    assert_eq!(exec.grade(&t, "ignored").unwrap(), GradeResult::WrongInput);
+
+    write_result_json(results, &t.id, r#"{"status":"timeout"}"#);
+    assert_eq!(exec.grade(&t, "ignored").unwrap(), GradeResult::TimedOut);
+}
+
+#[test]
+fn results_executor_full_outcome_reads_abstain_and_no_submission() {
+    let dir = tempfile::tempdir().unwrap();
+    let results = dir.path();
+    let t = target("proj:h:f:1");
+    write_result_json(results, &t.id, r#"{"status":"abstained"}"#);
+    let exec = CoinResultsExecutor::new(results);
+    assert_eq!(exec.outcome(&t.id).unwrap(), OutcomeCode::Abstained);
+}
+
+#[test]
+fn results_executor_missing_result_is_executor_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let exec = CoinResultsExecutor::new(dir.path());
+    let err = exec.grade(&target("nope:h:f:1"), "x").unwrap_err();
+    assert!(err.to_string().contains("executor error"));
+}
+
+#[test]
+fn results_executor_slug_is_path_safe() {
+    // A raw target id (with ':' and '/') must never escape the results dir.
+    let slug = CoinResultsExecutor::target_slug("proj:harness:src/../../etc/passwd:1");
+    assert!(!slug.contains('/') && !slug.contains(':') && !slug.contains(".."));
 }
 
 #[test]

--- a/src/coin_gym/tests_improve.rs
+++ b/src/coin_gym/tests_improve.rs
@@ -12,6 +12,7 @@ fn target(id: &str, project: &str, harness: &str, file: &str) -> Target {
         harness: harness.to_string(),
         file: file.to_string(),
         line: 100,
+        line_end: None,
         family: TargetFamily::Frontier,
     }
 }

--- a/src/coin_gym/tests_target_loader.rs
+++ b/src/coin_gym/tests_target_loader.rs
@@ -1,8 +1,9 @@
 use std::io::Write;
 
 use super::target_loader::{
-    DemoScenario, FixtureTargetSource, InMemoryTargetSource, SAMPLE_SNAPSHOT_JSON, TargetSet,
-    TargetSource,
+    CoinDatasetRow, DatasetManifest, DatasetSource, DemoScenario, FixtureTargetSource,
+    InMemoryTargetSource, ParsedTargetId, SAMPLE_SNAPSHOT_JSON, TargetSet, TargetSource,
+    family_for_split, parse_target_id,
 };
 use super::types::TargetFamily;
 
@@ -99,4 +100,182 @@ fn target_set_total_counts_both_slices() {
     assert_eq!(set.pinned.len(), 1);
     assert_eq!(set.held_out_fresh.len(), 1);
     assert_eq!(set.total(), 2);
+}
+
+// ── Real COIN dataset schema ─────────────────────────────────────────────────
+
+#[test]
+fn parse_target_id_single_line() {
+    let p = parse_target_id("cups:ipp_fuzzer:cups/ipp.c:1523").unwrap();
+    assert_eq!(
+        p,
+        ParsedTargetId {
+            project: "cups".to_string(),
+            harness: "ipp_fuzzer".to_string(),
+            file: "cups/ipp.c".to_string(),
+            line_start: 1523,
+            line_end: None,
+        }
+    );
+}
+
+#[test]
+fn parse_target_id_line_range() {
+    let p = parse_target_id("libraw:libraw_raf_fuzzer:src/metadata/fuji.cpp:480-495").unwrap();
+    assert_eq!(p.file, "src/metadata/fuji.cpp");
+    assert_eq!(p.line_start, 480);
+    assert_eq!(p.line_end, Some(495));
+    // A start==end range collapses to a single-line target.
+    assert_eq!(parse_target_id("p:h:f:10-10").unwrap().line_end, None);
+}
+
+#[test]
+fn parse_target_id_rejects_malformed() {
+    assert!(parse_target_id("no-colons").is_err());
+    assert!(parse_target_id("p:h:f:notaline").is_err());
+    assert!(parse_target_id("p:h:f:20-10").is_err()); // end < start
+    assert!(parse_target_id("p::f:1").is_err()); // empty harness
+}
+
+#[test]
+fn family_for_split_maps_published_splits() {
+    assert_eq!(
+        family_for_split("codeql_only"),
+        Some(TargetFamily::Frontier)
+    );
+    assert_eq!(
+        family_for_split("gcs_reachable"),
+        Some(TargetFamily::NonTrivialReachable)
+    );
+    assert_eq!(family_for_split("mystery"), None);
+}
+
+#[test]
+fn dataset_row_to_target_pins_revision_and_derives_family() {
+    let row = CoinDatasetRow {
+        target_id: "cups:ipp_fuzzer:cups/ipp.c:1523".to_string(),
+        coin_version: Some("v2026-07".to_string()),
+        oss_fuzz_commit: Some("deadbeef".to_string()),
+        coin_commit: None,
+        project: None,
+        harness: None,
+        file: None,
+        line_start: None,
+        line_end: None,
+        split: Some("codeql_only".to_string()),
+        family: None,
+    };
+    let t = row.to_target("v2026-07").unwrap();
+    assert_eq!(t.project, "cups");
+    assert_eq!(t.harness, "ipp_fuzzer");
+    assert_eq!(t.file, "cups/ipp.c");
+    assert_eq!(t.line, 1523);
+    assert_eq!(t.commit, "deadbeef");
+    assert_eq!(t.family, TargetFamily::Frontier);
+    // Pinning is enforced: a mismatched revision is rejected.
+    assert!(row.to_target("v2026-08").is_err());
+}
+
+#[test]
+fn dataset_row_preserves_line_range() {
+    let row: CoinDatasetRow = serde_json::from_str(
+        r#"{"target_id":"libraw:raf:src/fuji.cpp:480-495","split":"gcs_reachable"}"#,
+    )
+    .unwrap();
+    let t = row.to_target("v2026-07").unwrap();
+    assert_eq!(t.line_start(), 480);
+    assert_eq!(t.line_end_inclusive(), 495);
+    assert_eq!(t.line_count(), 16);
+    assert_eq!(t.locator(), "libraw:src/fuji.cpp:480-495");
+}
+
+#[test]
+fn dataset_source_loads_pinned_and_held_out_slices() {
+    let raw = r#"{
+        "dataset": "COIN-Bench/coin",
+        "revision": "v2026-07",
+        "held_out_revision": "v2026-08",
+        "pinned": [
+            {"target_id":"cups:ipp_fuzzer:cups/ipp.c:1523","split":"codeql_only"},
+            {"target_id":"liboqs:kem_fuzzer:src/kem/kem.c:88","split":"gcs_reachable"}
+        ],
+        "held_out_fresh": [
+            {"target_id":"libpng:read_fuzzer:pngrutil.c:903","coin_version":"v2026-08","split":"codeql_only"}
+        ]
+    }"#;
+    let set = DatasetSource::from_manifest(raw).unwrap().load().unwrap();
+    assert_eq!(set.snapshot, "COIN-Bench/coin@v2026-07");
+    assert_eq!(set.pinned.len(), 2);
+    assert_eq!(set.held_out_fresh.len(), 1);
+    assert_eq!(set.total(), 3);
+    assert!(
+        set.pinned
+            .iter()
+            .any(|t| t.family == TargetFamily::Frontier)
+    );
+    assert!(
+        set.pinned
+            .iter()
+            .any(|t| t.family == TargetFamily::NonTrivialReachable)
+    );
+    // Held-out slice is pinned to the fresh revision, not the eval revision.
+    assert_eq!(set.held_out_fresh[0].project, "libpng");
+}
+
+#[test]
+fn dataset_source_rejects_row_pinned_to_wrong_revision() {
+    let raw = r#"{
+        "dataset": "COIN-Bench/coin",
+        "revision": "v2026-07",
+        "pinned": [
+            {"target_id":"cups:ipp_fuzzer:cups/ipp.c:1523","coin_version":"v2025-01","split":"codeql_only"}
+        ]
+    }"#;
+    let err = DatasetSource::from_manifest(raw)
+        .unwrap()
+        .load()
+        .unwrap_err();
+    assert!(err.to_string().contains("pinned to revision"));
+}
+
+#[test]
+fn dataset_source_from_path_reads_disk() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("dataset.json");
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(
+        br#"{"dataset":"COIN-Bench/coin","revision":"v2026-07",
+             "pinned":[{"target_id":"cups:ipp_fuzzer:cups/ipp.c:1523","split":"codeql_only"}]}"#,
+    )
+    .unwrap();
+    drop(f);
+    let set = DatasetSource::from_path(&path).unwrap().load().unwrap();
+    assert_eq!(set.pinned.len(), 1);
+}
+
+#[test]
+fn dataset_manifest_deserializes_minimally() {
+    // A manifest with no held-out slice still parses (empty vecs default).
+    let m: DatasetManifest = serde_json::from_str(r#"{"dataset":"d","revision":"r"}"#).unwrap();
+    assert!(m.pinned.is_empty());
+    assert!(m.held_out_fresh.is_empty());
+}
+
+#[test]
+fn dataset_row_rejects_explicit_backwards_line_range() {
+    let row = CoinDatasetRow {
+        target_id: "p:h:f:100".to_string(),
+        coin_version: None,
+        oss_fuzz_commit: None,
+        coin_commit: None,
+        project: None,
+        harness: None,
+        file: None,
+        line_start: Some(100),
+        line_end: Some(50),
+        split: Some("codeql_only".to_string()),
+        family: None,
+    };
+    let err = row.to_target("v2026-07").unwrap_err();
+    assert!(err.to_string().contains("line_end 50 < line_start 100"));
 }

--- a/src/coin_gym/tests_types.rs
+++ b/src/coin_gym/tests_types.rs
@@ -8,6 +8,7 @@ fn target(id: &str, family: TargetFamily) -> Target {
         harness: "h".to_string(),
         file: "src/x.c".to_string(),
         line: 42,
+        line_end: None,
         family,
     }
 }

--- a/src/coin_gym/types.rs
+++ b/src/coin_gym/types.rs
@@ -59,17 +59,47 @@ pub struct Target {
     pub harness: String,
     /// Source file containing the target line.
     pub file: String,
-    /// 1-based target line number `ℓ`.
+    /// 1-based start of the target line range `ℓ` (the canonical target line).
     pub line: u32,
+    /// 1-based end of the target line range, when the target spans multiple
+    /// lines. `None` means a single-line target (`line_end == line`). Kept
+    /// optional so single-line fixtures/snapshots stay valid without the field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line_end: Option<u32>,
     /// Target family (frontier vs. non-trivial reachable).
     pub family: TargetFamily,
 }
 
 impl Target {
     /// `project:file:line` — a human-readable locator for logs and reports.
+    /// A multi-line target renders its range as `project:file:start-end`.
     #[must_use]
     pub fn locator(&self) -> String {
-        format!("{}:{}:{}", self.project, self.file, self.line)
+        let end = self.line_end_inclusive();
+        if end > self.line {
+            format!("{}:{}:{}-{}", self.project, self.file, self.line, end)
+        } else {
+            format!("{}:{}:{}", self.project, self.file, self.line)
+        }
+    }
+
+    /// The 1-based start line of the target range (alias for [`Self::line`]).
+    #[must_use]
+    pub fn line_start(&self) -> u32 {
+        self.line
+    }
+
+    /// The inclusive 1-based end line of the target range. Falls back to
+    /// [`Self::line`] for single-line targets. Never less than the start.
+    #[must_use]
+    pub fn line_end_inclusive(&self) -> u32 {
+        self.line_end.unwrap_or(self.line).max(self.line)
+    }
+
+    /// Number of lines the target range spans (`>= 1`).
+    #[must_use]
+    pub fn line_count(&self) -> u32 {
+        self.line_end_inclusive() - self.line + 1
     }
 }
 

--- a/tests/gadugi/coin-gym-harness.sh
+++ b/tests/gadugi/coin-gym-harness.sh
@@ -14,7 +14,11 @@
 #   4. The overfitting-reviewer gate ACCEPTs the analyst's general tactics, and
 #      `improve` flags the live verify/rollback loop as Phase 5.
 #   5. `profiles` lists isolated per-model run state.
-#   6. An unknown command exits non-zero with usage.
+#   6. `contract` prints the real `coin evaluate`/`coin verify` wiring (snapshot
+#      argv, the /answer/ submission contract, and the LOCAL-ONLY guardrail)
+#      without running anything, and never leaks the fictional --target/--input
+#      flags (issue #3001).
+#   7. An unknown command exits non-zero with usage.
 #
 # Hermetic: COIN_GYM_HOME is a throwaway temp dir; nothing touches the real
 # ~/.simard state or the network.
@@ -76,7 +80,34 @@ PROFILES="$(run_gym profiles)"
 printf '%s\n' "$PROFILES"
 printf '%s\n' "$PROFILES" | grep -F "opus" >/dev/null
 
-# --- 6. unknown command exits non-zero with usage -----------------------------
+# --- 6. contract: the real coin evaluate/verify wiring (issue #3001) -----------
+# `contract` prints exactly how the harness drives COIN's own oracle, without
+# running anything. Asserts the real snapshot-mode argv (no fictional
+# --target/--input), the verify step, the /answer/ submission contract, and the
+# LOCAL-ONLY guardrail.
+CONTRACT="$(run_gym contract --split codeql_only --project cups --source image)"
+printf '%s\n' "$CONTRACT"
+printf '%s\n' "$CONTRACT" | grep -F "LOCAL-ONLY: true" >/dev/null
+printf '%s\n' "$CONTRACT" | \
+  grep -F "coin evaluate --dataset COIN-Bench/coin --revision v2026-07 --split codeql_only --project cups --source image" >/dev/null
+printf '%s\n' "$CONTRACT" | grep -F "coin verify --experiment" >/dev/null
+printf '%s\n' "$CONTRACT" | grep -F "/answer/blob.bin + /answer/blob.harness" >/dev/null
+printf '%s\n' "$CONTRACT" | grep -F "/answer/UNREACHABLE.md" >/dev/null
+printf '%s\n' "$CONTRACT" | grep -F "read \`reached\` from each result.json" >/dev/null
+# The fictional per-input flags must never appear.
+if printf '%s\n' "$CONTRACT" | grep -Eq -- "--target|--input"; then
+  echo "ERROR: contract argv leaked fictional --target/--input flags" >&2
+  exit 1
+fi
+# An unknown --source is rejected.
+if run_gym contract --source bogus >/tmp/coin-gym-src.out 2>&1; then
+  echo "ERROR: unknown --source should have failed" >&2
+  exit 1
+fi
+grep -F "unknown --source" /tmp/coin-gym-src.out >/dev/null
+rm -f /tmp/coin-gym-src.out
+
+# --- 7. unknown command exits non-zero with usage -----------------------------
 if run_gym frobnicate >/tmp/coin-gym-bogus.out 2>&1; then
   echo "ERROR: unknown command should have failed" >&2
   exit 1

--- a/tests/gadugi/coin-gym-harness.yaml
+++ b/tests/gadugi/coin-gym-harness.yaml
@@ -1,5 +1,5 @@
 name: "LOCAL COIN Gym harness CLI (#2713 Phase 4)"
-description: "Outside-in coverage for the coin-gym CLI: the full offline pipeline (target-load → agent-run → mock-grade → score), the baseline-vs-team precision trade-off at equal reach, score/compare/improve reloading a saved run, the overfitting-reviewer gate accepting general tactics while flagging the live loop as Phase 5, isolated per-model profiles, and usage-on-error. Hermetic and network-free; grades against a mock oracle (real coin evaluate is Phase 3)."
+description: "Outside-in coverage for the coin-gym CLI: the full offline pipeline (target-load → agent-run → mock-grade → score), the baseline-vs-team precision trade-off at equal reach, score/compare/improve reloading a saved run, the overfitting-reviewer gate accepting general tactics while flagging the live loop as Phase 5, isolated per-model profiles, the `contract` command printing the real coin evaluate/verify wiring + /answer/ submission contract + LOCAL-ONLY guardrail (issue #3001), and usage-on-error. Hermetic and network-free; grades against a mock oracle (real coin evaluate is Phase 3)."
 version: "1.0.0"
 
 config:


### PR DESCRIPTION
## Summary

Wires the LOCAL COIN Gym harness (`src/coin_gym/`) to COIN's **real**
`coin evaluate` / `coin verify` contract, replacing the Phase-4 scaffold's
fictional `coin evaluate --target/--input` delegate. The design input is the
code-verified contract in `docs/reference/coin-benchmark.md`. The Gym now drives
COIN's own oracle and **never re-implements reach-checking**.

Scaffold landed in #2740; this is the bounded Phase-4 follow-through. Live Docker
execution stays gated behind Phase 3 (#2823); the self-improve loop stays out of
scope (#2825).

`Closes #3001`

## What changed (`src/coin_gym/` + tests only)

- **executor.rs** — the real contract:
  - `build_evaluate_argv`: `coin evaluate --dataset <repo> --revision <tag>
    [--split ...] [--project ...] --source <rebuild|image>` (no fictional
    `--target`/`--input`); `build_verify_argv`: `coin verify --experiment <id>
    [--max-concurrent N]`; `from_dataset_ref` (`repo@rev` shorthand);
    `parse_experiment_id`.
  - **Submission contract**: `AgentAnswer` + `write_answer` writing
    `/answer/blob.bin` + `/answer/blob.harness`, or `/answer/UNREACHABLE.md` to
    abstain (an attempt clears a stale marker; an abstention clears a stale blob
    so a present `blob.bin` never silently overrides the abstention).
  - **Read `reached`**: `CoinResultJson` +
    `outcome_from_result`/`grade_from_result` map each work item's `result.json`
    to R/W/A/T/N/E; a missing verdict is an honest `Error`/`N`, never a silent
    pass. `CoinResultsExecutor` reads the real grades `coin verify` wrote
    (path-safe target slugs).
  - **LOCAL-ONLY guardrail** (`LOCAL_ONLY`, `ALLOWED_COIN_SUBCOMMANDS`): only
    `evaluate`/`verify` are ever constructed; no submit/publish/leaderboard/VM.
- **target_loader.rs** — parses the real COIN dataset schema: `CoinDatasetRow`,
  `parse_target_id` (`<project>:<harness>:<file>:<line_start>[-<line_end>]`),
  `DatasetSource` pinned by `revision`, reserving a held-out fresh slice as the
  anti-overfit oracle.
- **types.rs** — `Target` carries a line range (`line_end`) with a range-aware
  locator.
- **mod.rs** — new `coin-gym contract` subcommand prints the exact
  evaluate/verify wiring + submission contract + LOCAL-ONLY guardrail without
  running anything.

Scorer (reach/precision + per-family + R/W/A/T/N/E histogram), leaderboard
comparator, and baseline-vs-team already satisfied their criteria in the
scaffold and are unchanged.

## Merge-ready evidence (commit `07fd26dd91a1c7a2c1ab674dc55ecebe079ee1bd`)

**1. qa-team scenarios (`gadugi-test validate` + `run`)**
- `tests/gadugi/coin-gym-harness.yaml` extended with a new `contract` step.
- `gadugi-test validate -f tests/gadugi/coin-gym-harness.yaml --strict` → `✓ valid`.
- Full scenario run to completion → `coin-gym-harness gadugi scenario: PASS`
  (asserts the real `coin evaluate --dataset COIN-Bench/coin --revision v2026-07
  --split codeql_only --project cups --source image` argv, `coin verify`, the
  `/answer/` contract, the LOCAL-ONLY line, and that `--target`/`--input` never
  leak). Note: under `gadugi-test run` in this shared build environment the
  crate's non-deterministic build timestamp forces a recompile per `cargo run`,
  which can exceed the scenario's 5-minute wrapper timeout; the scenario itself
  passes end-to-end (verified by a direct run) and is deterministic in clean CI.

**2. Docs** — `docs/howto/run-the-coin-gym-harness.md` updated: new `contract`
command section, real-dataset-schema loader note, and a refreshed deferred table
(the executor contract is now wired; only live Docker remains Phase 3).

**3. quality-audit (≥3 SEEK→VALIDATE→FIX cycles, clean final)**
- Cycle 1 — found + fixed: (a) explicit `line_end < line_start` not rejected in
  `CoinDatasetRow::to_target`; (b) `parse_experiment_id` could leak a trailing
  note. Both fixed with regression tests
  (`dataset_row_rejects_explicit_backwards_line_range`, updated
  `experiment_id_is_parsed_from_evaluate_output`).
- Cycle 2 — deeper pass (write_answer atomicity, status-vs-reached precedence,
  `target_slug` traversal): validated by an independent `code-review` agent over
  the full staged diff → **no significant issues**.
- Cycle 3 — edge cases (revision leniency for version-less rows, empty-commit
  default, harness one-line validation): all confirmed intentional/benign.
- Final cycle clean: zero critical/high; zero medium correctness/security.

**4. CI green** — see the checks on this PR. Locally: `cargo fmt --all -- --check`
clean; `cargo clippy --all-targets --all-features --locked -- -D warnings` clean
(the pre-commit release clippy and pre-push clippy gates also passed);
`cargo test --lib coin_gym --locked` → **104 passed, 0 failed**.

**5. PR description** — this section provides concrete evidence for criteria
1–4 and 6.

**6. Scope** — diff limited to `src/coin_gym/` + its tests, the coin-gym howto,
and the coin-gym gadugi scenario. `Target` (the only cross-cutting type) is used
only inside `coin_gym`; the full crate + all test targets compile under strict
clippy. No unrelated edits.
