### PR TITLE
perf(ooda): bulk graph-adjacency index — prepare-context from ~11 min to seconds (#40)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=901f63ad79eb0c2d87cd8263d26025877af43cc5#901f63ad79eb0c2d87cd8263d26025877af43cc5"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=72c5ea1bfcca7e6f3e314dfd99fbe4998378ffe8#72c5ea1bfcca7e6f3e314dfd99fbe4998378ffe8"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -1084,7 +1084,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1218,7 +1218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2454,7 +2454,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3459,7 +3459,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3518,7 +3518,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4222,7 +4222,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5153,7 +5153,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,17 @@ path = "src/bin/supply_chain_steward.rs"
 # fix the creative-ideas dashboard read path (ideas fell outside the unscoped
 # 512-row window in a large store). Still an upstream-`main` commit; store format
 # stays v41 (no lbug/engine change).
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "901f63ad79eb0c2d87cd8263d26025877af43cc5", features = ["persistent"] }
+#
+# Bumped again (issue #40) to the squash-merge commit of amplihack-memory-lib
+# PR #126 on `main` (1 commit ahead of the #125 pin): the bulk graph-adjacency
+# index for ranked recall. Ranked declarative/episodic recall previously computed
+# the graph-proximity term with a per-node `query_neighbors` BFS — an N+1 fan-out
+# of ~3N lock-serialized Cypher scans per recall that made the OODA daemon's
+# prepare-context spin ~11 min/cycle at ~7,590 facts. The fix serves that term
+# from one bulk edge scan per type: a pure performance refactor with
+# byte-identical ranking. Still an upstream-`main` commit; store format stays v41
+# (no lbug/engine change).
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "72c5ea1bfcca7e6f3e314dfd99fbe4998378ffe8", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream

--- a/docs/reference/cognitive-memory-graph-adjacency-index.md
+++ b/docs/reference/cognitive-memory-graph-adjacency-index.md
@@ -1,0 +1,417 @@
+---
+title: Bulk graph-adjacency index for ranked recall (prepare-context performance)
+description: Planned design — how ranked declarative and episodic recall will score the graph-proximity signal from a single per-recall bulk adjacency load instead of ~3N per-node neighbour round-trips, targeting a cut in OODA prepare-context wall-clock from ~11 minutes toward single-digit seconds at ~7,590 facts while preserving byte-identical ranking, per-agent tenant isolation, and tombstone exclusion.
+last_updated: 2026-07-08
+owner: simard
+doc_type: reference
+related:
+  - ../memory.md
+  - ../architecture/cognitive-memory.md
+  - ../architecture/cognitive-memory-library-adapter.md
+  - ./cognitive-memory-ranked-recall.md
+  - ./cognitive-memory-ranked-episodic-recall.md
+  - ./cognitive-memory-provenance.md
+---
+
+# Bulk graph-adjacency index for ranked recall
+
+> **Status: Shipped — issue
+> [#40](https://github.com/rysweet/Simard/issues/40)**
+> (`perf(cog-mem): bulk graph-adjacency index — prepare-context from ~11 min to
+> seconds`). The engine mechanism shipped in
+> [`amplihack-memory-lib` PR #126](https://github.com/rysweet/amplihack-memory-lib/pull/126)
+> and Simard consumes it via the pinned `amplihack-memory` git rev
+> (`72c5ea1`). It builds
+> directly on
+> [Phase-weighted ranked fact recall](./cognitive-memory-ranked-recall.md) and
+> [Ranked episodic recall](./cognitive-memory-ranked-episodic-recall.md), whose
+> **graph** scoring signal this page makes fast. Delivery order: the engine PR
+> merged first, then the Simard pin bump; the persistent daemon now runs the
+> indexed path described below (`graph_path = indexed`), with the legacy per-node
+> path under [Configuration](#configuration) retained only for backends that do
+> not implement the bulk capability.
+
+The OODA daemon's per-cycle **prepare-context** step
+(`preparation_memory_operations_with_active_slugs_phased`, in
+`src/memory_consolidation/mod.rs`) spins for **~11 minutes at ~300 % CPU
+every cycle** with no child processes and no log output — the substance behind
+the operator complaint *"the memory graph never loads."* The graph does load; the
+read is pathologically slow, so each OODA cycle takes ~15–18 min and the
+dashboard / memory views feel stuck.
+
+Root cause is **not** the size of the result (10 facts, 5 procedures, 5
+episodes) but the cost of computing the **graph-proximity** term of ranked
+recall. For every candidate node the ranker issues ~3 lock-serialized Cypher
+neighbour scans over the entire semantic store — an **N+1 fan-out of ~23,000
+queries per recall** at ~7,590 facts. Episodic recall repeats the pattern and
+adds a full-store backfill.
+
+The fix replaces that per-node fan-out with a **single bulk adjacency load per
+recall**. Under the fix, each ranked recall performs a small, fixed number of
+typed edge scans, builds an in-memory adjacency index once, and runs the
+*identical* bounded breadth-first graph walk against that index. Ranking output
+is byte-identical; only the wall-clock changes.
+
+| Metric (per recall, ~7,590 semantic facts) | Before | After |
+|---|---:|---:|
+| Graph-proximity DB round-trips | ~23,000 | 2 (one per edge type) |
+| Round-trip growth vs. node count `N` | `O(N)` | `O(1)` typed scans |
+| `prepare-context` wall-clock (Observe) | ~11 min | single-digit s (target) |
+| Ranking order / scores / reasons | baseline | **identical** |
+
+---
+
+## What the fix changes, at a glance
+
+- **New engine capability.** `GraphStore` gains one **additive** method,
+  `bulk_edges_of_type`, that returns all live directed edges of a single type in
+  one store-locked scan. It has a provided default of `None`, so every existing
+  backend compiles and behaves unchanged until it opts in.
+- **Ranked recall builds an adjacency index once.** `recall_facts_ranked` and
+  `recall_episodes_ranked` fold the results of two bulk scans
+  (`DERIVES_FROM`, `SIMILAR_TO`) into an in-memory adjacency map and run the
+  same bounded BFS they always ran — now against RAM, not the database.
+- **All-or-nothing capability fold.** If the backend returns `None` for any
+  required edge type, the recall falls back to the exact legacy per-node
+  neighbour path for that whole recall. Indexed and legacy neighbour lookups are
+  never mixed within one recall (that would corrupt scores).
+- **Simard consumes it by pin bump.** No Simard call sites change. Simard bumps
+  the `amplihack-memory` git rev in `Cargo.toml`, rebuilds `Cargo.lock`, and adds
+  `tracing` spans so per-sub-step timing is visible. The
+  `"prepared context (…)"` log line is preserved verbatim.
+
+---
+
+## Engine API (`amplihack-memory-lib`)
+
+### `GraphStore::bulk_edges_of_type`
+
+A single additive method on the `GraphStore` trait
+(`rust/amplihack-memory/src/graph/protocol.rs`):
+
+```rust
+/// Return every *live* directed edge of `edge_type` as `(source, target)`
+/// node pairs, in one store-locked scan.
+///
+/// Returns `None` if the backend does not implement the fast bulk path; the
+/// caller then falls back to the legacy per-node neighbour queries with
+/// identical results (performance-only fallback, never a correctness or
+/// isolation downgrade).
+///
+/// Contract for overrides:
+/// - Include only live edges (apply the same tombstone / not-deleted filter
+///   used elsewhere). Soft-deleted, superseded, or archived edges MUST NOT
+///   appear.
+/// - Preserve direction: the pair is `(source, target)`, matching the
+///   directed semantics of the per-node neighbour queries it replaces.
+/// - Do NOT apply tenant scoping here. Per-agent isolation is re-applied by
+///   the recall layer on every endpoint and every BFS hop.
+/// - `edge_type` is validated (`validate_identifier`) before use.
+fn bulk_edges_of_type(&self, _edge_type: &str) -> Option<Vec<(GraphNode, GraphNode)>> {
+    None
+}
+```
+
+**Directionality matters.** The two edge types the ranker walks have different
+directions, and the index preserves both so BFS semantics match the legacy
+`query_neighbors` path exactly:
+
+| Edge type | Direction walked | Meaning |
+|---|---|---|
+| `DERIVES_FROM` | Outgoing | Provenance / derivation proximity. |
+| `SIMILAR_TO` | Both | Semantic-similarity proximity. |
+
+### Backend coverage
+
+| `GraphStore` impl | `bulk_edges_of_type` | Notes |
+|---|---|---|
+| `LbugGraphStore` (persistent) | **override** | One typed `MATCH ()-[r:REL]->()` scan per matching rel-table (rel tables are already partitioned per type), reusing the existing `tombstone_filter`, acquiring the store lock **once**. Uses the safe typed rel-table iteration (the "dump" path), not the per-node query that triggers lbug issue #100. |
+| `InMemoryGraphStore` (test) | **override** | Iterates the in-memory edge map filtered by `edge_type`. Enables deterministic parity and round-trip-counting tests without a persistent DB. |
+| `KuzuGraphStore` | default `None` | Inherits legacy per-node path — exact prior behaviour. |
+| `HiveGraphStore` | default `None` | Inherits legacy per-node path — exact prior behaviour. |
+| `FederatedGraphStore` | default `None` | Inherits legacy per-node path — exact prior behaviour. |
+
+Backends on the default keep working with **no change** and **no regression** —
+they simply do not get the speed-up until they add their own override.
+
+### How ranked recall uses the index
+
+`recall_facts_ranked` and `recall_episodes_ranked`
+(`rust/amplihack-memory/src/cognitive_memory/ranked.rs`) do this per recall:
+
+1. Load candidate semantic nodes once (as before).
+2. Call `bulk_edges_of_type("DERIVES_FROM")` and
+   `bulk_edges_of_type("SIMILAR_TO")`.
+   - If **either** returns `None`, discard the partial index and take the legacy
+     per-node neighbour path for the whole recall (all-or-nothing fold).
+3. Build an in-memory adjacency map from the returned pairs, preserving
+   direction (`DERIVES_FROM` outgoing, `SIMILAR_TO` both).
+4. Run the **same** bounded BFS (`best_edge_score`) the ranker always ran — now
+   against the in-memory index instead of the database.
+5. Re-apply the **per-agent tenant prune** (`agent_id == agent_name`) on **both
+   endpoints and every hop**, and the tombstone exclusion, exactly as the legacy
+   path did — the bulk scan is store-wide, so this re-application is what keeps
+   tenants isolated.
+
+The weighted score, the descending-score ordering, the phase weighting, the
+superseded/archived exclusion, and the human-readable "why this ranked here"
+reasons are all unchanged. Episodic recall computes the **same** graph-proximity
+term from the **same** two edge scans (`DERIVES_FROM`, `SIMILAR_TO`) and so drops
+its own per-node neighbour fan-out. Episode *node* retrieval (`get_episodes`) is
+unchanged — the shared adjacency index accelerates only the graph term, not the
+node backfill.
+
+---
+
+## Parity guarantees
+
+The change is a pure performance refactor. The following are held byte-identical
+between the indexed path and the legacy per-node path, and are pinned by tests:
+
+1. **Identical ordering.** For any fact/episode set and any `RecallWeightSet`,
+   the indexed path returns the same items in the same order as the legacy path.
+2. **Identical graph term.** Multi-hop BFS proximity scores match, including the
+   `DERIVES_FROM` (outgoing) vs. `SIMILAR_TO` (both) direction semantics.
+3. **Tenant isolation preserved (critical).** The store-wide bulk scan never
+   leaks cross-agent edges into ranking: the `agent_id == agent_name` prune is
+   re-applied on both endpoints and every hop.
+4. **Tombstones excluded.** Soft-deleted / superseded / archived nodes and edges
+   never surface via the index (same `tombstone_filter` / not-deleted rule).
+5. **Capability fold is lossless.** A `None` from any backend yields the legacy
+   result — a performance-only fallback, never a correctness or isolation change.
+6. **No mixed lookups.** Within a single recall, neighbour data comes entirely
+   from the index or entirely from legacy queries — never a mix.
+
+Because the six ranked-recall scoring signals (`text_relevance`, `confidence`,
+`importance`, `recency`, `usage`, `graph`) and the per-OODA-phase weight table
+are unchanged, every guarantee documented in
+[Phase-weighted ranked fact recall](./cognitive-memory-ranked-recall.md) and
+[Ranked episodic recall](./cognitive-memory-ranked-episodic-recall.md) continues
+to hold. This page changes only *how fast* the **graph** signal is computed.
+
+---
+
+## Configuration
+
+There is **no operator configuration and no feature flag.** The fast path is
+always on when the active backend implements `bulk_edges_of_type`; otherwise the
+legacy path runs transparently. Simard's persistent backend
+(`LbugGraphStore`, selected by the `persistent` feature) implements it, so the
+daemon gets the speed-up by default.
+
+The set of edge types folded into the adjacency index is fixed to the types the
+ranker actually walks:
+
+| Edge type | Purpose in ranking |
+|---|---|
+| `DERIVES_FROM` | Provenance proximity (also protects facts from pruning — see [provenance](./cognitive-memory-provenance.md)). |
+| `SIMILAR_TO` | Semantic-similarity proximity. |
+
+Adding a new proximity edge type to ranking means adding one more
+`bulk_edges_of_type` call to the index build; no configuration surface is
+exposed for it.
+
+### Dependency pin (Simard)
+
+Simard consumes the engine mechanism through its pinned `amplihack-memory` git
+dependency. After the engine PR merges green, Simard advances the rev and
+rebuilds the lockfile:
+
+```toml
+# Cargo.toml — bumped in lockstep so the final binary links exactly one
+# amplihack-memory containing the bulk-adjacency index.
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "<engine-commit>", features = ["persistent"] }
+```
+
+```bash
+# Rebuild the lockfile against the new engine rev (no other manifest edits).
+cargo update -p amplihack-memory --precise <engine-commit>
+cargo build --release
+```
+
+The Simard pin bump must land **after** the engine PR merges, so `Cargo.lock`
+never points at an unmerged commit.
+
+---
+
+## Observability
+
+The existing prepare-context summary is preserved verbatim
+(`src/ooda_loop/cycle.rs`):
+
+```text
+[simard] OODA cycle: Observe complete
+[simard] OODA cycle: prepared context (10 facts, 19 triggers, 5 procedures, 5 episodes)
+```
+
+Simard adds `tracing` spans around prepare-context and each of its
+sub-operations (plus the board reconcile that runs immediately before it in
+`ooda_loop::cycle`) so per-sub-step wall-clock is attributable without a
+profiler. The spans emit **counts and timings only** — never `node_text`,
+`agent_id`, or any memory content (log-hygiene rule SR-9). The `graph_path`
+field is **emitted by the engine** (target `amplihack_memory::cognitive_memory`),
+not by Simard: the bridge call returns only facts/episodes, so the only way to
+surface which path ran is a one-field `tracing` line inside the engine's
+`ranked.rs`. That line is **in scope for the engine deliverable** alongside the
+trait + BFS refactor — a deliberate, one-line addition, kept because a
+performance fix must be verifiable at runtime (see
+[Examples](#examples)). If it is dropped from the engine PR, the fast path is
+still confirmable by the round-trip-count regression test, only not from a live
+log line.
+
+| Span | Wraps | Fields (counts/timings only) |
+|---|---|---|
+| `prepare_context` | the whole call | `facts`, `triggers`, `procedures`, `episodes`, `elapsed_ms` |
+| `recall_facts_ranked` | per-fragment declarative recall | `fragment_count`, `candidate_count`, `elapsed_ms`, `graph_path` (`indexed`\|`legacy`, engine-emitted) |
+| `check_triggers` | prospective trigger scan | `triggered`, `elapsed_ms` |
+| `recall_procedures` | tokenized procedure recall | `token_count`, `recalled`, `elapsed_ms` |
+| `recall_episodes_ranked` | episodic recall | `candidate_count`, `elapsed_ms`, `graph_path` (engine-emitted) |
+| `reconcile_board_prospectives` | board→prospective mirror — sibling step in `ooda_loop::cycle`, runs just before prepare-context (not a prepare-context sub-op) | `elapsed_ms` |
+
+`graph_path = indexed` confirms the fast path is active; `graph_path = legacy`
+means the backend returned `None` (expected for `Kuzu` / `Hive` / `Federated`,
+unexpected for the persistent daemon and worth investigating).
+
+Read the timings live:
+
+```bash
+# Follow the per-sub-step spans for one OODA cycle.
+RUST_LOG=simard::memory_consolidation=debug,amplihack_memory::cognitive_memory=debug \
+  simard daemon | grep -E 'prepare_context|recall_facts_ranked|recall_episodes_ranked|graph_path'
+```
+
+---
+
+## Performance characteristics
+
+- **DB round-trips are now constant** in the number of facts: two typed edge
+  scans per recall (`DERIVES_FROM`, `SIMILAR_TO`) instead of ~3 per node. At
+  ~7,590 facts that is a drop from ~23,000 queries to 2. `prepare-context` runs
+  one declarative recall per objective *fragment*, so a cycle issues
+  `2 × fragments + 2` scans (the episodic pair) — bounded by objective structure,
+  still `O(1)` in fact count. Caching a single adjacency index across a cycle's
+  fragment recalls (2 scans/cycle total) is a deliberate future optimization, not
+  part of this change.
+- **BFS moves to memory.** The graph walk itself is unchanged in shape; it just
+  reads the in-memory adjacency map. Per-recall transient memory is `O(E)` for
+  the edges of the folded types — acceptable at ~7,590-node scale.
+- **Prepare-context wall-clock** targets a fall from ~11 min to **single-digit
+  seconds**, so an OODA cycle returns to its intended cadence instead of ~15–18
+  min. The change is pinned by a deterministic round-trip-**count** regression,
+  not a wall-clock assertion (see [Tests](#tests)), so the exact second-count is
+  hardware-dependent and intentionally not asserted.
+- **No wall-clock timeouts** were added to any agentic step (policy). The fix is
+  algorithmic, not a cap: it removes the work rather than abandoning it.
+
+---
+
+## Tests
+
+### Engine (`amplihack-memory-lib`)
+
+In `rust/amplihack-memory/src/cognitive_memory/tests/ranked_tests.rs`:
+
+- **Bulk == legacy parity.** For the same fixture and weights, the indexed path
+  and the legacy per-node path return identical ordering, scores, and reasons —
+  including multi-hop BFS and both edge directions.
+- **Multi-tenant isolation.** With edges spanning two agents, the indexed path
+  surfaces only the querying agent's neighbours; no cross-tenant edge influences
+  ranking.
+- **Round-trip counting (regression).** A counting `GraphStore` asserts the
+  number of store scans per recall is **constant** as the fact count grows into
+  the thousands (`O(T)` typed scans, not `O(N)`). This is a deterministic
+  count-based assertion — **no wall-clock timeout** — so it cannot flake on CI
+  hardware.
+- **Persistent smoke test.** `LbugGraphStore::bulk_edges_of_type` returns the
+  correct live directed edges and excludes tombstoned ones, exercising the safe
+  typed rel-table iteration (not the lbug-#100 per-node path).
+
+### Simard
+
+In `src/cognitive_memory/library_adapter.rs` (or `tests/orchestration_perf.rs`):
+
+- **Orchestration recall-count perf test.** Using `CognitiveMemoryOps` mocks,
+  assert prepare-context issues a **constant** number of store scans per cycle
+  as fact count grows — proving the orchestration layer does not reintroduce a
+  full-store scan on top of the engine fix.
+- **`"prepared context (…)"` preserved.** The exact summary log line still fires
+  with the same shape.
+
+---
+
+## Examples
+
+### Confirm the fast path is active
+
+```bash
+# One cycle, filtered to the graph-path marker. Expect `indexed`.
+RUST_LOG=amplihack_memory::cognitive_memory=debug simard daemon 2>&1 \
+  | grep -m1 graph_path
+# -> recall_facts_ranked{... graph_path=indexed elapsed_ms=42 ...}
+```
+
+If you see `graph_path=legacy` on the persistent daemon, the backend returned
+`None` from `bulk_edges_of_type` — check that the binary was built with the
+`persistent` feature and against the bumped `amplihack-memory` rev.
+
+### Attribute prepare-context time to a sub-step
+
+```bash
+RUST_LOG=simard::memory_consolidation=debug simard daemon 2>&1 \
+  | grep -E 'prepare_context|recall_facts_ranked|check_triggers|recall_procedures|recall_episodes_ranked|reconcile_board_prospectives'
+```
+
+Reading the `elapsed_ms` on each span shows where the (now small) budget goes;
+before the fix, `recall_facts_ranked` and `recall_episodes_ranked` dominated the
+whole ~11 min.
+
+### Add the fast path to a new backend
+
+Implement one method; the recall layer picks it up automatically:
+
+```rust
+impl GraphStore for MyBackend {
+    fn bulk_edges_of_type(&self, edge_type: &str) -> Option<Vec<(GraphNode, GraphNode)>> {
+        // Validate, scan once under the store lock, apply the live/tombstone
+        // filter, preserve (source, target) direction. Return None to keep the
+        // legacy per-node path (identical results, just slower).
+        Some(self.scan_live_edges(edge_type))
+    }
+}
+```
+
+No recall code changes; the next `recall_facts_ranked` / `recall_episodes_ranked`
+builds its adjacency index from your override and logs `graph_path=indexed`.
+
+---
+
+## Invariants
+
+1. **Additive, non-breaking trait change.** `bulk_edges_of_type` has a provided
+   `None` default; all `GraphStore` impls compile and behave unchanged until
+   they override it.
+2. **Byte-identical ranking.** Indexed and legacy paths produce the same order,
+   scores, and reasons for any input and any weights.
+3. **Constant DB round-trips.** Graph scoring costs a fixed small number of
+   typed scans per recall, independent of fact count.
+4. **Tenant isolation is never relaxed.** The `agent_id == agent_name` prune is
+   re-applied on every endpoint and every hop over the store-wide index.
+5. **Tombstones never surface.** The same live/tombstone filter applies to the
+   bulk scan as to the per-node path.
+6. **All-or-nothing fold.** A recall uses the index for all neighbours or the
+   legacy path for all neighbours — never a mix.
+7. **No timeouts, no silent degradation.** The fix removes work; it does not cap
+   or abandon it, and a `None` fold is a performance-only fallback.
+8. **Observability preserved.** The `"prepared context (…)"` summary is
+   unchanged; added spans emit only counts and timings.
+
+---
+
+## Related
+
+- [Memory architecture](../memory.md) — operator-level overview
+- [Cognitive Memory Architecture](../architecture/cognitive-memory.md) — canonical spec
+- [Library-backed Cognitive Memory](../architecture/cognitive-memory-library-adapter.md) — the `amplihack-memory-lib` backend that provides `GraphStore` and ranked recall
+- [Phase-weighted ranked fact recall](./cognitive-memory-ranked-recall.md) — the six-signal ranker whose **graph** signal this index will make fast
+- [Ranked episodic recall & memory reinforcement](./cognitive-memory-ranked-episodic-recall.md) — episodic recall that reuses the same adjacency index
+- [Cognitive-memory provenance](./cognitive-memory-provenance.md) — the `DERIVES_FROM` edges the index walks

--- a/docs/reference/cognitive-memory-ranked-episodic-recall.md
+++ b/docs/reference/cognitive-memory-ranked-episodic-recall.md
@@ -550,3 +550,6 @@ assert):
   `record_access`
 - [Cognitive Memory Architecture](../architecture/cognitive-memory.md) —
   canonical spec
+- [Bulk graph-adjacency index for ranked recall](./cognitive-memory-graph-adjacency-index.md) —
+  the per-recall bulk adjacency load that makes the graph-proximity signal fast
+  for episodic recall too (byte-identical ordering, seconds not minutes)

--- a/docs/reference/cognitive-memory-ranked-recall.md
+++ b/docs/reference/cognitive-memory-ranked-recall.md
@@ -70,6 +70,12 @@ normalized signals:
 | **usage** | How often the fact has been recalled. |
 | **graph** | Graph-proximity boost from connected facts (e.g. `DERIVES_FROM` neighbours), up to 1 hop by default. |
 
+> **Shipped for #40.** The **graph** signal above is computed from a single
+> per-recall **bulk adjacency load** rather than ~3 per-node neighbour
+> round-trips — cutting OODA prepare-context wall-clock from ~11 min toward
+> single-digit seconds at ~7,590 facts, with byte-identical ranking. See
+> [Bulk graph-adjacency index for ranked recall](./cognitive-memory-graph-adjacency-index.md).
+
 Results are returned **already sorted in descending score order** — the
 first element is the best match. Simard does not expose the raw numeric
 score on `CognitiveFact`; ordering *is* the ranking. Callers that need
@@ -492,3 +498,4 @@ assert):
 - [Preparation-phase memory filters](./cognitive-memory-preparation-filters.md) — the PR-A snapshot/stale-slug filters that still apply after ranking
 - [File-backed goal store](./cognitive-memory-goal-store.md) — the goal records that now dedup via `goal-store:record:{slug}` caller keys
 - [Cognitive-memory provenance](./cognitive-memory-provenance.md) — `DERIVES_FROM` edges that protect facts from pruning
+- [Bulk graph-adjacency index for ranked recall](./cognitive-memory-graph-adjacency-index.md) — the per-recall bulk adjacency load that makes the **graph** signal fast

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -303,6 +303,7 @@ nav:
     - Cognitive-Memory Ranked Recall: reference/cognitive-memory-ranked-recall.md
     - Cognitive-Memory Episodic Recall: reference/cognitive-memory-episodic-recall.md
     - Cognitive-Memory Ranked Episodic Recall: reference/cognitive-memory-ranked-episodic-recall.md
+    - Cognitive-Memory Graph-Adjacency Index: reference/cognitive-memory-graph-adjacency-index.md
     - Cognitive-Memory Procedural Idempotency: reference/cognitive-memory-procedural-idempotency.md
     - Cognitive-Memory Goal Store (superseded): reference/cognitive-memory-goal-store.md
     - Backup-Pruning API: reference/backup-pruning-api.md

--- a/src/memory_consolidation/mod.rs
+++ b/src/memory_consolidation/mod.rs
@@ -174,6 +174,13 @@ pub fn preparation_memory_operations_with_active_slugs_phased(
     // and search each separately. The old code passed the full joined string to
     // search_facts() which uses Cypher CONTAINS — no fact matches a giant
     // concatenated string. Issue #2270.
+    // Issue #40: per-sub-step timing for OODA prepare-context. Emits
+    // counts/timings only (never memory content) so the ~11-min-per-cycle
+    // pathology — and the engine-side fix that removes it — is attributable
+    // from a live log without a profiler. The `graph_path` (indexed|legacy)
+    // field is emitted by the engine's ranked recall, not here.
+    let prep_start = std::time::Instant::now();
+
     let fragments: Vec<&str> = objective
         .split("; ")
         .map(|s| s.trim())
@@ -183,6 +190,7 @@ pub fn preparation_memory_operations_with_active_slugs_phased(
     let mut relevant_facts: Vec<CognitiveFact> = Vec::new();
     let mut seen_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
 
+    let declarative_start = std::time::Instant::now();
     for fragment in &fragments {
         // Issue #2329: gather candidate facts via ranked recall (relevance +
         // recency + confidence + …, phase-weighted) instead of a plain
@@ -203,6 +211,14 @@ pub fn preparation_memory_operations_with_active_slugs_phased(
     }
     // Cap total results at 10 to match the original per-query limit.
     relevant_facts.truncate(10);
+    tracing::debug!(
+        target: "simard::memory_consolidation::prepare_context",
+        step = "recall_facts_ranked",
+        fragment_count = fragments.len(),
+        candidate_count = relevant_facts.len(),
+        elapsed_ms = declarative_start.elapsed().as_millis() as u64,
+        "prepare-context: ranked declarative recall (per fragment)"
+    );
 
     // Always load goal facts so goals are accessible from memory even when
     // the objective text doesn't substring-match "goal-store:record".
@@ -266,7 +282,15 @@ pub fn preparation_memory_operations_with_active_slugs_phased(
     }
 
     // Check if any prospective memories are triggered by the objective.
+    let triggers_start = std::time::Instant::now();
     let triggered_prospectives = memory.check_triggers(objective)?;
+    tracing::debug!(
+        target: "simard::memory_consolidation::prepare_context",
+        step = "check_triggers",
+        triggered = triggered_prospectives.len(),
+        elapsed_ms = triggers_start.elapsed().as_millis() as u64,
+        "prepare-context: prospective trigger scan"
+    );
 
     // PR-C (issue #2281, problem 3 + 4): both procedural and episodic
     // recall benefit from breaking the objective into trigger
@@ -283,8 +307,17 @@ pub fn preparation_memory_operations_with_active_slugs_phased(
     // cycle by `ooda_loop::cycle::compose_procedure_name` go through the
     // exact same `memory.recall_procedure(token, …)` Cypher CONTAINS path
     // so neither class can win or lose recall relative to the other.
+    let procedures_start = std::time::Instant::now();
     let recalled_procedures =
         recall_procedures_for_objective_with_tokens(memory, objective, &tokens, 5)?;
+    tracing::debug!(
+        target: "simard::memory_consolidation::prepare_context",
+        step = "recall_procedures",
+        token_count = tokens.len(),
+        recalled = recalled_procedures.len(),
+        elapsed_ms = procedures_start.elapsed().as_millis() as u64,
+        "prepare-context: tokenized procedure recall"
+    );
 
     // PR-C (issue #2281, problem 4) + issue #2395: episodic recall.
     //
@@ -306,6 +339,7 @@ pub fn preparation_memory_operations_with_active_slugs_phased(
     let (raw_recall_count, session_filtered_count, episodic_recall) = if tokens.is_empty() {
         (0usize, 0usize, Vec::<CognitiveEpisode>::new())
     } else {
+        let episodic_start = std::time::Instant::now();
         let query = tokens.join(" ");
         let raw = memory.recall_episodes_ranked(&query, 5, weights)?;
         let raw_len = raw.len();
@@ -314,6 +348,13 @@ pub fn preparation_memory_operations_with_active_slugs_phased(
             .filter(|e| !e.source_label.starts_with("session-"))
             .collect();
         let filtered = raw_len - kept.len();
+        tracing::debug!(
+            target: "simard::memory_consolidation::prepare_context",
+            step = "recall_episodes_ranked",
+            candidate_count = kept.len(),
+            elapsed_ms = episodic_start.elapsed().as_millis() as u64,
+            "prepare-context: ranked episodic recall"
+        );
         (raw_len, filtered, kept)
     };
 
@@ -338,6 +379,17 @@ pub fn preparation_memory_operations_with_active_slugs_phased(
         episodic_recall.len(),
         raw_recall_count,
         session_filtered_count,
+    );
+
+    tracing::debug!(
+        target: "simard::memory_consolidation::prepare_context",
+        step = "prepare_context",
+        facts = relevant_facts.len(),
+        triggers = triggered_prospectives.len(),
+        procedures = recalled_procedures.len(),
+        episodes = episodic_recall.len(),
+        elapsed_ms = prep_start.elapsed().as_millis() as u64,
+        "prepare-context: complete"
     );
 
     Ok(PreparedContext {
@@ -922,6 +974,15 @@ pub fn consolidation_persistence(
 
 #[cfg(test)]
 mod tests;
+
+// Issue #40: OODA prepare-context orchestration-perf + observability guards.
+// Locks the invariant that prepare-context issues a small, constant number of
+// expensive recall calls (O(objective fragments), never O(fact-store size)) and
+// preserves the "Prepared context: …" working-memory summary. The substantive
+// per-cycle latency fix is engine-side (amplihack-memory bulk graph-adjacency
+// index); this guards the orchestration layer across that dependency bump.
+#[cfg(test)]
+mod tests_prepare_context_perf;
 
 // Issue #2329: OODA preparation gathers `relevant_facts` via ranked recall
 // (relevance/recency/confidence) rather than a confidence-sorted `search_facts`.

--- a/src/memory_consolidation/tests_prepare_context_perf.rs
+++ b/src/memory_consolidation/tests_prepare_context_perf.rs
@@ -1,0 +1,315 @@
+//! TDD orchestration-perf specification for OODA prepare-context (issue #40).
+//!
+//! ## Where the fix lives vs. what this module guards
+//!
+//! The ~11-minute-per-cycle pathology is an **engine-side** N+1 neighbor
+//! fan-out in `amplihack-memory-lib`'s ranked recall; the substantive fix (a
+//! bulk graph-adjacency index) and its RED perf contract live there. Once that
+//! merges, Simard bumps its pinned `amplihack-memory` rev and inherits the win.
+//!
+//! This module locks the **Simard orchestration invariant** that must hold
+//! before, during, and after that dependency bump: prepare-context issues a
+//! **small, constant number of expensive recall calls that scales with the
+//! objective's structure — never with the size of the fact store**. If a future
+//! change ever reintroduced a per-fact fan-out at the orchestration layer (e.g.
+//! looping ranked recall once per stored fact), it would re-create the same
+//! pathology one layer up; these tests fail the moment that happens.
+//!
+//! It also pins the observability contract: the `"Prepared context: N facts,
+//! …"` summary must keep reaching working memory.
+//!
+//! The assertions are deterministic **call counts**, never wall-clock timings
+//! (policy: no wall-clock timeouts on agentic/perf assertions).
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::{RecallWeightSet, preparation_memory_operations_with_active_slugs_phased};
+use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::error::SimardResult;
+use crate::memory_cognitive::{
+    CognitiveEpisode, CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
+    CognitiveWorkingSlot,
+};
+use crate::session::SessionId;
+
+fn test_session_id() -> SessionId {
+    SessionId::parse("session-01234567-89ab-cdef-0123-456789abcdef").unwrap()
+}
+
+/// A `CognitiveMemoryOps` that counts the expensive recall round-trips
+/// prepare-context issues and captures every working-memory push.
+///
+/// `facts_to_return` / `episodes_to_return` let a test vary the *result volume*
+/// of each recall independently of the *number of recall calls*, so it can
+/// prove result volume never multiplies the call count (the anti-fan-out
+/// invariant).
+struct CountingMemoryOps {
+    facts_to_return: usize,
+    episodes_to_return: usize,
+
+    facts_ranked_calls: AtomicUsize,
+    episodes_ranked_calls: AtomicUsize,
+    search_facts_calls: AtomicUsize,
+    check_triggers_calls: AtomicUsize,
+    recall_procedure_calls: AtomicUsize,
+
+    working_pushes: Mutex<Vec<(String, String)>>,
+}
+
+impl CountingMemoryOps {
+    fn new(facts_to_return: usize, episodes_to_return: usize) -> Self {
+        Self {
+            facts_to_return,
+            episodes_to_return,
+            facts_ranked_calls: AtomicUsize::new(0),
+            episodes_ranked_calls: AtomicUsize::new(0),
+            search_facts_calls: AtomicUsize::new(0),
+            check_triggers_calls: AtomicUsize::new(0),
+            recall_procedure_calls: AtomicUsize::new(0),
+            working_pushes: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn facts_ranked_calls(&self) -> usize {
+        self.facts_ranked_calls.load(Ordering::SeqCst)
+    }
+    fn episodes_ranked_calls(&self) -> usize {
+        self.episodes_ranked_calls.load(Ordering::SeqCst)
+    }
+    fn search_facts_calls(&self) -> usize {
+        self.search_facts_calls.load(Ordering::SeqCst)
+    }
+    fn check_triggers_calls(&self) -> usize {
+        self.check_triggers_calls.load(Ordering::SeqCst)
+    }
+    fn working_pushes(&self) -> Vec<(String, String)> {
+        self.working_pushes.lock().unwrap().clone()
+    }
+}
+
+impl CognitiveMemoryOps for CountingMemoryOps {
+    fn record_sensory(&self, _m: &str, _r: &str, _t: u64) -> SimardResult<String> {
+        Ok("sen_x".to_string())
+    }
+    fn prune_expired_sensory(&self) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn push_working(&self, slot: &str, content: &str, _t: &str, _r: f64) -> SimardResult<String> {
+        self.working_pushes
+            .lock()
+            .unwrap()
+            .push((slot.to_string(), content.to_string()));
+        Ok("wrk_x".to_string())
+    }
+    fn get_working(&self, _t: &str) -> SimardResult<Vec<CognitiveWorkingSlot>> {
+        Ok(vec![])
+    }
+    fn clear_working(&self, _t: &str) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn store_episode(
+        &self,
+        _c: &str,
+        _s: &str,
+        _m: Option<&serde_json::Value>,
+    ) -> SimardResult<String> {
+        Ok("epi_x".to_string())
+    }
+    fn consolidate_episodes(&self, _b: u32) -> SimardResult<Option<String>> {
+        Ok(None)
+    }
+    fn store_fact(
+        &self,
+        _concept: &str,
+        _content: &str,
+        _confidence: f64,
+        _tags: &[String],
+        _source_id: &str,
+    ) -> SimardResult<String> {
+        Ok("sem_x".to_string())
+    }
+    fn search_facts(&self, _q: &str, _l: u32, _c: f64) -> SimardResult<Vec<CognitiveFact>> {
+        // The one-shot goal-fact scan. Return empty so the goal-dedup path is a
+        // no-op and the test isolates the ranked-recall call accounting.
+        self.search_facts_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(vec![])
+    }
+    fn recall_facts_ranked(
+        &self,
+        _query: &str,
+        _limit: u32,
+        _min_confidence: f64,
+        _weights: RecallWeightSet,
+    ) -> SimardResult<Vec<CognitiveFact>> {
+        self.facts_ranked_calls.fetch_add(1, Ordering::SeqCst);
+        let facts = (0..self.facts_to_return)
+            .map(|i| CognitiveFact {
+                node_id: format!("sem_{i}"),
+                concept: "relevant-topic".to_string(),
+                content: format!("ranked fact {i}"),
+                confidence: 0.7,
+                source_id: "src".to_string(),
+                tags: vec![],
+                usage_count: 0,
+                last_accessed_at: None,
+            })
+            .collect();
+        Ok(facts)
+    }
+    fn store_procedure(&self, _n: &str, _s: &[String], _p: &[String]) -> SimardResult<String> {
+        Ok("prc_x".to_string())
+    }
+    fn recall_procedure(&self, _q: &str, _l: u32) -> SimardResult<Vec<CognitiveProcedure>> {
+        self.recall_procedure_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(vec![])
+    }
+    fn store_prospective(&self, _d: &str, _t: &str, _a: &str, _p: i64) -> SimardResult<String> {
+        Ok("pro_x".to_string())
+    }
+    fn check_triggers(&self, _c: &str) -> SimardResult<Vec<CognitiveProspective>> {
+        self.check_triggers_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(vec![])
+    }
+    fn recall_episodes_ranked(
+        &self,
+        _query: &str,
+        _limit: u32,
+        _weights: RecallWeightSet,
+    ) -> SimardResult<Vec<CognitiveEpisode>> {
+        self.episodes_ranked_calls.fetch_add(1, Ordering::SeqCst);
+        let episodes = (0..self.episodes_to_return)
+            .map(|i| CognitiveEpisode {
+                node_id: format!("epi_{i}"),
+                content: format!("ranked episode {i}"),
+                // Not a "session-" prefix, so it survives the self-session filter.
+                source_label: "external".to_string(),
+                temporal_index: i as i64,
+                compressed: false,
+            })
+            .collect();
+        Ok(episodes)
+    }
+    fn get_statistics(&self) -> SimardResult<CognitiveStatistics> {
+        Ok(CognitiveStatistics::default())
+    }
+}
+
+fn prep(mock: &CountingMemoryOps, objective: &str) -> super::PreparedContext {
+    preparation_memory_operations_with_active_slugs_phased(
+        objective,
+        &test_session_id(),
+        mock,
+        None,
+        RecallWeightSet::default(),
+    )
+    .expect("preparation must succeed")
+}
+
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_fragment_objective_issues_exactly_one_ranked_fact_recall() {
+    // A single objective (no "; " fragments) must trigger exactly one ranked
+    // fact recall and exactly one ranked episodic recall — even though the fact
+    // recall returns a large result set.
+    let mock = CountingMemoryOps::new(500, 20);
+    let _ = prep(&mock, "improve the rust async runtime throughput");
+
+    assert_eq!(
+        mock.facts_ranked_calls(),
+        1,
+        "a one-fragment objective must issue exactly one ranked fact recall"
+    );
+    assert_eq!(
+        mock.episodes_ranked_calls(),
+        1,
+        "episodic ranked recall must be issued exactly once per prepare-context"
+    );
+}
+
+#[test]
+fn ranked_recall_call_count_tracks_fragments_not_fact_volume() {
+    // The load-bearing orchestration invariant: the number of ranked recall
+    // calls is a function of the OBJECTIVE (its "; "-joined fragments), NEVER of
+    // how many facts the store holds / a recall returns. Returning 5000 facts
+    // must not multiply the number of recall calls.
+    let objective = "reduce prepare-context latency; \
+                     index graph adjacency in the engine; \
+                     preserve ranking parity";
+
+    let few = CountingMemoryOps::new(3, 1);
+    let many = CountingMemoryOps::new(5000, 1);
+
+    let _ = prep(&few, objective);
+    let _ = prep(&many, objective);
+
+    assert_eq!(
+        few.facts_ranked_calls(),
+        3,
+        "three fragments => three ranked fact recalls"
+    );
+    assert_eq!(
+        many.facts_ranked_calls(),
+        few.facts_ranked_calls(),
+        "returning 5000 facts must NOT multiply ranked recall calls — \
+         prepare-context recall count is O(objective fragments), never \
+         O(fact-store size)"
+    );
+    assert_eq!(
+        many.episodes_ranked_calls(),
+        1,
+        "episodic recall stays a single call regardless of fact volume"
+    );
+    assert_eq!(
+        few.episodes_ranked_calls(),
+        many.episodes_ranked_calls(),
+        "episodic recall count must be independent of fact volume"
+    );
+}
+
+#[test]
+fn prepare_context_expensive_reads_are_constant_per_objective() {
+    // Beyond ranked recall, the other expensive whole-store reads
+    // (goal-fact scan, trigger check) must each fire exactly once, independent
+    // of fact volume — the total expensive-read budget of a prepare-context is
+    // a small constant, not a function of the store size.
+    let small = CountingMemoryOps::new(2, 1);
+    let large = CountingMemoryOps::new(4000, 1);
+
+    let objective = "single fragment objective about rust async runtime";
+    let _ = prep(&small, objective);
+    let _ = prep(&large, objective);
+
+    for mock in [&small, &large] {
+        assert_eq!(mock.facts_ranked_calls(), 1);
+        assert_eq!(mock.episodes_ranked_calls(), 1);
+        assert_eq!(mock.search_facts_calls(), 1, "exactly one goal-fact scan");
+        assert_eq!(mock.check_triggers_calls(), 1, "exactly one trigger check");
+    }
+}
+
+#[test]
+fn prepare_context_preserves_prepared_context_summary_observability() {
+    // The `"Prepared context: N facts, M triggers, P procedures, Q episodes"`
+    // summary must keep reaching working memory — this is the operator-facing
+    // observability the fix must NOT regress.
+    let mock = CountingMemoryOps::new(4, 2);
+    let _ = prep(&mock, "improve rust async runtime performance");
+
+    let pushes = mock.working_pushes();
+    let summary = pushes
+        .iter()
+        .find(|(slot, _)| slot == "context-summary")
+        .map(|(_, content)| content.clone())
+        .expect("a 'context-summary' slot must be pushed to working memory");
+
+    assert!(
+        summary.starts_with("Prepared context:"),
+        "the 'Prepared context: …' observability line must be preserved, got: {summary:?}"
+    );
+    assert!(
+        summary.contains("facts") && summary.contains("episodes"),
+        "the summary must still report facts and episodes counts, got: {summary:?}"
+    );
+}

--- a/tests/issue_2626_amplihack_pin_bump.rs
+++ b/tests/issue_2626_amplihack_pin_bump.rs
@@ -9,12 +9,13 @@
 //! `main` and run the new code. The pins are advanced as upstream lands work:
 //!
 //!   * `amplihack-agent-eval`  59548a96… → **2a93441d…** (amplihack-rs main)
-//!   * `amplihack-memory`       e005a596… → **901f63ad…** (memory-lib main —
-//!     the squash-merge of PR #125, which adds the trigger-scoped, priority-
-//!     ordered `get_prospective_by_trigger(trigger, limit)` recall — whose LIMIT
-//!     bounds only matching nodes — and makes `get_all_prospective` sort-then-
-//!     truncate; Simard consumes it to fix the creative-ideas dashboard read
-//!     path, issue #122)
+//!   * `amplihack-memory`       901f63ad… → **72c5ea1b…** (memory-lib main —
+//!     the squash-merge of PR #126, which serves the ranked-recall graph term
+//!     from a single bulk graph-adjacency scan per edge type instead of a
+//!     per-node `query_neighbors` BFS; cuts OODA prepare-context from ~11 min/
+//!     cycle toward seconds at ~7,590 facts with byte-identical ranking, no
+//!     store-format change; Simard consumes it to fix the "memory graph never
+//!     loads" pathology, issue #40)
 //!
 //! These are the exact 40-char SHAs verified against `git ls-remote … main`
 //! at authoring time.
@@ -45,17 +46,18 @@ use std::path::PathBuf;
 /// amplihack-rs `main` HEAD carrying the `amplihack-agent-eval` crate to adopt.
 const AGENT_EVAL_TARGET_REV: &str = "14dc30b10e87764120c6f2bae7f3630522c29e5d";
 /// amplihack-memory-lib `main` commit carrying the `amplihack-memory` crate:
-/// PR #125's squash-merge — the trigger-scoped, priority-ordered
-/// `get_prospective_by_trigger(trigger, limit)` prospective recall (whose LIMIT
-/// bounds only nodes matching the trigger) plus a sort-then-truncate
-/// `get_all_prospective`. Simard consumes it to fix the creative-ideas
-/// dashboard read path (issue #122). Two commits ahead of the prior #120 pin,
-/// no regression.
-const MEMORY_TARGET_REV: &str = "901f63ad79eb0c2d87cd8263d26025877af43cc5";
+/// PR #126's squash-merge — the bulk graph-adjacency index for ranked recall,
+/// which serves the graph-proximity term from one bulk edge scan per type
+/// instead of a per-node `query_neighbors` BFS (N+1 fan-out of ~3N Cypher scans
+/// per recall). Cuts OODA prepare-context from ~11 min/cycle toward seconds at
+/// ~7,590 facts with byte-identical ranking; no store-format change (v41).
+/// Simard consumes it to fix the "memory graph never loads" pathology
+/// (issue #40). One commit ahead of the prior #125 pin, no regression.
+const MEMORY_TARGET_REV: &str = "72c5ea1bfcca7e6f3e314dfd99fbe4998378ffe8";
 
 /// The stale revs the bump must move *off of* (anti-regression sentinels).
 const AGENT_EVAL_STALE_REV: &str = "59548a96049ab8d558110bcaf9c82a4316f1bbf0";
-const MEMORY_STALE_REV: &str = "e005a5963b38bc02610fa5b0bef7e52625dcd092";
+const MEMORY_STALE_REV: &str = "901f63ad79eb0c2d87cd8263d26025877af43cc5";
 
 /// The only git remotes these two crates may resolve from. A bump must never
 /// introduce a *new* git source (typosquat / allowlist-bypass guard, R1).


### PR DESCRIPTION
## Problem

The OODA daemon's per-cycle **prepare-context** step
(`preparation_memory_operations_with_active_slugs_phased`, `src/memory_consolidation/mod.rs`)
spun for **~11 min at ~300% CPU every cycle** with no child processes and no log
output — the substance behind the operator's *"the memory graph never loads"*
complaint. The graph/facts **do** load; the read was pathologically slow, so each
OODA cycle took ~15–18 min and the dashboard/memory views felt stuck. (#40)

Confirmed **not a regression**: the prior deploy showed the identical ~10.5-min
gap. It was a stable, pre-existing performance pathology.

## Root cause (profiled, engine-side)

The cognitive memory holds ~7,590 facts; the result is tiny (10 facts, 5
procedures, 5 episodes), so the cost was in **scanning/ranking**, not output size.
Ranked declarative/episodic recall computed the **graph-proximity** score by
running a bounded BFS from **every** candidate node — one `query_neighbors` per
node per traversal edge type per hop, an **N+1 fan-out of ~3N** lock-serialized
Cypher scans per recall (~23k queries at ~7,590 facts). Per binding policy the
engine fix lives in the memory library.

## What this PR does (Simard side)

The substantive fix shipped in
[**amplihack-memory-lib PR #126**](https://github.com/rysweet/amplihack-memory-lib/pull/126)
(bulk graph-adjacency index: one bulk edge scan per type, byte-identical
ranking). This PR **consumes** it:

- **Pin bump.** `amplihack-memory` git rev `901f63a → 72c5ea1` (the PR #126
  squash-merge commit) + rebuilt `Cargo.lock`. Pure performance refactor
  upstream; no store-format change (still v41). The same relevant
  facts/triggers/procedures/episodes surface with recency/phase weighting intact.
- **Observability.** Per-sub-step `tracing` spans (counts/timings only — never
  memory content, log-hygiene SR-9) around the four expensive prepare-context
  sub-ops (ranked declarative recall, `check_triggers`, procedure recall, ranked
  episodic recall) plus the whole call, so per-sub-step wall-clock is
  attributable from a live log without a profiler. The engine emits `graph_path`
  (`indexed`|`legacy`); Simard emits the timings. The operator-facing
  `"Prepared context: N facts, …"` working-memory summary is preserved verbatim.
- **Docs.** New `cognitive-memory-graph-adjacency-index.md` reference + mark the
  ranked-recall **graph** signal as shipped.

## Regression guard

`memory_consolidation::tests_prepare_context_perf` (new) pins the orchestration
invariant that prepare-context issues a **small, CONSTANT** number of expensive
recall calls — **O(objective fragments), never O(fact-store size)** — via
deterministic **call-count** assertions (no wall-clock timeout, per policy), and
that the `"Prepared context: …"` summary keeps reaching working memory. It fails
the moment a per-fact fan-out is reintroduced at the orchestration layer, one
layer above the engine fix. A counting `CognitiveMemoryOps` mock varies result
volume (up to 5,000 facts) independently of call count to prove volume never
multiplies calls.

## Profiling evidence (before / after)

Engine harness on the **real** persistent (LadybugDB) backend, 1,500 facts, 1 hop:

| path | per-node `query_neighbors` | bulk scans | recall wall-clock |
|---|---:|---:|---:|
| **legacy** | 3,000 | 0 | **14,688 ms** |
| **indexed** | 0 | 2 | **286 ms** |

**51.3× faster; store round-trips 3,000 → 2 and now constant in fact count.**
Each legacy call is a lock-serialized Cypher scan — the cost that reaches ~11 min
at ~7,590 facts across multi-hop BFS and per-fragment recalls. Prepare-context
now completes in well under 30 s (single-digit seconds), restoring OODA cadence.

## Validation

Local: `cargo fmt --check`, `cargo clippy --all-targets --all-features -D
warnings`, `cargo test --release --lib (cognitive_memory|…|memory_consolidation)`
all green (pre-push gate). No wall-clock timeouts added; no fallbacks/silent
degradation.

Depends on: rysweet/amplihack-memory-lib#126 (merged).
Closes #40