### PR TITLE
feat(ooda): re-investigate already-blocked OODA goals so none sit bare (#17)

### DIFF
--- a/docs/concepts/no-progress-root-cause-resolution.md
+++ b/docs/concepts/no-progress-root-cause-resolution.md
@@ -33,6 +33,12 @@ related:
 > `SIMARD_NO_PROGRESS_INVESTIGATE=off` to fall back to the base verify-once
 > ladder. For the exact types and functions see the
 > [root-cause resolution API reference](../reference/no-progress-root-cause-resolution-api.md).
+>
+> **Extended (issue #17):** the same investigation now also runs each cycle over
+> goals **already** parked in a bare block — not only at the transition cycle — so
+> a goal parked bare by a pre-#16 build (or left bare by a reasoner error) is
+> re-investigated and upgraded away from bare instead of stranding forever. See
+> [Re-investigating already-blocked goals](#re-investigating-already-blocked-goals-issue-17).
 
 ## The defect this fixes
 
@@ -142,6 +148,50 @@ a goal has already burned its one guided retry and stalled again. Even then the
 **appends** the classified WHY token plus the evidence links. A human sees the
 concrete cause and the artifacts, never a bare "needs human review". See the
 [block-reason contract](../reference/no-progress-root-cause-resolution-api.md#block-reason-contract).
+
+## Re-investigating already-blocked goals (issue #17)
+
+The ladder above investigates a stall **only at the cycle the goal crosses the
+threshold** — the block *transition*. That leaves a gap: a goal parked in the
+**bare** sentinel by a daemon build that predates the root-cause investigation
+(issue #16), or one left bare because the reasoner erred on the transition cycle,
+sits `Blocked` with the unexplained "needs human review" reason forever and is
+never re-examined. The live deploy-#41 incident surfaced exactly this — several
+`kgpacks-rs` goals stranded with the bare marker while newer goals got a proper
+WHY.
+
+`reinvestigate_bare_blocked_goals` (in `src/ooda_loop/no_progress.rs`) closes the
+gap. Each cycle, **after** the on-transition breaker and independent of this
+cycle's action outcomes (mirroring the auto-clear scan), it:
+
+1. selects the **bare-blocked, non-perpetual** population via the thin
+   deterministic rail
+   [`is_bare_no_progress_block`](../reference/no-progress-breaker-api.md) — a
+   reason that carries the `🔒 [OODA-SAFEGUARD]` marker but **no**
+   `NoProgressClass` WHY token;
+2. runs the **same** injected reasoner and the **same**
+   [`resolution_for_why`](../reference/no-progress-root-cause-resolution-api.md#extended-noprogressresolution)
+   ladder over each — through the shared `apply_resolution_side_effects` driver,
+   so the transition and re-investigation populations can never diverge;
+3. **un-blocks** a goal handed to a fixer or healed back to `NotStarted` (an
+   already-`Blocked` goal the brain would never re-select would otherwise strand
+   its own fix), and rewrites every other outcome to its terminal non-bare status
+   (`Completed` / dropped / `Paused` / `Blocked`-WITH-why).
+
+The result: **no goal ever remains a bare "needs human review"** — each is
+re-classified to a concrete WHY and, when the WHY is actionable, completed,
+deferred behind its named upstream, healed, or handed to a spawned fixer.
+
+**Idempotency is two-layered.** The WHY-rewrite is the *primary* guarantee: once
+a goal's reason carries a class token it is no longer bare, so the rail excludes
+it next cycle. A persisted `(goal, class)` dedupe set on the tracker
+(`NoProgressTracker::reinvestigated`, serialized as the stable class **token**
+string alongside the no-action counter) is the *belt-and-suspenders* guard: if a
+crash/restart re-parks a goal bare after a fixer was already spawned, the dedupe
+set short-circuits the terminal action so **at most one fixer is spawned per
+`(goal, class)`** across restarts. Re-investigation is **fail-closed**: a reasoner
+error leaves the bare marker exactly as-is, records nothing in the dedupe set,
+and retries next cycle.
 
 ## Classification is deterministic-first, agentic-enriched
 

--- a/docs/concepts/ooda-reinvestigate-blocked-goals.md
+++ b/docs/concepts/ooda-reinvestigate-blocked-goals.md
@@ -1,0 +1,208 @@
+---
+title: Re-investigating already-blocked OODA goals
+description: Why the OODA no-progress safeguard re-investigates goals that are ALREADY sitting in a bare "[OODA-SAFEGUARD] … needs human review" state — not just goals crossing the block threshold — so no goal is ever stranded with an unexplained block, and how the population-driven re-investigation pass attaches a concrete WHY (already-complete / obsolete / missing-precondition / upstream-dependency / unclear-criteria / genuinely-stuck) and, when actionable, completes, drops, heals, defers, or spawns a fixer (#17).
+last_updated: 2026-07-08
+review_schedule: as-needed
+owner: simard
+doc_type: concept
+status: implemented
+related:
+  - ./perpetual-goal-no-progress-exemption.md
+  - ./ooda-loop-self-detection.md
+  - ../reference/no-progress-breaker-api.md
+  - ../reference/no-progress-reinvestigation-api.md
+  - ../howto/reinvestigate-bare-blocked-goals.md
+  - ../howto/unblock-stuck-ooda-goals.md
+  - ../howto/spawn-engineers-from-ooda-daemon.md
+---
+
+# Re-investigating already-blocked OODA goals
+
+> **Status: implemented.** The OODA no-progress safeguard investigates the WHY of
+> a block for **two** populations: goals crossing the no-progress threshold on this
+> cycle (the on-transition path, PR #2960) **and** goals that are *already* parked
+> in a bare `[OODA-SAFEGUARD] … needs human review` state (the re-investigation
+> pass, issue #17). The deterministic rail
+> [`is_bare_no_progress_block`](../reference/no-progress-reinvestigation-api.md#the-thin-deterministic-rail)
+> and the re-investigation pass `reinvestigate_bare_blocked_goals` live in
+> [`src/goal_curation/no_progress_breaker.rs`](https://github.com/rysweet/Simard/blob/main/src/goal_curation/no_progress_breaker.rs)
+> and
+> [`src/ooda_loop/no_progress.rs`](https://github.com/rysweet/Simard/blob/main/src/ooda_loop/no_progress.rs);
+> the WHY vocabulary (`NoProgressClass`) is reused unchanged from
+> [`src/goal_curation/no_progress_why.rs`](https://github.com/rysweet/Simard/blob/main/src/goal_curation/no_progress_why.rs).
+> The exact types and functions are in the
+> [no-progress re-investigation API reference](../reference/no-progress-reinvestigation-api.md).
+
+## The gap this closes (#17)
+
+The OODA daemon carries a deterministic **no-progress safeguard**: when a single
+goal produces `NO_PROGRESS_BREAKER_THRESHOLD` (3) consecutive *no-action* cycles
+and the done-gate cannot certify it complete or obsolete, the breaker hard-blocks
+it — setting `GoalProgress::Blocked` with a sentinel reason.
+
+PR #2960 improved that block from a bare "needs human review" note into a
+**WHY-investigated** block: at the moment a goal *crosses* the threshold, an
+agentic reasoner classifies *why* it is stuck and the safeguard resolves it along
+a ladder (complete it, drop it, heal a precondition, defer behind an upstream
+dependency, or spawn a guided fixer). That is the **on-transition** path.
+
+But the on-transition path only fires **on the transition**. It is driven by
+*this cycle's* action outcomes: a goal is investigated exactly once, at the cycle
+where its consecutive-no-action counter reaches the threshold. That leaves a real
+gap:
+
+- A goal that was blocked by an **older** daemon build — before the
+  WHY-investigation reasoner shipped — still carries the *bare* marker. It never
+  re-crosses the threshold, so it is never investigated.
+- A goal blocked on a cycle where the reasoner **erred** (fail-closed keeps the
+  bare marker) is never re-examined.
+- More fundamentally, once a goal is `Blocked`, the brain stops selecting it →
+  it emits no fresh no-action outcome → its counter is already reset → it can
+  **never re-cross the threshold**. Nothing scans the already-blocked population.
+
+The symptom, observed live (deploy #41): several goals stuck at the *old* bare
+message
+
+```
+🔒 [OODA-SAFEGUARD] OODA goal made no shippable progress for 3 consecutive no-action cycles; needs human review
+```
+
+with no explanation and no path forward —
+`advance-rysweet-agent-kgpacks-rs-to-full-parity`, `fix-agent-kgpacks-rs-issue-18`
+(WS3), `-issue-21` (WS6), `-issue-22` (WS7), and `-issue-23` (WS8) — while a peer,
+`fix-agent-kgpacks-rs-issue-17`, *did* get a proper WHY (an
+`UPSTREAM-DEPENDENCY` block naming the open eval-baseline issue `#16`). That rich,
+actionable format is what **every** blocked goal must have.
+
+The operator directive is binding:
+
+> whatever recipe is marking things as blocked needs to be updated to always
+> investigate and clearly state the *why* and if possible spawn an engineer to go
+> fix the why.
+
+**No goal should ever sit with a bare "needs human review."**
+
+## The fix: a population-driven re-investigation pass
+
+The on-transition path is *outcome-driven* — it looks at what happened this cycle.
+Issue #17 adds a complementary *population-driven* pass that looks at the **board
+state** itself, exactly like the sibling auto-clear scan:
+
+1. Each cycle, after the on-transition breaker runs, scan the active board for
+   every goal whose status is a **bare** no-progress block — carrying the
+   `[OODA-SAFEGUARD]` sentinel marker but *no* WHY classification — that is not a
+   [standing/perpetual goal](./perpetual-goal-no-progress-exemption.md).
+2. Run each such goal through the **same** injected reasoner the on-transition
+   path uses. There is no second reasoner and no new prompt.
+3. **Rewrite** the block reason to embed the concrete WHY (class token + cited
+   evidence), so the goal is no longer bare.
+4. **Resolve** it along the same ladder: complete it, drop it, heal a precondition,
+   defer it behind the named upstream dependency, or spawn exactly one guided
+   fixer — using the same shared resolution logic (`apply_resolution`) as the
+   on-transition path, so the two can never diverge.
+
+The result: a goal that was stranded with a bare marker is, on the next cycle,
+either re-blocked **with a concrete WHY** (upstream dependency named), **completed**
+(if the work was actually already done), **dropped** (if obsolete), **un-blocked
+and healed/retried** (if a precondition was missing), or handed to **exactly one
+fixer engineer**. None are left as a bare "needs human review."
+
+### Agentic classification behind a thin deterministic rail
+
+The classification is **agentic** — the reasoner decides *why* a goal is stuck by
+looking at evidence (open/closed issues, merged/absent PRs, named dependencies).
+The safeguard itself does **no** brittle parsing of that narrative. The only
+deterministic string check in the whole feature is the rail that decides whether a
+block is *bare*:
+
+```
+bare(reason)  ≡  is_no_progress_marker(reason)
+              ∧  reason contains NO CLASS_* token
+```
+
+Everything downstream consumes the reasoner's **structured** result
+(`NoProgressClass` + narrative), never a re-parse of the rendered text. This keeps
+the intelligence in the reasoner and the safeguard as a thin, testable rail — the
+[agentic-behind-a-thin-rail](./ooda-loop-self-detection.md) posture the daemon uses
+everywhere.
+
+## Why the two paths share one resolution ladder
+
+Both the on-transition path and the re-investigation pass funnel every
+classification through a single `apply_resolution` helper and a single
+`resolution_for_why` mapping. This is deliberate: the ladder (which WHY maps to
+complete / drop / heal / defer / spawn / escalate) is defined **once**, so the two
+populations cannot drift apart. The only per-site difference is whether a healed or
+fixer-assigned goal is left `Blocked` or un-blocked to `NotStarted` — see the
+[resolution ladder](../reference/no-progress-reinvestigation-api.md#resolution-ladder)
+in the API reference.
+
+| WHY classification | Resolution | Post-state |
+| --- | --- | --- |
+| `ALREADY-COMPLETE` | mark done | ✅ Completed |
+| `OBSOLETE` | drop from board | ✅ removed |
+| `MISSING-PRECONDITION` | heal precondition, retry | ✅ NotStarted (un-blocked) |
+| `UPSTREAM-DEPENDENCY` | defer behind the named upstream | ✅ Paused (auto-clears) |
+| `UNCLEAR-CRITERIA` / `GENUINELY-STUCK` (guided retry unused) | spawn **one** guided fixer | ✅ NotStarted (un-blocked) |
+| `UNCLEAR-CRITERIA` / `GENUINELY-STUCK` (guided retry spent) | block **with WHY** + file issue | ✅ Blocked-with-why |
+
+Every arm produces a **non-bare** post-state. That is the safeguard's core
+invariant: after a cycle in which the reasoner did not error for a goal, that goal
+is never bare again.
+
+## Idempotency: exactly one fixer, ever
+
+Re-investigation runs every cycle, so it must be **idempotent** — running it twice
+with no intervening change must not spawn a second fixer or take a second terminal
+action. Two guards enforce this:
+
+1. **Primary — the rewrite removes the goal from the population.** The moment a
+   goal's reason is rewritten to embed a `CLASS_*` token, `is_bare_no_progress_block`
+   returns `false` for it, so the *next* cycle's scan skips it. The bare predicate
+   is self-excluding.
+2. **Belt-and-suspenders — a persisted dedupe set.** `NoProgressTracker` carries a
+   persisted `reinvestigated: HashSet<(goal_id, class_token)>`. A terminal action
+   (spawn / mark-done / drop / defer) is skipped if `(goal, class)` is already in
+   the set; the pair is inserted **only on success**. This survives a daemon
+   restart between the board rewrite and the tracker persist, and it is the
+   security rate-limit that prevents runaway N-spawns per cycle.
+
+The dedupe key is a **string token**, not the `NoProgressClass` enum — a deliberate
+availability choice. The goal board read is *fail-to-empty*: a single unparseable
+value discards the whole board. A string token can never fail to deserialize on an
+older or rolled-back binary; an on-disk enum could. See the
+[persisted-data contract](../reference/no-progress-reinvestigation-api.md#persisted-data-contract).
+
+## Fail-closed, loudly
+
+If the reasoner errors for a goal, the pass **keeps the bare marker**, takes **no**
+terminal action, records an investigation error, logs at `error`, and retries the
+goal next cycle. It never guesses a classification, never silently completes or
+drops a goal, and never inserts into the dedupe set on an error. There are **no
+wall-clock timeouts** on the agentic step — liveness is governed by idle detection,
+never a stopwatch. A transient reasoner failure simply means the goal is
+re-examined next cycle, still visible as a bare block until a real classification
+lands.
+
+## What this is *not*
+
+- It does **not** touch [standing/perpetual goals](./perpetual-goal-no-progress-exemption.md).
+  A perpetual goal is exempt from the safeguard entirely and self-heals its stale
+  markers; the re-investigation scan skips it, mirroring the on-transition exemption.
+- It does **not** change the threshold, the sentinel marker contract, or the
+  on-transition behavior. Every rewritten reason keeps the
+  `NO_PROGRESS_BLOCKED_PREFIX` and a parseable leading count, so the overseer
+  root-cause sensor and the load-time self-heal keep recognizing the marker. The
+  existing on-transition tests pass byte-for-byte.
+- It adds **no** new capability, no new subprocess, and no memory-engine change. It
+  re-triggers existing trusted seams over a wider population behind the same
+  dispatcher.
+
+## See also
+
+- [No-progress re-investigation API reference](../reference/no-progress-reinvestigation-api.md) — the exact types, functions, resolution ladder, and serde contract.
+- [No-progress breaker API reference](../reference/no-progress-breaker-api.md) — the base breaker, sentinel marker, and load-time self-heal.
+- [Re-investigate bare-blocked OODA goals](../howto/reinvestigate-bare-blocked-goals.md) — operator runbook to observe and verify re-investigation.
+- [Standing/perpetual goals are exempt from the no-progress hard-block](./perpetual-goal-no-progress-exemption.md).
+- [OODA loop self-detection, reflectiveness, and proactivity](./ooda-loop-self-detection.md).
+- [Spawn engineers from the OODA daemon](../howto/spawn-engineers-from-ooda-daemon.md).

--- a/docs/howto/reinvestigate-bare-blocked-goals.md
+++ b/docs/howto/reinvestigate-bare-blocked-goals.md
@@ -1,0 +1,177 @@
+---
+title: Re-investigate bare-blocked OODA goals
+description: Operator runbook for the OODA no-progress re-investigation pass (#17) — how to spot goals stranded with a bare "[OODA-SAFEGUARD] … needs human review" block, how the daemon automatically re-investigates and re-classifies them each cycle (completing, dropping, healing, deferring, or spawning a fixer), how to verify the re-classification, and how to confirm idempotency (no duplicate fixers).
+last_updated: 2026-07-08
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../concepts/ooda-reinvestigate-blocked-goals.md
+  - ../reference/no-progress-reinvestigation-api.md
+  - ../reference/no-progress-breaker-api.md
+  - ../reference/simard-cli.md
+  - ./unblock-stuck-ooda-goals.md
+  - ./spawn-engineers-from-ooda-daemon.md
+  - ./run-ooda-daemon.md
+---
+
+# Re-investigate bare-blocked OODA goals
+
+## Symptom
+
+`simard goal list` shows one or more goals parked with the **bare** no-progress
+safeguard marker — the `[OODA-SAFEGUARD]` sentinel with *no* explanation of why:
+
+```
+🔒 [OODA-SAFEGUARD] OODA goal made no shippable progress for 3 consecutive no-action cycles; needs human review
+```
+
+There is no named upstream dependency, no fixer, and no path forward — just "needs
+human review." This is the exact state the live incident on deploy #41 left five
+kgpacks-rs goals in (`advance-rysweet-agent-kgpacks-rs-to-full-parity`,
+`fix-agent-kgpacks-rs-issue-18`, `-issue-21`, `-issue-22`, `-issue-23`).
+
+## Automatic recovery (no operator action needed)
+
+As of **issue #17** you do **not** need to unblock these by hand. Every OODA cycle,
+after the on-transition breaker runs, the daemon runs a **re-investigation pass**
+(`reinvestigate_bare_blocked_goals`) that:
+
+1. scans the active board for goals in a **bare** no-progress block
+   (`is_bare_no_progress_block`) that are not [standing/perpetual](../concepts/perpetual-goal-no-progress-exemption.md);
+2. runs each through the same agentic WHY reasoner the on-transition path uses;
+3. **rewrites** the block to embed a concrete WHY (class + cited evidence) so it is
+   no longer bare; and
+4. **resolves** it along the shared ladder — complete, drop, heal, defer behind the
+   named upstream, or spawn exactly one guided fixer.
+
+So a goal that appears today as a bare `[OODA-SAFEGUARD] … needs human review` will,
+within the next cycle or two, become one of:
+
+| Outcome | What you'll see in `simard goal list` |
+| --- | --- |
+| **WHY-stated block** | `blocked: 🔒 [OODA-SAFEGUARD] … why=UPSTREAM-DEPENDENCY evidence=[… #16 …]` |
+| **Completed** | the goal leaves the active board as done (work was already merged) |
+| **Dropped** | the goal is removed (obsolete) |
+| **Un-blocked + fixer** | `not-started`, with a new `engineer-*.log` under `~/.simard/agent_logs/` |
+| **Deferred** | `paused`, with a `[no-progress-defer]` ref naming the upstream it waits on |
+
+No goal is left as a bare "needs human review." Operator intervention is only
+needed when the daemon is **offline** (so the pass never runs) or when you want an
+immediate manual override — see [Unblock stuck OODA goals](./unblock-stuck-ooda-goals.md).
+
+## Verify the re-classification
+
+### 1. List the board and find bare blocks
+
+```bash
+simard goal list
+```
+
+A goal still bare will show `[OODA-SAFEGUARD] …` ending in `needs human review`
+with **no** `why=` segment. A re-classified goal carries a `why=<CLASS>` segment
+(the class token is upper-case and bracketless, e.g. `why=UPSTREAM-DEPENDENCY`):
+
+```text
+# before (bare — pre-#17 / offline)
+advance-rysweet-agent-kgpacks-rs-to-full-parity   p3   blocked: 🔒 [OODA-SAFEGUARD] OODA goal made no shippable progress for 3 consecutive no-action cycles; needs human review
+
+# after re-investigation (WHY-stated)
+fix-agent-kgpacks-rs-issue-18                      p4   blocked: 🔒 [OODA-SAFEGUARD] … 3 consecutive no-action cycles; why=UPSTREAM-DEPENDENCY evidence=[eval baseline #16 OPEN, no landed PR — unmeasurable until #16 lands]
+```
+
+### 2. Watch a cycle re-investigate
+
+The cycle report and logs record what the pass did. The compact cycle-log line now
+carries a `reinvestigated={n}` field:
+
+```bash
+# Tail the daemon and look for the re-investigation summary + per-goal traces.
+journalctl --user -u simard-ooda.service -f | grep -E "reinvestigat|OODA-SAFEGUARD|why="
+
+# Or inspect the latest cycle report.
+cat "$(ls -t ~/.simard/cycle_reports/*.json | head -1)" | jq '.no_progress'
+```
+
+You should see, per re-investigated goal, either a status rewrite (now carrying a
+`why=<CLASS>` segment), a completion/drop, a `paused` defer, or a spawned engineer.
+
+### 3. Confirm a spawned fixer
+
+When the WHY is actionable and the goal has not spent its one guided retry, the pass
+spawns exactly one fixer through the normal
+[engineer-dispatch path](./spawn-engineers-from-ooda-daemon.md):
+
+```bash
+ls -t ~/.simard/agent_logs/ | head -5           # new engineer-*.log
+ls ~/.simard/engineer-worktrees/                # its isolated worktree
+```
+
+## Confirm idempotency (no duplicate fixers)
+
+Re-investigation runs every cycle, but it is **idempotent** — a goal is taken to a
+terminal action (spawn / complete / drop / defer) **at most once per WHY class**.
+Two guards enforce this (see the
+[API reference](../reference/no-progress-reinvestigation-api.md#persisted-data-contract)):
+
+1. the rewrite makes the block non-bare, so the next scan skips it; and
+2. a persisted dedupe set `reinvestigated: {(goal_id, class_token)}` in the tracker
+   short-circuits any terminal action already taken — even across a daemon restart.
+
+To confirm no second fixer was spawned for the same goal:
+
+```bash
+# Count engineer logs referencing a given goal id — expect at most one active fixer
+# per (goal, WHY class).
+grep -l "advance-rysweet-agent-kgpacks-rs-to-full-parity" ~/.simard/agent_logs/engineer-*.log | wc -l
+
+# Inspect the persisted dedupe set (the goal board is the source of truth).
+jq '.no_progress.reinvestigated' ~/.simard/state/goal_board.json
+```
+
+A restart between the board rewrite and the tracker persist does **not** double-spawn:
+the `(goal, class)` pair is only inserted on success and is honored on reload.
+
+## Fail-closed behavior (what a reasoner error looks like)
+
+If the WHY reasoner errors for a goal, the pass **keeps the bare marker**, takes no
+action, and retries next cycle. You will see:
+
+- the goal *still* bare in `simard goal list` (no `why=` segment yet), and
+- an `investigation_errors` entry in the cycle report / an `error`-level trace.
+
+There are **no wall-clock timeouts** on the reasoner — a slow-but-live investigation
+is not killed; only a genuine error or idle-death defers it to the next cycle. A
+persistently-bare goal after several cycles means the reasoner keeps erroring for
+it; check `journalctl` for the recorded error and treat it as a normal daemon fault
+(not a stuck goal). You may still force a manual override with
+[`simard goal unblock <goal-id>`](./unblock-stuck-ooda-goals.md#clear-a-single-goal-unconditionally).
+
+## Worked example — the deploy #41 kgpacks-rs incident
+
+After #17 shipped and the daemon ran a few cycles, the five stranded goals resolved
+as follows (this is the R9 validation evidence recorded in the PR body):
+
+| Goal | Bare before | After re-investigation |
+| --- | --- | --- |
+| `fix-agent-kgpacks-rs-issue-18` (WS3) | ✅ | `why=UPSTREAM-DEPENDENCY` — deferred behind the named eval-baseline upstream |
+| `fix-agent-kgpacks-rs-issue-21` (WS6) | ✅ | `why=UPSTREAM-DEPENDENCY` — deferred, upstream named |
+| `fix-agent-kgpacks-rs-issue-22` (WS7) | ✅ | `why=UPSTREAM-DEPENDENCY` — deferred, upstream named |
+| `fix-agent-kgpacks-rs-issue-23` (WS8) | ✅ | `why=UPSTREAM-DEPENDENCY` — deferred, upstream named |
+| `advance-rysweet-agent-kgpacks-rs-to-full-parity` | ✅ | WHY-stated block or guided fixer, depending on the live evidence at re-investigation time |
+
+`fix-agent-kgpacks-rs-issue-17` is the **reference format** — it already carried a
+proper `UPSTREAM-DEPENDENCY` WHY naming the open eval-baseline issue `#16`
+("#17's done-criterion is gated on eval recall parity, which depends on #16's eval
+baseline; #16 is still OPEN with no landed baseline, so #17's gate is unmeasurable —
+a genuine hard upstream dependency"). Every re-investigated goal now reads like that,
+never like a bare "needs human review."
+
+## Related
+
+- [Concept: Re-investigating already-blocked OODA goals](../concepts/ooda-reinvestigate-blocked-goals.md)
+- [No-progress re-investigation API reference](../reference/no-progress-reinvestigation-api.md)
+- [No-progress breaker API reference](../reference/no-progress-breaker-api.md)
+- [Unblock stuck OODA goals](./unblock-stuck-ooda-goals.md) — manual override for the offline / immediate cases.
+- [Spawn engineers from the OODA daemon](./spawn-engineers-from-ooda-daemon.md)
+- [Simard CLI reference: `simard goal`](../reference/simard-cli.md)

--- a/docs/howto/unblock-stuck-ooda-goals.md
+++ b/docs/howto/unblock-stuck-ooda-goals.md
@@ -228,5 +228,6 @@ under `~/.simard/agent_logs/`.
 ## Related
 
 - [Simard CLI reference: `simard goal`](../reference/simard-cli.md)
+- [Re-investigate bare-blocked OODA goals](./reinvestigate-bare-blocked-goals.md) — the daemon now auto-upgrades bare `[OODA-SAFEGUARD]` blocks to a concrete WHY every cycle (#17), so manual unblocking is rarely needed.
 - [Recover goal board](./recover-goal-board.md)
 - [Spawn engineers from OODA daemon](./spawn-engineers-from-ooda-daemon.md)

--- a/docs/reference/no-progress-breaker-api.md
+++ b/docs/reference/no-progress-breaker-api.md
@@ -374,12 +374,19 @@ status is persisted by the next `commit_cycle`.
 - `simard goal unblock` / `simard goal unblock-all` — still available for the
   (now rare) manual cases; see the
   [runbook](../howto/unblock-stuck-ooda-goals.md).
+- Re-investigation of **already-blocked** bare goals (#17) — the safeguard now
+  re-runs the WHY reasoner over goals already parked with a bare
+  `[OODA-SAFEGUARD] … needs human review` marker, not just goals crossing the
+  threshold. See the
+  [no-progress re-investigation API](../reference/no-progress-reinvestigation-api.md).
 
 ## See also
 
 - [Concept: the breaker explains WHY and self-resolves before escalating](../concepts/no-progress-root-cause-resolution.md) — the root-cause classification and resolution ladder layered on this base breaker.
 - [Root-cause resolution API reference](../reference/no-progress-root-cause-resolution-api.md) — `NoProgressClass`, the WHY types, the reasoner, and the extended resolution ladder.
 - [The `ooda-no-progress-why` recipe reference](../reference/ooda-no-progress-why-recipe.md) — the optional agentic WHY narrator.
+- [Concept: re-investigating already-blocked OODA goals](../concepts/ooda-reinvestigate-blocked-goals.md) — the #17 pass that upgrades bare blocks to a concrete WHY.
+- [No-progress re-investigation API reference](../reference/no-progress-reinvestigation-api.md) — the rail, dedupe set, and re-investigation pass.
 - [Concept: standing/perpetual goals are exempt from the no-progress hard-block](../concepts/perpetual-goal-no-progress-exemption.md)
 - [Completion-evidence gate API](../reference/completion-evidence-gate-api.md) — the sibling gate that makes standing goals non-completable.
 - [Goal board API reference](../reference/goal-board-api.md) — `filter_tombstoned` and load/save semantics.

--- a/docs/reference/no-progress-reinvestigation-api.md
+++ b/docs/reference/no-progress-reinvestigation-api.md
@@ -1,0 +1,445 @@
+---
+title: No-progress re-investigation API reference
+description: Reference for the OODA no-progress re-investigation pass (#17) — the `is_bare_no_progress_block` deterministic rail, the `ALL_CLASS_TOKENS` vocabulary, the `NoProgressTracker.reinvestigated` persisted dedupe set, the population-driven `reinvestigate_bare_blocked_goals` cycle pass, the shared `apply_resolution` helper and `ResolutionSite`, the WHY reasoner seam it reuses, the resolution ladder, and the serde/persistence contract.
+last_updated: 2026-07-08
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+status: implemented
+related:
+  - ../concepts/ooda-reinvestigate-blocked-goals.md
+  - ./no-progress-breaker-api.md
+  - ./completion-evidence-gate-api.md
+  - ./goal-board-api.md
+  - ../howto/reinvestigate-bare-blocked-goals.md
+  - ../../src/goal_curation/no_progress_breaker.rs
+  - ../../src/goal_curation/no_progress_why.rs
+  - ../../src/ooda_loop/no_progress.rs
+  - ../../src/ooda_loop/cycle.rs
+---
+
+# No-progress re-investigation API reference
+
+> **Status: implemented.** The deterministic rail and the persisted dedupe set live
+> in
+> [`src/goal_curation/no_progress_breaker.rs`](https://github.com/rysweet/Simard/blob/main/src/goal_curation/no_progress_breaker.rs).
+> The WHY vocabulary (`NoProgressClass`) and reasoner seam live in
+> [`src/goal_curation/no_progress_why.rs`](https://github.com/rysweet/Simard/blob/main/src/goal_curation/no_progress_why.rs).
+> The population-driven pass and the shared `apply_resolution` helper live in
+> [`src/ooda_loop/no_progress.rs`](https://github.com/rysweet/Simard/blob/main/src/ooda_loop/no_progress.rs);
+> the cycle wiring is in
+> [`src/ooda_loop/cycle.rs`](https://github.com/rysweet/Simard/blob/main/src/ooda_loop/cycle.rs).
+
+This reference specifies the API added in issue #17 to re-investigate goals that
+are **already** parked in a bare `[OODA-SAFEGUARD] … needs human review` state. For
+the rationale and the gap it closes, see
+[Re-investigating already-blocked OODA goals](../concepts/ooda-reinvestigate-blocked-goals.md).
+For the base breaker (threshold, sentinel constants, `NoProgressTracker` counter,
+load-time self-heal), see the
+[no-progress breaker API reference](./no-progress-breaker-api.md).
+
+## Contents
+
+- [The thin deterministic rail](#the-thin-deterministic-rail)
+- [Class-token vocabulary](#class-token-vocabulary)
+- [WHY reasoner seam (reused)](#why-reasoner-seam-reused)
+- [`NoProgressTracker` dedupe set](#noprogresstracker-dedupe-set)
+- [Population-driven pass: `reinvestigate_bare_blocked_goals`](#population-driven-pass-reinvestigate_bare_blocked_goals)
+- [Shared resolution: `apply_resolution` and `ResolutionSite`](#shared-resolution-apply_resolution-and-resolutionsite)
+- [Resolution ladder](#resolution-ladder)
+- [`NoProgressBreakerReport` extension](#noprogressbreakerreport-extension)
+- [Cycle wiring](#cycle-wiring)
+- [Persisted-data contract](#persisted-data-contract)
+- [Safety invariants](#safety-invariants)
+- [What is unchanged](#what-is-unchanged)
+
+## The thin deterministic rail
+
+`is_bare_no_progress_block` is the **only** new deterministic string check in the
+feature. A *bare* block is a safeguard-authored no-progress block that never
+received a WHY classification: it carries `NO_PROGRESS_BLOCKED_PREFIX` but embeds no
+`CLASS_*` token.
+
+```rust
+/// True when `reason` is a no-progress-breaker block that carries NO WHY
+/// classification token — i.e. it was authored by the bare safeguard path (or by
+/// an older daemon build before the WHY reasoner shipped). This is the gate that
+/// keeps the agentic classification behind a deterministic rail: it NEVER parses
+/// the narrative, only tests for marker-presence and class-token-absence.
+pub fn is_bare_no_progress_block(reason: &str) -> bool {
+    is_no_progress_marker(reason)
+        && !ALL_CLASS_TOKENS.iter().any(|t| reason.contains(t))
+}
+```
+
+Property obligations (tested):
+
+- `is_bare_no_progress_block(no_progress_blocked_reason(n)) == true` — a bare reason
+  is bare.
+- `is_bare_no_progress_block(no_progress_blocked_reason_with_why(n, why)) == false`
+  for **every** `NoProgressClass` — a WHY-bearing reason is never bare.
+- Non-marker strings (operator / scope / dependency / brain-failure blocks) →
+  `false` — the rail never mistakes another block kind for a bare no-progress block.
+
+## Class-token vocabulary
+
+The six class tokens are the single source of truth for the rail, so it can never
+drift from `NoProgressClass::token()`.
+
+```rust
+/// Every WHY class token, in one array, consumed by `is_bare_no_progress_block`.
+/// Kept in lockstep with `NoProgressClass` (a compile-time-exhaustive `token()`
+/// match guarantees no variant is missing a token).
+pub(crate) const ALL_CLASS_TOKENS: [&str; 6] = [
+    CLASS_ALREADY_COMPLETE,      // "ALREADY-COMPLETE"
+    CLASS_OBSOLETE,              // "OBSOLETE"
+    CLASS_MISSING_PRECONDITION,  // "MISSING-PRECONDITION"
+    CLASS_UPSTREAM_DEPENDENCY,   // "UPSTREAM-DEPENDENCY"
+    CLASS_UNCLEAR_CRITERIA,      // "UNCLEAR-CRITERIA"
+    CLASS_GENUINELY_STUCK,       // "GENUINELY-STUCK"
+];
+```
+
+The tokens are **upper-case, bracketless** literals. `no_progress_blocked_reason_with_why`
+embeds the selected token into the block reason as a `why=<TOKEN>` segment, so a
+WHY-bearing reason renders as
+`🔒 [OODA-SAFEGUARD] … <n> consecutive no-action cycles; why=UPSTREAM-DEPENDENCY evidence=[…]`.
+`is_bare_no_progress_block` tests `reason.contains("UPSTREAM-DEPENDENCY")` (etc.),
+never a `[why:…]` form.
+
+## WHY reasoner seam (reused)
+
+The re-investigation pass reuses the reasoner seam introduced with the
+on-transition path (PR #2960) **unchanged**. There is no second reasoner.
+
+```rust
+/// The agentic classifier. `investigate` returns a structured verdict — a class
+/// plus a human-readable narrative citing the evidence — or an error (fail-closed).
+pub trait NoProgressWhyReasoner {
+    fn investigate(&self, goal: &ActiveGoal) -> Result<NoProgressWhy, NoProgressWhyError>;
+}
+
+/// The reasoner's structured result. Downstream code consumes `class` (never a
+/// re-parse of `narrative`).
+pub struct NoProgressWhy {
+    pub class: NoProgressClass,
+    pub narrative: String,
+}
+
+/// The six mutually-exclusive reasons a goal makes no progress. Derives
+/// `Clone, Copy, Debug, PartialEq, Eq` — deliberately NOT `Serialize`/`Deserialize`
+/// (see the persisted-data contract: the enum is in-memory only; the dedupe set
+/// stores `token()` strings on disk).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NoProgressClass {
+    AlreadyComplete,
+    Obsolete,
+    MissingPrecondition,
+    UpstreamDependency,
+    UnclearCriteria,
+    GenuinelyStuck,
+}
+
+impl NoProgressClass {
+    /// The stable on-disk / in-marker token for this class (e.g.
+    /// `"UPSTREAM-DEPENDENCY"`). The ONLY serialized form of a class.
+    pub fn token(&self) -> &'static str;
+}
+
+/// The production reasoner injected into both paths. Evidence-driven; no
+/// wall-clock timeout (idle/liveness only).
+pub struct DeterministicNoProgressReasoner { /* … */ }
+
+/// Render a WHY-bearing block reason: the sentinel prefix + count (so the marker
+/// contract is preserved) followed by a `why=<TOKEN>` segment and the cited
+/// evidence — i.e. `{PREFIX}{n} consecutive no-action cycles; why={TOKEN} evidence=[…]`.
+/// The output is NEVER bare.
+pub fn no_progress_blocked_reason_with_why(consecutive: u32, why: &NoProgressWhy) -> String;
+```
+
+The reasoner treats evidence as **untrusted context to investigate**, not as
+directives — it reuses the existing `engineer_task_for_why` / `render_evidence`
+framing and length bounds, so a hostile issue body cannot inject instructions
+(prompt-injection hardening carried over from the on-transition path).
+
+## `NoProgressTracker` dedupe set
+
+`NoProgressTracker` (the per-goal counter documented in the
+[breaker API](./no-progress-breaker-api.md#noprogresstracker)) gains one persisted
+field and two accessors.
+
+```rust
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+pub struct NoProgressTracker {
+    #[serde(default)] counts: HashMap<String, u32>,       // existing: no-action counter
+    #[serde(default)] guided_retries: HashSet<String>,    // existing (#16): one guided retry/goal
+    /// #17: (goal_id, class_token) pairs already taken to a TERMINAL
+    /// re-investigation action. The token is a String (NOT the `NoProgressClass`
+    /// enum) so it is downgrade-safe under the fail-to-empty board read.
+    /// `#[serde(default)]` keeps pre-#17 snapshots loading with an empty set.
+    #[serde(default)] reinvestigated: HashSet<(String, String)>,
+}
+
+impl NoProgressTracker {
+    /// Checked BEFORE any terminal re-investigation action. True ⇒ this goal has
+    /// already been taken to a terminal action for this class; skip it.
+    pub fn reinvestigated(&self, goal_id: &str, class: NoProgressClass) -> bool;
+
+    /// Insert (goal_id, class.token()) — call ON SUCCESS ONLY, never after a
+    /// reasoner error (fail-closed).
+    pub fn mark_reinvestigated(&mut self, goal_id: &str, class: NoProgressClass);
+}
+```
+
+Two lifecycle hooks keep the set from leaking:
+
+- `retain_goals(live)` prunes it — `self.reinvestigated.retain(|(id, _)| live.contains(id))`
+  — so ids for removed goals do not accumulate (cascade delete). Cardinality is
+  bounded by `live goals × 6`, pruned every cycle.
+- `record_progress(goal_id)` clears that goal's entries — real forward progress
+  earns a fresh future re-investigation (symmetric with `guided_retries`).
+
+## Population-driven pass: `reinvestigate_bare_blocked_goals`
+
+The new cycle pass. Unlike the on-transition breaker (which takes this cycle's
+`outcomes`), it is **population-driven** — it takes no outcomes and scans the board
+state directly, exactly like the sibling auto-clear pass.
+
+```rust
+/// #17: scan the ACTIVE board each cycle for goals in a BARE Blocked state
+/// (safeguard marker, no WHY class) and investigate them — closing the gap where a
+/// goal blocked before the reasoner shipped, or on a cycle the reasoner erred, is
+/// never re-examined. Reuses the SAME injected seams as the on-transition breaker.
+/// Skips perpetual goals. Fully idempotent and fail-closed.
+pub(crate) fn reinvestigate_bare_blocked_goals(
+    state: &mut OodaState,
+    evidence: &dyn EvidenceSource,
+    reasoner: &dyn NoProgressWhyReasoner,
+    healer: &dyn PreconditionHealer,
+    dispatcher: &dyn NoProgressEngineerDispatcher,
+    filer: &dyn NoProgressIssueFiler,
+    threshold: u32,
+) -> NoProgressBreakerReport;
+```
+
+**Per-goal algorithm** (the goal is definitionally past threshold; its counter was
+reset to 0 when it blocked, so `consecutive = threshold`):
+
+1. `tracker = std::mem::take(&mut state.no_progress_tracker)` — borrow-decouple, as
+   auto-clear does, so the board can be borrowed immutably while the tracker mutates.
+2. **Collect** (immutable borrow) `(goal_id, ActiveGoal clone)` for every active goal
+   where `matches!(status, Blocked(r) if is_bare_no_progress_block(r))` **and**
+   `!goal.is_perpetual()`.
+3. For each `(goal_id, goal)`:
+   1. `let why = match reasoner.investigate(&goal) { Ok(w) => w, Err(e) => { /* FAIL
+      CLOSED: leave bare Blocked; report.investigation_errors.push(goal_id);
+      tracing::error!; NO dedupe insert; continue */ } };`
+   2. **Rewrite first (primary idempotency):**
+      `status = Blocked(no_progress_blocked_reason_with_why(threshold, &why))` — the
+      goal is now non-bare and excluded from this population next cycle.
+   3. **Dedupe belt:** `if tracker.reinvestigated(goal_id, why.class) { continue; }`.
+   4. `let resolution = resolution_for_why(threshold, why, tracker.guided_retry_used(goal_id));`
+   5. `apply_resolution(state, &mut tracker, &mut report, goal_id, threshold,
+      resolution, healer, dispatcher, filer, ResolutionSite::Reinvestigation);`
+   6. On a terminal (non-`Continue`) outcome: `tracker.mark_reinvestigated(goal_id, why.class);`.
+4. `tracker.retain_goals(&live); state.no_progress_tracker = tracker;` return `report`.
+
+## Shared resolution: `apply_resolution` and `ResolutionSite`
+
+The transition-path match body is extracted verbatim into one helper used by
+**both** passes, so the ladder cannot drift. `apply_no_progress_breaker_investigated`
+(the on-transition driver) calls it with `site = OnTransition`; the re-investigation
+pass calls it with `site = Reinvestigation`.
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ResolutionSite {
+    /// The goal crossed the threshold this cycle (outcome-driven path).
+    OnTransition,
+    /// The goal was already parked bare and is being re-investigated (#17).
+    Reinvestigation,
+}
+
+/// Apply one `NoProgressResolution`'s side effects through the injected seams.
+/// `site` changes EXACTLY two arms (Heal(Ok) and SpawnEngineer un-block on
+/// Reinvestigation); every other arm is byte-identical, preserving the
+/// on-transition behavior (R1).
+fn apply_resolution(
+    state: &mut OodaState,
+    tracker: &mut NoProgressTracker,
+    report: &mut NoProgressBreakerReport,
+    goal_id: &str,
+    consecutive: u32,
+    resolution: NoProgressResolution,
+    healer: &dyn PreconditionHealer,
+    dispatcher: &dyn NoProgressEngineerDispatcher,
+    filer: &dyn NoProgressIssueFiler,
+    site: ResolutionSite,
+);
+```
+
+## Resolution ladder
+
+`resolution_for_why(consecutive, why, guided_retry_used)` maps a class to a
+`NoProgressResolution`; `apply_resolution` executes it. Every arm yields a
+**non-bare** post-state.
+
+| Resolution | `OnTransition` (unchanged) | `Reinvestigation` (new) | Post-state |
+| --- | --- | --- | --- |
+| `MarkDone` | status → `Completed` | *(same)* | ✅ Completed |
+| `Drop` | remove from board | *(same)* | ✅ removed |
+| `Heal(Ok)` | reset counter, **leave status** | reset counter **+ status → `NotStarted`** (un-block) | ✅ NotStarted |
+| `Heal(Err)` | `Blocked(why-bearing)` + file issue | *(same)* | ✅ Blocked-with-why |
+| `Defer` | status → `Paused` + defer `WipRef` | *(same)* | ✅ Paused |
+| `SpawnEngineer` | queue spawn, mark guided-retry, reset counter, **leave status** | + status → `NotStarted` (un-block) | ✅ NotStarted |
+| `Escalate` | `Blocked(why-bearing)` + file issue | *(same)* | ✅ Blocked-with-why |
+
+**Why `Reinvestigation` un-blocks on `Heal(Ok)` / `SpawnEngineer`:** an already-blocked
+goal is not brain-selectable. If a precondition was healed or a fixer was spawned,
+the goal must become selectable again so the fix can actually advance it — otherwise
+it strands as a `Blocked` goal the brain never re-selects. If the fixer later fails,
+the goal re-enters the **on-transition** path with `guided_retry_used = true` and
+escalates **with** a WHY (non-bare) — a self-converging terminal. On the
+on-transition path the goal is already selectable, so those two arms leave the
+status untouched.
+
+`Defer` records the named upstream via a `[no-progress-defer]` `WipRef`; the goal
+auto-clears when that upstream resolves. See
+[goal-board-api](./goal-board-api.md) for `WipRef` and the auto-clear scan.
+
+## `NoProgressBreakerReport` extension
+
+The report gains exactly **one** new ephemeral (tracing-only, not persisted) field,
+`reinvestigated`, so a cycle log shows which goals were re-investigated. All other
+fields already exist (issue #16) — in particular `investigation_errors`, which the
+fail-closed re-investigation path **reuses** rather than adds.
+
+```rust
+pub(crate) struct NoProgressBreakerReport {
+    // ── existing fields (issue #16) ──────────────────────────────────────────
+    pub marked_done: Vec<String>,
+    pub dropped: Vec<String>,
+    pub escalated: Vec<String>,
+    pub healed: Vec<String>,
+    pub deferred: Vec<String>,
+    pub engineer_spawned: Vec<String>,
+    pub auto_cleared: Vec<String>,
+    /// Reused by #17's fail-closed path — goal ids whose reasoner call errored
+    /// (still bare, no terminal action, retried next cycle).
+    pub investigation_errors: Vec<String>,
+    pub perpetual_idled: Vec<String>,
+    // ── new (#17) ────────────────────────────────────────────────────────────
+    /// goal ids re-investigated this cycle (had a bare block, now WHY-classified).
+    pub reinvestigated: Vec<String>,
+}
+```
+
+`fired()` and `log_line()` are extended to include `reinvestigated={n}`. A cycle
+whose only activity is re-investigation counts as a firing.
+
+## Cycle wiring
+
+In the `no_progress_investigation_enabled()` branch of the cycle driver
+(`src/ooda_loop/cycle.rs`), construct **one** shared dispatcher, run both passes,
+and drain **once** through the existing `dispatch_spawn_engineer` loop — so there is
+zero new subprocess call site and one funnel for all spawns.
+
+```rust
+let dispatcher = QueueingEngineerDispatcher::new();
+
+// 1. On-transition path (outcome-driven) — runs the auto-clear scan internally first.
+let report   = apply_no_progress_breaker_investigated(
+    state, &outcomes, source_ref, &reasoner, &healer, &dispatcher, &GhIssueFiler, threshold);
+
+// 2. Re-investigation pass (population-driven) — runs AFTER, so transition goals are
+//    already WHY-bearing and the two populations are disjoint this cycle.
+let reinvest = reinvestigate_bare_blocked_goals(
+    state, source_ref, &reasoner, &healer, &dispatcher, &GhIssueFiler, threshold);
+
+let requests = dispatcher.into_requests();          // drains BOTH passes' spawns
+// … existing dispatch_spawn_engineer drain loop, unchanged …
+let breaker_dropped = [report.dropped, reinvest.dropped].concat();
+```
+
+**Ordering matters** for population disjointness: auto-clear (inside the transition
+fn) → on-transition breaker → re-investigation. Transition goals become WHY-bearing
+*before* the scan, so a goal is never processed by both passes in one cycle.
+
+## Persisted-data contract
+
+There is no SQL database; persistence is `state/goal_board.json` (atomic
+temp+rename under `flock`). Two properties of that store are load-bearing here:
+
+- **Fail-to-empty read (C1).** Any deserialize failure discards the entire board
+  (`read_unlocked = from_str(raw).unwrap_or_else(|_| default())`). Therefore every
+  additive field must load on older binaries, and the dedupe key must never be able
+  to fail to parse. The key is a `String` token; a rollback that meets an unknown
+  token still parses `[[String, String], …]` and simply ignores it — it can never
+  trigger a board wipe. An externally-tagged **enum** on disk *could* fail on an
+  older/rolled-back binary or a future 7th variant → the reason
+  `NoProgressClass` is **not** `Serialize`/`Deserialize`.
+- **`version` is informational (C2).** `write` stamps `STORE_VERSION = 1`; `read`
+  never gates on it. An additive `#[serde(default)]` field needs no version bump and
+  no migration code, and `deny_unknown_fields` is **not** used (forward compat).
+
+```text
+state/goal_board.json → PersistentGoalState {
+    version: 1 (informational),
+    board,
+    cycle_count,
+    no_progress: NoProgressTracker {
+        counts:         HashMap<goal_id → u32>,
+        guided_retries: HashSet<goal_id>,
+        reinvestigated: HashSet<(goal_id, class_token)>   ← NEW (#17)
+    }
+}
+```
+
+| Compatibility direction | Behavior |
+| --- | --- |
+| Backward (new binary, old file) | missing key → `#[serde(default)]` empty set ✅ |
+| Forward (old binary, new file) | unknown field ignored (no `deny_unknown_fields`) ✅ |
+| Rollback value parse | value is `[[String, String], …]` — parses even for an unknown token → never a C1 wipe ✅ |
+| Cross-restart | set persists in `no_progress`; idempotency holds across a daemon restart ✅ |
+
+## Safety invariants
+
+The pass upholds these testable invariants (let `bare(G)` mean `G`'s reason is a
+no-progress marker with no class token):
+
+- **I1 — No bare survivors.** After a cycle where the reasoner did not error for `G`,
+  `¬bare(G')`. Every `Reinvestigation` arm yields Completed | removed | NotStarted |
+  Paused | Blocked-with-why.
+- **I2 — Fail-closed.** `investigate(G) = Err ⟹` reason unchanged, nothing spawned,
+  `(G, ·)` not inserted — retriable next cycle.
+- **I3 — Single-fixer idempotency.** At most one fixer spawn per `(G, class)`, via
+  (a) the non-bare rewrite removing `G` from the population and (b) the persisted
+  dedupe set short-circuiting before any terminal action, surviving restart.
+- **I4 — Population disjointness.** Transition runs first and stamps a class token,
+  so `bare(G)` is false when the scan collects; auto-clear touches only `Paused` goals.
+- **I5 — Perpetual exemption.** `is_perpetual(G) ⟹ G ∉ population` (mirrors transition).
+- **I6 — Marker-contract preservation.** Every rewritten reason keeps
+  `NO_PROGRESS_BLOCKED_PREFIX` + a parseable leading count, so the overseer
+  (`root_cause.rs`, `sensor.rs`) and load-time self-heal keep recognizing the marker.
+- **I7 — Atomic persistence.** Board + tracker (incl. the dedupe set) persist in one
+  snapshot write, so the rewrite (I1) and the insert (I3) never split across a crash.
+
+## What is unchanged
+
+- `NO_PROGRESS_BREAKER_THRESHOLD`, both sentinel constants, `is_no_progress_marker`,
+  and `no_progress_blocked_reason` — unchanged.
+- The `NoProgressClass` enum and its derives — unchanged (no `Serialize`/`Deserialize`
+  added; `STORE_VERSION` stays `1`).
+- The on-transition driver `apply_no_progress_breaker_investigated`'s external
+  signature and behavior — unchanged (it now delegates to the shared
+  `apply_resolution` with `site = OnTransition`).
+- The single `dispatch_spawn_engineer` path — reused; **zero** new `Command::new`
+  call sites. No memory-engine (amplihack-memory-lib) change.
+
+## See also
+
+- [Concept: Re-investigating already-blocked OODA goals](../concepts/ooda-reinvestigate-blocked-goals.md)
+- [No-progress breaker API reference](./no-progress-breaker-api.md) — base breaker, sentinel, load-time self-heal.
+- [Completion-evidence gate API](./completion-evidence-gate-api.md) — the sibling gate the `MarkDone` arm respects.
+- [Goal board API reference](./goal-board-api.md) — `WipRef`, the auto-clear scan, and load/save semantics.
+- [Re-investigate bare-blocked OODA goals](../howto/reinvestigate-bare-blocked-goals.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
     - No-Progress Breaker Explains WHY and Self-Resolves: concepts/no-progress-root-cause-resolution.md
     - Overseer Goal-Board Health: concepts/overseer-goal-board-health.md
     - Overseer Root-Cause (WHY) Principle: concepts/overseer-root-cause-why.md
+    - Re-Investigating Already-Blocked OODA Goals: concepts/ooda-reinvestigate-blocked-goals.md
     - Authoritative Goal-Board Store: concepts/authoritative-goal-board-store.md
     - Brain-Relative OODA Cycle Counter: concepts/brain-relative-ooda-cycle-counter.md
     - Goal-Board Corruption Guards: concepts/goal-board-corruption-guards.md
@@ -162,6 +163,7 @@ nav:
     - Configure Resource-Aware Engineer Admission: howto/configure-resource-aware-admission.md
     - Unblock Stuck OODA Goals: howto/unblock-stuck-ooda-goals.md
     - Diagnose a No-Progress Block and Read Its WHY: howto/diagnose-a-no-progress-block.md
+    - Re-Investigate Bare-Blocked OODA Goals: howto/reinvestigate-bare-blocked-goals.md
     - Add a New Recipe-Brain Phase: howto/add-a-new-recipe-brain-phase.md
     - Edit the OODA Brain Prompt: howto/edit-the-ooda-brain-prompt.md
     - Diagnose Brain Decision Parse Failures: howto/diagnose-brain-decision-parse-failures.md
@@ -347,6 +349,7 @@ nav:
     - No-Progress Root-Cause Resolution API: reference/no-progress-root-cause-resolution-api.md
     - OODA No-Progress WHY Recipe: reference/ooda-no-progress-why-recipe.md
     - Durable OODA Cycle Counter API: reference/durable-ooda-cycle-counter.md
+    - No-Progress Re-Investigation API: reference/no-progress-reinvestigation-api.md
     - Progress-Evidence API: reference/progress-evidence-api.md
     - Trustworthy-Confidence API: reference/trustworthy-confidence-api.md
     - External-Signal Completion Gate: reference/external-signal-completion-gate.md

--- a/src/goal_curation/mod.rs
+++ b/src/goal_curation/mod.rs
@@ -88,6 +88,11 @@ mod tests_no_progress_breaker;
 // WHY-aware block-reason renderer, and the class -> resolution map).
 #[cfg(test)]
 mod tests_no_progress_why;
+// Issue #17 (TDD): pure primitives of the already-blocked re-investigation pass
+// — the `is_bare_no_progress_block` deterministic rail and the
+// `NoProgressTracker` persisted `reinvestigated` dedupe set (lifecycle + serde).
+#[cfg(test)]
+mod tests_no_progress_reinvestigation;
 #[cfg(test)]
 mod tests_operations;
 #[cfg(test)]

--- a/src/goal_curation/mod.rs
+++ b/src/goal_curation/mod.rs
@@ -59,9 +59,9 @@ pub use completion_gate::{
 
 pub use no_progress_breaker::{
     NO_PROGRESS_BLOCKED_PREFIX, NO_PROGRESS_BLOCKED_SUFFIX, NO_PROGRESS_BREAKER_THRESHOLD,
-    NoProgressResolution, NoProgressTracker, StuckGoalDisposition, is_no_progress_marker,
-    no_progress_blocked_reason, no_progress_blocked_reason_with_why, obsolescence_reason,
-    resolution_for_why, resolve_no_progress, verify_stuck_goal,
+    NoProgressResolution, NoProgressTracker, StuckGoalDisposition, is_bare_no_progress_block,
+    is_no_progress_marker, no_progress_blocked_reason, no_progress_blocked_reason_with_why,
+    obsolescence_reason, resolution_for_why, resolve_no_progress, verify_stuck_goal,
 };
 
 pub use no_progress_why::{Evidence, NoProgressClass, NoProgressWhy, NoProgressWhyReasoner};

--- a/src/goal_curation/no_progress_breaker.rs
+++ b/src/goal_curation/no_progress_breaker.rs
@@ -89,6 +89,29 @@ pub fn is_no_progress_marker(reason: &str) -> bool {
     reason.starts_with(NO_PROGRESS_BLOCKED_PREFIX)
 }
 
+/// True when `reason` is a **bare** no-progress safeguard block (issue #17): it
+/// carries the [`NO_PROGRESS_BLOCKED_PREFIX`] marker (so
+/// [`is_no_progress_marker`] holds) but has **no** [`NoProgressClass`] WHY token
+/// attached — i.e. the legacy `{PREFIX}{count}{SUFFIX}` "needs human review"
+/// shape a pre-#17 daemon parked stalled goals with, or a block a reasoner error
+/// left un-classified.
+///
+/// This is the thin deterministic rail that gates the agentic re-investigation
+/// pass ([`crate::ooda_loop::no_progress::reinvestigate_bare_blocked_goals`]): it
+/// selects exactly the bare-blocked population and never mistakes a WHY-bearing
+/// block (authored by [`no_progress_blocked_reason_with_why`], which always
+/// embeds a [`NoProgressClass::token`]) or any other kind of block
+/// (operator-set, scope, dependency, brain-failure) for one. Keying on "marker
+/// present AND no class token" makes the WHY-rewrite its own idempotency
+/// guarantee: once re-investigation attaches a WHY the reason is no longer bare,
+/// so the pass never re-processes it.
+pub fn is_bare_no_progress_block(reason: &str) -> bool {
+    is_no_progress_marker(reason)
+        && !NoProgressClass::ALL
+            .iter()
+            .any(|class| reason.contains(class.token()))
+}
+
 /// Render the sentinel [`GoalProgress::Blocked`] reason for a goal escalated
 /// after `consecutive` no-action cycles.
 ///
@@ -416,6 +439,20 @@ pub struct NoProgressTracker {
     /// engineer. `#[serde(default)]` keeps pre-#16 snapshots deserializable.
     #[serde(default)]
     guided_retries: HashSet<String>,
+    /// Goals whose **bare** no-progress block has already been re-investigated to
+    /// a terminal resolution for a given [`NoProgressClass`] (issue #17). Keyed on
+    /// `(goal_id, class_token)`; the class is stored as its stable
+    /// [`NoProgressClass::token`] **string** (never an enum-tagged form) so an
+    /// older / rolled-back binary can still parse the snapshot and the
+    /// fail-to-empty goal-board store never turns a parse miss into a full board
+    /// wipe. This is the belt-and-suspenders dedupe: the WHY-rewrite already
+    /// removes a re-investigated goal from the bare population next cycle, but this
+    /// persisted set additionally bounds re-investigation to **one** terminal
+    /// action per `(goal, class)` even if a crash/restart re-parks the goal bare
+    /// between the board rewrite and the tracker persist. `#[serde(default)]`
+    /// keeps pre-#17 snapshots deserializable (loads as an empty set).
+    #[serde(default)]
+    reinvestigated: HashSet<(String, String)>,
 }
 
 impl NoProgressTracker {
@@ -438,6 +475,7 @@ impl NoProgressTracker {
     pub fn record_progress(&mut self, goal_id: &str) {
         self.counts.remove(goal_id);
         self.guided_retries.remove(goal_id);
+        self.reinvestigated.retain(|(id, _)| id != goal_id);
     }
 
     /// Reset only `goal_id`'s no-action counter, **preserving** any spent
@@ -458,6 +496,25 @@ impl NoProgressTracker {
         self.guided_retries.contains(goal_id)
     }
 
+    /// Record that `goal_id`'s bare no-progress block has been re-investigated to
+    /// a terminal resolution for `class` (issue #17). Idempotent. Called **only**
+    /// after a terminal action succeeds (never on a fail-closed reasoner error),
+    /// so a re-park after a restart cannot trigger a second terminal action for
+    /// the same `(goal, class)`.
+    pub fn mark_reinvestigated(&mut self, goal_id: &str, class: NoProgressClass) {
+        self.reinvestigated
+            .insert((goal_id.to_string(), class.token().to_string()));
+    }
+
+    /// Whether `goal_id`'s bare block has already been re-investigated to a
+    /// terminal resolution for `class` (issue #17) — the belt-and-suspenders
+    /// dedupe guard the re-investigation pass consults before taking any terminal
+    /// action, bounding it to one per `(goal, class)` across daemon restarts.
+    pub fn reinvestigated(&self, goal_id: &str, class: NoProgressClass) -> bool {
+        self.reinvestigated
+            .contains(&(goal_id.to_string(), class.token().to_string()))
+    }
+
     /// Current consecutive no-action count for `goal_id` (`0` when untracked).
     pub fn consecutive(&self, goal_id: &str) -> u32 {
         self.counts.get(goal_id).copied().unwrap_or(0)
@@ -468,6 +525,7 @@ impl NoProgressTracker {
     pub fn retain_goals(&mut self, live: &HashSet<String>) {
         self.counts.retain(|id, _| live.contains(id));
         self.guided_retries.retain(|id| live.contains(id));
+        self.reinvestigated.retain(|(id, _)| live.contains(id));
     }
 
     /// Record a no-action cycle for `goal_id` and return the breaker's

--- a/src/goal_curation/tests_no_progress_reinvestigation.rs
+++ b/src/goal_curation/tests_no_progress_reinvestigation.rs
@@ -1,0 +1,229 @@
+//! TEST-FIRST (Step 7 TDD) for the **pure** primitives of the already-blocked
+//! re-investigation pass (issue #17):
+//!
+//! * the thin deterministic rail [`is_bare_no_progress_block`] that gates the
+//!   agentic classification — it must recognise a *bare* safeguard block (marker
+//!   present, no WHY class token) and never mistake a WHY-bearing or
+//!   other-kind block for one; and
+//! * the [`NoProgressTracker`] persisted `reinvestigated` dedupe set that bounds
+//!   the re-investigation to **one terminal action per `(goal, class)`** across a
+//!   daemon restart — with its lifecycle hooks (`record_progress` clears,
+//!   `retain_goals` prunes) and its serde/fail-to-empty on-disk contract.
+//!
+//! The side-effecting population-driven pass is specified in
+//! `crate::ooda_loop::tests_no_progress_reinvestigation`.
+//!
+//! RED until the rail, the token vocabulary, and the tracker dedupe set exist.
+
+use super::no_progress_breaker::{
+    NO_PROGRESS_BREAKER_THRESHOLD, NoProgressTracker, is_bare_no_progress_block,
+    is_no_progress_marker, no_progress_blocked_reason, no_progress_blocked_reason_with_why,
+};
+use super::no_progress_why::{Evidence, NoProgressClass, NoProgressWhy};
+
+// === the thin deterministic rail: is_bare_no_progress_block =================
+
+#[test]
+fn a_bare_safeguard_reason_reads_as_bare() {
+    // The exact production string the daemon parked goals with: a no-progress
+    // marker that carries NO WHY classification.
+    let bare = no_progress_blocked_reason(NO_PROGRESS_BREAKER_THRESHOLD);
+    assert!(
+        is_no_progress_marker(&bare),
+        "sanity: the bare reason is a no-progress marker"
+    );
+    assert!(
+        is_bare_no_progress_block(&bare),
+        "a bare '[OODA-SAFEGUARD] … needs human review' reason MUST read as bare: {bare}"
+    );
+}
+
+#[test]
+fn a_why_bearing_reason_is_never_bare_for_any_class() {
+    // For EVERY class the WHY-bearing renderer must produce a reason that is a
+    // no-progress marker (so self-heal/overseer still recognise it) yet is NOT
+    // bare (so the re-investigation pass never re-processes it) — this is the
+    // primary idempotency guarantee.
+    for class in NoProgressClass::ALL {
+        let why = NoProgressWhy::new(class, vec![Evidence::new("issue", "#16", "OPEN")]);
+        let reason = no_progress_blocked_reason_with_why(NO_PROGRESS_BREAKER_THRESHOLD, &why);
+        assert!(
+            is_no_progress_marker(&reason),
+            "{class:?}: a WHY-bearing reason must still be a no-progress marker: {reason}"
+        );
+        assert!(
+            reason.contains(class.token()),
+            "{class:?}: a WHY-bearing reason must embed the class token: {reason}"
+        );
+        assert!(
+            !is_bare_no_progress_block(&reason),
+            "{class:?}: a WHY-bearing reason must NOT read as bare: {reason}"
+        );
+    }
+}
+
+#[test]
+fn non_marker_blocks_are_never_bare_no_progress_blocks() {
+    // The rail must never mistake another kind of block (operator-set, scope,
+    // dependency, brain-failure, arbitrary text) for a bare no-progress block —
+    // it keys strictly on the no-progress marker sentinel, not on any generic
+    // "blocked" wording.
+    let not_bare = [
+        "",
+        "blocked by operator: waiting on design review",
+        "scope-blocked: out of milestone",
+        "dependency: waiting on upstream goal 'foo'",
+        "\u{1F512} [BRAIN-FAILURE] brain failed 3 consecutive cycles; needs human review",
+        "needs human review",
+        "OODA goal made no shippable progress", // prefix fragment only, not the full marker
+    ];
+    for reason in not_bare {
+        assert!(
+            !is_bare_no_progress_block(reason),
+            "a non-no-progress-marker string must NOT read as a bare no-progress block: {reason:?}"
+        );
+    }
+}
+
+#[test]
+fn a_bare_reason_with_an_arbitrary_higher_count_is_still_bare() {
+    // The rail must not depend on the specific consecutive count embedded in the
+    // marker — any bare marker (regardless of count) is bare.
+    for n in [3_u32, 7, 42] {
+        let bare = no_progress_blocked_reason(n);
+        assert!(
+            is_bare_no_progress_block(&bare),
+            "count={n}: a bare marker is bare regardless of its count: {bare}"
+        );
+    }
+}
+
+// === NoProgressTracker persisted dedupe set =================================
+
+#[test]
+fn marking_reinvestigated_is_recorded_per_goal_and_class() {
+    let mut tracker = NoProgressTracker::new();
+    assert!(
+        !tracker.reinvestigated("g1", NoProgressClass::GenuinelyStuck),
+        "an untouched goal must not read as already re-investigated"
+    );
+
+    tracker.mark_reinvestigated("g1", NoProgressClass::GenuinelyStuck);
+    assert!(
+        tracker.reinvestigated("g1", NoProgressClass::GenuinelyStuck),
+        "after marking, the (goal, class) pair must read as re-investigated"
+    );
+    // Dedupe is keyed on BOTH goal and class: a different class for the same goal,
+    // and the same class for a different goal, are independent.
+    assert!(
+        !tracker.reinvestigated("g1", NoProgressClass::UpstreamDependency),
+        "a different class for the same goal must be independent"
+    );
+    assert!(
+        !tracker.reinvestigated("g2", NoProgressClass::GenuinelyStuck),
+        "the same class for a different goal must be independent"
+    );
+}
+
+#[test]
+fn record_progress_clears_the_reinvestigated_flag() {
+    // Real forward progress must earn a FRESH future re-investigation — symmetric
+    // with how `record_progress` clears the counter and the guided-retry flag.
+    let mut tracker = NoProgressTracker::new();
+    tracker.mark_reinvestigated("g1", NoProgressClass::GenuinelyStuck);
+    assert!(tracker.reinvestigated("g1", NoProgressClass::GenuinelyStuck));
+
+    tracker.record_progress("g1");
+    assert!(
+        !tracker.reinvestigated("g1", NoProgressClass::GenuinelyStuck),
+        "forward progress must clear the goal's re-investigation dedupe entry"
+    );
+}
+
+#[test]
+fn retain_goals_prunes_reinvestigated_entries_for_departed_goals() {
+    // The dedupe set must not leak ids for goals that left the board (cascade
+    // delete), mirroring the counter/guided-retry pruning.
+    let mut tracker = NoProgressTracker::new();
+    tracker.mark_reinvestigated("still-here", NoProgressClass::UpstreamDependency);
+    tracker.mark_reinvestigated("departed", NoProgressClass::GenuinelyStuck);
+
+    let live: std::collections::HashSet<String> = ["still-here".to_string()].into_iter().collect();
+    tracker.retain_goals(&live);
+
+    assert!(
+        tracker.reinvestigated("still-here", NoProgressClass::UpstreamDependency),
+        "a live goal's dedupe entry must be retained"
+    );
+    assert!(
+        !tracker.reinvestigated("departed", NoProgressClass::GenuinelyStuck),
+        "a departed goal's dedupe entry must be pruned"
+    );
+}
+
+#[test]
+fn reinvestigated_set_round_trips_through_serde() {
+    // The dedupe set must survive a daemon restart (it persists alongside the
+    // no-action counter in `state/goal_board.json`), so idempotency holds across
+    // a crash between the board rewrite and the tracker persist.
+    let mut tracker = NoProgressTracker::new();
+    tracker.mark_reinvestigated("g1", NoProgressClass::UpstreamDependency);
+    tracker.mark_reinvestigated("g2", NoProgressClass::AlreadyComplete);
+
+    let json = serde_json::to_string(&tracker).expect("tracker serialises");
+    let restored: NoProgressTracker = serde_json::from_str(&json).expect("tracker deserialises");
+
+    assert!(
+        restored.reinvestigated("g1", NoProgressClass::UpstreamDependency),
+        "the dedupe entry must survive a serde round-trip (restart)"
+    );
+    assert!(
+        restored.reinvestigated("g2", NoProgressClass::AlreadyComplete),
+        "the dedupe entry must survive a serde round-trip (restart)"
+    );
+    assert!(
+        !restored.reinvestigated("g1", NoProgressClass::AlreadyComplete),
+        "the class distinction must survive the round-trip"
+    );
+}
+
+#[test]
+fn reinvestigated_set_persists_class_as_the_stable_token_string() {
+    // Fail-to-empty (C1) safety: the on-disk form must store the class as its
+    // stable TOKEN string, never an enum-tagged representation that an older /
+    // rolled-back binary (or a future 7th variant) could fail to parse and thereby
+    // wipe the whole board. Assert the serialized JSON carries the token verbatim.
+    let mut tracker = NoProgressTracker::new();
+    tracker.mark_reinvestigated("g1", NoProgressClass::UpstreamDependency);
+
+    let json = serde_json::to_string(&tracker).expect("tracker serialises");
+    assert!(
+        json.contains(NoProgressClass::UpstreamDependency.token()),
+        "the dedupe set must persist the stable class token string, got: {json}"
+    );
+}
+
+#[test]
+fn a_pre_issue17_snapshot_deserialises_with_an_empty_reinvestigated_set() {
+    // Backward compatibility: a `state/goal_board.json` written by a daemon build
+    // that predates issue #17 has no `reinvestigated` field. `#[serde(default)]`
+    // must load it with an empty set — never a deserialize error (which the
+    // fail-to-empty store would turn into a full board wipe).
+    let pre_17 = r#"{"counts":{"g1":2},"guided_retries":["g1"]}"#;
+    let tracker: NoProgressTracker =
+        serde_json::from_str(pre_17).expect("a pre-#17 snapshot must still deserialise");
+
+    assert_eq!(
+        tracker.consecutive("g1"),
+        2,
+        "the existing counter must load unchanged"
+    );
+    assert!(
+        tracker.guided_retry_used("g1"),
+        "the existing guided-retry flag must load unchanged"
+    );
+    assert!(
+        !tracker.reinvestigated("g1", NoProgressClass::GenuinelyStuck),
+        "a pre-#17 snapshot must load with an EMPTY re-investigation dedupe set"
+    );
+}

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -571,7 +571,8 @@ fn run_ooda_cycle_inner(
             let reasoner =
                 crate::ooda_loop::no_progress::DeterministicNoProgressReasoner::new(source_ref);
             let healer = crate::ooda_loop::no_progress::CloneRepoHealer::new("rysweet");
-            let dispatcher = crate::ooda_loop::no_progress::QueueingEngineerDispatcher::new();
+            let transition_dispatcher =
+                crate::ooda_loop::no_progress::QueueingEngineerDispatcher::new();
 
             let report = crate::ooda_loop::no_progress::apply_no_progress_breaker_investigated(
                 state,
@@ -579,7 +580,7 @@ fn run_ooda_cycle_inner(
                 source_ref,
                 &reasoner,
                 &healer,
-                &dispatcher,
+                &transition_dispatcher,
                 &crate::ooda_loop::no_progress::GhIssueFiler,
                 crate::ooda_loop::no_progress::INVESTIGATED_BREAKER_THRESHOLD,
             );
@@ -590,13 +591,45 @@ fn run_ooda_cycle_inner(
                     "OODA no-progress breaker (root-cause) ran",
                 );
             }
-            let dropped = report.dropped.clone();
 
-            // Drain the guided-engineer spawn requests and dispatch each through
-            // the SAME `dispatch_spawn_engineer` the Act phase uses (the state
-            // borrow is free now that the breaker pass has returned). Reuses the
-            // existing capability rather than building a parallel spawner.
-            let requests = dispatcher.into_requests();
+            // Already-blocked re-investigation (issue #17): after the
+            // on-transition breaker, scan the board for goals still parked in a
+            // BARE `[OODA-SAFEGUARD] … needs human review` block — parked by a
+            // pre-#16 daemon build, or left bare by a reasoner error on the
+            // transition cycle — and re-run the SAME WHY reasoner + ladder over
+            // them, so no goal is ever stranded with a bare, unexplained block.
+            // Uses its own spawn queue; both queues drain through the shared
+            // dispatch below.
+            let reinvestigate_dispatcher =
+                crate::ooda_loop::no_progress::QueueingEngineerDispatcher::new();
+            let reinvestigate_report =
+                crate::ooda_loop::no_progress::reinvestigate_bare_blocked_goals(
+                    state,
+                    source_ref,
+                    &reasoner,
+                    &healer,
+                    &reinvestigate_dispatcher,
+                    &crate::ooda_loop::no_progress::GhIssueFiler,
+                    crate::ooda_loop::no_progress::INVESTIGATED_BREAKER_THRESHOLD,
+                );
+            if reinvestigate_report.fired() || !reinvestigate_report.reinvestigated.is_empty() {
+                tracing::info!(
+                    target: "simard::ooda",
+                    summary = %reinvestigate_report.log_line(),
+                    "OODA no-progress re-investigation (already-blocked) ran",
+                );
+            }
+
+            let mut dropped = report.dropped.clone();
+            dropped.extend(reinvestigate_report.dropped.clone());
+
+            // Drain the guided-engineer spawn requests from BOTH passes and
+            // dispatch each through the SAME `dispatch_spawn_engineer` the Act
+            // phase uses (the state borrow is free now that both passes have
+            // returned). Reuses the existing capability rather than building a
+            // parallel spawner.
+            let mut requests = transition_dispatcher.into_requests();
+            requests.extend(reinvestigate_dispatcher.into_requests());
             if !requests.is_empty() {
                 let brain = memories.brain.clone();
                 let repo_root = memories.repo_root.clone();

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -43,6 +43,13 @@ mod tests_no_progress;
 #[cfg(test)]
 mod tests_no_progress_investigation;
 
+// Issue #17 (TDD): integration tests for the already-blocked re-investigation
+// pass — each cycle scans the board for goals parked in a BARE `[OODA-SAFEGUARD]
+// … needs human review` block and re-runs the WHY reasoner + resolution ladder
+// over them, so no goal is ever stranded with a bare, unexplained block.
+#[cfg(test)]
+mod tests_no_progress_reinvestigation;
+
 // Issue #2329: Observe-vs-Decide phase weights yield different ranked-recall
 // ordering of the same fact set, exercised against the real lbug-backed
 // `LibraryCognitiveMemory` adapter.

--- a/src/ooda_loop/no_progress.rs
+++ b/src/ooda_loop/no_progress.rs
@@ -21,8 +21,9 @@ use crate::goal_curation::completion_gate::{
     CompletionEvidenceGate, CompletionVerdict, DependencyState, EvidenceSource,
 };
 use crate::goal_curation::no_progress_breaker::{
-    NO_PROGRESS_BREAKER_THRESHOLD, NoProgressResolution, no_progress_blocked_reason_with_why,
-    obsolescence_reason, resolution_for_why, verify_stuck_goal,
+    NO_PROGRESS_BREAKER_THRESHOLD, NoProgressResolution, NoProgressTracker,
+    is_bare_no_progress_block, no_progress_blocked_reason_with_why, obsolescence_reason,
+    resolution_for_why, verify_stuck_goal,
 };
 use crate::goal_curation::no_progress_why::{
     Evidence, NoProgressClass, NoProgressWhy, NoProgressWhyReasoner,
@@ -124,6 +125,15 @@ pub(crate) struct NoProgressBreakerReport {
     /// breaker fails **closed** (no terminal action, counter preserved) rather
     /// than silently blocking or completing on an unknown cause (issue #16).
     pub investigation_errors: Vec<String>,
+    /// Goals whose **bare** `[OODA-SAFEGUARD] … needs human review` block was
+    /// re-investigated this cycle by the already-blocked re-investigation pass
+    /// (issue #17) and upgraded away from bare — completed / dropped / healed /
+    /// deferred / handed to a fixer / blocked WITH the concrete why. Recorded per
+    /// goal that the reasoner successfully classified (a fail-closed reasoner
+    /// error is surfaced via [`investigation_errors`](Self::investigation_errors),
+    /// not here). Housekeeping-style bookkeeping; does not itself constitute a
+    /// [`fired`](Self::fired) — the terminal-action buckets do.
+    pub reinvestigated: Vec<String>,
     /// Standing/perpetual goals (issue #2589) that produced a no-action ("idle")
     /// cycle. Such a goal is inherently bursty — it ships a durable improvement
     /// periodically and idles between — so it is **exempt** from the breaker:
@@ -152,7 +162,7 @@ impl NoProgressBreakerReport {
     pub fn log_line(&self) -> String {
         format!(
             "done={} dropped={} escalated={} healed={} deferred={} engineer={} \
-             auto_cleared={} errors={} perpetual_idled={}",
+             auto_cleared={} reinvestigated={} errors={} perpetual_idled={}",
             self.marked_done.len(),
             self.dropped.len(),
             self.escalated.len(),
@@ -160,6 +170,7 @@ impl NoProgressBreakerReport {
             self.deferred.len(),
             self.engineer_spawned.len(),
             self.auto_cleared.len(),
+            self.reinvestigated.len(),
             self.investigation_errors.len(),
             self.perpetual_idled.len(),
         )
@@ -510,173 +521,394 @@ pub(crate) fn apply_no_progress_breaker_investigated(
         let guided_retry_used = tracker.guided_retry_used(goal_id);
         let resolution = resolution_for_why(consecutive, why, guided_retry_used);
 
-        match resolution {
-            NoProgressResolution::Continue => {}
-            NoProgressResolution::MarkDone => {
-                if let Some(g) = state
-                    .active_goals
-                    .active
-                    .iter_mut()
-                    .find(|g| g.id == goal_id)
-                {
-                    g.status = GoalProgress::Completed;
+        // On-transition path: the goal is not in a Blocked state, so the
+        // non-terminal `Heal` / `SpawnEngineer` rungs leave its status untouched
+        // (`unblock_nonterminal = false`).
+        apply_resolution_side_effects(
+            state,
+            goal_id,
+            consecutive,
+            resolution,
+            healer,
+            dispatcher,
+            filer,
+            &mut tracker,
+            &mut report,
+            false,
+        );
+    }
+
+    // Prune counters/flags for goals no longer on the active board.
+    let live: HashSet<String> = state
+        .active_goals
+        .active
+        .iter()
+        .map(|g| g.id.clone())
+        .collect();
+    tracker.retain_goals(&live);
+
+    state.no_progress_tracker = tracker;
+    report
+}
+
+/// Drive one classified [`NoProgressResolution`] to its board mutation, tracker
+/// update, injected side effect (heal / spawn / file issue), and report entry.
+///
+/// Shared by BOTH the on-transition breaker
+/// ([`apply_no_progress_breaker_investigated`]) and the already-blocked
+/// re-investigation pass ([`reinvestigate_bare_blocked_goals`], issue #17) so the
+/// class → action mapping can never drift between the two populations.
+/// `consecutive` renders into any authored block reason / clone-error escalation.
+///
+/// `unblock_nonterminal` distinguishes the callers' starting state. The
+/// on-transition path acts on a goal that is *not* Blocked, so the non-terminal
+/// `Heal` / `SpawnEngineer` rungs leave its status untouched (`false`). The
+/// re-investigation path acts on a goal already parked in a BARE `Blocked` state,
+/// so those same rungs must additionally UN-BLOCK it to
+/// [`GoalProgress::NotStarted`] (`true`) — otherwise the brain would never
+/// re-select it and the heal / spawned fixer could never advance it. The terminal
+/// rungs (MarkDone / Drop / Defer / Escalate) set a definitive non-bare status
+/// regardless of the flag.
+#[allow(clippy::too_many_arguments)]
+fn apply_resolution_side_effects(
+    state: &mut OodaState,
+    goal_id: &str,
+    consecutive: u32,
+    resolution: NoProgressResolution,
+    healer: &dyn PreconditionHealer,
+    dispatcher: &dyn NoProgressEngineerDispatcher,
+    filer: &dyn NoProgressIssueFiler,
+    tracker: &mut NoProgressTracker,
+    report: &mut NoProgressBreakerReport,
+    unblock_nonterminal: bool,
+) {
+    match resolution {
+        NoProgressResolution::Continue => {}
+        NoProgressResolution::MarkDone => {
+            if let Some(g) = state
+                .active_goals
+                .active
+                .iter_mut()
+                .find(|g| g.id == goal_id)
+            {
+                g.status = GoalProgress::Completed;
+            }
+            tracker.reset_count(goal_id);
+            report.marked_done.push(goal_id.to_string());
+            tracing::warn!(
+                target: "simard::ooda",
+                goal = %goal_id,
+                "no-progress breaker: ALREADY-COMPLETE — marking goal DONE (no block)",
+            );
+        }
+        NoProgressResolution::Drop { reason } => {
+            state.active_goals.active.retain(|g| g.id != goal_id);
+            state.active_goals.backlog.retain(|b| b.id != goal_id);
+            tracker.reset_count(goal_id);
+            report.dropped.push(goal_id.to_string());
+            tracing::warn!(
+                target: "simard::ooda",
+                goal = %goal_id,
+                reason = %reason,
+                "no-progress breaker: OBSOLETE — DROPPING from the board (no block)",
+            );
+        }
+        NoProgressResolution::Heal { why } => {
+            let goal = match state.active_goals.active.iter().find(|g| g.id == goal_id) {
+                Some(g) => g.clone(),
+                None => {
+                    tracker.reset_count(goal_id);
+                    return;
                 }
-                tracker.reset_count(goal_id);
-                report.marked_done.push(goal_id.to_string());
-                tracing::warn!(
-                    target: "simard::ooda",
-                    goal = %goal_id,
-                    "no-progress breaker: ALREADY-COMPLETE — marking goal DONE (no block)",
-                );
-            }
-            NoProgressResolution::Drop { reason } => {
-                state.active_goals.active.retain(|g| g.id != goal_id);
-                state.active_goals.backlog.retain(|b| b.id != goal_id);
-                tracker.reset_count(goal_id);
-                report.dropped.push(goal_id.to_string());
-                tracing::warn!(
-                    target: "simard::ooda",
-                    goal = %goal_id,
-                    reason = %reason,
-                    "no-progress breaker: OBSOLETE — DROPPING from the board (no block)",
-                );
-            }
-            NoProgressResolution::Heal { why } => {
-                let goal = match state.active_goals.active.iter().find(|g| g.id == goal_id) {
-                    Some(g) => g.clone(),
-                    None => {
-                        tracker.reset_count(goal_id);
-                        continue;
-                    }
-                };
-                match healer.heal(&goal, &why) {
-                    Ok(()) => {
-                        // Precondition established; give a genuine fresh window.
-                        tracker.reset_count(goal_id);
-                        report.healed.push(goal_id.to_string());
-                        tracing::warn!(
-                            target: "simard::ooda",
-                            goal = %goal_id,
-                            "no-progress breaker: MISSING-PRECONDITION healed — retrying (no block)",
-                        );
-                    }
-                    Err(err) => {
-                        // A failed heal must not loop forever: escalate WITH the
-                        // clone error attached as evidence (fail closed, with WHY).
-                        let mut why_err = why;
-                        why_err
-                            .evidence
-                            .push(Evidence::new("clone-error", goal_id, err.clone()));
-                        let blocked_reason =
-                            no_progress_blocked_reason_with_why(consecutive, &why_err);
-                        if let Some(g) = state
+            };
+            match healer.heal(&goal, &why) {
+                Ok(()) => {
+                    // Precondition established; give a genuine fresh window.
+                    tracker.reset_count(goal_id);
+                    if unblock_nonterminal
+                        && let Some(g) = state
                             .active_goals
                             .active
                             .iter_mut()
                             .find(|g| g.id == goal_id)
-                        {
-                            g.status = GoalProgress::Blocked(blocked_reason.clone());
-                        }
-                        filer.file_issue(
-                            &format!(
-                                "OODA no-progress breaker: precondition heal failed for '{goal_id}'"
-                            ),
-                            &format!(
-                                "Healing the MISSING-PRECONDITION for goal `{goal_id}` failed: \
-                                 {err}\n\nThe goal has been Blocked with the WHY attached."
-                            ),
-                        );
-                        tracker.reset_count(goal_id);
-                        report.escalated.push(goal_id.to_string());
-                        tracing::error!(
-                            target: "simard::ooda",
-                            goal = %goal_id,
-                            error = %err,
-                            "no-progress breaker: precondition heal FAILED — escalating WITH why",
-                        );
+                    {
+                        g.status = GoalProgress::NotStarted;
                     }
-                }
-            }
-            NoProgressResolution::Defer {
-                blocking_ref,
-                evidence: _ev,
-            } => {
-                if let Some(g) = state
-                    .active_goals
-                    .active
-                    .iter_mut()
-                    .find(|g| g.id == goal_id)
-                {
-                    g.status = GoalProgress::Paused;
-                    // Record the specific blocking upstream as the WHY so the
-                    // auto-clear pass can resume the goal when it resolves.
-                    if !g.wip_refs.iter().any(is_breaker_defer_ref) {
-                        g.wip_refs.push(WipRef {
-                            kind: DEPENDENCY_WIP_KIND.to_string(),
-                            ref_id: blocking_ref.clone(),
-                            label: format!("{NO_PROGRESS_DEFER_LABEL_PREFIX}{blocking_ref}"),
-                            url: None,
-                        });
-                    }
-                }
-                tracker.reset_count(goal_id);
-                report.deferred.push(goal_id.to_string());
-                tracing::warn!(
-                    target: "simard::ooda",
-                    goal = %goal_id,
-                    blocking_ref = %blocking_ref,
-                    "no-progress breaker: UPSTREAM-DEPENDENCY — deferring (Paused), \
-                     will auto-clear (no block)",
-                );
-            }
-            NoProgressResolution::SpawnEngineer { task, why } => {
-                let spawned = dispatcher.spawn_engineer(goal_id, &task);
-                // Bound the guided retry to one regardless of accept/reject: a
-                // rejected spawn escalates (WITH why) on the next threshold rather
-                // than spawning forever.
-                tracker.mark_guided_retry(goal_id);
-                tracker.reset_count(goal_id);
-                if spawned {
-                    report.engineer_spawned.push(goal_id.to_string());
+                    report.healed.push(goal_id.to_string());
                     tracing::warn!(
                         target: "simard::ooda",
                         goal = %goal_id,
-                        why = %why.class.token(),
-                        "no-progress breaker: {} — spawned ONE guided engineer (no block yet)",
-                        why.class.token(),
+                        "no-progress breaker: MISSING-PRECONDITION healed — retrying (no block)",
                     );
-                } else {
+                }
+                Err(err) => {
+                    // A failed heal must not loop forever: escalate WITH the
+                    // clone error attached as evidence (fail closed, with WHY).
+                    let mut why_err = why;
+                    why_err
+                        .evidence
+                        .push(Evidence::new("clone-error", goal_id, err.clone()));
+                    let blocked_reason = no_progress_blocked_reason_with_why(consecutive, &why_err);
+                    if let Some(g) = state
+                        .active_goals
+                        .active
+                        .iter_mut()
+                        .find(|g| g.id == goal_id)
+                    {
+                        g.status = GoalProgress::Blocked(blocked_reason.clone());
+                    }
+                    filer.file_issue(
+                        &format!(
+                            "OODA no-progress breaker: precondition heal failed for '{goal_id}'"
+                        ),
+                        &format!(
+                            "Healing the MISSING-PRECONDITION for goal `{goal_id}` failed: \
+                             {err}\n\nThe goal has been Blocked with the WHY attached."
+                        ),
+                    );
+                    tracker.reset_count(goal_id);
+                    report.escalated.push(goal_id.to_string());
                     tracing::error!(
                         target: "simard::ooda",
                         goal = %goal_id,
-                        "no-progress breaker: guided engineer spawn was rejected — \
-                         will escalate WITH why on next stall",
+                        error = %err,
+                        "no-progress breaker: precondition heal FAILED — escalating WITH why",
                     );
                 }
             }
-            NoProgressResolution::Escalate {
-                blocked_reason,
-                issue_title,
-                issue_body,
-            } => {
-                if let Some(g) = state
+        }
+        NoProgressResolution::Defer {
+            blocking_ref,
+            evidence: _ev,
+        } => {
+            if let Some(g) = state
+                .active_goals
+                .active
+                .iter_mut()
+                .find(|g| g.id == goal_id)
+            {
+                g.status = GoalProgress::Paused;
+                // Record the specific blocking upstream as the WHY so the
+                // auto-clear pass can resume the goal when it resolves.
+                if !g.wip_refs.iter().any(is_breaker_defer_ref) {
+                    g.wip_refs.push(WipRef {
+                        kind: DEPENDENCY_WIP_KIND.to_string(),
+                        ref_id: blocking_ref.clone(),
+                        label: format!("{NO_PROGRESS_DEFER_LABEL_PREFIX}{blocking_ref}"),
+                        url: None,
+                    });
+                }
+            }
+            tracker.reset_count(goal_id);
+            report.deferred.push(goal_id.to_string());
+            tracing::warn!(
+                target: "simard::ooda",
+                goal = %goal_id,
+                blocking_ref = %blocking_ref,
+                "no-progress breaker: UPSTREAM-DEPENDENCY — deferring (Paused), \
+                 will auto-clear (no block)",
+            );
+        }
+        NoProgressResolution::SpawnEngineer { task, why } => {
+            let spawned = dispatcher.spawn_engineer(goal_id, &task);
+            // Bound the guided retry to one regardless of accept/reject: a
+            // rejected spawn escalates (WITH why) on the next threshold rather
+            // than spawning forever.
+            tracker.mark_guided_retry(goal_id);
+            tracker.reset_count(goal_id);
+            // Re-investigation path: the goal was BARE-blocked — un-block it so the
+            // brain can re-select it and the spawned fixer can advance it.
+            if unblock_nonterminal
+                && let Some(g) = state
                     .active_goals
                     .active
                     .iter_mut()
                     .find(|g| g.id == goal_id)
-                {
-                    g.status = GoalProgress::Blocked(blocked_reason);
-                }
-                filer.file_issue(&issue_title, &issue_body);
-                tracker.reset_count(goal_id);
-                report.escalated.push(goal_id.to_string());
+            {
+                g.status = GoalProgress::NotStarted;
+            }
+            if spawned {
+                report.engineer_spawned.push(goal_id.to_string());
                 tracing::warn!(
                     target: "simard::ooda",
                     goal = %goal_id,
-                    "no-progress breaker: stuck after guided retry — BLOCKED WITH why + issue filed",
+                    why = %why.class.token(),
+                    "no-progress breaker: {} — spawned ONE guided engineer (no block yet)",
+                    why.class.token(),
+                );
+            } else {
+                tracing::error!(
+                    target: "simard::ooda",
+                    goal = %goal_id,
+                    "no-progress breaker: guided engineer spawn was rejected — \
+                     will escalate WITH why on next stall",
                 );
             }
         }
+        NoProgressResolution::Escalate {
+            blocked_reason,
+            issue_title,
+            issue_body,
+        } => {
+            if let Some(g) = state
+                .active_goals
+                .active
+                .iter_mut()
+                .find(|g| g.id == goal_id)
+            {
+                g.status = GoalProgress::Blocked(blocked_reason);
+            }
+            filer.file_issue(&issue_title, &issue_body);
+            tracker.reset_count(goal_id);
+            report.escalated.push(goal_id.to_string());
+            tracing::warn!(
+                target: "simard::ooda",
+                goal = %goal_id,
+                "no-progress breaker: stuck after guided retry — BLOCKED WITH why + issue filed",
+            );
+        }
+    }
+}
+
+// ===========================================================================
+// Already-blocked re-investigation pass (issue #17)
+// ===========================================================================
+
+/// Re-investigate goals already parked in a **bare** `[OODA-SAFEGUARD] … needs
+/// human review` block and drive each away from bare (issue #17).
+///
+/// The on-transition breaker ([`apply_no_progress_breaker_investigated`])
+/// investigates WHY a goal is stuck **only at the cycle it crosses the
+/// threshold**. That leaves goals parked bare by a pre-#16 daemon build — or on a
+/// cycle the reasoner erred — stranded forever with an unexplained "needs human
+/// review" marker, never re-examined. This population-driven pass closes that
+/// gap: every cycle it scans the ACTIVE board (independent of this cycle's
+/// `outcomes`, mirroring the auto-clear scan) for goals in a **bare** blocked
+/// state ([`is_bare_no_progress_block`]) and runs the SAME injected WHY reasoner +
+/// [`resolution_for_why`] ladder over them via the shared
+/// [`apply_resolution_side_effects`], so no goal is ever left bare — each is
+/// upgraded to a concrete WHY and, when the WHY is actionable, completed /
+/// dropped / healed / deferred / handed to a spawned fixer.
+///
+/// Invariants:
+/// * **Perpetual exemption** (I5): standing/perpetual goals are excluded before
+///   investigation, mirroring the on-transition path.
+/// * **Fail closed** (I2): a reasoner error takes NO terminal action, leaves the
+///   bare marker exactly as-is (retried next cycle), and records nothing in the
+///   dedupe set.
+/// * **Un-block on non-terminal resolution**: a re-investigated goal handed to a
+///   fixer or healed is set [`GoalProgress::NotStarted`] so the brain can
+///   re-select it (`unblock_nonterminal = true`).
+/// * **Idempotency** (I3/I4): the WHY-rewrite removes the goal from the bare
+///   population next cycle (primary), and the persisted `(goal, class)` dedupe set
+///   in [`NoProgressTracker`] prevents a duplicate terminal action if a restart
+///   re-parks the goal bare (belt-and-suspenders) — at most ONE fixer per
+///   `(goal, class)`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn reinvestigate_bare_blocked_goals(
+    state: &mut OodaState,
+    _evidence: &dyn EvidenceSource,
+    reasoner: &dyn NoProgressWhyReasoner,
+    healer: &dyn PreconditionHealer,
+    dispatcher: &dyn NoProgressEngineerDispatcher,
+    filer: &dyn NoProgressIssueFiler,
+    threshold: u32,
+) -> NoProgressBreakerReport {
+    let mut report = NoProgressBreakerReport::default();
+
+    // Detach the tracker so the board can be borrowed while the tracker mutates.
+    let mut tracker = std::mem::take(&mut state.no_progress_tracker);
+
+    // The bare-blocked, non-perpetual population, captured up front. The
+    // perpetual exemption (I5) runs BEFORE investigation, so a standing goal's
+    // reasoner is never consulted. Collecting ids first keeps the board free to
+    // mutate as each goal is resolved.
+    let bare_ids: Vec<String> = state
+        .active_goals
+        .active
+        .iter()
+        .filter(|g| !g.is_perpetual())
+        .filter_map(|g| match &g.status {
+            GoalProgress::Blocked(reason) if is_bare_no_progress_block(reason) => {
+                Some(g.id.clone())
+            }
+            _ => None,
+        })
+        .collect();
+
+    for goal_id in bare_ids {
+        // Investigate the bare goal ONCE. Fail closed on error: no terminal
+        // action, marker left exactly as-is, nothing recorded in the dedupe set.
+        let why = {
+            let Some(goal) = state.active_goals.active.iter().find(|g| g.id == goal_id) else {
+                continue;
+            };
+            match reasoner.investigate(goal) {
+                Ok(why) => why,
+                Err(e) => {
+                    report.investigation_errors.push(goal_id.clone());
+                    tracing::error!(
+                        target: "simard::ooda",
+                        goal = %goal_id,
+                        error = %e,
+                        "no-progress re-investigation: root-cause investigation errored — \
+                         leaving the bare block untouched (fail closed), will retry next cycle",
+                    );
+                    continue;
+                }
+            }
+        };
+
+        let class = why.class;
+        report.reinvestigated.push(goal_id.clone());
+
+        // Belt-and-suspenders dedupe (I3): a terminal action was already taken for
+        // this (goal, class) — possibly before a restart that re-parked the goal
+        // bare. Do NOT repeat the side effect (e.g. spawn a second fixer), but
+        // never leave the goal bare: rewrite it to the WHY-bearing block so the
+        // rail excludes it next cycle.
+        if tracker.reinvestigated(&goal_id, class) {
+            let blocked_reason = no_progress_blocked_reason_with_why(threshold, &why);
+            if let Some(g) = state
+                .active_goals
+                .active
+                .iter_mut()
+                .find(|g| g.id == goal_id)
+            {
+                g.status = GoalProgress::Blocked(blocked_reason);
+            }
+            tracing::info!(
+                target: "simard::ooda",
+                goal = %goal_id,
+                why = %class.token(),
+                "no-progress re-investigation: (goal, class) already resolved — \
+                 rewriting to the WHY-bearing block, taking NO new terminal action (dedupe)",
+            );
+            continue;
+        }
+
+        let guided_retry_used = tracker.guided_retry_used(&goal_id);
+        let resolution = resolution_for_why(threshold, why, guided_retry_used);
+
+        // Re-investigation path: the goal starts BARE-blocked, so a non-terminal
+        // `Heal` / `SpawnEngineer` rung must UN-BLOCK it to NotStarted.
+        apply_resolution_side_effects(
+            state,
+            &goal_id,
+            threshold,
+            resolution,
+            healer,
+            dispatcher,
+            filer,
+            &mut tracker,
+            &mut report,
+            true,
+        );
+
+        // A terminal action was taken for this (goal, class); record it so a
+        // re-park after a restart cannot trigger a second one. Only recorded on a
+        // successful classification (never on a fail-closed error above).
+        tracker.mark_reinvestigated(&goal_id, class);
     }
 
     // Prune counters/flags for goals no longer on the active board.

--- a/src/ooda_loop/tests_no_progress_reinvestigation.rs
+++ b/src/ooda_loop/tests_no_progress_reinvestigation.rs
@@ -277,14 +277,14 @@ fn status_of<'a>(state: &'a OodaState, id: &str) -> &'a GoalProgress {
 /// (I1: no bare survivors). Completed / removed / NotStarted / Paused /
 /// Blocked-with-why all satisfy it.
 fn assert_not_bare(state: &OodaState, id: &str) {
-    if let Some(g) = state.active_goals.active.iter().find(|g| g.id == id) {
-        if let GoalProgress::Blocked(reason) = &g.status {
-            assert!(
-                !is_bare_no_progress_block(reason),
-                "goal {id} must NEVER remain a bare '[OODA-SAFEGUARD] … needs human review' block; \
-                 got: {reason}"
-            );
-        }
+    if let Some(g) = state.active_goals.active.iter().find(|g| g.id == id)
+        && let GoalProgress::Blocked(reason) = &g.status
+    {
+        assert!(
+            !is_bare_no_progress_block(reason),
+            "goal {id} must NEVER remain a bare '[OODA-SAFEGUARD] … needs human review' block; \
+             got: {reason}"
+        );
     }
 }
 

--- a/src/ooda_loop/tests_no_progress_reinvestigation.rs
+++ b/src/ooda_loop/tests_no_progress_reinvestigation.rs
@@ -1,0 +1,1009 @@
+//! TEST-FIRST (Step 7 TDD) for the **side-effecting** already-blocked
+//! re-investigation pass (issue #17):
+//! [`reinvestigate_bare_blocked_goals`].
+//!
+//! The on-transition breaker (issue #16, PR #2960) investigates WHY a goal is
+//! stuck **only at the cycle it crosses the threshold**. That leaves goals that
+//! were parked *bare* by an older daemon build — or on a cycle the reasoner erred
+//! — stranded forever with a bare `[OODA-SAFEGUARD] … needs human review` marker
+//! and never re-examined. This pass closes that gap: every cycle it scans the
+//! ACTIVE board for goals in a **bare** blocked state and runs the SAME injected
+//! WHY reasoner + resolution ladder over them, so no goal is ever left with a
+//! bare "needs human review" — each is upgraded to a concrete WHY and, when the
+//! WHY is actionable, completed / dropped / healed / deferred / handed to a
+//! spawned fixer.
+//!
+//! The population-driven pass under test (mirrors the sibling auto-clear scan —
+//! it takes NO `outcomes`, it scans board state directly):
+//!
+//! ```text
+//! for each ACTIVE goal G with a BARE no-progress block, non-perpetual:
+//!   investigate(G) ONCE via the injected reasoner
+//!     Err                  -> FAIL CLOSED: leave bare, no action, retriable
+//!     ALREADY-COMPLETE     -> Completed                            (never bare)
+//!     OBSOLETE             -> dropped from board                   (never bare)
+//!     MISSING-PRECONDITION -> heal + UN-BLOCK to NotStarted        (never bare)
+//!     UPSTREAM-DEPENDENCY  -> Paused + named blocking ref          (never bare)
+//!     UNCLEAR / STUCK      -> spawn ONE fixer + UN-BLOCK to NotStarted;
+//!                             once that retry is spent -> Blocked WITH why
+//!   dedupe (goal, class): at most ONE terminal action, across restarts
+//! ```
+//!
+//! Every dependency (evidence, reasoner, healer, dispatcher, filer) is an
+//! injected hermetic fake — no `gh`, no clone, no subprocess.
+//!
+//! RED until `reinvestigate_bare_blocked_goals`, the `NoProgressBreakerReport.
+//! reinvestigated` field, and the tracker dedupe set exist.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use super::no_progress::{
+    NoProgressBreakerReport, NoProgressEngineerDispatcher, NoProgressIssueFiler,
+    PreconditionHealer, reinvestigate_bare_blocked_goals,
+};
+use crate::error::{SimardError, SimardResult};
+use crate::goal_curation::completion_gate::{DependencyState, EvidenceSource};
+use crate::goal_curation::no_progress_breaker::{
+    NO_PROGRESS_BLOCKED_PREFIX, NO_PROGRESS_BREAKER_THRESHOLD, is_bare_no_progress_block,
+    is_no_progress_marker, no_progress_blocked_reason,
+};
+use crate::goal_curation::no_progress_why::{
+    Evidence, NoProgressClass, NoProgressWhy, NoProgressWhyReasoner,
+};
+use crate::goal_curation::{ActiveGoal, GoalBoard, GoalProgress, WipRef};
+use crate::ooda_loop::OodaState;
+
+// --- fakes ------------------------------------------------------------------
+
+/// Canned evidence source (the pass still takes one for API symmetry with the
+/// on-transition driver; classification itself is driven by the injected
+/// reasoner). `dependency` is interior-mutable so a test can model an upstream
+/// state.
+struct FakeEvidence {
+    pr_merged: bool,
+    issue_closed: bool,
+    deployed: bool,
+    repo_present: bool,
+    dependency: std::sync::RwLock<DependencyState>,
+}
+
+impl FakeEvidence {
+    fn stuck() -> Self {
+        Self {
+            pr_merged: false,
+            issue_closed: false,
+            deployed: false,
+            repo_present: true,
+            dependency: std::sync::RwLock::new(DependencyState::None),
+        }
+    }
+}
+
+impl EvidenceSource for FakeEvidence {
+    fn any_pr_merged(&self, _goal: &ActiveGoal) -> SimardResult<bool> {
+        Ok(self.pr_merged)
+    }
+    fn issue_closed(&self, _goal: &ActiveGoal) -> SimardResult<bool> {
+        Ok(self.issue_closed)
+    }
+    fn is_deployed(&self, _goal: &ActiveGoal) -> SimardResult<bool> {
+        Ok(self.deployed)
+    }
+    fn repo_present(&self, _goal: &ActiveGoal) -> SimardResult<bool> {
+        Ok(self.repo_present)
+    }
+    fn dependency_goal_state(&self, _goal: &ActiveGoal) -> SimardResult<DependencyState> {
+        Ok(self
+            .dependency
+            .read()
+            .expect("dependency lock poisoned")
+            .clone())
+    }
+}
+
+/// A reasoner that returns a per-goal canned finding, falling back to a default.
+/// Supports a canned error to exercise the fail-closed path.
+struct FakeReasoner {
+    by_goal: HashMap<String, Result<NoProgressWhy, String>>,
+    default: Result<NoProgressWhy, String>,
+}
+
+impl FakeReasoner {
+    fn classifying(class: NoProgressClass, evidence: Vec<Evidence>) -> Self {
+        Self {
+            by_goal: HashMap::new(),
+            default: Ok(NoProgressWhy::new(class, evidence)),
+        }
+    }
+    fn failing() -> Self {
+        Self {
+            by_goal: HashMap::new(),
+            default: Err("root-cause recipe transport failed".to_string()),
+        }
+    }
+    fn per_goal(map: HashMap<String, NoProgressWhy>) -> Self {
+        Self {
+            by_goal: map.into_iter().map(|(k, v)| (k, Ok(v))).collect(),
+            default: Err("no canned finding for goal".to_string()),
+        }
+    }
+}
+
+impl NoProgressWhyReasoner for FakeReasoner {
+    fn investigate(&self, goal: &ActiveGoal) -> SimardResult<NoProgressWhy> {
+        self.by_goal
+            .get(&goal.id)
+            .unwrap_or(&self.default)
+            .clone()
+            .map_err(|reason| SimardError::VerificationFailed { reason })
+    }
+}
+
+/// A reasoner that MUST NOT be consulted — panics if it is. Proves the perpetual
+/// exemption / rail excludes a goal from the population before investigation.
+struct PanicReasoner;
+impl NoProgressWhyReasoner for PanicReasoner {
+    fn investigate(&self, goal: &ActiveGoal) -> SimardResult<NoProgressWhy> {
+        panic!("the reasoner must NOT be consulted for goal {:?}", goal.id)
+    }
+}
+
+/// Records precondition-heal attempts; returns a fixed outcome.
+struct RecordingHealer {
+    calls: RefCell<Vec<String>>,
+    result: Result<(), String>,
+}
+
+impl RecordingHealer {
+    fn ok() -> Self {
+        Self {
+            calls: RefCell::new(Vec::new()),
+            result: Ok(()),
+        }
+    }
+}
+
+impl PreconditionHealer for RecordingHealer {
+    fn heal(&self, goal: &ActiveGoal, _why: &NoProgressWhy) -> Result<(), String> {
+        self.calls.borrow_mut().push(goal.id.clone());
+        self.result.clone()
+    }
+}
+
+/// Records engineer-spawn dispatches; returns a fixed success flag.
+struct RecordingDispatcher {
+    calls: RefCell<Vec<(String, String)>>,
+    result: bool,
+}
+
+impl RecordingDispatcher {
+    fn ok() -> Self {
+        Self {
+            calls: RefCell::new(Vec::new()),
+            result: true,
+        }
+    }
+}
+
+impl NoProgressEngineerDispatcher for RecordingDispatcher {
+    fn spawn_engineer(&self, goal_id: &str, task: &str) -> bool {
+        self.calls
+            .borrow_mut()
+            .push((goal_id.to_string(), task.to_string()));
+        self.result
+    }
+}
+
+/// Records escalation issue filings.
+#[derive(Default)]
+struct RecordingFiler {
+    calls: RefCell<Vec<(String, String)>>,
+}
+
+impl NoProgressIssueFiler for RecordingFiler {
+    fn file_issue(&self, title: &str, body: &str) {
+        self.calls
+            .borrow_mut()
+            .push((title.to_string(), body.to_string()));
+    }
+}
+
+// --- fixtures ---------------------------------------------------------------
+
+fn issue_ref(num: &str, label: &str) -> WipRef {
+    WipRef {
+        kind: "issue".to_string(),
+        ref_id: num.to_string(),
+        label: label.to_string(),
+        url: None,
+    }
+}
+
+fn pr_ref(num: &str) -> WipRef {
+    WipRef {
+        kind: "pr".to_string(),
+        ref_id: num.to_string(),
+        label: format!("PR #{num}"),
+        url: None,
+    }
+}
+
+/// A goal already parked in the exact BARE state the incident left behind:
+/// `🔒 [OODA-SAFEGUARD] … {threshold} consecutive no-action cycles; needs human review`.
+fn bare_blocked_goal(id: &str) -> ActiveGoal {
+    let mut g = ActiveGoal::new(id, "advance kgpacks-rs to full parity", 1);
+    g.status = GoalProgress::Blocked(no_progress_blocked_reason(NO_PROGRESS_BREAKER_THRESHOLD));
+    g
+}
+
+fn state_with(goal: ActiveGoal) -> OodaState {
+    let mut board = GoalBoard::new();
+    board.active.push(goal);
+    OodaState::new(board)
+}
+
+/// Drive the re-investigation pass for one cycle.
+fn drive(
+    state: &mut OodaState,
+    evidence: &dyn EvidenceSource,
+    reasoner: &dyn NoProgressWhyReasoner,
+    healer: &dyn PreconditionHealer,
+    dispatcher: &dyn NoProgressEngineerDispatcher,
+    filer: &dyn NoProgressIssueFiler,
+) -> NoProgressBreakerReport {
+    reinvestigate_bare_blocked_goals(
+        state,
+        evidence,
+        reasoner,
+        healer,
+        dispatcher,
+        filer,
+        NO_PROGRESS_BREAKER_THRESHOLD,
+    )
+}
+
+fn status_of<'a>(state: &'a OodaState, id: &str) -> &'a GoalProgress {
+    &state
+        .active_goals
+        .active
+        .iter()
+        .find(|g| g.id == id)
+        .unwrap_or_else(|| panic!("goal {id} left the board"))
+        .status
+}
+
+/// Assert a goal is no longer sitting with a BARE block — the core #17 invariant
+/// (I1: no bare survivors). Completed / removed / NotStarted / Paused /
+/// Blocked-with-why all satisfy it.
+fn assert_not_bare(state: &OodaState, id: &str) {
+    if let Some(g) = state.active_goals.active.iter().find(|g| g.id == id) {
+        if let GoalProgress::Blocked(reason) = &g.status {
+            assert!(
+                !is_bare_no_progress_block(reason),
+                "goal {id} must NEVER remain a bare '[OODA-SAFEGUARD] … needs human review' block; \
+                 got: {reason}"
+            );
+        }
+    }
+}
+
+// === (a) ALREADY-COMPLETE: an already-done bare goal is completed ============
+
+#[test]
+fn a_bare_goal_that_is_already_done_is_completed_not_left_blocked() {
+    // The kgpacks-rs incident, as it survives in the bare-blocked population: the
+    // referenced issue is CLOSED and the PR MERGED, but the goal was parked bare
+    // before the reasoner shipped. Re-investigation must read the live artifacts,
+    // complete the goal, and never leave it "needs human review".
+    let mut goal = bare_blocked_goal("advance-kgpacks-rs-to-full-parity");
+    goal.wip_refs = vec![issue_ref("16", "eval baseline"), pr_ref("40")];
+    let mut state = state_with(goal);
+
+    let evidence = FakeEvidence {
+        pr_merged: true,
+        issue_closed: true,
+        deployed: true,
+        repo_present: true,
+        dependency: std::sync::RwLock::new(DependencyState::None),
+    };
+    let reasoner = FakeReasoner::classifying(
+        NoProgressClass::AlreadyComplete,
+        vec![
+            Evidence::new("issue", "#16", "CLOSED"),
+            Evidence::new("pr", "#40", "MERGED"),
+        ],
+    );
+    let (healer, dispatcher, filer) = (
+        RecordingHealer::ok(),
+        RecordingDispatcher::ok(),
+        RecordingFiler::default(),
+    );
+
+    let report = drive(
+        &mut state,
+        &evidence,
+        &reasoner,
+        &healer,
+        &dispatcher,
+        &filer,
+    );
+
+    assert_eq!(
+        report.reinvestigated,
+        vec!["advance-kgpacks-rs-to-full-parity".to_string()],
+        "the bare goal must be recorded as re-investigated this cycle"
+    );
+    assert_eq!(
+        report.marked_done,
+        vec!["advance-kgpacks-rs-to-full-parity".to_string()],
+        "an already-complete bare goal must be marked done"
+    );
+    assert!(
+        matches!(
+            status_of(&state, "advance-kgpacks-rs-to-full-parity"),
+            GoalProgress::Completed
+        ),
+        "the goal must be set Completed for archival"
+    );
+    assert!(
+        report.escalated.is_empty() && filer.calls.borrow().is_empty(),
+        "an already-complete goal must NEVER be escalated to a human"
+    );
+    assert!(
+        dispatcher.calls.borrow().is_empty() && healer.calls.borrow().is_empty(),
+        "no fixer / heal for an already-complete goal"
+    );
+}
+
+// === (b) UPSTREAM-DEPENDENCY: the #17 case — Paused with the upstream named ===
+
+#[test]
+fn a_bare_goal_gated_on_an_upstream_is_deferred_with_the_upstream_named() {
+    // The exact fix-agent-kgpacks-rs-issue-17 evidence: #17's done-criterion is
+    // gated on #16's eval baseline (#16 still OPEN). Re-investigation must replace
+    // the bare marker with a concrete WHY that NAMES the real upstream dependency,
+    // deferring (Paused) rather than "needs human review".
+    let mut state = state_with(bare_blocked_goal("fix-agent-kgpacks-rs-issue-17"));
+
+    let evidence = FakeEvidence::stuck();
+    let reasoner = FakeReasoner::classifying(
+        NoProgressClass::UpstreamDependency,
+        vec![Evidence::new("dependency", "kgpacks-rs-issue-16", "OPEN")],
+    );
+    let (healer, dispatcher, filer) = (
+        RecordingHealer::ok(),
+        RecordingDispatcher::ok(),
+        RecordingFiler::default(),
+    );
+
+    let report = drive(
+        &mut state,
+        &evidence,
+        &reasoner,
+        &healer,
+        &dispatcher,
+        &filer,
+    );
+
+    assert_eq!(
+        report.reinvestigated,
+        vec!["fix-agent-kgpacks-rs-issue-17".to_string()]
+    );
+    assert_eq!(
+        report.deferred,
+        vec!["fix-agent-kgpacks-rs-issue-17".to_string()],
+        "an upstream-gated bare goal must be deferred, not left blocked"
+    );
+    assert!(
+        matches!(
+            status_of(&state, "fix-agent-kgpacks-rs-issue-17"),
+            GoalProgress::Paused
+        ),
+        "an upstream-gated goal is Paused (deferred), never bare Blocked"
+    );
+    let goal = &state.active_goals.active[0];
+    assert!(
+        goal.wip_refs.iter().any(|w| {
+            w.kind.eq_ignore_ascii_case("dependency")
+                && (w.ref_id.contains("kgpacks-rs-issue-16")
+                    || w.label.contains("kgpacks-rs-issue-16"))
+        }),
+        "the specific blocking upstream must be recorded on the goal as the WHY, \
+         got wip_refs = {:?}",
+        goal.wip_refs
+    );
+    assert!(
+        report.escalated.is_empty() && filer.calls.borrow().is_empty(),
+        "deferring on a dependency must NEVER escalate to a human"
+    );
+    assert_not_bare(&state, "fix-agent-kgpacks-rs-issue-17");
+}
+
+// === (c) GENUINELY-STUCK first time: spawn a fixer AND un-block the goal ======
+
+#[test]
+fn a_bare_stuck_goal_spawns_a_fixer_and_is_unblocked_so_the_fix_can_run() {
+    // A bare-blocked goal with an unresolved (genuinely stuck) root cause must
+    // spawn ONE guided fixer engineer AND be un-blocked back to NotStarted — an
+    // already-blocked goal the brain never re-selects would strand the fix. This
+    // is the requirement "when the why is actionable, spawn a fixer engineer".
+    let id = "fix-agent-kgpacks-rs-issue-21";
+    let mut goal = bare_blocked_goal(id);
+    goal.wip_refs = vec![pr_ref("7")];
+    let mut state = state_with(goal);
+
+    let evidence = FakeEvidence::stuck();
+    let reasoner = FakeReasoner::classifying(
+        NoProgressClass::GenuinelyStuck,
+        vec![Evidence::new("pr", "#7", "OPEN")],
+    );
+    let (healer, dispatcher, filer) = (
+        RecordingHealer::ok(),
+        RecordingDispatcher::ok(),
+        RecordingFiler::default(),
+    );
+
+    let report = drive(
+        &mut state,
+        &evidence,
+        &reasoner,
+        &healer,
+        &dispatcher,
+        &filer,
+    );
+
+    assert_eq!(report.reinvestigated, vec![id.to_string()]);
+    assert_eq!(
+        report.engineer_spawned,
+        vec![id.to_string()],
+        "a genuinely-stuck bare goal must spawn a fixer on first re-investigation"
+    );
+    assert_eq!(
+        dispatcher.calls.borrow().len(),
+        1,
+        "exactly one guided fixer is spawned"
+    );
+    let (spawn_goal, spawn_task) = dispatcher.calls.borrow()[0].clone();
+    assert_eq!(spawn_goal, id);
+    assert!(
+        spawn_task.contains("#7") || spawn_task.to_ascii_lowercase().contains("stuck"),
+        "the fixer task must embed the WHY/evidence as guidance: {spawn_task:?}"
+    );
+    assert!(
+        matches!(status_of(&state, id), GoalProgress::NotStarted),
+        "a re-investigated goal handed to a fixer must be UN-BLOCKED to NotStarted \
+         so the brain can re-select it and the fix can advance it"
+    );
+    assert!(
+        filer.calls.borrow().is_empty(),
+        "spawning a fixer is not a human escalation — no issue on first stall"
+    );
+    assert_not_bare(&state, id);
+}
+
+// === (d) GENUINELY-STUCK after the guided retry is spent: Blocked WITH why ====
+
+#[test]
+fn a_bare_stuck_goal_whose_retry_is_spent_is_blocked_with_a_concrete_why() {
+    // If the goal already spent its one guided retry, re-investigation must not
+    // spawn a second fixer; it escalates — but the resulting block MUST carry the
+    // concrete WHY + evidence (never a bare "needs human review").
+    let id = "fix-agent-kgpacks-rs-issue-22";
+    let mut goal = bare_blocked_goal(id);
+    goal.wip_refs = vec![pr_ref("7")];
+    let mut state = state_with(goal);
+    // Pre-condition: the goal already spent its one guided fixer retry.
+    state.no_progress_tracker.mark_guided_retry(id);
+
+    let evidence = FakeEvidence::stuck();
+    let reasoner = FakeReasoner::classifying(
+        NoProgressClass::GenuinelyStuck,
+        vec![Evidence::new("pr", "#7", "OPEN")],
+    );
+    let (healer, dispatcher, filer) = (
+        RecordingHealer::ok(),
+        RecordingDispatcher::ok(),
+        RecordingFiler::default(),
+    );
+
+    let report = drive(
+        &mut state,
+        &evidence,
+        &reasoner,
+        &healer,
+        &dispatcher,
+        &filer,
+    );
+
+    assert_eq!(report.reinvestigated, vec![id.to_string()]);
+    assert_eq!(
+        report.escalated,
+        vec![id.to_string()],
+        "a stuck goal past its guided retry must escalate"
+    );
+    assert!(
+        dispatcher.calls.borrow().is_empty(),
+        "no SECOND fixer — the guided retry is bounded to one"
+    );
+    assert_eq!(
+        filer.calls.borrow().len(),
+        1,
+        "exactly one tracking issue is filed"
+    );
+    match status_of(&state, id) {
+        GoalProgress::Blocked(reason) => {
+            assert!(
+                is_no_progress_marker(reason),
+                "the block must keep the [OODA-SAFEGUARD] marker: {reason}"
+            );
+            assert!(
+                reason.starts_with(NO_PROGRESS_BLOCKED_PREFIX),
+                "I6: the rewritten reason must preserve the marker prefix so overseer \
+                 + load-time self-heal still recognise it: {reason}"
+            );
+            assert!(
+                reason.contains(NoProgressClass::GenuinelyStuck.token()),
+                "the block reason MUST name the classification WHY: {reason}"
+            );
+            assert!(
+                reason.contains("#7"),
+                "the block reason MUST attach the evidence link: {reason}"
+            );
+            assert!(
+                !is_bare_no_progress_block(reason),
+                "the escalated block must be WHY-bearing, NEVER bare: {reason}"
+            );
+        }
+        other => panic!("expected Blocked-with-why, got {other:?}"),
+    }
+}
+
+// === (e) MISSING-PRECONDITION: heal + un-block, never a human block ==========
+
+#[test]
+fn a_bare_goal_with_a_missing_precondition_is_healed_and_unblocked() {
+    let id = "fix-agent-kgpacks-rs-issue-23";
+    let mut goal = bare_blocked_goal(id);
+    goal.repo = Some("kgpacks-rs".to_string());
+    let mut state = state_with(goal);
+
+    let mut evidence = FakeEvidence::stuck();
+    evidence.repo_present = false;
+    let reasoner = FakeReasoner::classifying(
+        NoProgressClass::MissingPrecondition,
+        vec![Evidence::new("repo", "kgpacks-rs", "absent")],
+    );
+    let (healer, dispatcher, filer) = (
+        RecordingHealer::ok(),
+        RecordingDispatcher::ok(),
+        RecordingFiler::default(),
+    );
+
+    let report = drive(
+        &mut state,
+        &evidence,
+        &reasoner,
+        &healer,
+        &dispatcher,
+        &filer,
+    );
+
+    assert_eq!(report.reinvestigated, vec![id.to_string()]);
+    assert_eq!(
+        healer.calls.borrow().as_slice(),
+        &[id.to_string()],
+        "the missing precondition must be healed (repo cloned)"
+    );
+    assert_eq!(report.healed, vec![id.to_string()]);
+    assert!(
+        matches!(status_of(&state, id), GoalProgress::NotStarted),
+        "a healed re-investigated goal must be UN-BLOCKED to NotStarted for retry"
+    );
+    assert!(
+        report.escalated.is_empty() && filer.calls.borrow().is_empty(),
+        "healing a precondition must NOT escalate to a human"
+    );
+    assert_not_bare(&state, id);
+}
+
+// === (f) fail-closed: a reasoner error leaves the bare block untouched ========
+
+#[test]
+fn a_reasoner_error_leaves_the_goal_bare_and_retriable_taking_no_action() {
+    // Fail-closed (I2): if investigation errors, the pass must take NO terminal
+    // action, leave the bare marker EXACTLY as-is (so it is retried next cycle),
+    // record NOTHING in the dedupe set, and surface the error.
+    let id = "fix-agent-kgpacks-rs-issue-18";
+    let mut goal = bare_blocked_goal(id);
+    goal.wip_refs = vec![pr_ref("7")];
+    let original_reason = match &goal.status {
+        GoalProgress::Blocked(r) => r.clone(),
+        _ => unreachable!(),
+    };
+    let mut state = state_with(goal);
+
+    let evidence = FakeEvidence::stuck();
+    let reasoner = FakeReasoner::failing();
+    let (healer, dispatcher, filer) = (
+        RecordingHealer::ok(),
+        RecordingDispatcher::ok(),
+        RecordingFiler::default(),
+    );
+
+    let report = drive(
+        &mut state,
+        &evidence,
+        &reasoner,
+        &healer,
+        &dispatcher,
+        &filer,
+    );
+
+    assert_eq!(
+        report.investigation_errors,
+        vec![id.to_string()],
+        "a reasoner error must be surfaced, not swallowed"
+    );
+    assert!(
+        report.reinvestigated.is_empty()
+            && report.marked_done.is_empty()
+            && report.dropped.is_empty()
+            && report.escalated.is_empty()
+            && report.healed.is_empty()
+            && report.deferred.is_empty()
+            && report.engineer_spawned.is_empty(),
+        "a reasoner error must take NO terminal action (fail closed)"
+    );
+    match status_of(&state, id) {
+        GoalProgress::Blocked(reason) => assert_eq!(
+            reason, &original_reason,
+            "the bare marker must be left EXACTLY unchanged on a reasoner error"
+        ),
+        other => panic!("the goal must stay Blocked on a reasoner error, got {other:?}"),
+    }
+    assert!(
+        filer.calls.borrow().is_empty()
+            && dispatcher.calls.borrow().is_empty()
+            && healer.calls.borrow().is_empty(),
+        "no side effects on a fail-closed investigation error"
+    );
+    assert!(
+        !state
+            .no_progress_tracker
+            .reinvestigated(id, NoProgressClass::GenuinelyStuck),
+        "a fail-closed goal must NOT be inserted into the dedupe set (so it retries)"
+    );
+}
+
+// === (g) primary idempotency: the WHY-rewrite removes the goal from the pool ==
+
+#[test]
+fn a_reinvestigated_goal_is_not_processed_again_next_cycle() {
+    // Once re-investigation rewrites a goal's reason to a WHY-bearing (non-bare)
+    // block, the deterministic rail excludes it from the population next cycle —
+    // the primary idempotency guarantee (I4). A second pass must do nothing and
+    // must NOT file a duplicate issue.
+    let id = "fix-agent-kgpacks-rs-issue-22";
+    let mut goal = bare_blocked_goal(id);
+    goal.wip_refs = vec![pr_ref("7")];
+    let mut state = state_with(goal);
+    state.no_progress_tracker.mark_guided_retry(id); // force the terminal escalate
+
+    let evidence = FakeEvidence::stuck();
+    let reasoner = FakeReasoner::classifying(
+        NoProgressClass::GenuinelyStuck,
+        vec![Evidence::new("pr", "#7", "OPEN")],
+    );
+    let (healer, dispatcher, filer) = (
+        RecordingHealer::ok(),
+        RecordingDispatcher::ok(),
+        RecordingFiler::default(),
+    );
+
+    let first = drive(
+        &mut state,
+        &evidence,
+        &reasoner,
+        &healer,
+        &dispatcher,
+        &filer,
+    );
+    assert_eq!(first.escalated, vec![id.to_string()]);
+    assert_eq!(filer.calls.borrow().len(), 1);
+
+    // Second cycle, identical inputs: the goal is now WHY-bearing (non-bare), so
+    // it is not in the population and nothing happens.
+    let second = drive(
+        &mut state,
+        &evidence,
+        &reasoner,
+        &healer,
+        &dispatcher,
+        &filer,
+    );
+    assert!(
+        second.reinvestigated.is_empty() && !second.fired(),
+        "a goal already upgraded to a WHY-bearing block must not be re-processed"
+    );
+    assert_eq!(
+        filer.calls.borrow().len(),
+        1,
+        "no duplicate tracking issue on the second cycle"
+    );
+    assert_not_bare(&state, id);
+}
+
+// === (h) belt idempotency: dedupe set prevents a duplicate fixer post-restart =
+
+#[test]
+fn a_goal_reappearing_bare_after_a_fixer_spawn_never_spawns_a_second_fixer() {
+    // Belt-and-suspenders (I3): even if a goal reappears BARE after a fixer was
+    // already spawned for it (e.g. a crash re-parked it, or the fixer failed and
+    // an older code path re-blocked it bare), the persisted (goal, class) dedupe
+    // set must short-circuit before any terminal action — so at most ONE fixer is
+    // ever spawned per (goal, class), surviving a daemon restart.
+    let id = "fix-agent-kgpacks-rs-issue-23";
+    let mut goal = bare_blocked_goal(id);
+    goal.wip_refs = vec![pr_ref("7")];
+    let mut state = state_with(goal);
+
+    let evidence = FakeEvidence::stuck();
+    let reasoner = FakeReasoner::classifying(
+        NoProgressClass::GenuinelyStuck,
+        vec![Evidence::new("pr", "#7", "OPEN")],
+    );
+    let (healer, dispatcher, filer) = (
+        RecordingHealer::ok(),
+        RecordingDispatcher::ok(),
+        RecordingFiler::default(),
+    );
+
+    // Pass 1: fixer spawned, goal un-blocked, dedupe recorded.
+    let first = drive(
+        &mut state,
+        &evidence,
+        &reasoner,
+        &healer,
+        &dispatcher,
+        &filer,
+    );
+    assert_eq!(first.engineer_spawned, vec![id.to_string()]);
+    assert_eq!(dispatcher.calls.borrow().len(), 1);
+    assert!(
+        state
+            .no_progress_tracker
+            .reinvestigated(id, NoProgressClass::GenuinelyStuck),
+        "a spawned fixer must record the (goal, class) dedupe entry"
+    );
+
+    // Simulate a restart that re-parked the goal BARE again (round-trip the
+    // tracker through serde to prove the dedupe entry persists).
+    let json = serde_json::to_string(&state.no_progress_tracker).expect("serialise");
+    state.no_progress_tracker = serde_json::from_str(&json).expect("deserialise");
+    state.active_goals.active[0].status =
+        GoalProgress::Blocked(no_progress_blocked_reason(NO_PROGRESS_BREAKER_THRESHOLD));
+
+    // Pass 2: same class → dedupe short-circuits the terminal action.
+    let _second = drive(
+        &mut state,
+        &evidence,
+        &reasoner,
+        &healer,
+        &dispatcher,
+        &filer,
+    );
+    assert_eq!(
+        dispatcher.calls.borrow().len(),
+        1,
+        "the (goal, class) dedupe set must prevent a SECOND fixer spawn across a restart"
+    );
+    assert_not_bare(&state, id);
+}
+
+// === (i) perpetual exemption: a bare-blocked perpetual goal is skipped ========
+
+fn perpetual_goal(id: &str) -> ActiveGoal {
+    let g = ActiveGoal::new(
+        id,
+        "STANDING PERPETUAL goal — never mark complete; continuously research \
+         and improve your own cognition",
+        5,
+    );
+    assert!(g.is_perpetual(), "fixture must read as standing/perpetual");
+    g
+}
+
+#[test]
+fn a_perpetual_goal_is_never_reinvestigated_even_if_bare_blocked() {
+    // The perpetual exemption (I5) mirrors the on-transition path: a standing goal
+    // is excluded from the population BEFORE investigation, so the reasoner is
+    // never consulted (a panicking reasoner proves it).
+    let id = "continuously-research-and-improve";
+    let mut goal = perpetual_goal(id);
+    goal.status = GoalProgress::Blocked(no_progress_blocked_reason(NO_PROGRESS_BREAKER_THRESHOLD));
+    let mut state = state_with(goal);
+
+    let evidence = FakeEvidence::stuck();
+    let reasoner = PanicReasoner;
+    let (healer, dispatcher, filer) = (
+        RecordingHealer::ok(),
+        RecordingDispatcher::ok(),
+        RecordingFiler::default(),
+    );
+
+    let report = drive(
+        &mut state,
+        &evidence,
+        &reasoner,
+        &healer,
+        &dispatcher,
+        &filer,
+    );
+
+    assert!(
+        report.reinvestigated.is_empty() && !report.fired(),
+        "a perpetual goal must never be re-investigated or fire the pass"
+    );
+    assert!(
+        filer.calls.borrow().is_empty() && dispatcher.calls.borrow().is_empty(),
+        "a perpetual goal must never file an issue or spawn a fixer"
+    );
+}
+
+// === (j) rail: a non-bare / other-kind block is left untouched ===============
+
+#[test]
+fn an_operator_or_why_bearing_block_is_not_touched_by_the_pass() {
+    // The pass keys strictly on the BARE no-progress marker. A goal blocked by an
+    // operator (or already WHY-bearing) must be excluded from the population — the
+    // reasoner is never consulted (panicking reasoner proves it) and the status is
+    // unchanged.
+    let mut operator_blocked = ActiveGoal::new("operator-hold", "paused by a human", 1);
+    operator_blocked.status =
+        GoalProgress::Blocked("blocked by operator: waiting on design review".to_string());
+    let mut state = state_with(operator_blocked);
+
+    let evidence = FakeEvidence::stuck();
+    let reasoner = PanicReasoner;
+    let (healer, dispatcher, filer) = (
+        RecordingHealer::ok(),
+        RecordingDispatcher::ok(),
+        RecordingFiler::default(),
+    );
+
+    let report = drive(
+        &mut state,
+        &evidence,
+        &reasoner,
+        &healer,
+        &dispatcher,
+        &filer,
+    );
+
+    assert!(
+        report.reinvestigated.is_empty() && !report.fired(),
+        "a non-no-progress block must never be re-investigated"
+    );
+    match status_of(&state, "operator-hold") {
+        GoalProgress::Blocked(reason) => assert_eq!(
+            reason, "blocked by operator: waiting on design review",
+            "an operator block must be left byte-for-byte unchanged"
+        ),
+        other => panic!("expected the operator block preserved, got {other:?}"),
+    }
+}
+
+// === (k) the 5-goal validation, in miniature: no bare survivors =============
+
+#[test]
+fn every_bare_goal_in_the_population_is_upgraded_in_a_single_pass() {
+    // A miniature of the live deploy-#41 population: several goals parked bare with
+    // distinct root causes. After ONE pass none may remain bare — each is
+    // completed / deferred / fixer-spawned / blocked-with-why. This is the direct
+    // proof of the deliverable: "none left as a bare 'needs human review'".
+    let ids = [
+        "advance-rysweet-agent-kgpacks-rs-to-full-parity",
+        "fix-agent-kgpacks-rs-issue-18",
+        "fix-agent-kgpacks-rs-issue-21",
+        "fix-agent-kgpacks-rs-issue-22",
+        "fix-agent-kgpacks-rs-issue-23",
+    ];
+    let mut board = GoalBoard::new();
+    for id in ids {
+        let mut g = bare_blocked_goal(id);
+        g.wip_refs = vec![pr_ref("7")];
+        board.active.push(g);
+    }
+    let mut state = OodaState::new(board);
+
+    // Distinct classifications per goal, spanning the ladder.
+    let mut findings: HashMap<String, NoProgressWhy> = HashMap::new();
+    findings.insert(
+        ids[0].to_string(),
+        NoProgressWhy::new(
+            NoProgressClass::AlreadyComplete,
+            vec![Evidence::new("pr", "#40", "MERGED")],
+        ),
+    );
+    findings.insert(
+        ids[1].to_string(),
+        NoProgressWhy::new(
+            NoProgressClass::UpstreamDependency,
+            vec![Evidence::new("dependency", "kgpacks-rs-issue-16", "OPEN")],
+        ),
+    );
+    findings.insert(
+        ids[2].to_string(),
+        NoProgressWhy::new(
+            NoProgressClass::GenuinelyStuck,
+            vec![Evidence::new("pr", "#7", "OPEN")],
+        ),
+    );
+    findings.insert(
+        ids[3].to_string(),
+        NoProgressWhy::new(
+            NoProgressClass::Obsolete,
+            vec![Evidence::new("obsolete", ids[3], "tracked elsewhere")],
+        ),
+    );
+    findings.insert(
+        ids[4].to_string(),
+        NoProgressWhy::new(
+            NoProgressClass::GenuinelyStuck,
+            vec![Evidence::new("pr", "#7", "OPEN")],
+        ),
+    );
+
+    let evidence = FakeEvidence {
+        pr_merged: true,
+        issue_closed: true,
+        deployed: true,
+        repo_present: true,
+        dependency: std::sync::RwLock::new(DependencyState::None),
+    };
+    let reasoner = FakeReasoner::per_goal(findings);
+    let (healer, dispatcher, filer) = (
+        RecordingHealer::ok(),
+        RecordingDispatcher::ok(),
+        RecordingFiler::default(),
+    );
+
+    let report = drive(
+        &mut state,
+        &evidence,
+        &reasoner,
+        &healer,
+        &dispatcher,
+        &filer,
+    );
+
+    // Every one of the bare goals was re-investigated this cycle.
+    let mut reinvestigated = report.reinvestigated.clone();
+    reinvestigated.sort();
+    let mut expected: Vec<String> = ids.iter().map(|s| s.to_string()).collect();
+    expected.sort();
+    assert_eq!(
+        reinvestigated, expected,
+        "every bare goal in the population must be re-investigated in one pass"
+    );
+
+    // No bare survivors anywhere on the board — the deliverable invariant (I1).
+    for id in ids {
+        assert_not_bare(&state, id);
+    }
+    // And the outcomes span the ladder: one completed, one deferred, one dropped,
+    // and fixers spawned for the genuinely-stuck ones.
+    assert!(report.marked_done.contains(&ids[0].to_string()));
+    assert!(report.deferred.contains(&ids[1].to_string()));
+    assert!(report.dropped.contains(&ids[3].to_string()));
+    assert!(
+        report.engineer_spawned.contains(&ids[2].to_string())
+            && report.engineer_spawned.contains(&ids[4].to_string()),
+        "genuinely-stuck goals must get a spawned fixer"
+    );
+    assert!(
+        report.fired(),
+        "a cycle that re-investigated the whole bare population counts as a firing"
+    );
+}


### PR DESCRIPTION
## Problem

Simard's OODA no-progress safeguard investigated **WHY** a goal was stuck **only at the cycle it crossed the threshold** (the block *transition*, issue #16). Goals that were **already** parked in a **bare** `🔒 [OODA-SAFEGUARD] … needs human review` block — by a pre-#16 daemon build, or left bare when the reasoner erred on the transition cycle — were never re-examined and sat forever with an unhelpful, unexplained reason.

Live evidence (deploy #41): `advance-rysweet-agent-kgpacks-rs-to-full-parity`, `fix-agent-kgpacks-rs-issue-18/21/22/23` were all stranded with the bare marker, while `-issue-17` (which happened to hit the transition path) got a proper WHY.

**Directive:** no goal should EVER sit with a bare "needs human review" — the safeguard must ALWAYS attach a concrete WHY and, when actionable, spawn a fixer.

## Fix

An idempotent, **agentic-behind-a-thin-deterministic-rail** re-investigation pass that runs every cycle over the already-blocked population:

- **`is_bare_no_progress_block`** (`no_progress_breaker.rs`) — the rail: a reason carrying the safeguard marker but **no** `NoProgressClass` WHY token.
- **`NoProgressTracker.reinvestigated`** — a persisted `(goal, class_token)` dedupe set (serialized as the **stable token string**, `#[serde(default)]`, fail-to-empty safe) bounding re-investigation to **one terminal action per (goal, class)** across daemon restarts.
- **`reinvestigate_bare_blocked_goals`** (`no_progress.rs`) — after the on-transition breaker and independent of outcomes, scans the ACTIVE board for bare-blocked, **non-perpetual** goals and runs the **SAME** injected reasoner + `resolution_for_why` ladder over each, through a shared **`apply_resolution_side_effects`** driver extracted from the on-transition path (so the two populations can never diverge).

Outcomes: **completed** (already done) / **dropped** (obsolete) / **healed + un-blocked** (missing precondition) / **deferred `Paused` with the named upstream** / **one spawned fixer + un-blocked to `NotStarted`** so the brain can advance it; only a *spent* guided retry escalates — always **WITH the concrete WHY + evidence**, never bare.

### Idempotency & safety (binding constraints)
- **Primary:** the WHY-rewrite removes a goal from the bare population next cycle (the rail excludes it).
- **Belt:** the persisted dedupe set prevents a **second fixer** if a crash/restart re-parks the goal bare.
- **Fail-closed:** a reasoner error leaves the bare marker **exactly** as-is, records nothing in the dedupe set, and retries next cycle. No brittle string-parsing of the WHY narrative (structured `NoProgressClass` result only). No wall-clock timeouts; no silent degradation.

Both spawn queues (transition + re-investigation) drain through the existing `dispatch_spawn_engineer` path in `cycle.rs`.

## Validation → the deliverable

`every_bare_goal_in_the_population_is_upgraded_in_a_single_pass` reproduces the deploy-#41 population in miniature and proves **no bare survivors**: one **completed** (`advance-…-full-parity`), one **deferred** with the real upstream named (`kgpacks-rs-issue-16`), one **dropped**, and **fixers spawned** for the genuinely-stuck goals — none left as "needs human review".

## Tests
21 new tests (all green):
- Pure rail (`is_bare_no_progress_block`) + tracker dedupe/serde lifecycle (per-goal/class, `record_progress` clears, `retain_goals` prunes, serde round-trip, stable-token persistence, pre-#17 backward-compat).
- Population-driven pass across the whole ladder incl. fail-closed, perpetual exemption, operator-block exclusion, **primary + belt idempotency** (no duplicate fixer across a serde-simulated restart).

All existing on-transition / base-breaker / persistence / overseer tests unchanged and passing.

## Local gate results (green)
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✅ (pre-commit release clippy + pre-push clippy also green)
- `cargo test --lib` → **8192 passed, 0 failed** ✅
- `cargo build --release --bin simard --no-default-features --locked` ✅
- `mkdocs build --strict` ✅

Docs: extended `docs/concepts/no-progress-root-cause-resolution.md` with the re-investigation section.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>