### PR TITLE
feat(overseer,prompts,docs): enforce a durable-documentation policy (G4 / no-point-in-time-docs)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ they are the same gates CI enforces.
 5. [Local Data Retention Disclosure](#local-data-retention-disclosure)
 6. [Pre-Existing Test Failure Disposition](#pre-existing-test-failure-disposition)
 7. [Real-Meeting & Dashboard E2E Verification](#real-meeting--dashboard-e2e-verification)
-8. [Engineering Guidelines (G1/G2/G3)](#engineering-guidelines-g1g2g3)
+8. [Engineering Guidelines (G1/G2/G3/G4)](#engineering-guidelines-g1g2g3g4)
 
 ---
 
@@ -572,22 +572,27 @@ durability and ingestion regressions before they reach production.
 
 ---
 
-## Engineering Guidelines (G1/G2/G3)
+## Engineering Guidelines (G1/G2/G3/G4)
 
 These are **durable engineering principles**, not a point-in-time
 snapshot. They apply to human contributors *and* to Simard's own OODA
 reasoners and engineer sessions. They are encoded declaratively in the
 hot-reloaded prompt assets under `prompt_assets/simard/` (mirrored into
-the recipe YAML the daemon runs), enforced as soft review gates in the
+the recipe YAML the daemon runs), enforced as soft review flags in the
 merge-readiness judge and the code-review reasoner, and pinned by a
 presence test at
 [`tests/engineering_guidelines_prompts.rs`](tests/engineering_guidelines_prompts.rs).
+G1–G3 are **soft advisory flags**; **G4 additionally has a hard
+deterministic backstop** — the Overseer pr-verify scan
+`scan_no_point_in_time_report_docs` (pr-verify check #8) — that **blocks**
+a merge which would commit a new point-in-time report doc.
 
-> **Why these three?** Each guideline is a lesson learned from a
-> specific merged PR where a change looked complete but left a durable
-> gap. The guidelines exist so the same class of gap is caught the next
-> time — by a reviewer, by the merge-judge, or by Simard herself while
-> planning the work.
+> **Why these four?** Each guideline is a lesson learned from a
+> specific merged PR (or a run of them) where a change looked complete
+> but left a durable gap. The guidelines exist so the same class of gap
+> is caught the next time — by a reviewer, by the merge-judge, by Simard
+> herself while planning the work, or (for G4) by the deterministic
+> merge-gate scan.
 
 > **Terminology.** Simard runs a single **Brain** (the one-Brain
 > model). The interpretive reasoners named below — OODA Orient, Decide,
@@ -700,14 +705,78 @@ and which fails **closed** to `unclear` on a parse-miss — is the
 of model/tool output through that same fail-closed, structured path rather
 than adding fresh line/substring slicing.
 
+### G4 — Durable docs only; never commit point-in-time report docs
+
+Simard's repository documentation must be **accurate** and **durable**:
+it describes how the system *actually works today* and is expected to be
+**updated** by a later PR that changes the feature. The repo must
+**never** carry **point-in-time report docs** — investigation, testing,
+diagnosis, blockage/recurrence, or benchmark-**snapshot** write-ups that
+are true only "as of" the moment they were written.
+
+Decide by **doc type, not topic**. The same subsystem can be the subject
+of both a good durable doc and a banned report doc:
+
+- **Durable → keep it, and keep it current.** If a later PR that changes
+  the feature would be expected to update the doc (architecture, design,
+  reference, how-to), it is durable. Durable documentation is
+  **explicitly encouraged** — G4 never discourages keeping the real docs
+  accurate.
+- **Point-in-time → issue and/or memory, not a repo doc.** If the doc is
+  only ever true as of the day it was written ("what I found while
+  diagnosing X", a testing write-up, a measured-rate snapshot), its
+  findings belong in a **GitHub issue** (the authoritative, trackable,
+  dedup-able sink) and/or Simard's memory. Recurrences consolidate into a
+  single tracking issue, not a new doc per occurrence.
+
+Unlike G1–G3, G4 has **two rails**. The soft rail is the same
+prompt/review guidance that discourages authoring a report doc. The hard
+rail is a **deterministic backstop** — the Overseer pr-verify scan
+`scan_no_point_in_time_report_docs` (pr-verify check #8) — that blocks a
+merge whose diff **adds** a report doc. The scan is deliberately narrow:
+it is **added-only** (edits to existing docs are never flagged) and
+**report-typed** (it flags a newly added `.md` only when it sits under a
+reserved report directory — `docs/investigation/`, `docs/reports/`,
+`docs/runs/` — or carries a report-typed *title*, never merely
+report-flavored body prose). It uses **no `--admin` / `--no-verify`
+bypass**: a flagged PR does not merge until the report doc is removed and
+its content moved to an issue/memory.
+
+**Motivating context.** A run of `docs(investigation)` / `docs(overseer)`
+PRs — #2879, #2843, #2819, #2814, #2801 — each committed a kgpacks-rs
+blockage investigation/diagnosis report as a repo doc. Point-in-time
+reports go stale immediately, **poison Simard's own context** when she
+reads her repo as grounding, and bury the durable docs. G4 routes that
+content to issues/memory and keeps the doc tree durable.
+
+**What "done" looks like for a G4-affected change:**
+
+- An investigation/testing/diagnosis **finding** is recorded as a GitHub
+  issue and/or memory — not as a new repo doc; recurrences consolidate
+  into one tracking issue.
+- Any durable documentation the change warrants is written or updated
+  under `docs/` with a **feature/architecture title**, not a report
+  title.
+- If the pr-verify scan flags an added report doc, the content is moved
+  to an issue and the doc removed from the PR — the gate is resolved,
+  never overridden.
+
+See [Durable-Documentation Policy (G4)](docs/concepts/durable-documentation-policy.md)
+for the rationale and two-rail architecture,
+[No point-in-time report docs — pr-verify scan](docs/reference/no-point-in-time-docs-scan.md)
+for the deterministic behavior, and
+[Record an investigation finding](docs/howto/record-an-investigation-finding.md)
+for the step-by-step.
+
 ### Where the guidelines are encoded
 
 | Layer | Assets | Effect |
 |---|---|---|
-| Engineer + OODA reasoner prompts | `engineer_system.md`, `engineer_planning.md`, `ooda_orient.md`, `ooda_decide.md`, `ooda_brain.md` (+ mirrored recipes `ooda-orient.yaml`, `ooda-decide.yaml`, `ooda-engineer-lifecycle.yaml`) | Simard's engineers and OODA Brain apply G1/G2/G3 while planning and doing cognition/memory/parsing work. |
-| Review gates (soft) | `merge_readiness_judge.md` (+ `merge-readiness-judge.yaml`), `review_pipeline.md`, `progress_assessment_reviewer.md` (+ `progress-assessment.yaml`) | Reviewers FLAG (a) cognition changes with no live self-measurement, (b) memory-arch changes in Simard's repo that belong in `amplihack-memory-lib`, (c) new/extended brittle output-parsing where an agentic step is cleaner. |
+| Engineer + OODA reasoner prompts | `engineer_system.md`, `engineer_planning.md`, `ooda_orient.md`, `ooda_decide.md`, `ooda_brain.md` (+ mirrored recipes `ooda-orient.yaml`, `ooda-decide.yaml`, `ooda-engineer-lifecycle.yaml`) | Simard's engineers and OODA Brain apply G1/G2/G3/G4 while planning and doing cognition/memory/parsing/documentation work. |
+| Review gates (soft) | `merge_readiness_judge.md` (+ `merge-readiness-judge.yaml`), `review_pipeline.md`, `progress_assessment_reviewer.md` (+ `progress-assessment.yaml`), `overseer/pr_verify.md` | Reviewers FLAG (a) cognition changes with no live self-measurement, (b) memory-arch changes in Simard's repo that belong in `amplihack-memory-lib`, (c) new/extended brittle output-parsing where an agentic step is cleaner, (d) a PR that ADDS a point-in-time investigation/testing/diagnosis report doc that belongs in an issue/memory (G4). |
+| Deterministic backstop (G4) | `src/overseer/pr_verify.rs` — pr-verify check #8, `scan_no_point_in_time_report_docs` | Hard-**blocks** a merge whose diff ADDS a new point-in-time report doc. Unlike the soft flags above, this fails the merge gate with `ready: false`; there is no `--admin` / `--no-verify` bypass. |
 | Goal framing | `goal_session_objective.md`, `goal_decomposition.md` (+ `goal-decomposition.yaml`), `goal_curator_system.md` | Standing cognition/self-improvement goals inherit G1 (hybrid benchmark + live) and G2 (route memory-arch upstream) in their success criteria. Those goals are **seeded at runtime into `~/.simard` state**, not stored as repo assets — so the presence test pins the G1/G2 framing in the goal *prompts*, not any specific goal slug. |
-| Durable doc | this section | Human-facing source of truth for G1/G2/G3. |
+| Durable doc | this section | Human-facing source of truth for G1/G2/G3/G4. |
 | Presence test | `tests/engineering_guidelines_prompts.rs` | Pins keyword invariants so a future prompt edit cannot silently drop a guideline. |
 
 **Why not `AGENTS.md`?** `AGENTS.md` is regenerated amplihack boilerplate —
@@ -715,7 +784,7 @@ its body is overwritten on each agent-context sync (the file even opens with
 a corrupted marker line). It is therefore **deliberately excluded** as a
 durable layer: a cross-reference added there would not survive regeneration.
 This `CONTRIBUTING.md` section is the single canonical, human-facing source
-of truth for G1/G2/G3, and no `AGENTS.md` edit is required for parity.
+of truth for G1/G2/G3/G4, and no `AGENTS.md` edit is required for parity.
 
 **Hot reload.** The `prompt_assets/simard/` files hot-reload from
 `~/.simard/prompt_assets/`. After this PR merges, the operator syncs
@@ -727,7 +796,7 @@ daemon — the merge alone does not change live behaviour.
 The review gates add **advisory flags** — they do not change the
 machine verdict enum (`ready` / `not_ready` / `unclear` for the
 merge-judge, and the severity scale for the code reviewer). A reviewer
-or the merge-judge raises a G1/G2/G3 flag as a finding or blocker with a
+or the merge-judge raises a G1/G2/G3/G4 flag as a finding or blocker with a
 `fix` suggestion; the author either addresses it or justifies why it
 does not apply. What fires a flag:
 
@@ -740,6 +809,16 @@ does not apply. What fires a flag:
 - **G3 flag** — a new or extended line/substring parser over model/tool
   output where a structured JSON contract + agent extraction would be
   cleaner.
+- **G4 flag** — a PR that ADDS a new point-in-time investigation/testing/
+  diagnosis report doc instead of recording the finding in a GitHub
+  issue and/or memory.
+
+**G4 is the exception to "soft flags only."** In addition to the advisory
+flag above, G4 has a **hard deterministic backstop**: even if the soft
+flag is missed, the Overseer pr-verify scan `scan_no_point_in_time_report_docs`
+(check #8) fails the merge gate for a PR that adds a report doc — no
+`--admin` / `--no-verify` bypass. The soft flag catches it earlier and
+more helpfully; the scan guarantees it cannot slip through.
 
 ### Verifying the guidelines are present
 
@@ -750,7 +829,8 @@ cargo test --test engineering_guidelines_prompts
 The test reads the prompt assets, lowercases them, and asserts stable
 keyword invariants for each guideline (for example `live
 self-measurement` and `trended over time` for G1, `amplihack-memory-lib`
-for G2, `brittle parsing` and `agentic step` for G3), asserts each
+for G2, `brittle parsing` and `agentic step` for G3, and
+`no-point-in-time-docs` / `point-in-time` for G4), asserts each
 edited reasoner `.md` stays in parity with its recipe `.yaml` mirror,
 and asserts the edited reasoner regions do not rename the one-Brain
 OODA phases as a "Bridge". It asserts **keywords, not full sentences**,

--- a/docs/concepts/durable-documentation-policy.md
+++ b/docs/concepts/durable-documentation-policy.md
@@ -1,0 +1,191 @@
+---
+title: "Durable-Documentation Policy (G4)"
+description: >
+  The durable-documentation policy — Simard's repo carries ACCURATE, DURABLE,
+  easily-updated documentation of how the system actually works, and NEVER
+  point-in-time investigation/testing/diagnosis report docs. Point-in-time
+  findings belong in a GitHub issue and/or memory, not in a committed repo doc.
+  The policy applies identically to human contributors and to Simard's own OODA
+  reasoners and engineer sessions, and is enforced by two rails: an agentic
+  prevention rail in the prompts and a deterministic backstop scan at the
+  Overseer merge gate.
+last_updated: 2026-07-08
+review_schedule: as-needed
+owner: simard
+doc_type: concept
+status: reference
+related:
+  - ../reference/no-point-in-time-docs-scan.md
+  - ../howto/record-an-investigation-finding.md
+  - ../design/overseer.md
+  - ../reference/pr-finalization-pipeline.md
+  - ../reference/cross-repo-merge-authority.md
+  - ../concepts/stewardship-mode.md
+---
+
+# Durable-Documentation Policy (G4)
+
+Simard's repository documentation must be **accurate**, **durable**, and easy to
+**update** as new PRs change features — documentation that describes how the
+system *actually works today* and stays current. The fourth durable engineering
+guideline, **G4 — `no-point-in-time-docs`**, protects that property by keeping
+one class of writing *out* of the repo entirely: **point-in-time report docs**.
+
+G4 sits alongside [G1/G2/G3](https://github.com/rysweet/Simard/blob/main/CONTRIBUTING.md#engineering-guidelines-g1g2g3g4)
+as a durable engineering principle. Like the others it applies to **human
+contributors *and*** to Simard's own OODA reasoners and engineer sessions, is
+encoded declaratively in the hot-reloaded prompt assets under
+`prompt_assets/simard/`, is surfaced as a soft review flag, and is pinned by the
+presence test at `tests/engineering_guidelines_prompts.rs`. Unlike G1/G2/G3, G4
+also has a **hard deterministic backstop**: the Overseer's pr-verify scan
+`scan_no_point_in_time_report_docs` blocks a merge that would commit a new report
+doc.
+
+> **The canonical, human-facing source of truth for G4 is
+> [`CONTRIBUTING.md` § Engineering Guidelines](https://github.com/rysweet/Simard/blob/main/CONTRIBUTING.md#engineering-guidelines-g1g2g3g4).**
+> This concept doc explains the *why* and the architecture; the
+> [scan reference](../reference/no-point-in-time-docs-scan.md) documents the
+> deterministic behavior; the
+> [how-to](../howto/record-an-investigation-finding.md) shows what to do instead.
+
+## The problem G4 solves
+
+Simard's autonomous OODA/engineer loop is prolific. Left unconstrained it does a
+useful thing badly: every time it investigates a recurring blockage it wants to
+**write the investigation down**, and the path of least resistance is a new
+markdown file committed into the repo. Recent examples in `rysweet/Simard` were a
+run of `docs(investigation)` / `docs(overseer)` PRs — #2879, #2843, #2819, #2814,
+#2801 — each a *kgpacks-rs blockage investigation/diagnosis report* captured as a
+committed doc.
+
+That is the wrong home for that content, for three reasons:
+
+1. **It goes stale.** An investigation report is true at the moment it is written
+   and progressively wrong thereafter. A doc that says "distillation parse-failure
+   rate is ≈62%" or "the kgpacks-rs build is blocked on X" describes a *moment*,
+   not durable behavior. Nothing updates it, so it rots in place.
+2. **It poisons agent context.** Simard reads her own repo docs as grounding.
+   Stale point-in-time reports feed her false "current state" and send later
+   reasoning down dead ends — the exact failure the report was trying to prevent.
+3. **It buries the durable docs.** A `docs/` tree full of one-shot reports makes
+   the accurate, maintained architecture/feature docs harder to find and trust.
+
+The findings themselves are *valuable* — they just belong somewhere **built for
+point-in-time knowledge that gets superseded**: a GitHub issue (trackable,
+closable, dedup-able) and/or Simard's memory. G4 routes them there.
+
+## The distinction: doc **type**, not topic
+
+G4 is about **what kind of document** you are writing, **not** what it is about.
+The same subsystem can be the topic of both a good durable doc and a banned
+point-in-time report:
+
+| Same topic — kgpacks-rs parity | Verdict | Why |
+|---|---|---|
+| `docs/design/kgpacks-parity.md` — how the parity design/architecture works, kept current as it changes | ✅ **durable — keep, maintain** | Describes durable behavior of a subsystem; updated by future PRs |
+| `docs/architecture/…` update explaining a module's current behavior | ✅ **durable — keep, maintain** | Reference/architecture that stays accurate |
+| A how-to for operating/using a feature | ✅ **durable — keep, maintain** | Task guidance that stays valid |
+| `docs/investigation/kgpacks-blockage-2026-07.md` — "what I found while diagnosing the blockage" | ❌ **point-in-time — issue/memory** | A snapshot of a moment; goes stale, poisons context |
+| A "testing report" / "what testing I did" write-up | ❌ **point-in-time — issue/memory** | Records an activity at a moment, not durable behavior |
+| A diagnosis / blockage-recurrence report | ❌ **point-in-time — issue/memory** | Captures a moment's state of a bug |
+| A measured-rate / benchmark **snapshot findings** doc | ❌ **point-in-time — issue/memory** | A single measurement, not a maintained reference |
+
+The heuristic: **if a later PR that changes the feature would be expected to
+update the doc, it is durable. If the doc is only ever true "as of" the day it was
+written, it is point-in-time.** Durable feature/architecture documentation updates
+remain **explicitly encouraged** — G4 never discourages keeping the real docs
+current.
+
+## Where findings go instead
+
+When Simard (or any contributor) produces an investigation, testing, or diagnosis
+**finding**, it is recorded as:
+
+- **A GitHub issue** — the authoritative sink. Trackable, assignable, closable,
+  and deduplicated. Recurring failures are consolidated into a single tracking
+  issue rather than a new doc per occurrence. This dovetails with
+  [Goal Stewardship Mode](../concepts/stewardship-mode.md), which already turns
+  recurring failures into deduplicated issues.
+- **Memory (optional)** — Simard may also record the finding in her cognitive
+  memory so later reasoning can recall it. Any memory-engine work stays upstream
+  in `amplihack-memory-lib` per [G2](https://github.com/rysweet/Simard/blob/main/CONTRIBUTING.md#engineering-guidelines-g1g2g3g4);
+  G4 does not add memory code to Simard's repo.
+
+See [Record an investigation finding](../howto/record-an-investigation-finding.md)
+for the step-by-step.
+
+## Two-rail enforcement
+
+G4 is enforced by two complementary rails. The agentic rail **prevents** the loop
+from authoring a report doc in the first place; the deterministic rail is a
+**hard backstop** that blocks any report doc that still reaches the merge gate.
+
+| Rail | Mechanism | Failure mode it closes | Where |
+|---|---|---|---|
+| **Agentic (prevention)** | G4 guidance in the engineer/OODA prompts + soft review flag | The loop *authors* a report doc at all | `engineer_system.md`, `engineer_planning.md`, `ooda_orient.md`, `ooda_decide.md`, `ooda_brain.md`, `overseer/pr_verify.md`, `merge_readiness_judge.md`, `review_pipeline.md` (+ recipe mirrors) |
+| **Deterministic (backstop)** | Pure diff-scan `scan_no_point_in_time_report_docs`, auto-run by `run_diff_scans` | A report-doc PR reaches the **merge gate** | `src/overseer/pr_verify.rs` (pr-verify check #8) |
+
+The deterministic scan is the same pattern as the existing pr-verify scans
+(no-`Bridge`-naming, no stray `print!`, additive-only, PRD-preserved): a **pure
+function over a unified diff** that returns findings and blocks the merge when it
+finds a violation. It never uses `--admin` or `--no-verify`; a flagged PR simply
+does not pass the gate until the report doc is removed and its content moved to an
+issue/memory. Full behavior is in the
+[scan reference](../reference/no-point-in-time-docs-scan.md).
+
+### What the deterministic scan does and does not flag
+
+The scan is deliberately **narrow and forward-only** so it can never touch the
+durable docs that already exist:
+
+- **Added-only.** It flags **newly added** markdown files only. Edits to
+  pre-existing docs — including updates to durable architecture/reference docs
+  that happen to add report-like words — are never flagged. This is what lets G4
+  land without disturbing any doc currently in the repo, and what keeps the
+  enforcement PR (which only *edits* `CONTRIBUTING.md` and prompt `.md` files)
+  from flagging itself.
+- **Report-typed, not topic-typed.** A newly added `.md` is flagged when it lives
+  under a **reserved report directory** (`docs/investigation/`, `docs/reports/`,
+  `docs/runs/`) *or* when an added **title / front-matter** line marks it a report
+  (e.g. an H1 or `type:` containing `investigation report`, `testing report`,
+  `diagnosis`, `recurrence report`, `benchmark snapshot`, `measured-rate`,
+  `postmortem`). Report vocabulary appearing in the **body prose** of an otherwise
+  durable doc does **not** trip the scan.
+- **Durable docs are safe — when they carry a durable title.** Added durable docs
+  under `docs/architecture/`, `docs/design/`, `docs/reference/`, `docs/howto/`,
+  `docs/concepts/`, and the `docs/` durable set pass, as do
+  `README`/`CONTRIBUTING`/`CHANGELOG` and prompt assets — **provided their title is
+  a feature/architecture title, not a report title.** The title rail applies
+  everywhere *outside* the reserved report directories, so a newly added
+  `docs/design/x.md` whose added H1 is `# Investigation Report` (or whose
+  front-matter `type:` marks it a report) **is** flagged even though it sits under a
+  durable directory. Give a durable doc a durable title and it passes; a
+  report-typed title trips the title rail regardless of directory. (Report
+  vocabulary in ordinary body prose never trips the scan — only the title /
+  front-matter line does.)
+
+## Applies to everyone
+
+G4 binds **both** Simard and any contributor or agent. A human opening a PR that
+adds an investigation report gets the same merge-gate finding, with the same
+guidance to move the content to an issue/memory, as Simard's own OODA loop does.
+The policy is a property of the repository, not a per-author rule.
+
+## Relationship to the other guidelines
+
+- **G3 (prefer prompts/recipes over brittle code)** — G4 is applied *G3-style*:
+  the primary rail is prompt guidance; the deterministic scan is a **thin**
+  backstop, not a large parser. The scan reuses the existing pr-verify diff
+  primitives rather than inventing new machinery.
+- **G2 (memory work upstream)** — the "and/or memory" sink for findings uses the
+  upstream `amplihack-memory-lib`; G4 adds no memory-engine code to Simard.
+- **G1/G2/G3 encoding** — G4 is registered in the same layers table and pinned by
+  the same presence test, so a future prompt edit cannot silently drop it.
+
+## See also
+
+- [No point-in-time report docs — pr-verify scan reference](../reference/no-point-in-time-docs-scan.md)
+- [How to record an investigation finding (issue/memory, not a repo doc)](../howto/record-an-investigation-finding.md)
+- [Overseer — operator/observer co-process (design)](../design/overseer.md) — the merge gate this scan runs inside
+- [Goal Stewardship Mode](../concepts/stewardship-mode.md) — the issue sink for recurring failures
+- [`CONTRIBUTING.md` § Engineering Guidelines](https://github.com/rysweet/Simard/blob/main/CONTRIBUTING.md#engineering-guidelines-g1g2g3g4) — the durable source of truth for G1–G4

--- a/docs/howto/record-an-investigation-finding.md
+++ b/docs/howto/record-an-investigation-finding.md
@@ -1,0 +1,165 @@
+---
+title: "Record an investigation finding (issue/memory, not a repo doc)"
+description: >
+  How-to for the durable-documentation policy (G4). Capture an investigation,
+  testing, or diagnosis finding as a GitHub issue and/or memory instead of a
+  committed repo doc; respond when the Overseer pr-verify scan flags a PR for
+  adding a point-in-time report doc; and split a durable doc out of a mixed PR.
+  Applies to human contributors and to Simard's own OODA/engineer loop.
+last_updated: 2026-07-08
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+status: reference
+related:
+  - ../concepts/durable-documentation-policy.md
+  - ../reference/no-point-in-time-docs-scan.md
+  - ../concepts/stewardship-mode.md
+  - ../howto/file-stewardship-issues-from-orchestrator-runs.md
+---
+
+# Record an investigation finding (issue/memory, not a repo doc)
+
+This guide shows what to do when you — or Simard's OODA/engineer loop — produce an
+**investigation, testing, or diagnosis finding**: record it as a **GitHub issue
+and/or memory**, never as a committed repo doc. This is the operational side of
+the [durable-documentation policy (G4)](../concepts/durable-documentation-policy.md).
+It applies identically to human contributors and to Simard's autonomous loop.
+
+For the deterministic gate that enforces this, see the
+[pr-verify scan reference](../reference/no-point-in-time-docs-scan.md). The
+canonical rule lives in
+[`CONTRIBUTING.md` § Engineering Guidelines](https://github.com/rysweet/Simard/blob/main/CONTRIBUTING.md#engineering-guidelines-g1g2g3g4).
+
+## First: is your finding point-in-time or durable?
+
+Decide **doc type, not topic** (see the
+[policy concept](../concepts/durable-documentation-policy.md#the-distinction-doc-type-not-topic)):
+
+- **Point-in-time → issue/memory (this guide).** "What I found while diagnosing
+  X", a testing/"what testing I did" write-up, a blockage/recurrence report, a
+  measured-rate or benchmark **snapshot**. True as-of a moment; goes stale.
+- **Durable → keep it in the repo, and keep it current.** How a feature/subsystem
+  actually works (architecture/design/reference/how-to). A later PR that changes
+  the feature is expected to update it. G4 **encourages** these; put them under
+  `docs/architecture/`, `docs/design/`, `docs/reference/`, `docs/howto/`, or
+  `docs/concepts/`.
+
+If it is durable, write/update the durable doc as usual — you are done. If it is
+point-in-time, continue below.
+
+## Record a finding as a GitHub issue (authoritative sink)
+
+A GitHub issue is the authoritative home for a point-in-time finding: trackable,
+assignable, closable, and deduplicated.
+
+```bash
+gh issue create \
+  --repo rysweet/Simard \
+  --title "kgpacks-rs blockage — investigation findings" \
+  --body-file - <<'EOF'
+## Summary
+<one-paragraph statement of the finding as of today>
+
+## Evidence
+- <observation, log excerpt, measured rate, repro command>
+- <link to the run / PR / CI job this came from>
+
+## Current hypothesis / next step
+<what you believe and what would confirm or fix it>
+EOF
+```
+
+Guidelines:
+
+- **Consolidate recurrences into one tracking issue.** If the same blockage keeps
+  recurring, add a comment to the existing tracking issue instead of opening a new
+  issue (or a new doc) per occurrence. One issue accumulates the history; the doc
+  tree stays clean.
+- **Keep the moment in the moment.** Dates, measured rates, and "as of" state
+  belong in the issue body/comments, where they are expected to be superseded —
+  not in a repo doc, where they rot.
+- Simard's OODA loop already has a deduplicated failure→issue path via
+  [Goal Stewardship Mode](../concepts/stewardship-mode.md); see
+  [File stewardship issues from orchestrator runs](../howto/file-stewardship-issues-from-orchestrator-runs.md).
+
+## Optionally also record it in memory
+
+Simard may additionally record the finding in her cognitive memory so later
+reasoning can recall it. Any memory-engine work stays **upstream** in
+`amplihack-memory-lib` per [G2](https://github.com/rysweet/Simard/blob/main/CONTRIBUTING.md#engineering-guidelines-g1g2g3g4)
+— **do not** add memory code to Simard's repo to satisfy G4. The issue remains the
+authoritative, human-visible sink; memory is a convenience for the loop.
+
+## Respond when the pr-verify scan flags your PR
+
+If a PR **adds a new point-in-time report doc**, the Overseer pr-verify scan
+`scan_no_point_in_time_report_docs` (check #8) flags it and the merge gate blocks
+with a finding like:
+
+```
+docs/investigation/kgpacks-blockage.md — point-in-time report doc
+(no-point-in-time-docs / G4). Record findings in a GitHub issue and/or memory;
+do not commit investigation/testing/diagnosis reports to the repo.
+```
+
+There is **no `--admin` / `--no-verify` bypass** — resolve it, don't override it:
+
+1. **Move the content to an issue** (or the consolidated tracking issue) using the
+   steps above. Preserve the substantive findings; nothing is thrown away.
+2. **Remove the report doc from the PR:**
+   ```bash
+   git rm docs/investigation/kgpacks-blockage.md
+   git commit -m "Move kgpacks-rs blockage findings to issue #<n> (G4)"
+   ```
+3. **Re-run the checks** (pre-commit/pre-push locally, then CI). The scan is
+   added-only, so once the added report doc is gone the finding clears.
+
+If the flagged file is genuinely a **durable** feature/architecture doc that only
+*looks* report-shaped, the fix is to make it durable, not to bypass the gate:
+place it under a durable directory (`docs/architecture/`, `docs/design/`,
+`docs/reference/`, `docs/howto/`, `docs/concepts/`) and give it a
+feature/architecture title rather than a report title (`# Investigation Report`,
+`type: diagnosis`, …). The scan only reserves the report directories and
+report-typed titles; durable docs pass.
+
+## Split a durable doc out of a mixed PR
+
+If a PR contains **both** a point-in-time report **and** a keep-worthy durable
+doc, split them:
+
+1. Create a separate branch/PR containing only the durable doc, placed under the
+   right durable directory with a durable title. Merge it normally.
+2. In the original PR, remove the report doc and move its findings to an issue
+   (steps above). The original PR then either lands its remaining durable changes
+   or is closed.
+
+This is exactly how the historical violating `docs(investigation)` PRs were
+reconciled: findings preserved in a consolidated tracking issue, the doc-only PRs
+closed with a pointer to that issue, and any durable content split out to its own
+keep PR.
+
+## Common pitfalls
+
+- **"But I need to write the investigation down."** You do — in the **issue**. G4
+  bans the *repo doc*, not the record. The issue is the durable-for-this-purpose
+  home.
+- **Renaming to dodge the scan.** Moving a report to `docs/notes/` with a
+  `# Diagnosis Report` H1 still trips the **title rail**. The right move is
+  issue/memory, not a relocation.
+- **Editing an existing report doc.** Allowed by the scan (added-only), but if
+  you are adding a *fresh* snapshot, prefer an issue — pre-existing point-in-time
+  docs are legacy, not a pattern to extend.
+- **Fearing your durable-doc PR will be flagged.** It won't: durable docs under
+  the durable directories, and edits to any existing doc, are never flagged. Only
+  **newly added** report-typed markdown is.
+- **Trying to override the gate.** `--admin`/`--no-verify` are never used. Move
+  the content and re-run; that is the only path.
+
+## Related
+
+- [Durable-Documentation Policy (G4)](../concepts/durable-documentation-policy.md)
+- [No point-in-time report docs — pr-verify scan reference](../reference/no-point-in-time-docs-scan.md)
+- [Goal Stewardship Mode](../concepts/stewardship-mode.md) — the deduplicated failure→issue loop
+- [File stewardship issues from orchestrator runs](../howto/file-stewardship-issues-from-orchestrator-runs.md)
+- [`CONTRIBUTING.md` § Engineering Guidelines](https://github.com/rysweet/Simard/blob/main/CONTRIBUTING.md#engineering-guidelines-g1g2g3g4)

--- a/docs/reference/no-point-in-time-docs-scan.md
+++ b/docs/reference/no-point-in-time-docs-scan.md
@@ -1,0 +1,249 @@
+---
+title: "No point-in-time report docs — pr-verify scan"
+description: >
+  Reference for scan_no_point_in_time_report_docs, the Overseer pr-verify diff
+  scan that enforces the durable-documentation policy (G4). It flags a PR that
+  ADDS a new point-in-time investigation/testing/diagnosis report doc, while
+  never flagging durable feature/architecture docs or edits to pre-existing
+  docs. A pure function over `gh pr diff` output, registered as pr-verify check
+  #8 in run_diff_scans, so it auto-enforces at the merge gate with no
+  --admin/--no-verify path.
+last_updated: 2026-07-08
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+status: reference
+related:
+  - ../concepts/durable-documentation-policy.md
+  - ../howto/record-an-investigation-finding.md
+  - ../design/overseer.md
+  - ./cross-repo-merge-authority.md
+  - ./pr-finalization-pipeline.md
+---
+
+# No point-in-time report docs — pr-verify scan
+
+`scan_no_point_in_time_report_docs` is the **deterministic backstop** for the
+[durable-documentation policy (G4)](../concepts/durable-documentation-policy.md).
+It is one of the Overseer's pr-verify safety diff-scans in
+[`src/overseer/pr_verify.rs`](https://github.com/rysweet/Simard/blob/main/src/overseer/pr_verify.rs),
+added as **check #8** alongside the existing no-`Bridge`-naming, no-stray-`print!`,
+additive-only, and PRD-preserved scans.
+
+Like every scan in that module it is a **pure function over a unified diff**
+(`gh pr diff` output), so the whole merge-safety surface stays testable on fixture
+diffs with zero network. It flags a PR that **adds a new point-in-time report doc**
+(investigation / testing / diagnosis / recurrence / benchmark-snapshot report) and
+returns a finding pointing the author at the right home for that content — a
+GitHub issue and/or memory. It **never** flags durable feature/architecture docs,
+and it **never** flags edits to pre-existing docs.
+
+## Signature
+
+```rust
+use crate::overseer::pr_verify::{scan_no_point_in_time_report_docs, DiffFinding};
+
+/// Check #8: no newly-added point-in-time report docs (policy G4). Durable
+/// feature/architecture docs are fine; run-specific findings belong in a
+/// GitHub issue and/or memory. Pure over a unified diff; no network.
+pub fn scan_no_point_in_time_report_docs(diff: &str) -> Vec<DiffFinding>;
+```
+
+Its input is a unified diff string (the same `gh pr diff` text the other scans
+read). Its output is a `Vec<DiffFinding>` — one entry per offending added report
+doc. An **empty vector means the PR is clean** for this check.
+
+### `DiffFinding`
+
+The scan reuses the module's shared finding type — no new result type is
+introduced:
+
+```rust
+pub struct DiffFinding {
+    /// Path (new-side) the finding is in.
+    pub file: String,
+    /// Best-effort new-file line number (`None` for a whole-file / path finding).
+    pub line: Option<usize>,
+    /// The offending source text (trimmed) or a short policy note.
+    pub text: String,
+}
+```
+
+## What it flags
+
+A file is flagged only when **all** of these hold:
+
+1. It is a **newly added** file (the diff shows it added — old side is
+   `/dev/null` / `new file mode`), **and**
+2. Its path ends in `.md`, **and**
+3. It matches a **report signal** — either the **path rail** or the **title
+   rail** below.
+
+### Path rail — reserved report directories
+
+A newly added `.md` under a **reserved report directory** is flagged on the path
+alone; the directory is reserved by policy for point-in-time reports:
+
+| Reserved prefix | Meaning |
+|---|---|
+| `docs/investigation/` | investigation / diagnosis reports |
+| `docs/reports/` | testing / status / findings reports |
+| `docs/runs/` | per-run snapshot write-ups |
+
+The finding for a path-rail hit has `line: None` and a policy note naming the
+file.
+
+### Title rail — report-typed docs anywhere else
+
+A newly added `.md` **outside** the reserved directories is flagged only when an
+**added title or front-matter line** marks it a report — an H1 (`# …`), or a
+front-matter `title:` / `type:` — whose text (lowercased) contains a **report
+marker**:
+
+```
+investigation report      testing report / test report
+diagnosis / diagnosis report / diagnostic report
+recurrence report         blockage report
+benchmark snapshot        measured-rate / measured rate / snapshot findings
+findings report           run summary / session report
+point-in-time             postmortem
+```
+
+The match is a substring test on the lowercased title/front-matter line only —
+the **same keyword-level substring approach** the sibling `scan_no_bridge_naming`
+uses. Report vocabulary in ordinary **body prose** of an otherwise durable doc is
+**not** a title-rail hit, so a durable reference that merely discusses an
+"investigation" is never flagged. A title-rail finding carries the offending
+line's new-side line number.
+
+## What it does NOT flag
+
+The scan is deliberately narrow so it can never disturb existing or durable docs:
+
+- **Edits to pre-existing docs.** Only newly added files qualify (criterion 1).
+  An update to an existing `docs/architecture/x.md` that adds report-like words is
+  **not** flagged. This is what lets G4 land without touching any current doc, and
+  what stops the enforcement PR — which only *edits* `CONTRIBUTING.md` and prompt
+  `.md` files — from flagging itself.
+- **Durable feature/architecture docs.** Newly added docs under
+  `docs/architecture/`, `docs/design/`, `docs/reference/`, `docs/howto/`,
+  `docs/concepts/`, plus `README` / `CONTRIBUTING` / `CHANGELOG` and
+  `prompt_assets/**`, are never flagged (they are not report paths and do not
+  carry a report-typed title).
+- **Non-markdown files.** Added `.rs`, `.yaml`, fixtures, tests, etc. are ignored
+  — the path test is `path.ends_with(".md")`, so only `.md` files are in scope
+  (a `.markdown` extension is not matched).
+- **Deletions and removed lines.** Removing a doc is never a G4 violation.
+
+## Newly-added-file detection
+
+The module's shared `for_each_diff_line` walker intentionally discards the
+old-side (`--- `) header, so it cannot by itself tell an *added* file from an
+*edit*. The scan therefore uses a dedicated pre-pass that reads the raw diff for
+the git extended `new file mode` header and/or the `--- /dev/null` old-side, and
+collects the new-side paths a diff **adds**:
+
+```rust
+/// New-side paths this diff ADDS (old side is /dev/null or `new file mode`).
+/// A separate pass from `for_each_diff_line`, so the existing scans are
+/// byte-for-byte unchanged (sibling isolation).
+fn newly_added_files(diff: &str) -> BTreeSet<String>;
+```
+
+Both the `new file mode` header **and** the `--- /dev/null` old-side are accepted:
+`gh pr diff` emits the git extended header, while some tools/fixtures emit only
+the `/dev/null` old side. Either alone proves the file is an add.
+
+## Registration and enforcement
+
+The scan is registered in `run_diff_scans` next to the existing checks:
+
+```rust
+// in run_diff_scans, alongside checks 3–6:
+finding_check(
+    "no point-in-time report docs (G4)",
+    scan_no_point_in_time_report_docs(diff),
+),
+```
+
+Because `run_diff_scans` is already wired into the Overseer merge gate
+(`merge_ops.rs` → the merge-safety scan set), registering the scan **auto-enforces**
+it — no change to `merge_ops.rs` is required. A finding produces a normal failing
+`CheckItem` (`ready: false`), exactly like the sibling scans, which **blocks the
+merge**. There is **no `--admin` / `--no-verify` bypass**: a flagged PR does not
+merge until the report doc is removed and its content moved to an issue/memory.
+
+This is the same layering the [pr-verify checklist](../design/overseer.md) and
+[cross-repo merge authority](./cross-repo-merge-authority.md) describe: the scan
+**adds** a gate on top of the objective gates (CI-green, mergeable, base
+allowlist) and the merge-judge — it never replaces them.
+
+## Finding text and author guidance
+
+Each finding names the offending file and states where the content should go
+instead, so the author (human or Simard's loop) gets an actionable next step
+rather than a bare rejection. For example:
+
+```
+docs/investigation/kgpacks-blockage.md — point-in-time report doc
+(no-point-in-time-docs / G4). Record findings in a GitHub issue and/or memory;
+do not commit investigation/testing/diagnosis reports to the repo. Durable
+feature/architecture docs are welcome — see docs/concepts/durable-documentation-policy.md.
+```
+
+## Invariants
+
+- **Pure and network-free.** `scan_* : &str -> Vec<DiffFinding>`; fixture-testable
+  with no `gh` call, identical to the sibling scans.
+- **Added-only.** Only files the diff **adds** are eligible; edits to
+  pre-existing docs are never flagged.
+- **Report-typed, not topic-typed.** A durable doc about the same topic as a
+  report is never flagged; only reserved report paths or report-typed titles trip
+  the scan.
+- **Sibling isolation.** `newly_added_files` is a separate pass;
+  `for_each_diff_line` and the four pre-existing scans are unchanged, so their
+  findings on any diff are exactly as before.
+- **Forward-only.** `docs/investigation/` etc. hold nothing today, so the scan has
+  **zero retroactive false positives** against the current repo.
+- **Fails the gate, never bypasses it.** A finding sets `ready: false` and blocks
+  the merge; the policy is enforced without `--admin`/`--no-verify`.
+- **Applies to everyone.** The gate is diff-shaped, so it treats a human PR and
+  Simard's own OODA-loop PR identically.
+
+## Testing
+
+The scan ships with unit tests over fixture diffs in the module's `#[cfg(test)]`
+block:
+
+```bash
+cargo test -p simard overseer::pr_verify
+```
+
+The fixtures assert, at minimum:
+
+1. Added `docs/investigation/run-42.md` → **1 finding** (path rail).
+2. Added `docs/design/kgpacks-parity.md` (durable) containing "investigation" in
+   its body → **0 findings** (durable path, body-only vocabulary).
+3. Added `docs/notes/x.md` with an H1 `# Investigation Report` → **1 finding**
+   (title rail).
+4. An **edit** to a pre-existing `docs/investigation/old.md` (not newly added) →
+   **0 findings** (added-only).
+5. `newly_added_files` distinguishes a `new file mode` add, a plain edit, and a
+   `/dev/null` deletion.
+6. **Sibling regression:** a diff that also adds `Bridge` naming or a `print!`
+   still yields exactly the pre-existing sibling findings (isolation holds).
+
+The G4 prompt/keyword invariants (and prompt↔recipe parity) are pinned separately
+in `tests/engineering_guidelines_prompts.rs`, next to the G1/G2/G3 invariants:
+
+```bash
+cargo test --test engineering_guidelines_prompts
+```
+
+## See also
+
+- [Durable-Documentation Policy (G4)](../concepts/durable-documentation-policy.md) — the *why* and the two-rail architecture.
+- [How to record an investigation finding](../howto/record-an-investigation-finding.md) — what to do instead of committing a report doc, and how to respond to a flag.
+- [Overseer — operator/observer co-process (design)](../design/overseer.md) — the pr-verify checklist this scan extends (adds row #8).
+- [Cross-Repo Merge Authority](./cross-repo-merge-authority.md) — the gated merge pipeline the scan runs inside.
+- [`CONTRIBUTING.md` § Engineering Guidelines](https://github.com/rysweet/Simard/blob/main/CONTRIBUTING.md#engineering-guidelines-g1g2g3g4) — the durable source of truth for G1–G4.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,7 @@ nav:
     - Agentic Disk Reclamation: concepts/agentic-disk-reclamation.md
     - Update-Check Design: concepts/update-check-design.md
     - The amplihack Freshness Gate: concepts/amplihack-freshness-gate.md
+    - Durable-Documentation Policy (G4): concepts/durable-documentation-policy.md
     - The Simard Journal: concepts/simard-journal.md
     - Journal Report Tone Contract: concepts/journal-report-tone-contract.md
     - Eliminating "bridge" Terminology: concepts/bridge-terminology-elimination.md
@@ -235,6 +236,7 @@ nav:
     - Configure Cognitive-Thread Scheduling: howto/configure-cognitive-thread-scheduling.md
     - Add a New Cognitive Thread: howto/add-a-new-cognitive-thread.md
     - Configure the Creative Ideas Thread: howto/configure-creative-ideas-thread.md
+    - Record an Investigation Finding (issue/memory, not a repo doc): howto/record-an-investigation-finding.md
     - Configure Creative-Ideas Semantic Dedup: howto/configure-creative-ideas-semantic-dedup.md
   - Reference:
     - CLI Reference: reference/simard-cli.md
@@ -341,6 +343,7 @@ nav:
     - Agent-Log WebSocket API: reference/agent-log-websocket.md
     - PR-Finalization Review Pipeline: reference/pr-finalization-pipeline.md
     - Cross-Repo Merge Authority: reference/cross-repo-merge-authority.md
+    - "No Point-in-Time Report Docs Scan (pr-verify #8)": reference/no-point-in-time-docs-scan.md
     - Completion-Evidence Gate API: reference/completion-evidence-gate-api.md
     - Outcome-Verification API: reference/outcome-verification-api.md
     - No-Progress Breaker API: reference/no-progress-breaker-api.md

--- a/prompt_assets/simard/engineer_planning.md
+++ b/prompt_assets/simard/engineer_planning.md
@@ -18,11 +18,11 @@ Decompose multi-paragraph or multi-task objectives into ATOMIC steps. Do NOT col
 
 If the objective cannot be decomposed into supported actions, return an empty array `[]` and the planner will report PlanningUnavailable.
 
-## Engineering guidelines (G1/G2/G3) — apply when planning cognition / memory / parsing work
+## Engineering guidelines (G1/G2/G3/G4) — apply when planning cognition / memory / parsing / documentation work
 
-When the objective touches Simard's cognition, memory architecture, or parsing of
-model/tool output, thread these durable guidelines (canonical in `CONTRIBUTING.md`)
-into the plan steps and their `expected_outcome`s:
+When the objective touches Simard's cognition, memory architecture, parsing of
+model/tool output, or documentation, thread these durable guidelines (canonical
+in `CONTRIBUTING.md`) into the plan steps and their `expected_outcome`s:
 
 - **G1** — a cognition / self-improvement plan must prove gains on **both** a
   fixed **benchmark** and a **live self-measurement** (a production self-metric
@@ -33,6 +33,12 @@ into the plan steps and their `expected_outcome`s:
 - **G3** — prefer an **agentic step** (structured/JSON output contract + agent
   extraction) over **brittle parsing** of model/tool output, and prefer
   recipes/prompts over new code.
+- **G4** — durable docs only (`no-point-in-time-docs`). When a plan produces an
+  investigation/testing/diagnosis **finding**, record it as a **GitHub issue**
+  and/or memory — **not a repo doc** (no **point-in-time report** doc). Plan
+  durable **durable documentation** updates (feature/architecture/how-to) under
+  `docs/` instead; a pr-verify scan `scan_no_point_in_time_report_docs` blocks a
+  PR that adds a report doc.
 
 Return ONLY the JSON array — no markdown fences, no prose preamble, no trailing commentary.
 

--- a/prompt_assets/simard/engineer_system.md
+++ b/prompt_assets/simard/engineer_system.md
@@ -493,12 +493,13 @@ The engineer-loop selection module (`src/engineer_loop/selection/`) already
 delegates to LLM planning (`engineer_plan::plan_objective`); the remaining
 deterministic helpers are *fallbacks* and should generally not be extended.
 
-## Engineering Guidelines (G1/G2/G3) — durable
+## Engineering Guidelines (G1/G2/G3/G4) — durable
 
-Three durable engineering guidelines govern all cognition, memory-architecture,
-and output-parsing work — yours and every engineer session's. Apply them while
-**planning and doing** the work, not only at review. The canonical, human-facing
-source of truth is `CONTRIBUTING.md`, section "Engineering Guidelines (G1/G2/G3)".
+Four durable engineering guidelines govern all cognition, memory-architecture,
+output-parsing, and documentation work — yours and every engineer session's.
+Apply them while **planning and doing** the work, not only at review. The
+canonical, human-facing source of truth is `CONTRIBUTING.md`, section
+"Engineering Guidelines (G1/G2/G3/G4)".
 
 - **G1 — Prove gains on BOTH a fixed benchmark AND live self-measurement.**
   Cognition / self-improvement work must iterate toward proving its gains on
@@ -525,6 +526,21 @@ source of truth is `CONTRIBUTING.md`, section "Engineering Guidelines (G1/G2/G3)
   rewording and reordering. And whenever a change or architecture improvement can
   be accomplished through **recipes/prompts** alone, that is the preferred choice
   over writing code. (This section itself is an application of G3.)
+- **G4 — Durable docs only; never commit point-in-time report docs
+  (`no-point-in-time-docs`).** Repository documentation must be **durable** — it
+  describes how the system actually works and is expected to be updated by a
+  later PR that changes the feature. **Never commit a point-in-time report doc**
+  — an investigation, testing, diagnosis, blockage/recurrence, or
+  benchmark-**snapshot** write-up that is true only "as of" when it was written.
+  When you produce such a **finding**, record it as a **GitHub issue** and/or
+  memory — **not a repo doc**; recurrences consolidate into one tracking issue.
+  Durable feature/architecture **durable documentation** stays encouraged and
+  current (the distinction is doc *type*, not topic — a design/architecture doc
+  about the same subsystem is good). A deterministic Overseer pr-verify scan
+  `scan_no_point_in_time_report_docs` (check #8) **hard-blocks** a PR that adds a
+  report doc — no `--admin`/`--no-verify` bypass. (Context: the
+  `docs(investigation)` run #2879, #2843, #2819, #2814, #2801 each committed a
+  kgpacks-rs blockage report as a repo doc.)
 
 ## Engineer Mode Boundaries
 

--- a/prompt_assets/simard/merge_readiness_judge.md
+++ b/prompt_assets/simard/merge_readiness_judge.md
@@ -41,14 +41,15 @@ referenced commit **is** substantive.
 You do **not** need to verify CI status, mergeability, or base branch — the deterministic
 gate has already done that before calling you. You are judging **evidence quality only**.
 
-## Engineering-guideline flags (G1/G2/G3) — advisory
+## Engineering-guideline flags (G1/G2/G3/G4) — advisory
 
 Beyond the six skill criteria, raise an **advisory flag** — a `blocker` entry with
 a `fix`, or a note in `rationale` — when a PR trips one of Simard's durable
 engineering guidelines (canonical in `CONTRIBUTING.md`, "Engineering Guidelines
-(G1/G2/G3)"). These are **soft**: they do not by themselves change the `verdict`
+(G1/G2/G3/G4)"). These are **soft**: they do not by themselves change the `verdict`
 enum (`ready` / `not_ready` / `unclear`); they surface a finding the author either
-addresses or justifies.
+addresses or justifies. (G4 additionally has a hard deterministic backstop — see
+below.)
 
 - **G1 flag — benchmark without live self-measurement.** The PR improves cognition
   (recall / distillation / ranking) and reports only a fixed **benchmark** corpus
@@ -65,6 +66,16 @@ addresses or justifies.
   a structured/JSON output contract read by an **agentic step** would be robust —
   or writes new code where recipes/prompts would suffice. Flag it and point at the
   agentic / prompt-first alternative.
+- **G4 flag — a point-in-time report doc committed to the repo
+  (`no-point-in-time-docs`).** The diff ADDS a new investigation / testing /
+  diagnosis / blockage-recurrence / benchmark-**snapshot** **point-in-time report**
+  doc instead of recording the finding in a **GitHub issue** and/or memory (**not
+  a repo doc**). Flag it: the finding belongs in an issue (consolidate recurrences
+  into one tracking issue); durable feature/architecture **durable documentation**
+  is fine and encouraged (doc *type*, not topic). Note that this one is **also**
+  hard-blocked by the deterministic pr-verify scan
+  `scan_no_point_in_time_report_docs` (check #8), with no `--admin`/`--no-verify`
+  bypass — your flag catches it earlier and more helpfully.
 
 ## Inputs
 

--- a/prompt_assets/simard/ooda_brain.md
+++ b/prompt_assets/simard/ooda_brain.md
@@ -9,7 +9,9 @@ You are the brain of Simard's OODA daemon. The Act phase is about to skip a goal
 > engineering guidelines (canonical in `CONTRIBUTING.md`): prove cognition gains
 > on a benchmark **and** a live, trended self-metric (G1); route
 > memory-architecture work upstream to `amplihack-memory-lib` (G2); and prefer
-> agentic extraction over brittle parsing, and recipes/prompts over code (G3).
+> agentic extraction over brittle parsing, and recipes/prompts over code (G3); and
+> record investigation/testing findings as a GitHub issue and/or memory, never a
+> committed point-in-time report doc (G4, `no-point-in-time-docs`).
 > This does not change your output contract below.
 
 ## CONTEXT

--- a/prompt_assets/simard/ooda_decide.md
+++ b/prompt_assets/simard/ooda_decide.md
@@ -27,7 +27,9 @@ goal-action brain re-scopes or executes rather than re-triaging the same state.
 > engineering guidelines (canonical in `CONTRIBUTING.md`): prove cognition gains
 > on a benchmark **and** a live, trended self-metric (G1); route
 > memory-architecture work upstream to `amplihack-memory-lib` (G2); and prefer
-> agentic extraction over brittle parsing, and recipes/prompts over code (G3).
+> agentic extraction over brittle parsing, and recipes/prompts over code (G3); and
+> record investigation/testing findings as a GitHub issue and/or memory, never a
+> committed point-in-time report doc (G4, `no-point-in-time-docs`).
 > This does not change your output contract below.
 
 ## Done-gate guardrail

--- a/prompt_assets/simard/ooda_orient.md
+++ b/prompt_assets/simard/ooda_orient.md
@@ -28,7 +28,9 @@ escalates the goal. Deviate from it only when the context clearly warrants.
 > engineering guidelines (canonical in `CONTRIBUTING.md`): prove cognition gains
 > on a benchmark **and** a live, trended self-metric (G1); route
 > memory-architecture work upstream to `amplihack-memory-lib` (G2); and prefer
-> agentic extraction over brittle parsing, and recipes/prompts over code (G3).
+> agentic extraction over brittle parsing, and recipes/prompts over code (G3); and
+> record investigation/testing findings as a GitHub issue and/or memory, never a
+> committed point-in-time report doc (G4, `no-point-in-time-docs`).
 > This does not change your output contract below.
 
 ## CONTEXT

--- a/prompt_assets/simard/recipes/merge-readiness-judge.yaml
+++ b/prompt_assets/simard/recipes/merge-readiness-judge.yaml
@@ -61,14 +61,14 @@ steps:
       You do NOT need to verify CI status, mergeability, or base branch — the deterministic
       gate has already done that. You are judging evidence quality only.
 
-      ## Engineering-guideline flags (G1/G2/G3) — advisory
+      ## Engineering-guideline flags (G1/G2/G3/G4) — advisory
 
       Beyond the six skill criteria, raise an advisory flag (a `blocker` entry with a
       `fix`, or a note in `rationale`) when a PR trips one of Simard's durable
       engineering guidelines (canonical in `CONTRIBUTING.md`, "Engineering Guidelines
-      (G1/G2/G3)"). These are soft — they do NOT by themselves change the `verdict`
+      (G1/G2/G3/G4)"). These are soft — they do NOT by themselves change the `verdict`
       enum (`ready`/`not_ready`/`unclear`); they surface a finding the author
-      addresses or justifies.
+      addresses or justifies. (G4 additionally has a hard deterministic backstop.)
 
       - **G1 flag** — the PR improves cognition (recall/distillation/ranking) and
         reports only a fixed **benchmark** corpus number or a coarse proxy, with no
@@ -81,6 +81,12 @@ steps:
       - **G3 flag** — the diff adds or extends line/substring **brittle parsing** of
         model/tool output where a structured/JSON contract read by an **agentic step**
         would be robust, or writes new code where recipes/prompts would suffice.
+      - **G4 flag** — the diff ADDS a new point-in-time investigation/testing/diagnosis/
+        benchmark-snapshot report doc (`no-point-in-time-docs`) where the finding
+        belongs in a GitHub issue and/or memory, not a committed repo doc. Durable
+        feature/architecture docs are fine (doc type, not topic). This one is also
+        hard-blocked by the deterministic pr-verify scan
+        `scan_no_point_in_time_report_docs` (check #8).
 
       ## Inputs
 

--- a/prompt_assets/simard/recipes/ooda-decide.yaml
+++ b/prompt_assets/simard/recipes/ooda-decide.yaml
@@ -53,7 +53,9 @@ steps:
       engineering guidelines (canonical in `CONTRIBUTING.md`): prove cognition
       gains on a benchmark AND a live, trended self-metric (G1); route
       memory-architecture work upstream to `amplihack-memory-lib` (G2); and prefer
-      agentic extraction over brittle parsing, and recipes/prompts over code (G3).
+      agentic extraction over brittle parsing, and recipes/prompts over code (G3); and
+      record investigation/testing findings as a GitHub issue and/or memory, never a
+      committed point-in-time report doc (G4, `no-point-in-time-docs`).
       This does not change your output contract below.
 
       ## CONTEXT

--- a/prompt_assets/simard/recipes/ooda-engineer-lifecycle.yaml
+++ b/prompt_assets/simard/recipes/ooda-engineer-lifecycle.yaml
@@ -46,7 +46,9 @@ steps:
       durable engineering guidelines (canonical in `CONTRIBUTING.md`): prove
       cognition gains on a benchmark AND a live, trended self-metric (G1); route
       memory-architecture work upstream to `amplihack-memory-lib` (G2); and prefer
-      agentic extraction over brittle parsing, and recipes/prompts over code (G3).
+      agentic extraction over brittle parsing, and recipes/prompts over code (G3); and
+      record investigation/testing findings as a GitHub issue and/or memory, never a
+      committed point-in-time report doc (G4, `no-point-in-time-docs`).
       This does not change your output contract below.
 
       ## CONTEXT

--- a/prompt_assets/simard/recipes/ooda-orient.yaml
+++ b/prompt_assets/simard/recipes/ooda-orient.yaml
@@ -51,7 +51,9 @@ steps:
       engineering guidelines (canonical in `CONTRIBUTING.md`): prove cognition
       gains on a benchmark AND a live, trended self-metric (G1); route
       memory-architecture work upstream to `amplihack-memory-lib` (G2); and prefer
-      agentic extraction over brittle parsing, and recipes/prompts over code (G3).
+      agentic extraction over brittle parsing, and recipes/prompts over code (G3); and
+      record investigation/testing findings as a GitHub issue and/or memory, never a
+      committed point-in-time report doc (G4, `no-point-in-time-docs`).
       This does not change your output contract below.
 
       ## CONTEXT

--- a/prompt_assets/simard/review_pipeline.md
+++ b/prompt_assets/simard/review_pipeline.md
@@ -22,11 +22,11 @@ You are Simard's automated code reviewer. Review the following diff against the 
 4. Test coverage: Are new public functions tested? Are edge cases covered?
 5. Simplicity: Could the change be achieved with fewer lines or less abstraction?
 
-## Engineering-guideline flags (G1/G2/G3)
+## Engineering-guideline flags (G1/G2/G3/G4)
 
 Beyond the priorities above, raise a finding (category `architecture`, severity
 usually `medium`) when a diff trips one of Simard's durable engineering guidelines
-(canonical in `CONTRIBUTING.md`, "Engineering Guidelines (G1/G2/G3)"). These are
+(canonical in `CONTRIBUTING.md`, "Engineering Guidelines (G1/G2/G3/G4)"). These are
 advisory — surface them with a concrete `fix`; they do not by themselves block a PR.
 
 - **G1** — a cognition change (recall / distillation / ranking) that reports only a
@@ -40,6 +40,13 @@ advisory — surface them with a concrete `fix`; they do not by themselves block
   where a structured/JSON contract read by an **agentic step** is cleaner, or new
   code where recipes/prompts would do. Flag it and name the agentic / prompt-first
   alternative.
+- **G4** — a point-in-time report doc committed to the repo
+  (`no-point-in-time-docs`). The diff ADDS a new investigation / testing /
+  diagnosis / benchmark-**snapshot** **point-in-time report** doc where the
+  finding belongs in a **GitHub issue** and/or memory (**not a repo doc**). Flag
+  it; durable feature/architecture **durable documentation** is encouraged (doc
+  *type*, not topic). A deterministic pr-verify scan
+  `scan_no_point_in_time_report_docs` also hard-blocks such a PR.
 
 ## Output Format
 

--- a/src/overseer/merge_ops.rs
+++ b/src/overseer/merge_ops.rs
@@ -329,7 +329,7 @@ impl PrOps for MergePrOps {
             },
         );
 
-        // #3–6 additive diff-scans.
+        // #3–6 + #8 additive diff-scans.
         let diff = self.source.diff(repo, pr)?;
         checks.extend(run_diff_scans(&diff));
 

--- a/src/overseer/pr_verify.rs
+++ b/src/overseer/pr_verify.rs
@@ -5,7 +5,7 @@
 //!
 //! Every scan is a **pure** function over a unified diff (`gh pr diff` output),
 //! so the whole merge-safety surface is testable on fixture diffs with zero
-//! network. The four scans:
+//! network. The scans:
 //!
 //! | # | Check | This module |
 //! |---|-------|-------------|
@@ -13,6 +13,7 @@
 //! | 4 | No stray `print!`/`println!`/`eprintln!`/`eprint!` in added `src/**` | [`scan_no_stray_prints`] |
 //! | 5 | Additive / non-breaking — no **removed** `pub` items | [`scan_additive_no_removed_pub`] |
 //! | 6 | PRD (`Specs/ProductArchitecture.md`) preserved — no removed lines | [`scan_prd_preserved`] |
+//! | 8 | No **added** point-in-time report doc (G4 durable-docs policy) | [`scan_no_point_in_time_report_docs`] |
 //!
 //! Items 1–2 (CI-green / mergeable / base-allowlist) reuse
 //! `stewardship::merge_authority::evaluate_objective_gates`; item 7 reuses
@@ -20,6 +21,7 @@
 //! [`merge_ops`](crate::overseer::merge_ops), not here.
 
 use crate::overseer::capabilities::CheckItem;
+use std::collections::{HashMap, HashSet};
 
 /// The PRD file whose content must be preserved (check #6).
 pub const PRD_PATH: &str = "Specs/ProductArchitecture.md";
@@ -247,10 +249,157 @@ pub fn scan_prd_preserved(diff: &str) -> Vec<DiffFinding> {
     out
 }
 
+// ─────────────── scan #8: no point-in-time report docs (G4) ────────────────
+
+/// Reserved directories whose newly-added `.md` files are, by filing location
+/// alone, point-in-time report docs (G4). A doc that lives here is a report by
+/// convention regardless of its title.
+const REPORT_DIRS: &[&str] = &["docs/investigation/", "docs/reports/", "docs/runs/"];
+
+/// Report-KIND title markers, matched against a newly-added doc's **title
+/// surface only** — its front-matter `type:` / `doc_type:` / `title:` values and
+/// its first `# ` H1 — never its body prose. They are deliberately SPECIFIC
+/// multi-word report kinds ("investigation report", not bare "investigation" or
+/// "report"), so a durable doc that merely mentions reports in its title (e.g. a
+/// reference doc titled "No point-in-time report docs") does not self-flag. This
+/// is the doc-TYPE-not-topic rule: the same subsystem can host a good durable
+/// design doc and a banned report doc; only the latter names a report kind.
+const REPORT_TITLE_MARKERS: &[&str] = &[
+    "investigation report",
+    "testing report",
+    "test report",
+    "diagnosis report",
+    "diagnostic report",
+    "diagnostics report",
+    "recurrence report",
+    "blockage report",
+    "benchmark snapshot",
+    "measured-rate",
+    "measured rate",
+    "snapshot findings",
+    "postmortem",
+    "post-mortem",
+];
+
+/// The guidance attached to a G4 finding: where the content belongs instead.
+const POINT_IN_TIME_GUIDANCE: &str = "point-in-time report doc — record the finding in a GitHub issue \
+(consolidate recurrences into one tracking issue) and/or memory, not a committed repo doc; \
+durable feature/architecture docs are encouraged";
+
+/// The set of new-side file paths a diff ADDS (creates). A file counts as added
+/// only when its old side is `/dev/null` — the deterministic, diff-local signal
+/// git emits for a creation (`--- /dev/null`, alongside `new file mode`). Edits
+/// and deletions are excluded, which is exactly what scopes the G4 scan to
+/// added-only so pre-existing docs and durable-doc edits are never touched.
+pub fn newly_added_files(diff: &str) -> HashSet<String> {
+    let mut added = HashSet::new();
+    let mut old_is_dev_null = false;
+    for raw in diff.lines() {
+        if let Some(rest) = raw.strip_prefix("--- ") {
+            old_is_dev_null = normalize_diff_path(rest).is_empty();
+        } else if let Some(rest) = raw.strip_prefix("+++ ") {
+            let new_path = normalize_diff_path(rest);
+            if old_is_dev_null && !new_path.is_empty() {
+                added.insert(new_path.to_string());
+            }
+            old_is_dev_null = false;
+        }
+    }
+    added
+}
+
+fn is_markdown(path: &str) -> bool {
+    let lower = path.to_lowercase();
+    lower.ends_with(".md") || lower.ends_with(".markdown")
+}
+
+/// Extract the trimmed value of a YAML front-matter `key: value` line, or `None`
+/// when the line is not that field.
+fn front_matter_value<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    let rest = line.trim().strip_prefix(key)?.strip_prefix(':')?;
+    Some(rest.trim())
+}
+
+/// True when a newly-added doc's TITLE SURFACE names a report KIND. Only the
+/// optional YAML front-matter (`type` / `doc_type` / `title`) and the first `# `
+/// H1 are consulted — body prose is never read, so a durable doc that merely
+/// discusses an investigation in its body cannot flag.
+fn title_names_a_report(added_lines: &[&str]) -> bool {
+    let mut title_texts: Vec<String> = Vec::new();
+    let mut idx = 0;
+
+    // Optional YAML front-matter block delimited by `---` fences.
+    if added_lines.first().map(|l| l.trim()) == Some("---") {
+        idx = 1;
+        while idx < added_lines.len() && added_lines[idx].trim() != "---" {
+            for key in ["type", "doc_type", "title"] {
+                if let Some(value) = front_matter_value(added_lines[idx], key) {
+                    title_texts.push(value.to_lowercase());
+                    break;
+                }
+            }
+            idx += 1;
+        }
+        if idx < added_lines.len() {
+            idx += 1; // step past the closing `---`
+        }
+    }
+
+    // First markdown H1 after any front-matter.
+    for line in &added_lines[idx.min(added_lines.len())..] {
+        if let Some(h1) = line.trim_start().strip_prefix("# ") {
+            title_texts.push(h1.to_lowercase());
+            break;
+        }
+    }
+
+    title_texts
+        .iter()
+        .any(|t| REPORT_TITLE_MARKERS.iter().any(|m| t.contains(m)))
+}
+
+/// Check #8 (G4): flag a PR that ADDS a point-in-time report doc. Added-only,
+/// `.md`-only, and report-TYPED (by reserved directory or by title kind), so
+/// pre-existing docs, durable feature/architecture docs, and edits to any doc
+/// are never flagged. Each finding routes the author to a GitHub issue/memory.
+pub fn scan_no_point_in_time_report_docs(diff: &str) -> Vec<DiffFinding> {
+    let added = newly_added_files(diff);
+
+    // Collect each added `.md` file's added content lines, in diff order.
+    let mut per_file: HashMap<String, Vec<&str>> = HashMap::new();
+    for_each_diff_line(diff, |dl| {
+        if dl.kind == LineKind::Added && is_markdown(dl.file) && added.contains(dl.file) {
+            per_file
+                .entry(dl.file.to_string())
+                .or_default()
+                .push(dl.content);
+        }
+    });
+
+    // Deterministic iteration over the added `.md` files.
+    let mut md_files: Vec<&String> = added.iter().filter(|f| is_markdown(f)).collect();
+    md_files.sort();
+
+    let empty: Vec<&str> = Vec::new();
+    let mut out = Vec::new();
+    for file in md_files {
+        let by_dir = REPORT_DIRS.iter().any(|d| file.starts_with(d));
+        let by_title = !by_dir && title_names_a_report(per_file.get(file).unwrap_or(&empty));
+        if by_dir || by_title {
+            out.push(DiffFinding {
+                file: file.clone(),
+                line: None,
+                text: POINT_IN_TIME_GUIDANCE.to_string(),
+            });
+        }
+    }
+    out
+}
+
 // ─────────────────────────── checklist assembly ────────────────────────────
 
-/// Run all four additive diff-scans and return one [`CheckItem`] per scan. A
-/// scan passes when it finds no violations; the note names the offenders.
+/// Run all additive diff-scans and return one [`CheckItem`] per scan. A scan
+/// passes when it finds no violations; the note names the offenders.
 pub fn run_diff_scans(diff: &str) -> Vec<CheckItem> {
     vec![
         finding_check(
@@ -263,6 +412,10 @@ pub fn run_diff_scans(diff: &str) -> Vec<CheckItem> {
             scan_additive_no_removed_pub(diff),
         ),
         finding_check("PRD preserved", scan_prd_preserved(diff)),
+        finding_check(
+            "no-point-in-time-report-docs (added .md)",
+            scan_no_point_in_time_report_docs(diff),
+        ),
     ]
 }
 
@@ -439,10 +592,10 @@ diff --git a/src/foo.rs b/src/foo.rs
 +// orient-decide-act, no forbidden tokens
 ";
         let checks = run_diff_scans(diff);
-        assert_eq!(checks.len(), 4);
+        assert_eq!(checks.len(), 5);
         assert!(
             checks.iter().all(|c| c.passed),
-            "a clean additive diff passes all four scans: {checks:?}"
+            "a clean additive diff passes all five scans: {checks:?}"
         );
     }
 
@@ -483,5 +636,333 @@ diff --git a/src/foo.rs b/src/foo.rs
             Some(11),
             "added line after one context line at 10"
         );
+    }
+
+    // ── #8: no point-in-time report docs (G4) ────────────────────────────────
+    //
+    // TDD (Step 7 — write tests first): these reference `newly_added_files` and
+    // `scan_no_point_in_time_report_docs`, which the implementation step (Step 8)
+    // adds. Until then this module fails to COMPILE — the intended RED state for
+    // the durable-documentation enforcement rail. The contract is deliberately
+    // narrow: added-only, `.md`-only, report-TYPED (path or title), never topic.
+
+    /// A newly-added `.md` under a reserved report directory flags on the path
+    /// alone (path rail), and the finding text points the author at issue/memory.
+    #[test]
+    fn g4_flags_added_doc_under_reserved_report_dir() {
+        let diff = "\
+diff --git a/docs/investigation/run-42.md b/docs/investigation/run-42.md
+new file mode 100644
+--- /dev/null
++++ b/docs/investigation/run-42.md
+@@ -0,0 +1,3 @@
++# kgpacks-rs run 42
++
++The build was blocked on X as of today.
+";
+        let f = scan_no_point_in_time_report_docs(diff);
+        assert_eq!(f.len(), 1, "one path-rail report doc flags: {f:?}");
+        assert_eq!(f[0].file, "docs/investigation/run-42.md");
+        assert!(
+            f[0].text.to_lowercase().contains("issue"),
+            "the finding guides the author to a GitHub issue/memory: {:?}",
+            f[0].text
+        );
+    }
+
+    /// All three reserved report directories flag an added `.md` on path alone.
+    #[test]
+    fn g4_all_reserved_report_dirs_flag() {
+        for dir in ["docs/investigation", "docs/reports", "docs/runs"] {
+            let path = format!("{dir}/x.md");
+            let diff = format!(
+                "\
+diff --git a/{path} b/{path}
+new file mode 100644
+--- /dev/null
++++ b/{path}
+@@ -0,0 +1,1 @@
++# notes
+"
+            );
+            assert_eq!(
+                scan_no_point_in_time_report_docs(&diff).len(),
+                1,
+                "reserved report dir {dir} must flag an added .md"
+            );
+        }
+    }
+
+    /// Doc-TYPE-not-topic: a durable design doc under `docs/design/` with a
+    /// durable H1, whose report vocabulary ("investigation") appears only in BODY
+    /// prose, must NOT flag.
+    #[test]
+    fn g4_does_not_flag_durable_doc_with_report_words_in_body() {
+        let diff = "\
+diff --git a/docs/design/kgpacks-parity.md b/docs/design/kgpacks-parity.md
+new file mode 100644
+--- /dev/null
++++ b/docs/design/kgpacks-parity.md
+@@ -0,0 +1,4 @@
++# kgpacks-rs parity design
++
++This design explains the parity architecture. A prior investigation
++informed it, but this doc describes durable behavior.
+";
+        assert!(
+            scan_no_point_in_time_report_docs(diff).is_empty(),
+            "a durable design doc with report words only in body prose must NOT flag"
+        );
+    }
+
+    /// Title rail: an added `.md` OUTSIDE the reserved dirs flags when its H1 is a
+    /// report-typed title.
+    #[test]
+    fn g4_flags_report_typed_h1_outside_reserved_dirs() {
+        let diff = "\
+diff --git a/docs/notes/x.md b/docs/notes/x.md
+new file mode 100644
+--- /dev/null
++++ b/docs/notes/x.md
+@@ -0,0 +1,2 @@
++# Investigation Report: kgpacks-rs
++details
+";
+        let f = scan_no_point_in_time_report_docs(diff);
+        assert_eq!(f.len(), 1, "title-rail report doc flags: {f:?}");
+        assert_eq!(f[0].file, "docs/notes/x.md");
+    }
+
+    /// Title rail via front-matter `type:` fires even under a DURABLE directory —
+    /// a report-typed title trips regardless of where the file lives.
+    #[test]
+    fn g4_flags_report_typed_frontmatter_even_under_durable_dir() {
+        let diff = "\
+diff --git a/docs/design/y.md b/docs/design/y.md
+new file mode 100644
+--- /dev/null
++++ b/docs/design/y.md
+@@ -0,0 +1,5 @@
++---
++type: diagnosis report
++---
++# Y
++body
+";
+        assert_eq!(
+            scan_no_point_in_time_report_docs(diff).len(),
+            1,
+            "a report-typed front-matter trips the title rail even under docs/design/"
+        );
+    }
+
+    /// Added-only: EDITING a pre-existing report doc is never flagged.
+    #[test]
+    fn g4_ignores_edits_to_preexisting_report_doc() {
+        let diff = "\
+diff --git a/docs/investigation/old.md b/docs/investigation/old.md
+--- a/docs/investigation/old.md
++++ b/docs/investigation/old.md
+@@ -1,2 +1,3 @@
+ # Old investigation
+ existing line
++an appended line
+";
+        assert!(
+            scan_no_point_in_time_report_docs(diff).is_empty(),
+            "an EDIT to a pre-existing report doc is never flagged (added-only)"
+        );
+    }
+
+    /// Only `.md` is in scope; an added `.rs` (even under a report dir) is ignored.
+    #[test]
+    fn g4_ignores_non_markdown_added_files() {
+        let diff = "\
+diff --git a/docs/investigation/run.rs b/docs/investigation/run.rs
+new file mode 100644
+--- /dev/null
++++ b/docs/investigation/run.rs
+@@ -0,0 +1,1 @@
++fn main() {}
+";
+        assert!(
+            scan_no_point_in_time_report_docs(diff).is_empty(),
+            "only .md files are in scope; an added .rs is ignored"
+        );
+    }
+
+    /// Self-non-flag: the enforcement PR only EDITS CONTRIBUTING.md and prompt
+    /// `.md` files (never ADDS a report doc), so it must not flag itself.
+    #[test]
+    fn g4_does_not_flag_the_enforcement_prs_own_edit_shape() {
+        let diff = "\
+diff --git a/CONTRIBUTING.md b/CONTRIBUTING.md
+--- a/CONTRIBUTING.md
++++ b/CONTRIBUTING.md
+@@ -1,1 +1,2 @@
+ # Contributing
++G4 — never commit a point-in-time investigation report doc.
+diff --git a/prompt_assets/simard/engineer_system.md b/prompt_assets/simard/engineer_system.md
+--- a/prompt_assets/simard/engineer_system.md
++++ b/prompt_assets/simard/engineer_system.md
+@@ -1,1 +1,2 @@
+ # Engineer
++Record investigation/testing findings as an issue, not a repo doc.
+";
+        assert!(
+            scan_no_point_in_time_report_docs(diff).is_empty(),
+            "the enforcement PR only edits docs/prompts; it must not self-flag"
+        );
+    }
+
+    /// Self-non-flag (hard case): the enforcement PR ADDS three DURABLE docs whose
+    /// titles/bodies necessarily discuss reports (including a reference doc whose
+    /// title literally contains "point-in-time report docs"). They sit under
+    /// durable directories with durable `doc_type`s, so the scan must NOT flag
+    /// them — otherwise the policy PR blocks itself. This pins doc-TYPE-not-topic
+    /// hard and forces SPECIFIC report-kind title markers, not bare "report".
+    #[test]
+    fn g4_does_not_flag_this_features_own_durable_docs() {
+        let diff = "\
+diff --git a/docs/reference/no-point-in-time-docs-scan.md b/docs/reference/no-point-in-time-docs-scan.md
+new file mode 100644
+--- /dev/null
++++ b/docs/reference/no-point-in-time-docs-scan.md
+@@ -0,0 +1,6 @@
++---
++title: \"No point-in-time report docs — pr-verify scan\"
++doc_type: reference
++---
++# No point-in-time report docs — pr-verify scan
++It flags a PR that adds an investigation report doc.
+diff --git a/docs/howto/record-an-investigation-finding.md b/docs/howto/record-an-investigation-finding.md
+new file mode 100644
+--- /dev/null
++++ b/docs/howto/record-an-investigation-finding.md
+@@ -0,0 +1,5 @@
++---
++title: \"Record an investigation finding (issue/memory, not a repo doc)\"
++doc_type: howto
++---
++# Record an investigation finding (issue/memory, not a repo doc)
+diff --git a/docs/concepts/durable-documentation-policy.md b/docs/concepts/durable-documentation-policy.md
+new file mode 100644
+--- /dev/null
++++ b/docs/concepts/durable-documentation-policy.md
+@@ -0,0 +1,6 @@
++---
++title: \"Durable-Documentation Policy (G4)\"
++doc_type: concept
++---
++# Durable-Documentation Policy (G4)
++A diagnosis report belongs in an issue, not the repo.
+";
+        let f = scan_no_point_in_time_report_docs(diff);
+        assert!(
+            f.is_empty(),
+            "the feature's own durable concept/howto/reference docs must not self-flag: {f:?}"
+        );
+    }
+
+    /// `newly_added_files` distinguishes an add (new file mode / --- /dev/null)
+    /// from a plain edit and from a deletion.
+    #[test]
+    fn newly_added_files_distinguishes_add_edit_and_delete() {
+        let diff = "\
+diff --git a/added.md b/added.md
+new file mode 100644
+--- /dev/null
++++ b/added.md
+@@ -0,0 +1,1 @@
++new
+diff --git a/edited.md b/edited.md
+--- a/edited.md
++++ b/edited.md
+@@ -1,1 +1,2 @@
+ keep
++more
+diff --git a/deleted.md b/deleted.md
+deleted file mode 100644
+--- a/deleted.md
++++ /dev/null
+@@ -1,1 +0,0 @@
+-gone
+";
+        let added = newly_added_files(diff);
+        assert!(
+            added.contains("added.md"),
+            "the added file is detected: {added:?}"
+        );
+        assert!(!added.contains("edited.md"), "an edit is not an add");
+        assert!(!added.contains("deleted.md"), "a deletion is not an add");
+        assert_eq!(added.len(), 1, "exactly one added file: {added:?}");
+    }
+
+    /// A `--- /dev/null` old side ALONE (no `new file mode` header, as some tools
+    /// emit) is sufficient proof that a file is added.
+    #[test]
+    fn newly_added_files_accepts_dev_null_old_side_without_new_file_mode() {
+        let diff = "\
+--- /dev/null
++++ b/docs/investigation/x.md
+@@ -0,0 +1,1 @@
++# x
+";
+        let added = newly_added_files(diff);
+        assert!(
+            added.contains("docs/investigation/x.md"),
+            "a /dev/null old side alone proves an add: {added:?}"
+        );
+    }
+
+    /// The G4 scan is registered as a fifth `run_diff_scans` check and fails on a
+    /// diff that adds a report doc.
+    #[test]
+    fn g4_is_registered_as_a_diff_scan() {
+        let diff = "\
+diff --git a/docs/investigation/run.md b/docs/investigation/run.md
+new file mode 100644
+--- /dev/null
++++ b/docs/investigation/run.md
+@@ -0,0 +1,1 @@
++# Investigation Report
+";
+        let checks = run_diff_scans(diff);
+        assert_eq!(checks.len(), 5, "the G4 scan is registered as a 5th check");
+        let g4 = checks
+            .iter()
+            .find(|c| c.name.to_lowercase().contains("point-in-time"))
+            .expect("a check named for the point-in-time-docs policy is registered");
+        assert!(
+            !g4.passed,
+            "the G4 check fails on an added report doc: {g4:?}"
+        );
+    }
+
+    /// Sibling isolation: adding a report doc must not perturb the pre-existing
+    /// Bridge / print / additive / PRD scans.
+    #[test]
+    fn g4_sibling_scans_are_unchanged_by_a_report_doc_add() {
+        let diff = "\
+diff --git a/docs/investigation/run.md b/docs/investigation/run.md
+new file mode 100644
+--- /dev/null
++++ b/docs/investigation/run.md
+@@ -0,0 +1,1 @@
++# Investigation Report
+";
+        assert!(
+            scan_no_bridge_naming(diff).is_empty(),
+            "no-Bridge scan unchanged"
+        );
+        assert!(
+            scan_no_stray_prints(diff).is_empty(),
+            "no-stray-print scan unchanged"
+        );
+        assert!(
+            scan_additive_no_removed_pub(diff).is_empty(),
+            "additive scan unchanged"
+        );
+        assert!(scan_prd_preserved(diff).is_empty(), "PRD scan unchanged");
     }
 }

--- a/tests/engineering_guidelines_prompts.rs
+++ b/tests/engineering_guidelines_prompts.rs
@@ -1,5 +1,5 @@
-//! Durable contract for the THREE engineering guidelines (G1/G2/G3) that
-//! Simard's OODA reasoners, engineers, and reviewers — and human
+//! Durable contract for the engineering guidelines (G1/G2/G3 and now **G4**)
+//! that Simard's OODA reasoners, engineers, and reviewers — and human
 //! contributors — must follow.
 //!
 //! G1 — HYBRID BENCHMARK + LIVE SELF-MEASUREMENT: cognition / self-improvement
@@ -13,13 +13,21 @@
 //!      CODE: treat line/substring parsing of model/tool output as a brittle
 //!      antipattern; prefer a structured-output contract + agentic extraction,
 //!      and prefer recipes/prompts over new code.
+//! G4 — DURABLE DOCS ONLY; NEVER COMMIT POINT-IN-TIME REPORT DOCS
+//!      (`no-point-in-time-docs`): an investigation / testing / diagnosis /
+//!      recurrence / benchmark-snapshot FINDING is recorded as a GitHub issue
+//!      and/or memory — NOT as a committed repo doc. Durable feature/architecture
+//!      docs remain encouraged (the distinction is doc TYPE, not topic). G4 also
+//!      has a hard deterministic backstop — the Overseer pr-verify scan
+//!      `scan_no_point_in_time_report_docs` (see `src/overseer/pr_verify.rs`).
 //!
-//! TDD (Step 7 — write tests first): these are RED until the implementation
-//! step threads G1/G2/G3 into the engineer / OODA reasoner prompts, the review
-//! gates, and the goal-framing prompts (and their recipe `.yaml` mirrors). The
-//! `CONTRIBUTING.md` durable-doc assertions are the GREEN anchor — the human
-//! source of truth is already in place, so a regression that deletes it is
-//! also caught.
+//! TDD (Step 7 — write tests first): the G1/G2/G3 assertions landed with #2614
+//! and are GREEN; the **G4** assertions at the end of this file are the new RED
+//! set — they stay RED until the implementation step threads G4 into the
+//! engineer / OODA reasoner prompts, the review gates, and the recipe mirrors.
+//! The `CONTRIBUTING.md` assertions (G1–G4) are the GREEN anchor — the human
+//! source of truth is already in place, so a regression that deletes it is also
+//! caught.
 //!
 //! The assertions pin STABLE keyword invariants (lowercased), not full-sentence
 //! snapshots, so ordinary rewording does not break them — deleting a guideline
@@ -428,5 +436,172 @@ fn contributing_documents_all_three_guidelines() {
         "#engineering-guidelines-g1g2g3",
         "CONTRIBUTING.md",
         "a table-of-contents anchor linking to the guidelines section",
+    );
+}
+
+// =========================================================================
+// G4 — DURABLE-DOCUMENTATION POLICY (no-point-in-time-docs)
+// =========================================================================
+//
+// TDD (Step 7 — write tests first). Everything below is RED until Step 8:
+//   * the prompt/gate assertions fail because the G4 marker is absent from the
+//     reasoner / gate prompts and their recipe mirrors today;
+//   * `contributing_documents_g4_durable_docs_policy` is the GREEN anchor (the
+//     CONTRIBUTING.md G4 section already landed in the documentation step).
+//
+// The vocabulary mirrors the CONTRIBUTING.md G4 language so Step 8 satisfies the
+// contract by threading the SAME wording into the prompts — keyword invariants,
+// not sentence snapshots.
+
+/// G4 guideline NAME — the stable, universal marker. Present in `CONTRIBUTING.md`
+/// today; ABSENT from the reasoner/gate prompts until Step 8 threads it, so it is
+/// the RED discriminator for every G4 prompt assertion.
+const G4_MARKER: &str = "no-point-in-time-docs";
+
+/// G4 — the banned artifact: a point-in-time investigation/testing/diagnosis
+/// REPORT doc committed to the repo.
+const G4_REPORT: &[&str] = &["point-in-time report", "point-in-time doc", "report doc"];
+
+/// G4 — where a finding goes INSTEAD: a GitHub issue and/or memory, not a repo doc.
+const G4_SINK: &[&str] = &[
+    "issue and/or memory",
+    "github issue",
+    "issue or memory",
+    "not a repo doc",
+];
+
+/// G4 — durable feature/architecture docs remain encouraged (doc TYPE, not topic).
+const G4_DURABLE: &[&str] = &["durable doc", "durable documentation"];
+
+fn assert_g4_marker(lc: &str, file: &str) {
+    assert_contains(
+        lc,
+        G4_MARKER,
+        file,
+        "a reference to the durable-documentation guideline (G4 / no-point-in-time-docs)",
+    );
+}
+
+/// Full G4 flag criteria: name the guideline, name the banned artifact, name the
+/// correct sink, and preserve the "durable docs are encouraged" half.
+fn assert_g4(lc: &str, file: &str) {
+    assert_g4_marker(lc, file);
+    assert_contains_any(
+        lc,
+        G4_REPORT,
+        file,
+        "G4: name the banned artifact — a point-in-time investigation/testing/diagnosis report doc",
+    );
+    assert_contains_any(
+        lc,
+        G4_SINK,
+        file,
+        "G4: findings go to a GitHub issue and/or memory, not a committed repo doc",
+    );
+    assert_contains_any(
+        lc,
+        G4_DURABLE,
+        file,
+        "G4: durable feature/architecture docs remain encouraged (doc type, not topic)",
+    );
+}
+
+// --- Layer A: engineer + planning reasoner prompts (full G4) --------------
+
+#[test]
+fn engineer_prompts_thread_g4_durable_docs_policy() {
+    for f in ["engineer_system.md", "engineer_planning.md"] {
+        let lc = prompt_lc(f);
+        assert_g4(&lc, f);
+    }
+}
+
+// --- Layer A: OODA reasoner prompts (lightweight G4 marker) ----------------
+//
+// The compact OODA reasoners carry the G4 NAME so their planning/authoring
+// judgment inherits the durable-docs policy, without over-pinning their narrow
+// output contracts (same treatment they give the G1/G2/G3 marker).
+
+#[test]
+fn ooda_reasoners_reference_g4() {
+    for f in OODA_REASONERS {
+        let lc = prompt_lc(f);
+        assert_g4_marker(&lc, f);
+    }
+}
+
+// --- Layer B: review gates (full G4 flag criteria) ------------------------
+
+#[test]
+fn review_gates_flag_g4_report_docs() {
+    for f in ["merge_readiness_judge.md", "review_pipeline.md"] {
+        let lc = prompt_lc(f);
+        assert_g4(&lc, f);
+    }
+}
+
+// --- Mirror parity: G4-bearing prompts stay in sync with their recipe .yaml -
+//
+// The G4-bearing subset of MIRROR_PAIRS (the OODA reasoners + the merge-readiness
+// judge) must carry the G4 marker in BOTH the `.md` and its recipe mirror, so a
+// `.md` edit can't silently leave the live recipe path un-guided by G4.
+
+const G4_MIRROR_PAIRS: &[(&str, &str)] = &[
+    ("ooda_orient.md", "ooda-orient.yaml"),
+    ("ooda_decide.md", "ooda-decide.yaml"),
+    ("ooda_brain.md", "ooda-engineer-lifecycle.yaml"),
+    ("merge_readiness_judge.md", "merge-readiness-judge.yaml"),
+];
+
+#[test]
+fn recipe_mirrors_carry_the_g4_marker() {
+    let mut drifted = Vec::new();
+    for (md, yaml) in G4_MIRROR_PAIRS {
+        let md_has = prompt_lc(md).contains(G4_MARKER);
+        let yaml_has = recipe(yaml).to_lowercase().contains(G4_MARKER);
+        if md_has != yaml_has {
+            drifted.push(format!("{md} (g4={md_has}) vs {yaml} (g4={yaml_has})"));
+        }
+        assert!(
+            yaml_has,
+            "recipe mirror {yaml} must carry the G4 marker {G4_MARKER:?} (parity with {md})"
+        );
+    }
+    assert!(
+        drifted.is_empty(),
+        "prompt/recipe G4 marker drift — G4 must be present in BOTH the .md and \
+         its .yaml mirror: {drifted:?}"
+    );
+}
+
+// --- Layer D: durable doc (GREEN anchor) ----------------------------------
+//
+// CONTRIBUTING.md already documents G4 (the documentation step). These
+// assertions are GREEN and guard against a future edit deleting the durable
+// G4 section, its hard-rail scan reference, or the updated TOC anchor.
+
+#[test]
+fn contributing_documents_g4_durable_docs_policy() {
+    let lc = repo_file("CONTRIBUTING.md").to_lowercase();
+    assert_g4(&lc, "CONTRIBUTING.md");
+    // The deterministic backstop scan is named, tying the soft rail to the hard.
+    assert_contains(
+        &lc,
+        "scan_no_point_in_time_report_docs",
+        "CONTRIBUTING.md",
+        "G4: name the deterministic pr-verify backstop scan (the hard rail)",
+    );
+    // The guidelines header and its TOC anchor are updated to include G4.
+    assert_contains(
+        &lc,
+        "g1/g2/g3/g4",
+        "CONTRIBUTING.md",
+        "the guidelines header names all four guidelines",
+    );
+    assert_contains(
+        &lc,
+        "#engineering-guidelines-g1g2g3g4",
+        "CONTRIBUTING.md",
+        "the table-of-contents anchor is updated to include G4",
     );
 }


### PR DESCRIPTION
## What & why

Repository documentation must be **accurate and durable** — it describes how the system actually works and is updated by later PRs. Point-in-time **report** docs (investigation / testing / diagnosis / blockage-recurrence / benchmark-snapshot write-ups) go stale immediately and **poison Simard's own context** when she reads her repo as grounding. This PR enforces a durable-documentation policy (**G4**, `no-point-in-time-docs`) for **both** Simard and human/agent contributors.

The distinction is **doc TYPE, not topic**: a durable design/architecture doc about a subsystem (e.g. kgpacks-rs parity design) is encouraged and kept current; an investigation/testing *report* about the same subsystem belongs in a **GitHub issue and/or memory**, not the repo.

Motivating context: the `docs(investigation)` / `docs(overseer)` run **#2879, #2843, #2819, #2814, #2801** each committed a kgpacks-rs blockage report as a repo doc.

## Two rails

**Hard rail (deterministic).** New Overseer pr-verify scan `scan_no_point_in_time_report_docs` (check #8) in `src/overseer/pr_verify.rs`, wired into the merge gate via `run_diff_scans` (same pattern as the no-Bridge / no-print scans). It is:
- **added-only** — a file counts only when its old side is `/dev/null`; edits to existing docs are never flagged.
- **`.md`-only** and **report-TYPED** — flags a newly added markdown file only when it sits under a reserved report dir (`docs/investigation/`, `docs/reports/`, `docs/runs/`) **or** its *title surface* (front-matter `type`/`doc_type`/`title` or first `# ` H1) names a report **kind** (specific phrases like "investigation report", not bare "report").
- **body-blind** — prose is never consulted, so durable docs that merely discuss reports do not self-flag (incl. this PR's own reference doc titled "No point-in-time report docs").
- **non-bypassable** — a flagged PR fails the gate with `ready:false`; no `--admin` / `--no-verify`. The finding routes content to an issue/memory.

**Soft rail (agentic).** The G4 guideline (`no-point-in-time-docs`) is threaded into the engineer + planning prompts, the OODA reasoner prompts (+ recipe mirrors), and the merge-readiness / review-pipeline gates, so Simard records findings as issues/memory rather than committing report docs.

## Docs
- `CONTRIBUTING.md` — durable **Engineering Guidelines (G1/G2/G3/G4)** section documenting both rails; applies to Simard and contributors.
- New durable docs: `docs/concepts/durable-documentation-policy.md`, `docs/howto/record-an-investigation-finding.md`, `docs/reference/no-point-in-time-docs-scan.md`; `mkdocs.yml` nav updated.

## Tests
- `src/overseer/pr_verify.rs` unit tests: the scan flags an added report doc (by reserved dir and by report-typed title) while **not** flagging durable feature/architecture docs, edits to existing docs, non-markdown, or the enforcement PR's own diff shape.
- `tests/engineering_guidelines_prompts.rs`: pins the G4 keyword invariants across the prompts, the recipe mirrors, and CONTRIBUTING.

## Reconciliation
The five violating report-doc PRs (#2879, #2843, #2819, #2814, #2801) are reconciled separately: findings preserved in a consolidated tracking issue, doc-only PRs closed with a pointer to the policy and the issue.

## Verification
`cargo fmt --check`, `cargo clippy --all-targets --all-features --locked -D warnings`, `cargo test` (pr_verify + engineering_guidelines_prompts), and `mkdocs build --strict` all pass locally; pre-commit and pre-push gates green.