### PR TITLE
feat(kgpacks-rs): source-citation URLs + measurable parity spec unstick the goal

### DIFF
--- a/Specs/agent-kgpacks-rs-parity.md
+++ b/Specs/agent-kgpacks-rs-parity.md
@@ -1,0 +1,121 @@
+# agent-kgpacks-rs Parity Specification
+
+## Purpose
+
+The goal **"advance agent-kgpacks-rs to full parity"** repeatedly stalled with
+"no shippable progress" (diagnosis: `GENUINELY-STUCK`). The root cause was not a
+technical blocker — it was that **"full parity" had no measurable definition**.
+Each OODA cycle could not tell what "done" meant or what the next concrete step
+was, so it produced `NO ACTION`.
+
+This spec fixes that WHY. It makes the done-criteria **measurable**: it
+enumerates every parity criterion as an id + a checkable acceptance test + a
+current status + code evidence, and it defines an ordered backlog so the next
+cycle always has a concrete, non-stuck next step.
+
+## What "agent-kgpacks-rs" is here
+
+"kgpacks-rs" is Simard's **native Rust reimplementation** of the knowledge-graph
+pack client, which replaces the Python subprocess client:
+
+| Layer | Rust (kgpacks-rs) | Python reference (agent-kgpacks) |
+|-------|-------------------|-----------------------------------|
+| Typed client | [`src/knowledge_client.rs`](../src/knowledge_client.rs) | `simard_knowledge_client.py` |
+| In-process handlers | [`src/native_knowledge.rs`](../src/native_knowledge.rs) | `python/simard_knowledge_bridge.py` wrapping `KnowledgeGraphAgent` |
+| Transport wiring | [`src/rpc_subprocess_launcher.rs`](../src/rpc_subprocess_launcher.rs) `launch_knowledge_client_native` | Python subprocess client |
+
+**Reference contract.** "Parity" is measured against the observable
+`knowledge.*` JSON-line RPC contract and the documented agent-kgpacks guarantee
+that *every answer traces back to a specific source article* (see
+[`docs/ecosystem-map.md`](../docs/ecosystem-map.md) and the provenance guarantee
+mirrored in [`src/rust_expertise/pack.rs`](../src/rust_expertise/pack.rs)). The
+canonical upstream is `rysweet/agent-kgpacks`. Criteria below are derived from
+that contract and the in-tree port markers (e.g. the `native_knowledge.rs`
+comment "simplified version of the Python `KnowledgeGraphAgent.query()`").
+
+## Scope boundary
+
+Per the Implementation Plan Phase 2, kgpacks-rs covers **read-only queries
+against existing packs**. Pack *building* and *installation* are explicitly
+Phase 9+ and are **out of scope** for "full parity" here (criteria `KGP-B*`).
+
+## Measurable parity criteria
+
+Status legend: **DONE** (acceptance test present + green) · **OPEN** (not yet
+implemented; acceptance test is the definition of done) · **OUT-OF-SCOPE**.
+
+### Discovery & metadata
+
+| ID | Criterion | Acceptance check | Status | Evidence |
+|----|-----------|------------------|--------|----------|
+| KGP-M1 | `knowledge.list_packs` returns installed packs with name/description/article/section counts | `native_knowledge_transport_list_packs` green | DONE | `native_knowledge.rs::discover_packs`, `register_knowledge_handlers` |
+| KGP-M2 | `knowledge.pack_info` returns one pack's metadata; errors on unknown pack | `native_knowledge_transport_pack_info`, `native_knowledge_transport_pack_not_found` green | DONE | `native_knowledge.rs` `knowledge.pack_info` handler |
+| KGP-M3 | `manifest.json` (`graph_stats`) parsed with directory-name fallback | `discover_packs_finds_packs_with_manifests` green | DONE | `native_knowledge.rs::PackManifest`, `discover_packs` |
+
+### Query & retrieval
+
+| ID | Criterion | Acceptance check | Status | Evidence |
+|----|-----------|------------------|--------|----------|
+| KGP-Q1 | Query answers carry **source citations with URLs** (the traceability guarantee) | `query_pack_db_returns_source_urls_when_present`, `query_pack_db_treats_empty_url_as_no_citation`, `native_knowledge_transport_query_surfaces_source_url` green; urlless packs still work (`query_pack_db_omits_urls_when_column_absent`) | DONE | `native_knowledge.rs::query_articles` (url column projection), `table_has_column` |
+| KGP-Q2 | Confidence score matches the Python `_estimate_confidence` heuristic | `estimate_confidence_matches_python_heuristics` green | DONE | `native_knowledge.rs::estimate_confidence` |
+| KGP-Q3 | Empty / too-short questions degrade to a graceful low-confidence answer | `native_knowledge_transport_empty_question`, `query_pack_db_handles_empty_question_keywords` green | DONE | `native_knowledge.rs::query_pack_db` keyword filter |
+| KGP-Q6 | Answer synthesis truncates snippets on a UTF-8 char boundary | `query_pack_db_finds_matching_articles` green + no panic on multibyte content | DONE | `native_knowledge.rs::build_answer` + `util::string_truncate` |
+| KGP-Q7 | Each source surfaces its `section` | asserted within KGP-M/query tests | DONE | `native_knowledge.rs::SourceInfo.section` |
+| KGP-Q4 | Keyword search binds parameters instead of string-interpolating LIKE clauses | NEW test: a question keyword containing `%`, `_`, and `'` returns correct rows and cannot alter the SQL | OPEN | `native_knowledge.rs::query_articles` currently interpolates escaped keywords |
+| KGP-Q5 | GraphRAG retrieval: traverse entity + relationship tables (multi-hop), not only a single-table LIKE scan | NEW test: a pack fixture with `relationships` yields a graph-grounded answer joining linked entities | OPEN | `native_knowledge.rs::query_articles` comment: "simplified version of the Python `KnowledgeGraphAgent.query()`" |
+
+### Transport, health & lifecycle
+
+| ID | Criterion | Acceptance check | Status | Evidence |
+|----|-----------|------------------|--------|----------|
+| KGP-T1 | Native in-process transport — no Python subprocess | `launch_knowledge_client_native` wired; `knowledge_client.rs` tests green | DONE | `rpc_subprocess_launcher.rs`, `native_knowledge.rs::register_knowledge_handlers` |
+| KGP-T2 | Health endpoint reports server liveness | `health_check_succeeds` green | DONE | `knowledge_client.rs::health`, `RpcHealth` |
+| KGP-T3 | Connection reuse across queries | NEW test: two queries to one pack reuse an open `Connection` (or document why path-caching suffices) | OPEN | `native_knowledge.rs` `conn_cache` currently caches the db *path*, not a live connection |
+
+### Cross-cutting guarantee
+
+| ID | Criterion | Acceptance check | Status | Evidence |
+|----|-----------|------------------|--------|----------|
+| KGP-P1 | Every answer's sources trace back to a specific source article | Satisfied by KGP-Q1 + KGP-Q7 | DONE | see KGP-Q1, KGP-Q7 |
+
+### Out of scope (Phase 9+)
+
+| ID | Criterion | Status |
+|----|-----------|--------|
+| KGP-B1 | Install a knowledge pack | OUT-OF-SCOPE (deferred) |
+| KGP-B2 | Build a pack from documentation | OUT-OF-SCOPE (deferred) |
+
+## Definition of "full parity" (the done-gate)
+
+kgpacks-rs is at **full parity** when **every in-scope criterion**
+(`KGP-M*`, `KGP-Q*`, `KGP-T*`, `KGP-P*`) is **DONE** — i.e. each row's named
+acceptance test exists and the following are green:
+
+```
+cargo test --lib native_knowledge
+cargo test --lib knowledge_client
+```
+
+Out-of-scope `KGP-B*` criteria do **not** gate parity; they are tracked
+separately for the Phase 9+ pack-authoring work.
+
+## Ordered backlog (so the next cycle is never stuck)
+
+Work the OPEN criteria top-to-bottom; each is a self-contained, shippable unit
+with its acceptance test already specified above:
+
+1. **KGP-Q4** — parameterize the keyword LIKE search (correctness + removes the
+   injection-shaped interpolation). Smallest, highest-confidence next step.
+2. **KGP-T3** — reuse an open `Connection` in `conn_cache` (or document the
+   path-cache decision and add the reuse test).
+3. **KGP-Q5** — GraphRAG multi-hop retrieval over entities + relationships.
+   Largest; do last and consider splitting into a fixture step and a traversal
+   step.
+
+## Progress log
+
+- **2026-07-08** — Spec created; **KGP-Q1 closed**: `native_knowledge.rs` now
+  projects the pack's `url` column into `SourceInfo`, so query answers carry
+  source citation URLs (degrading to `None` for urlless pack schemas). This is
+  the first measurable parity advance and the reason this goal is no longer
+  `GENUINELY-STUCK`.

--- a/docs/ecosystem-map.md
+++ b/docs/ecosystem-map.md
@@ -271,6 +271,11 @@ its own codebase, the amplihack framework internals, or external domain
 knowledge to enrich its orient/decide phases with grounded facts rather than
 relying solely on LLM training data.
 
+Simard's **native Rust reimplementation** of the knowledge-pack client
+("kgpacks-rs", `src/native_knowledge.rs` + `src/knowledge_client.rs`) is tracked to full parity
+with the Python agent-kgpacks contract by a measurable criteria checklist at
+`Specs/agent-kgpacks-rs-parity.md`.
+
 ### amplihack-rs ↔ amplihack-xpia-defender
 
 The XPIA defender library scans text, bash commands, URLs, and inter-agent

--- a/src/native_knowledge.rs
+++ b/src/native_knowledge.rs
@@ -3,6 +3,9 @@
 //! Replaces `python/simard_knowledge_client.py` with in-process Rust logic.
 //! Reads knowledge pack manifests from disk and queries pack databases via
 //! rusqlite, eliminating the Python subprocess dependency.
+//!
+//! Parity with the Python agent-kgpacks contract is tracked by a measurable
+//! criteria checklist in `Specs/agent-kgpacks-rs-parity.md`.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -147,7 +150,31 @@ struct SourceInfo {
     url: Option<String>,
 }
 
+/// Whether `table` has a column named `col` (case-insensitive; best-effort —
+/// any error, e.g. a missing table, degrades to `false`).
+///
+/// `table` is always drawn from the fixed allowlist in [`query_articles`], so
+/// interpolating it into the `PRAGMA` (which cannot bind an identifier
+/// parameter) introduces no injection surface.
+fn table_has_column(conn: &Connection, table: &str, col: &str) -> bool {
+    let sql = format!("PRAGMA table_info({table})");
+    let Ok(mut stmt) = conn.prepare(&sql) else {
+        return false;
+    };
+    // PRAGMA table_info column 1 (`name`) is the column name.
+    let Ok(rows) = stmt.query_map([], |row| row.get::<_, String>(1)) else {
+        return false;
+    };
+    rows.flatten().any(|name| name.eq_ignore_ascii_case(col))
+}
+
 /// Query the articles table for matching content.
+///
+/// When the matched table carries a `url` column, each returned [`SourceInfo`]
+/// is populated with the article's source URL so answers trace back to a
+/// specific source article — the agent-kgpacks citation guarantee. Packs whose
+/// schema has no `url` column degrade gracefully to `url: None` (unchanged
+/// behaviour).
 fn query_articles(conn: &Connection, keywords: &[&str], limit: usize) -> Vec<SourceInfo> {
     // Build a LIKE-based search (pack databases don't always have FTS).
     let like_clauses: Vec<String> = keywords
@@ -166,8 +193,16 @@ fn query_articles(conn: &Connection, keywords: &[&str], limit: usize) -> Vec<Sou
 
     // Try "articles" table first, then "nodes"/"entities" as fallback.
     for table in &["articles", "nodes", "entities"] {
+        // Select the real `url` column when the schema has one; otherwise
+        // project a literal NULL so the row shape (and the reader closure
+        // below) stays uniform across pack schemas.
+        let url_col = if table_has_column(conn, table, "url") {
+            "url"
+        } else {
+            "NULL AS url"
+        };
         let sql = format!(
-            "SELECT title, COALESCE(section, '') as section FROM {table} WHERE {clauses} LIMIT {limit}",
+            "SELECT title, COALESCE(section, '') as section, {url_col} FROM {table} WHERE {clauses} LIMIT {limit}",
             table = table,
             clauses = like_clauses.join(" OR "),
             limit = limit,
@@ -176,10 +211,15 @@ fn query_articles(conn: &Connection, keywords: &[&str], limit: usize) -> Vec<Sou
         if let Ok(mut stmt) = conn.prepare(&sql) {
             let mut sources = Vec::new();
             if let Ok(rows) = stmt.query_map([], |row| {
+                let url = row
+                    .get::<_, Option<String>>(2)
+                    .unwrap_or(None)
+                    // Treat a present-but-empty URL as "no citation".
+                    .filter(|u| !u.is_empty());
                 Ok(SourceInfo {
                     title: row.get::<_, String>(0).unwrap_or_default(),
                     section: row.get::<_, String>(1).unwrap_or_default(),
-                    url: None,
+                    url,
                 })
             }) {
                 for row in rows.flatten() {
@@ -459,6 +499,36 @@ mod tests {
         pack_dir
     }
 
+    /// Like [`create_test_pack`] but the `articles` schema carries a `url`
+    /// column, mirroring a real agent-kgpacks pack whose articles cite a
+    /// source URL. Used to prove the native knowledge reader surfaces those citations.
+    fn create_test_pack_with_urls(packs_dir: &Path, name: &str) -> PathBuf {
+        let pack_dir = packs_dir.join(name);
+        fs::create_dir_all(&pack_dir).unwrap();
+
+        let manifest = serde_json::json!({
+            "name": name,
+            "description": format!("{name} knowledge pack"),
+            "graph_stats": { "articles": 2, "entities": 4, "relationships": 3, "size_mb": 0.1 }
+        });
+        fs::write(
+            pack_dir.join("manifest.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let db_path = pack_dir.join("pack.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE articles (title TEXT, section TEXT, content TEXT, url TEXT);
+             INSERT INTO articles VALUES ('Ownership in Rust', 'Basics', 'Ownership is a set of rules that govern how a Rust program manages memory.', 'https://doc.rust-lang.org/book/ch04-01-what-is-ownership.html');
+             INSERT INTO articles VALUES ('Borrowing', 'References', 'References let you refer to a value without taking ownership.', '');",
+        )
+        .unwrap();
+
+        pack_dir
+    }
+
     #[test]
     fn discover_packs_finds_packs_with_manifests() {
         let tmp = TempDir::new().unwrap();
@@ -590,6 +660,100 @@ mod tests {
         let result = response.result.unwrap();
         assert!(!result["answer"].as_str().unwrap().is_empty());
         assert!(result["confidence"].as_f64().unwrap() > 0.0);
+    }
+
+    #[test]
+    fn query_pack_db_returns_source_urls_when_present() {
+        // Parity criterion KGP-Q1: a pack whose articles carry a `url` column
+        // yields source citations with that URL, so answers trace back to a
+        // specific source article (the agent-kgpacks guarantee).
+        let tmp = TempDir::new().unwrap();
+        let pack_dir = create_test_pack_with_urls(tmp.path(), "url-pack");
+        let db_path = pack_dir.join("pack.db");
+
+        let (_answer, sources, _confidence) =
+            query_pack_db(&db_path, "What is ownership in Rust?", 5).unwrap();
+
+        let cited = sources
+            .iter()
+            .find(|s| s.title.contains("Ownership"))
+            .expect("the Ownership article must match");
+        assert_eq!(
+            cited.url.as_deref(),
+            Some("https://doc.rust-lang.org/book/ch04-01-what-is-ownership.html"),
+            "a matched article with a url column must surface its citation URL"
+        );
+    }
+
+    #[test]
+    fn query_pack_db_treats_empty_url_as_no_citation() {
+        // A present-but-empty url column value is not a usable citation and
+        // must degrade to `None`, not `Some("")`.
+        let tmp = TempDir::new().unwrap();
+        let pack_dir = create_test_pack_with_urls(tmp.path(), "url-pack");
+        let db_path = pack_dir.join("pack.db");
+
+        let (_answer, sources, _confidence) =
+            query_pack_db(&db_path, "References borrowing", 5).unwrap();
+
+        let borrowing = sources
+            .iter()
+            .find(|s| s.title.contains("Borrowing"))
+            .expect("the Borrowing article must match");
+        assert_eq!(
+            borrowing.url, None,
+            "an empty url value must be reported as no citation (None)"
+        );
+    }
+
+    #[test]
+    fn query_pack_db_omits_urls_when_column_absent() {
+        // Backward compatibility: packs whose schema has no `url` column keep
+        // the prior behaviour (url: None) rather than erroring.
+        let tmp = TempDir::new().unwrap();
+        let pack_dir = create_test_pack(tmp.path(), "no-url-pack");
+        let db_path = pack_dir.join("pack.db");
+
+        let (_answer, sources, _confidence) =
+            query_pack_db(&db_path, "What is ownership in Rust?", 5).unwrap();
+
+        assert!(
+            !sources.is_empty(),
+            "the query must still match without urls"
+        );
+        assert!(
+            sources.iter().all(|s| s.url.is_none()),
+            "a urlless pack schema must yield no citation URLs, not an error"
+        );
+    }
+
+    #[test]
+    fn native_knowledge_transport_query_surfaces_source_url() {
+        // End-to-end: the citation URL propagates through the RPC handler into
+        // the `sources[].url` field of the wire response.
+        let tmp = TempDir::new().unwrap();
+        create_test_pack_with_urls(tmp.path(), "url-pack");
+
+        let mut transport = NativeRpcTransport::new("simard-knowledge");
+        register_knowledge_handlers(&mut transport, tmp.path().to_path_buf());
+
+        let request = crate::rpc::RpcRequest {
+            id: crate::rpc::new_request_id(),
+            method: "knowledge.query".to_string(),
+            params: serde_json::json!({
+                "pack_name": "url-pack",
+                "question": "What is ownership in Rust?",
+                "limit": 5,
+            }),
+        };
+        let response = crate::rpc::RpcTransport::call(&transport, request).unwrap();
+        let result = response.result.expect("query must succeed");
+        let sources = result["sources"].as_array().expect("sources array");
+        assert!(
+            sources.iter().any(|s| s["url"].as_str()
+                == Some("https://doc.rust-lang.org/book/ch04-01-what-is-ownership.html")),
+            "the wire response must include the article's source citation URL; got: {sources:?}"
+        );
     }
 
     #[test]

--- a/tests/gadugi/kgpacks-rs-source-citation.sh
+++ b/tests/gadugi/kgpacks-rs-source-citation.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Outside-in scenario for kgpacks-rs parity criterion KGP-Q1 (source-citation
+# URLs). It proves the native Rust knowledge client — Simard's port of the
+# Python agent-kgpacks contract — surfaces each matched article's source URL so
+# answers trace back to a specific source (the agent-kgpacks guarantee), while
+# degrading gracefully to no citation for packs whose schema has no `url`
+# column.
+#
+# What this proves, without an LLM, via the in-tree native_knowledge tests:
+#
+#   (a) query_pack_db_returns_source_urls_when_present — a pack whose `articles`
+#       table carries a `url` column yields SourceInfo citations with that URL.
+#   (b) query_pack_db_treats_empty_url_as_no_citation — a present-but-empty URL
+#       degrades to None (not Some("")).
+#   (c) query_pack_db_omits_urls_when_column_absent — a urlless pack schema still
+#       returns matches with no citation URL, never an error (back-compat).
+#   (d) native_knowledge_transport_query_surfaces_source_url — the URL propagates
+#       end-to-end through the knowledge.query RPC handler into sources[].url.
+#
+# Each rung asserts the NAMED test actually ran+passed (a cargo filter that
+# matches zero tests still exits 0), so a future rename cannot silently turn
+# this scenario into a no-op.
+#
+# Reference: Specs/agent-kgpacks-rs-parity.md (criterion KGP-Q1 / KGP-P1).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+WORK="$(mktemp -d /tmp/simard-kgpacks-rs-citation.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+TEST_LOG="$WORK/native-knowledge-cargo-test.log"
+
+echo "== kgpacks-rs KGP-Q1: native knowledge client source-citation URL tests =="
+cargo test --lib --locked native_knowledge -- --nocapture \
+    >"$TEST_LOG" 2>&1
+
+grep -qE 'test result: ok\.' "$TEST_LOG" \
+  || { echo "FAIL: cargo test did not report an ok result" >&2; cat "$TEST_LOG" >&2; exit 1; }
+if grep -qE 'test result: FAILED' "$TEST_LOG"; then
+  echo "FAIL: one or more native_knowledge tests FAILED" >&2; cat "$TEST_LOG" >&2; exit 1
+fi
+
+for t in \
+  'native_knowledge::tests::query_pack_db_returns_source_urls_when_present' \
+  'native_knowledge::tests::query_pack_db_treats_empty_url_as_no_citation' \
+  'native_knowledge::tests::query_pack_db_omits_urls_when_column_absent' \
+  'native_knowledge::tests::native_knowledge_transport_query_surfaces_source_url'
+do
+  grep -qF "$t ... ok" "$TEST_LOG" \
+    || { echo "FAIL: expected KGP-Q1 test did not run/pass: $t" >&2; cat "$TEST_LOG" >&2; exit 1; }
+done
+
+PASSED_LINE="$(grep -oE 'test result: ok\. [0-9]+ passed' "$TEST_LOG" | tail -1 || true)"
+echo "final ${PASSED_LINE:-<no ok line>}"
+echo "PASS: kgpacks-rs KGP-Q1 source-citation URLs (agent-kgpacks parity)"

--- a/tests/gadugi/kgpacks-rs-source-citation.yaml
+++ b/tests/gadugi/kgpacks-rs-source-citation.yaml
@@ -1,0 +1,55 @@
+name: "kgpacks-rs source-citation parity (KGP-Q1)"
+description: "Outside-in coverage for kgpacks-rs parity criterion KGP-Q1: Simard's native Rust knowledge client (the agent-kgpacks port) must surface each matched article's source-citation URL through knowledge.query so answers trace back to a specific source article, while degrading gracefully to no citation for pack schemas that carry no url column. See Specs/agent-kgpacks-rs-parity.md."
+version: "1.0.0"
+
+config:
+  timeout: 600000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 600000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "native knowledge query surfaces source-citation URLs"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/kgpacks-rs-source-citation.sh"
+    timeout: 600000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "behavior"
+    - "simard"
+    - "kgpacks-rs"
+    - "knowledge"
+    - "parity"
+    - "citation"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Why

The goal **"advance agent-kgpacks-rs to full parity"** stalled every OODA cycle
with "no shippable progress" (diagnosis `GENUINELY-STUCK`, `evidence=[(none)]`).
The real WHY was **not** a technical blocker: **"full parity" had no measurable
definition**, so each cycle the engineer could not tell what "done" meant or
what the next concrete step was → `NO ACTION`.

"kgpacks-rs" = Simard's native Rust reimplementation of the Python
`agent-kgpacks` knowledge bridge (`src/native_knowledge.rs` +
`src/knowledge_client.rs`, replacing the retired Python subprocess bridge).

This PR **fixes that WHY** (makes the done-criteria measurable) and **advances
the goal** (closes the first measurable criterion).

## What

1. **Root-cause fix — measurable done-criteria.** New
   `Specs/agent-kgpacks-rs-parity.md` enumerates every parity criterion as an
   `id + checkable acceptance test + current status + code evidence`, defines
   the done-gate, marks Phase 9+ pack-building explicitly out of scope, and
   gives an **ordered backlog** (KGP-Q4 → KGP-T3 → KGP-Q5) so the next cycle
   always has a concrete, non-stuck next step.

2. **Advance the goal — close criterion KGP-Q1 (source citations).**
   `native_knowledge.rs::query_articles` previously hardcoded `url: None`,
   dropping the source URL — breaking agent-kgpacks' core guarantee that
   *answers trace back to a specific source article*. It now projects the
   pack's `url` column into `SourceInfo` (via a new `table_has_column` probe),
   so `knowledge.query` answers carry citation URLs. **Backward compatible:**
   pack schemas with no `url` column degrade to `None` (prior behaviour);
   present-but-empty URLs are treated as no citation.

## Merge-ready evidence

### 1. qa-team scenarios (written, validated, run)
- Added `tests/gadugi/kgpacks-rs-source-citation.{yaml,sh}` (outside-in,
  pins the 4 KGP-Q1 tests actually ran+passed so a rename can't no-op it).
- `gadugi-test validate -f tests/gadugi/kgpacks-rs-source-citation.yaml`
  → `✓ Scenario "kgpacks-rs source-citation parity (KGP-Q1)" is valid`.
- `gadugi-test run -d tests/gadugi -s kgpacks-rs-source-citation`
  → `✓ Passed: 1  ✗ Failed: 0` (command exit 0).

### 2. Docs (internal surface)
The knowledge bridge has no user-facing CLI surface — it is consumed
internally by the OODA loop. Docs updated regardless:
- `Specs/agent-kgpacks-rs-parity.md` (new spec / measurable criteria).
- `docs/ecosystem-map.md` — links the parity spec under Simard ↔ agent-kgpacks.
- `src/native_knowledge.rs` module doc — cross-links the spec.
- `mkdocs build --strict` → passes (link-integrity gate green).

### 3. Quality-audit (SEEK → VALIDATE → FIX cycles, clean final)
- Cycle 1 (correctness): transport test used a question with a literal `?` that
  became a non-matching LIKE keyword → **fixed** the fixture; all 15
  `native_knowledge` tests pass.
- Cycle 2 (docs link-integrity): a markdown link to `../Specs/` would break
  `mkdocs --strict` (`unrecognized_links`) → **fixed** to the backtick
  convention; strict build green.
- Cycle 3 (lint/format): `cargo fmt --check` diff → **fixed**;
  `cargo clippy --all-targets --all-features --locked -- -D warnings` clean.
- Final cycle: clean — no critical/high, no medium correctness/security
  findings. Security note: the new `PRAGMA table_info(<table>)` interpolates
  only fixed-allowlist identifiers (`articles`/`nodes`/`entities`), adding no
  injection surface; the pre-existing LIKE-interpolation is tracked as OPEN
  criterion **KGP-Q4** (not regressed).

### 4. CI / local gates
- `cargo test --lib native_knowledge` → **15 passed / 0 failed**.
- `cargo test --lib knowledge_client` → **8 passed / 0 failed**.
- Pre-commit hooks (rust-only-gate, `cargo fmt --check`,
  `cargo clippy --release --no-deps -D warnings`) → **passed**.
- Pre-push hooks (release test subset, `cargo clippy --all-targets
  --all-features --locked -D warnings`) → **passed**.
- Full `cargo test --lib`: 7570 pass. The only 2 non-passing tests are
  **pre-existing and unrelated** to this diff (`src/ooda_loop/decide.rs` is
  untouched): `decide_respects_max_concurrent_actions` fails **only** because
  this daemon host sets `SIMARD_SCALING=auto` (the adaptive scaler overrides
  the test's `max=2` on a 64-CPU box) — it **passes with `SIMARD_SCALING`
  unset**, i.e. the CI-equivalent env; `concurrent_dispatch_parallelizes_
  and_respects_cap` is a timing perf assertion that flaked under load and
  **passes in isolation**.

### 6. Focused diff
5 files, +404/-2: the spec, the `native_knowledge.rs` change + its tests, the
gadugi scenario, and two doc cross-links. No unrelated edits.

## Follow-ups (already scheduled by the spec's ordered backlog)
`KGP-Q4` parameterize the LIKE search · `KGP-T3` reuse an open `Connection` ·
`KGP-Q5` GraphRAG multi-hop retrieval. Each has a pre-specified acceptance test
so the goal stays measurable and never returns to `GENUINELY-STUCK`.
