### PR TITLE
feat(identity): observe-only read-only floor + identity isolation for a second identity (Crocutus, #1)

### DIFF
--- a/docs/concepts/multi-identity-host-isolation.md
+++ b/docs/concepts/multi-identity-host-isolation.md
@@ -1,0 +1,184 @@
+---
+title: Multi-identity host isolation — running a second agent identity side-by-side
+description: Why and how two autonomous Simard identities (for example the primary simard identity and the read-only crocutus identity) run concurrently on one host without contending for state, ports, sockets, systemd units, or the cognitive-memory exclusive lock, via the SIMARD_HOME instance-root layer.
+last_updated: 2026-07-08
+owner: simard
+doc_type: concept
+related:
+  - ./pluggable-identity.md
+  - ./write-authority-posture.md
+  - ../reference/agent-instance-isolation.md
+  - ../howto/run-a-second-agent-identity.md
+  - ../tutorials/deploy-crocutus-read-only-observer.md
+  - ../reference/state-root-resolution.md
+---
+
+# Multi-identity host isolation — running a second agent identity side-by-side
+
+!!! warning "Implementation status — shipped v1 isolates the state tree only (tracking #3067)"
+    **Shipped today:** two identities are kept apart by **`SIMARD_STATE_ROOT`**, which
+    relocates the durable state tree — cognitive-memory store (exclusive `flock`) and
+    goal board — so `crocutus` uses `~/.crocutus` and cannot collide with `simard`'s
+    `~/.simard` state. This is the load-bearing constraint (the flock refuses a second
+    daemon on a shared root).
+    **Planned (NOT yet implemented):** the **`SIMARD_HOME`** instance root,
+    `instance_home()`, and systemd unit-name templating that also relocate the ambient
+    singletons which still default to `$HOME/.simard` (install dir, agent registry,
+    snapshots, engineer-worktrees) — tracked in
+    [#3067](https://github.com/rysweet/Simard/issues/3067). Until then, set a distinct
+    `SIMARD_STATE_ROOT` (and distinct port/socket/unit name) per instance; a read-only
+    observer never spawns engineer-worktrees, so that singleton is moot for `crocutus`.
+
+## The problem
+
+[Pluggable identity](./pluggable-identity.md) lets one Simard process load a
+different **persona** (prompts, operating mode, memory policy) from an
+`identity.toml`. That is enough when only one autonomous daemon runs on a host.
+
+It is **not** enough to run two autonomous daemons at once. Simard's second
+identity — `crocutus`, a read-only observer of an external Azure DevOps
+project (issue #1) — must run on the same host as the primary `simard`
+daemon, continuously, without interfering with it. Two independent OODA
+daemons collide on a set of **ambient, host-level singletons** that were
+written when only one identity existed:
+
+| Singleton | Default location | Collision if shared |
+|-----------|------------------|---------------------|
+| Cognitive-memory store | `$HOME/.simard` state root | **Exclusive `flock` per state root** — the second process is refused |
+| Binary install dir | `$HOME/.simard/bin/simard` | Self-update of one identity overwrites the other |
+| Agent registry | `$HOME/.simard/agent_registry.json` | Registrations interleave and corrupt |
+| Memory snapshots | `$HOME/.simard/snapshots/` | Snapshot restore crosses identities |
+| Self-update state / backups | `$HOME/.simard/{bin,state}` | Rollback of one reverts the other |
+| Engineer worktrees | `$HOME/.simard/engineer-worktrees/` | Worktree sweep deletes the peer's trees |
+| systemd unit | `simard-ooda.service` | Only one unit name; second cannot install |
+| Dashboard port | `SIMARD_DASHBOARD_PORT` default | Bind conflict |
+| Memory IPC socket | `SIMARD_MEMORY_SOCKET` default | Bridge cross-talk |
+
+The cognitive-memory exclusive lock is the load-bearing constraint: two
+daemons pointed at the same state root **cannot** both run. That is by
+design (see [Cognitive-memory durability](../operations/cognitive-memory-durability.md)),
+and the isolation layer leans on it rather than fighting it.
+
+## The solution: an instance root (`SIMARD_HOME`)
+
+Multi-identity host isolation introduces a single **instance root** concept.
+Every ambient host-level singleton derives from one directory:
+
+- **`SIMARD_HOME`** — the instance root. Defaults to `$HOME/.simard` for the
+  primary instance. The `crocutus` instance sets `SIMARD_HOME=$HOME/.crocutus`.
+- A single helper, **`instance_home()`**, resolves `SIMARD_HOME` (falling back
+  to `$HOME/.simard`). Every previously-hardcoded `$HOME/.simard` call site —
+  install dir, agent registry, snapshots, self-update state, engineer
+  worktrees — routes through it. See the
+  [agent instance-isolation reference](../reference/agent-instance-isolation.md).
+- The **systemd unit name is derived from the instance name** rather than the
+  literal `simard-ooda.service`. The primary keeps `simard-ooda.service`; the
+  second installs as `crocutus-ooda.service` (and `crocutus-signal.service`).
+- The narrow per-subsystem overrides already shipped —
+  [`SIMARD_STATE_ROOT`](../reference/state-root-resolution.md),
+  `SIMARD_DASHBOARD_PORT`, `SIMARD_MEMORY_SOCKET`, `SIMARD_AGENT_NAME`,
+  and the [pluggable-identity](./pluggable-identity.md) selectors
+  (`SIMARD_IDENTITY`, `SIMARD_IDENTITY_PATH`, `SIMARD_PROMPT_ROOT`) — continue
+  to work and layer **on top of** `SIMARD_HOME`.
+
+This closes the pre-existing inconsistency where some paths honored
+`SIMARD_STATE_ROOT` and others hardcoded `$HOME/.simard`.
+
+```mermaid
+flowchart TD
+    HOME["SIMARD_HOME<br/>(instance root)"]
+    HOME --> BIN["bin/simard<br/>(install + self-update)"]
+    HOME --> REG["agent_registry.json"]
+    HOME --> SNAP["snapshots/"]
+    HOME --> WT["engineer-worktrees/"]
+    HOME --> SR["state root<br/>(SIMARD_STATE_ROOT override)"]
+    SR --> MEM["cognitive_memory/<br/>(exclusive flock)"]
+    SR --> GOAL["state/goal_store.json"]
+    NAME["instance name"] --> UNIT["systemd unit<br/>&lt;name&gt;-ooda.service"]
+```
+
+## Two instances, two disjoint trees
+
+With `SIMARD_HOME` set per instance, the two daemons own disjoint trees:
+
+```
+$HOME/.simard/                 $HOME/.crocutus/
+├── bin/simard                 ├── bin/simard        (same binary, own copy)
+├── agent_registry.json        ├── agent_registry.json
+├── snapshots/                 ├── snapshots/
+├── engineer-worktrees/        ├── engineer-worktrees/   (unused: read-only)
+└── state/                     └── state/
+    ├── cognitive_memory/          ├── cognitive_memory/  (own flock)
+    └── goal_store.json            └── goal_store.json
+
+simard-ooda.service            crocutus-ooda.service
+:8080 (dashboard)              :8090 (dashboard)
+memory.sock                    crocutus-memory.sock
+```
+
+They share **only** the Rust binary artifact (both instances are the same
+`simard` build; `crocutus` is a *configuration* of it, not a fork — see
+[Depend on Simard, do not copy it](#what-this-is-not)). Everything stateful is
+per-instance.
+
+## Fail loud, never silently degrade
+
+Two instances that accidentally share a state root **must fail loudly**. The
+cognitive-memory exclusive `flock` already does this: the second daemon to
+start on a shared root is refused at startup with a visible error.
+
+The isolation layer must **not** add a fallback that silently opens a
+file-backed or in-memory store when the lock is held. That would be exactly
+the kind of hidden degradation that
+[honest degradation (Pillar 11)](../fail-open-audit.md) forbids: the operator
+would believe two isolated identities are running when in fact one is writing
+to a degraded, unlocked store. Startup surfaces the collision; the operator
+fixes the configuration.
+
+## The isolation invariant
+
+An instance is correctly isolated when **all** of the following differ from
+every other instance on the host:
+
+1. `SIMARD_HOME` (⇒ install dir, agent registry, snapshots, worktrees).
+2. `SIMARD_STATE_ROOT` (⇒ cognitive-memory `flock`, goal store, handoffs).
+3. `SIMARD_DASHBOARD_PORT`.
+4. `SIMARD_MEMORY_SOCKET`.
+5. systemd unit name (`<instance>-ooda.service`).
+6. GitHub / Azure DevOps credentials (see
+   [pluggable-identity auth](./pluggable-identity.md) and the
+   [Crocutus tutorial](../tutorials/deploy-crocutus-read-only-observer.md)).
+
+The [`simard debug instance`](../reference/agent-instance-isolation.md#simard-debug-instance)
+command prints all six for the current environment so an operator can verify
+isolation before starting the second daemon.
+
+## What this is not
+
+- **Not a fork.** `crocutus` reuses the primary `simard` binary, runtime,
+  session model, memory model, identity loader, precedence, and composition
+  unchanged. It is expressed as an `identity.toml` persona plus an environment
+  profile plus a per-instance `SIMARD_HOME`. If a second identity required
+  large amounts of duplicated Rust, that would signal an abstraction gap to be
+  fixed in Simard, not copied downstream.
+- **Not a container/VM boundary.** Instance isolation is process- and
+  filesystem-level namespacing on a shared host, not a security sandbox. The
+  read-only guarantee for `crocutus` comes from the
+  [write-authority posture](./write-authority-posture.md) and credential
+  scoping, not from `SIMARD_HOME`.
+- **Not a scheduler.** Each instance runs its own OODA daemon under its own
+  systemd unit. There is no cross-instance orchestration; they are independent.
+
+## See also
+
+- [Write-authority posture](./write-authority-posture.md) — the read-only /
+  scoped-write / full contract that makes a second identity a *bounded*
+  observer rather than a second full-write actor.
+- [Agent instance-isolation reference](../reference/agent-instance-isolation.md)
+  — `SIMARD_HOME`, `instance_home()`, the env matrix, and unit templating.
+- [How to run a second agent identity](../howto/run-a-second-agent-identity.md)
+  — the operator procedure.
+- [Deploy Crocutus as a read-only observer](../tutorials/deploy-crocutus-read-only-observer.md)
+  — the end-to-end worked example.
+- [State-root resolution](../reference/state-root-resolution.md) — the
+  pre-existing per-subsystem resolution ladder that `SIMARD_HOME` sits above.

--- a/docs/concepts/pluggable-identity.md
+++ b/docs/concepts/pluggable-identity.md
@@ -9,6 +9,8 @@ related:
   - ../howto/configure-pluggable-identity.md
   - ../reference/runtime-contracts.md
   - ../architecture/agent-composition.md
+  - ./multi-identity-host-isolation.md
+  - ./write-authority-posture.md
 ---
 
 # Pluggable identity — TOML-driven agent personas

--- a/docs/concepts/write-authority-posture.md
+++ b/docs/concepts/write-authority-posture.md
@@ -1,0 +1,203 @@
+---
+title: Write-authority posture — read-only, scoped-write, and full identities
+description: The identity-level write-authority contract that lets a Simard identity be a bounded observer. A read-only posture makes the git, Azure DevOps, and GitHub write paths hard-refuse (fail-closed), enforced at the same guardrail seams that already screen destructive git ops and ADO ACL self-escalation.
+last_updated: 2026-07-08
+owner: simard
+doc_type: concept
+related:
+  - ./pluggable-identity.md
+  - ./multi-identity-host-isolation.md
+  - ../reference/write-authority-posture-api.md
+  - ../reference/ado-acl-self-escalation-guard.md
+  - ../tutorials/deploy-crocutus-read-only-observer.md
+---
+
+# Write-authority posture — read-only, scoped-write, and full identities
+
+!!! warning "Implementation status — shipped v1 is env-driven (issue #1, tracking #3067)"
+    **Shipped today:** the read-only mandate is enforced by **`SIMARD_OBSERVE_ONLY=1`**,
+    a fail-closed, default-DENY command classifier (`read_only_guard`) wired into
+    `git_guardrails::check_git_safety` (the git write seam) and the OODA
+    engineer-dispatch (`dispatch_spawn_engineer`, which then dispatches **0** write
+    actions). Identity isolation uses the pre-existing **`SIMARD_STATE_ROOT`**.
+    **Planned (NOT yet implemented):** the typed `IdentityAuthority` manifest posture,
+    the `[identities.authority]` TOML block, and the `check_git_safety_with_authority` /
+    `check_ado_write_safety` / `simard debug authority` surfaces described below —
+    tracked in [#3067](https://github.com/rysweet/Simard/issues/3067). Treat those as
+    the target design; the runnable, shipped guardrail proof lives in the
+    `rysweet/Crocutus` repo (`scripts/prove-guardrail.sh`).
+
+## The problem
+
+A *second* autonomous identity should not be a second uncontrolled writer.
+The `crocutus` identity (issue #1) observes an external Azure DevOps project
+**read-only** and only proposes repo-hygiene goals — it must be
+*structurally* unable to commit, push, open a PR, edit a work item, or change
+an ACL anywhere in that project. "It won't, because the prompt says so" is not
+sufficient; the guarantee has to hold even if the prompt is wrong.
+
+Before write-authority posture, Simard's write authority was scattered and was
+**not read-only-clean**:
+
+- [`git_guardrails`](../reference/ado-acl-self-escalation-guard.md#cross-references)
+  blocks *destructive* git operations (force-push, `reset --hard`, `branch -D`
+  on protected branches) but still **allows** ordinary `push` and `commit`.
+- [`ado_acl_guard`](../reference/ado-acl-self-escalation-guard.md) blocks only
+  ACL **self-escalation**; other Azure DevOps writes (branch push, PR create,
+  work-item edit) pass through.
+- The [memory policy](./pluggable-identity.md) already blocks *project-scoped
+  memory writes*, but nothing governed the git / ADO / GitHub write paths at
+  the identity level.
+
+There was no single, typed field on the identity contract that said "this
+identity may not write." An operator could scope credentials, but the code
+paths themselves had no notion of a read-only identity.
+
+## The solution: a posture on the identity contract
+
+Write-authority posture adds one typed field to the identity contract
+(`IdentityManifest`) and its `identity.toml` surface:
+
+```toml
+[[identities]]
+name = "crocutus"
+default_mode = "engineer"
+
+[identities.authority]
+posture = "read-only"          # read-only | scoped-write | full
+allowed_write_repos = []       # allowlist, only meaningful when scoped-write
+allow_git_push = false
+allow_ado_writes = false
+allow_github_writes = false
+```
+
+The three postures:
+
+| Posture | Meaning | git push/commit | ADO writes | GitHub writes |
+|---------|---------|-----------------|------------|---------------|
+| `read-only` | Bounded observer. Reads and reasons; never writes anywhere. | ❌ refused | ❌ refused | ❌ refused |
+| `scoped-write` | Writes only to repos on `allowed_write_repos`; refuses all others. | ✅ allowlist only | ✅ allowlist only | ✅ allowlist only |
+| `full` | Historical behavior — no posture restriction beyond the existing destructive-op and ACL guards. | ✅ (guarded) | ✅ (guarded) | ✅ |
+
+**`full` is the default** for built-in identities and for TOML identities that
+omit `[identities.authority]`, so existing behavior is unchanged. `crocutus`
+ships as `read-only` explicitly.
+
+## Enforcement: posture-aware guardrails, not a parallel system
+
+Posture is enforced by making the **existing** guardrail seams
+posture-aware, not by bolting on a second enforcement layer:
+
+```mermaid
+flowchart TD
+    OP["autonomous op<br/>(git / az / gh)"]
+    POSTURE{"identity posture"}
+    OP --> POSTURE
+    POSTURE -->|read-only| REFUSE["hard refuse<br/>visible error, fail-closed"]
+    POSTURE -->|scoped-write| ALLOWLIST{"target in<br/>allowed_write_repos?"}
+    POSTURE -->|full| LEGACY["existing guards:<br/>git_guardrails + ado_acl_guard"]
+    ALLOWLIST -->|no| REFUSE
+    ALLOWLIST -->|yes| LEGACY
+    LEGACY --> RUN["execute"]
+```
+
+Posture-aware entry points live at the **same seam** as today's guards — the
+existing `check_git_safety` / `check_ado_acl_safety` functions keep their
+signatures and behavior, and posture is layered by adjacent
+`*_with_authority` entry points that call them:
+
+- **`check_git_safety_with_authority`** (git guardrails) wraps
+  `check_git_safety`; under `read-only` it refuses `push`, `commit`, and every
+  other mutating verb, in addition to the destructive patterns the base
+  function already blocks.
+- **`check_ado_write_safety`** (ADO guard) wraps `check_ado_acl_safety`; under
+  `read-only` it refuses *all* Azure DevOps write verbs, not just ACL
+  self-escalation.
+- The **GitHub write path** refuses PR creation, issue edits, and comments
+  under `read-only`.
+
+Every refusal is a **hard, visible error** (fail-closed), never a silent
+no-op. A read-only identity that attempts a write stops and surfaces exactly
+what it refused and why — consistent with the
+[ADO ACL guard's fail-closed detection](../reference/ado-acl-self-escalation-guard.md#what-is-detected-as-an-acl-mutation).
+
+See the [write-authority posture API reference](../reference/write-authority-posture-api.md)
+for the exact `*_with_authority` function signatures and error variants.
+
+### Enforcement must reach the dispatch layer, not just three functions
+
+Posture-aware guardrails are necessary but **not sufficient** on their own.
+Simard's OODA **ACT** phase (`dispatch_spawn_engineer` and the other
+`ooda_actions` dispatchers) can spawn engineer worktrees and sub-agents that
+themselves invoke `git` / `az` / `gh`. If posture were threaded only into the
+three guardrail functions, a dispatched sub-agent could still attempt writes.
+
+The invariant is therefore stronger: **every write path routes through a
+posture-aware seam**, and under `read-only` the ACT/dispatch phase
+**short-circuits** — the identity proposes goals but dispatches zero
+write-bearing actions. This is why a correctly configured read-only identity
+reports `dispatched 0 actions (read-only), 0 writes` (see the
+[tutorial end state](../tutorials/deploy-crocutus-read-only-observer.md#step-8-verify-the-end-state)).
+Delivering that guarantee is an implementation acceptance criterion, not an
+emergent property of the guardrail functions alone.
+
+## Why a contract, not just an env var
+
+Posture must be enforced *inside the code* at the guardrail layer, so it has
+to be a typed field the guardrails read from the resolved identity — not
+merely an environment variable an operator remembers to set. That is the one
+genuinely new element of the contract. It composes like the existing
+`memory_policy`: when a
+[composite identity](./pluggable-identity.md#3-composition-is-bounded-and-cycle-safe)
+merges components, **all components must agree on `posture`**, or composition
+fails with `InvalidIdentityComposition`. You cannot dilute a read-only
+component by composing it with a full one.
+
+## Defense in depth for a read-only identity
+
+Posture is *one* layer. A correctly read-only identity such as `crocutus`
+stacks four independent layers, any one of which alone denies writes
+(fail-closed):
+
+1. **Credential scope.** The identity holds **no write-capable credential** to
+   the target — a read-only Azure DevOps PAT or an anonymous read-only clone,
+   never a write token. Absence of a write credential is itself a guardrail.
+2. **Capability / posture.** `posture = "read-only"` makes the git, ADO, and
+   GitHub write paths hard-refuse in code.
+3. **Identity mandate.** The persona prompt states it is a read-only observer
+   and must never act on the target repos.
+4. **Isolation.** It runs as its own
+   [host instance](./multi-identity-host-isolation.md) with its own state, so
+   it cannot reach the primary identity's write credentials either.
+
+If any layer is uncertain, the identity **fails closed** — it does nothing
+rather than risk a write. Proving the guarantee (no write credential + posture
+refuses + a dry-run check) is a required acceptance step, documented in the
+[Crocutus tutorial](../tutorials/deploy-crocutus-read-only-observer.md#step-6-prove-the-read-only-guardrail).
+
+## What this is not
+
+- **Not a replacement for credential scoping.** Posture is the in-process
+  belt; the read-only credential is the suspenders. A read-only identity must
+  have both. Never rely on posture alone with a write-capable token present.
+- **Not a sandbox.** Posture governs Simard's own git/ADO/GitHub code paths.
+  It does not sandbox arbitrary subprocesses; a read-only identity must also be
+  denied write credentials so that even an out-of-band tool cannot write.
+- **Not a per-command toggle.** Posture is an identity-level property, resolved
+  once at load time from the manifest. It is not something a running session
+  can raise for itself (that would be self-escalation, which the
+  [ADO ACL guard](../reference/ado-acl-self-escalation-guard.md) already
+  forbids by the same principle).
+
+## See also
+
+- [Write-authority posture API reference](../reference/write-authority-posture-api.md)
+  — the `IdentityAuthority` type, `identity.toml` block, and guardrail
+  signatures.
+- [Multi-identity host isolation](./multi-identity-host-isolation.md) — the
+  per-instance isolation that keeps a read-only identity away from the
+  primary's credentials and state.
+- [Azure DevOps ACL self-escalation guard](../reference/ado-acl-self-escalation-guard.md)
+  — the pre-existing fail-closed guard that posture extends.
+- [Deploy Crocutus as a read-only observer](../tutorials/deploy-crocutus-read-only-observer.md)
+  — the worked example, including the guardrail proof.

--- a/docs/howto/configure-pluggable-identity.md
+++ b/docs/howto/configure-pluggable-identity.md
@@ -10,6 +10,8 @@ related:
   - ../reference/pluggable-identity-api.md
   - ../reference/simard-cli.md
   - ../howto/move-from-terminal-recipes-into-engineer-runs.md
+  - ../howto/run-a-second-agent-identity.md
+  - ../concepts/write-authority-posture.md
 ---
 
 # How to configure pluggable identities

--- a/docs/howto/run-a-second-agent-identity.md
+++ b/docs/howto/run-a-second-agent-identity.md
@@ -1,0 +1,211 @@
+---
+title: How to run a second agent identity side-by-side
+description: Configure and launch a second autonomous Simard identity (its own SIMARD_HOME instance root, state, port, socket, systemd unit, credentials, and write-authority posture) on the same host as the primary simard daemon, without interference.
+last_updated: 2026-07-08
+review_schedule: as-needed
+owner: simard
+related:
+  - ../concepts/multi-identity-host-isolation.md
+  - ../concepts/write-authority-posture.md
+  - ../reference/agent-instance-isolation.md
+  - ../reference/write-authority-posture-api.md
+  - ../howto/run-ooda-daemon.md
+  - ../tutorials/deploy-crocutus-read-only-observer.md
+doc_type: howto
+---
+
+# How to run a second agent identity side-by-side
+
+!!! warning "Implementation status — shipped v1 is env-driven (issue #1, tracking #3067)"
+    Commands and blocks on this page that use `SIMARD_HOME`, `[identities.authority]`
+    posture, or `simard debug instance` / `simard debug authority` describe the
+    **planned** design tracked in
+    [#3067](https://github.com/rysweet/Simard/issues/3067). **What ships today** is
+    env-driven: **`SIMARD_STATE_ROOT`** (distinct state tree per identity, e.g.
+    `~/.crocutus`) plus **`SIMARD_OBSERVE_ONLY=1`** for a read-only identity (enforced
+    fail-closed by `read_only_guard` wired into `git_guardrails::check_git_safety` and
+    the OODA engineer-dispatch). For the concrete, runnable procedure and guardrail
+    proof see the `rysweet/Crocutus` repo (`README.md`, `scripts/prove-guardrail.sh`).
+
+This guide runs a **second** autonomous Simard identity on a host that is
+already running the primary `simard` daemon. The two share one binary but
+nothing stateful: each gets its own instance root, state, dashboard port,
+memory socket, systemd unit, and credentials. For the full end-to-end
+deployment of the concrete `crocutus` read-only observer, see the
+[Crocutus tutorial](../tutorials/deploy-crocutus-read-only-observer.md); this
+page is the generic procedure.
+
+## Prerequisites
+
+- The primary `simard` daemon already installed and running on the host.
+- The second identity's persona available as an
+  [`identity.toml`](../howto/configure-pluggable-identity.md) plus prompt
+  assets (a directory you point `SIMARD_IDENTITY_PATH` / `SIMARD_PROMPT_ROOT`
+  at). For a **downstream** identity such as Crocutus this is a separate repo
+  that *depends on* Simard, not a fork of it.
+- Credentials scoped to the second identity's needs — and **no broader**. A
+  read-only identity gets a read-only credential (or none), never a
+  write-capable token to a target it must not modify.
+
+## 1. Choose a distinct instance root
+
+Every ambient host-level singleton derives from `SIMARD_HOME`. Give the second
+identity its own:
+
+```bash
+export SIMARD_HOME="$HOME/.crocutus"     # primary keeps $HOME/.simard
+export SIMARD_INSTANCE="crocutus"        # drives the systemd unit name
+```
+
+## 2. Assign non-colliding endpoints
+
+```bash
+export SIMARD_STATE_ROOT="$SIMARD_HOME/state"   # own cognitive-memory flock
+export SIMARD_DASHBOARD_PORT=8090               # primary uses 8080
+export SIMARD_MEMORY_SOCKET="$SIMARD_STATE_ROOT/crocutus-memory.sock"
+export SIMARD_AGENT_NAME="crocutus-ooda"
+```
+
+See the
+[per-instance environment matrix](../reference/agent-instance-isolation.md#per-instance-environment-matrix)
+for every variable and why each must differ.
+
+## 3. Select the identity and its posture
+
+```bash
+export SIMARD_IDENTITY="crocutus"
+export SIMARD_IDENTITY_PATH="$CROCUTUS_REPO/identity"   # dir holding identity.toml
+export SIMARD_PROMPT_ROOT="$CROCUTUS_REPO"
+```
+
+The persona's `identity.toml` declares its
+[write-authority posture](../reference/write-authority-posture-api.md#identitytoml-surface).
+A bounded observer sets:
+
+```toml
+[[identities]]
+name = "crocutus"
+default_mode = "engineer"
+
+[identities.authority]
+posture = "read-only"
+allow_git_push = false
+allow_ado_writes = false
+allow_github_writes = false
+```
+
+## 4. Verify isolation before starting anything
+
+Run the pre-flight checks. **Do not start the daemon until both pass.**
+
+```bash
+simard debug instance --check-collision
+simard debug authority
+```
+
+`--check-collision` confirms the instance's paths, port, socket, and unit name
+do not overlap a running instance (it exits non-zero on any overlap). `debug
+authority` confirms the resolved posture. Expected posture output for a
+read-only identity:
+
+```
+identity=crocutus
+posture=read-only
+git_push_check=REFUSED (read-only)
+ado_write_check=REFUSED (read-only)
+github_write_check=REFUSED (read-only)
+```
+
+!!! danger "Fail closed"
+    If either check is uncertain — a path overlaps, the posture does not
+    resolve to what you intend, or a write credential to a forbidden target is
+    present — **stop**. Do nothing rather than risk the second identity writing
+    where it must not. This is non-negotiable for read-only identities.
+
+## 5. Install the second identity's binary copy
+
+`simard install` writes to `$SIMARD_HOME/bin/simard`, so with `SIMARD_HOME`
+set it installs the second instance's own copy without touching the primary's:
+
+```bash
+simard install     # installs to $SIMARD_HOME/bin/simard
+```
+
+## 6. Create the systemd unit
+
+The unit name is derived from `SIMARD_INSTANCE`
+([`systemd_unit_name`](../reference/agent-instance-isolation.md#systemd_unit_namekind-unitkind-string)),
+so it never clashes with `simard-ooda.service`. Create a user unit that
+exports the instance environment and runs the daemon:
+
+```ini
+# ~/.config/systemd/user/crocutus-ooda.service
+[Unit]
+Description=Crocutus OODA daemon (read-only observer, side-by-side with simard)
+After=network-online.target
+
+[Service]
+Type=simple
+Environment=SIMARD_HOME=%h/.crocutus
+Environment=SIMARD_INSTANCE=crocutus
+Environment=SIMARD_STATE_ROOT=%h/.crocutus/state
+Environment=SIMARD_DASHBOARD_PORT=8090
+Environment=SIMARD_MEMORY_SOCKET=%h/.crocutus/state/crocutus-memory.sock
+Environment=SIMARD_AGENT_NAME=crocutus-ooda
+Environment=SIMARD_IDENTITY=crocutus
+Environment=SIMARD_IDENTITY_PATH=%h/crocutus/identity
+Environment=SIMARD_PROMPT_ROOT=%h/crocutus
+ExecStartPre=%h/.crocutus/bin/simard debug instance --check-collision
+ExecStart=%h/.crocutus/bin/simard ooda run
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+```
+
+The `ExecStartPre` collision check makes the unit **refuse to start** if it
+would collide with the primary — a systemd-level fail-closed gate.
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now crocutus-ooda.service
+```
+
+## 7. Confirm both run without interference
+
+```bash
+systemctl --user status simard-ooda.service crocutus-ooda.service --no-pager
+ss -ltnp | grep -E ':8080|:8090'          # two distinct dashboard ports
+ls "$HOME/.simard/state" "$HOME/.crocutus/state"   # two distinct state trees
+```
+
+Each daemon logs one-line OODA summaries to its own journal:
+
+```bash
+journalctl --user -u crocutus-ooda.service -n 20 --no-pager
+```
+
+You should see the second identity observing its own goal board, referencing
+its own target — with no writes if it is read-only.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Second daemon exits immediately with a `flock`/lock error | Shared `SIMARD_STATE_ROOT` with the primary | Give it a distinct `SIMARD_HOME`/`SIMARD_STATE_ROOT`; the exclusive lock is refusing a shared root **by design** (no silent fallback) |
+| Dashboard fails to bind | `SIMARD_DASHBOARD_PORT` collides | Assign a free port |
+| `debug authority` shows `posture=full` unexpectedly | `identity.toml` omits `[identities.authority]`, or `SIMARD_IDENTITY_PATH` points at the wrong dir | Point at the correct identity dir; add the `[identities.authority]` block |
+| A read-only identity still holds a write token | Credential scoping missed | Revoke the write credential; a read-only identity must have no write-capable credential to its target |
+
+## See also
+
+- [Multi-identity host isolation](../concepts/multi-identity-host-isolation.md)
+  — why each singleton must be per-instance.
+- [Write-authority posture](../concepts/write-authority-posture.md) — the
+  read-only / scoped-write / full contract.
+- [Agent instance-isolation reference](../reference/agent-instance-isolation.md)
+  — the full env matrix and `simard debug instance`.
+- [Deploy Crocutus as a read-only observer](../tutorials/deploy-crocutus-read-only-observer.md)
+  — the concrete end-to-end deployment.
+- [How to run the OODA daemon](../howto/run-ooda-daemon.md) — the base daemon
+  this guide runs a second copy of.

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,6 +112,12 @@ Terminal sessions and repo-grounded engineer runs now bridge through one explici
 - [Concept: pluggable identity](./concepts/pluggable-identity.md) - Design rationale for TOML-driven agent personas that let different repos define distinct identities (#2242).
 - [How to configure pluggable identities](./howto/configure-pluggable-identity.md) - Create an `identity.toml` file for custom agent personas, operating modes, and prompt assets.
 - [Pluggable identity API reference](./reference/pluggable-identity-api.md) - Rust API for `FileIdentityLoader`, TOML types, `load_watches_from_file`, and error variants.
+- [Concept: multi-identity host isolation](./concepts/multi-identity-host-isolation.md) - How a second autonomous identity (e.g. the read-only `crocutus`) runs side-by-side with the primary `simard` daemon on one host via the `SIMARD_HOME` instance root, without colliding on state, ports, sockets, systemd units, or the cognitive-memory exclusive lock (#1).
+- [Concept: write-authority posture](./concepts/write-authority-posture.md) - The identity-level `read-only` / `scoped-write` / `full` contract that makes a second identity a bounded observer, enforced fail-closed at the git/ADO/GitHub guardrail seams (#1).
+- [Agent instance-isolation reference](./reference/agent-instance-isolation.md) - `SIMARD_HOME`, `instance_home()`, the per-instance environment matrix, systemd unit-name templating, and `simard debug instance`.
+- [Write-authority posture API reference](./reference/write-authority-posture-api.md) - The `IdentityAuthority` manifest field, the `[identities.authority]` TOML block, posture-aware `check_git_safety` / `check_ado_write_safety`, and `simard debug authority`.
+- [How to run a second agent identity side-by-side](./howto/run-a-second-agent-identity.md) - Configure a distinct instance root, endpoints, posture, and systemd unit, verify isolation, and launch a second daemon.
+- [Tutorial: Deploy Crocutus, a read-only observer of an Azure DevOps project](./tutorials/deploy-crocutus-read-only-observer.md) - End-to-end deployment of the `crocutus` identity observing the `acs-mdash` project (hyenas + sisters) read-only on host `dev`, with the guardrail proof (#1).
 
 ## Canonical executable surface
 

--- a/docs/reference/agent-instance-isolation.md
+++ b/docs/reference/agent-instance-isolation.md
@@ -1,0 +1,257 @@
+---
+title: Agent instance-isolation reference
+description: The SIMARD_HOME instance-root layer, the instance_home() resolver, the full per-instance environment matrix, systemd unit-name templating, and the `simard debug instance` verification command that let two Simard identities run side-by-side on one host.
+last_updated: 2026-07-08
+owner: simard
+doc_type: reference
+related:
+  - ../concepts/multi-identity-host-isolation.md
+  - ../reference/state-root-resolution.md
+  - ../reference/write-authority-posture-api.md
+  - ../howto/run-a-second-agent-identity.md
+---
+
+# Agent instance-isolation reference
+
+!!! warning "Implementation status — this page describes the PLANNED instance-root layer (tracking #3067)"
+    The `simard::instance_home` module, `SIMARD_HOME`, `instance_home()`,
+    `instance_subdir()`, `instance_name()`, `systemd_unit_name()`, and the
+    `simard debug instance` verb documented here are **not yet implemented** — they are
+    the target design tracked in
+    [#3067](https://github.com/rysweet/Simard/issues/3067). **What ships today** is
+    [`SIMARD_STATE_ROOT`](./state-root-resolution.md), which isolates the durable state
+    tree (cognitive-memory `flock` + goal board) per identity — sufficient for the
+    load-bearing collision guarantee. Set `SIMARD_STATE_ROOT`, `SIMARD_DASHBOARD_PORT`,
+    `SIMARD_MEMORY_SOCKET`, and a distinct systemd unit name per instance; the
+    `SIMARD_HOME`-derived singletons below are planned. See the `rysweet/Crocutus` repo
+    for the shipped, runnable configuration.
+
+Module: `simard::instance_home`
+
+An **instance** is one autonomous Simard identity running on a host with its
+own state, ports, socket, systemd unit, and credentials. This page is the
+reference for the instance-root layer that makes two instances (for example
+the primary `simard` and the read-only `crocutus`) coexist. For the rationale
+see [Multi-identity host isolation](../concepts/multi-identity-host-isolation.md).
+
+---
+
+## Public API
+
+```rust
+pub fn instance_home() -> PathBuf;
+
+pub fn instance_subdir(name: &str) -> PathBuf;
+
+pub fn instance_name() -> String;
+
+pub fn systemd_unit_name(kind: UnitKind) -> String;
+```
+
+Re-exported from the crate root:
+
+```rust
+use simard::instance_home::{instance_home, instance_subdir, instance_name, systemd_unit_name};
+```
+
+### `instance_home() -> PathBuf`
+
+Returns the resolved instance root. Resolution order:
+
+1. `$SIMARD_HOME` if set, **non-empty**, **absolute**, and free of interior
+   NUL bytes.
+2. `$HOME/.simard` otherwise (the primary instance default).
+
+A non-absolute or NUL-bearing `SIMARD_HOME` is **ignored with a WARN**, not an
+error — boot never fails on a malformed instance-root env, exactly like
+[`simard_state_root()`](./state-root-resolution.md#simard_state_root-pathbuf).
+The helper does not create the directory; callers create it on first write.
+
+Every ambient host-level singleton that previously hardcoded `$HOME/.simard`
+now resolves through this helper:
+
+| Singleton | Path (via `instance_home()`) | Previously |
+|-----------|------------------------------|------------|
+| Binary install dir | `<home>/bin/simard` | hardcoded `~/.simard/bin/simard` |
+| Agent registry | `<home>/agent_registry.json` | hardcoded, ignored state root |
+| Memory snapshots | `<home>/snapshots/` | hardcoded |
+| Self-update state / backups | `<home>/{bin,state}` | hardcoded (cwd fallback) |
+| Engineer worktrees | `<home>/engineer-worktrees/` | hardcoded |
+
+### `instance_subdir(name: &str) -> PathBuf`
+
+Returns `instance_home().join(name)`. Callers pass a static subdirectory
+string (`"snapshots"`, `"engineer-worktrees"`, ...); the helper does no
+validation on `name`.
+
+### `instance_name() -> String`
+
+Returns the instance name used for the systemd unit and log labeling.
+Resolution order:
+
+1. `$SIMARD_INSTANCE` if set and non-empty.
+2. The final path component of `instance_home()` with a leading dot stripped
+   (`$HOME/.crocutus` → `crocutus`, `$HOME/.simard` → `simard`).
+
+### `systemd_unit_name(kind: UnitKind) -> String`
+
+Returns the instance-scoped unit name, replacing the historical hardcoded
+`simard-ooda.service` constant.
+
+```rust
+pub enum UnitKind { Ooda, Signal, Overseer }
+```
+
+| `instance_name()` | `UnitKind::Ooda` | `UnitKind::Signal` |
+|-------------------|------------------|--------------------|
+| `simard` | `simard-ooda.service` | `simard-signal.service` |
+| `crocutus` | `crocutus-ooda.service` | `crocutus-signal.service` |
+
+The primary instance's unit names are unchanged, so existing deployments and
+the TUI/deploy paths that referenced `simard-ooda.service` keep working.
+
+---
+
+## Relationship to `SIMARD_STATE_ROOT`
+
+`SIMARD_HOME` sits **above** the pre-existing
+[state-root resolution](./state-root-resolution.md). It relocates the ambient
+singletons (install, registry, snapshots, worktrees) that state-root never
+covered. `SIMARD_STATE_ROOT` continues to relocate the durable state tree
+(cognitive memory, goal store, handoffs) and, when set, wins for that tree.
+
+Resolution precedence for the **state tree**, per instance:
+
+1. The subsystem's narrow env var (e.g. `SIMARD_HANDOFF_DIR`).
+2. `$SIMARD_STATE_ROOT/<subdir>`.
+3. `$SIMARD_HOME/state/<subdir>` — **new**: when neither of the above is set,
+   the state tree defaults under the instance root instead of the bare
+   `$HOME/.simard`.
+4. `$HOME/.simard/state/<subdir>` (primary default when `SIMARD_HOME` unset).
+
+This removes the old inconsistency where some paths honored
+`SIMARD_STATE_ROOT` and others hardcoded `$HOME/.simard`.
+
+---
+
+## Per-instance environment matrix
+
+Set these together to define an instance. Every row must differ from every
+other instance on the host (the
+[isolation invariant](../concepts/multi-identity-host-isolation.md#the-isolation-invariant)).
+
+| Variable | Purpose | Primary (`simard`) | Second (`crocutus`) |
+|----------|---------|--------------------|---------------------|
+| `SIMARD_HOME` | Instance root (install, registry, snapshots, worktrees) | `$HOME/.simard` (default) | `$HOME/.crocutus` |
+| `SIMARD_INSTANCE` | Instance name (unit, labels) | `simard` (derived) | `crocutus` |
+| `SIMARD_STATE_ROOT` | Durable state tree + cognitive-memory `flock` | `$HOME/.simard/state` | `$HOME/.crocutus/state` |
+| `SIMARD_DASHBOARD_PORT` | Dashboard HTTP port | `8080` | `8090` |
+| `SIMARD_MEMORY_SOCKET` | Memory IPC socket | `.../memory.sock` | `.../crocutus-memory.sock` |
+| `SIMARD_AGENT_NAME` | Bridge registration label | `simard-ooda` | `crocutus-ooda` |
+| `SIMARD_IDENTITY` | Selected identity name | `simard-engineer` | `crocutus` |
+| `SIMARD_IDENTITY_PATH` | Directory holding `identity.toml` | (built-in) | `<crocutus-repo>/identity` |
+| `SIMARD_PROMPT_ROOT` | Prompt-asset root | repo root | `<crocutus-repo>` |
+
+The identity-selection variables (`SIMARD_IDENTITY`, `SIMARD_IDENTITY_PATH`,
+`SIMARD_PROMPT_ROOT`) and the persona itself are covered by
+[pluggable identity](../concepts/pluggable-identity.md); the
+[write-authority posture](./write-authority-posture-api.md) governs the
+read-only mandate.
+
+---
+
+## `simard debug instance`
+
+Prints the resolved instance identity and every instance-scoped path for the
+current environment, without performing any writes — the instance analogue of
+[`simard debug state-root`](./state-root-resolution.md#verifying-the-resolved-root).
+Use it to verify isolation **before** starting a second daemon.
+
+```bash
+SIMARD_HOME=$HOME/.crocutus SIMARD_INSTANCE=crocutus simard debug instance
+```
+
+```
+instance_name=crocutus
+  source=SIMARD_INSTANCE
+instance_home=/home/azureuser/.crocutus
+  source=SIMARD_HOME
+install_bin=/home/azureuser/.crocutus/bin/simard
+agent_registry=/home/azureuser/.crocutus/agent_registry.json
+snapshots=/home/azureuser/.crocutus/snapshots
+engineer_worktrees=/home/azureuser/.crocutus/engineer-worktrees
+state_root=/home/azureuser/.crocutus/state
+  source=SIMARD_HOME
+memory_flock=/home/azureuser/.crocutus/state/cognitive_memory/LOCK
+dashboard_port=8090
+  source=SIMARD_DASHBOARD_PORT
+memory_socket=/home/azureuser/.crocutus/state/crocutus-memory.sock
+  source=SIMARD_MEMORY_SOCKET
+ooda_unit=crocutus-ooda.service
+signal_unit=crocutus-signal.service
+```
+
+### Collision detection
+
+`simard debug instance --check-collision` compares the resolved paths, port,
+socket, and unit name against any **running** Simard instance discovered via
+the agent registry and returns non-zero (with a loud diagnostic) if any
+overlap. This is a pre-flight check; the ultimate guarantee remains the
+cognitive-memory exclusive `flock`, which refuses a second daemon on a shared
+state root at startup.
+
+```
+error: instance collision: SIMARD_STATE_ROOT '/home/azureuser/.simard/state'
+       is already locked by running instance 'simard' (pid 4123).
+       Two instances must not share a state root. Set a distinct SIMARD_HOME
+       or SIMARD_STATE_ROOT. Refusing to start (fail-closed).
+```
+
+There is intentionally **no** fallback that opens a degraded unlocked store
+when the `flock` is held — that would be silent degradation
+([Pillar 11](../fail-open-audit.md)).
+
+---
+
+## Validation rules
+
+Applied to `SIMARD_HOME`, mirroring
+[state-root validation](./state-root-resolution.md#validation-rules):
+
+| Check | Behavior on failure |
+|-------|---------------------|
+| Non-empty | Empty string treated as unset (falls back to `$HOME/.simard`) |
+| Absolute path | Relative path **ignored with a WARN** |
+| No interior NUL | Path containing `\0` **ignored with a WARN** |
+
+The helper does not reject `..`, does not resolve symlinks, and does not
+create the directory (first writer does). The single-user CLI threat model of
+[state-root resolution](./state-root-resolution.md#security-notes) applies
+unchanged.
+
+---
+
+## Permissions
+
+Freshly-created instance directories are created owner-only:
+
+| Artifact | Mode |
+|----------|------|
+| New instance-root subdirectory (`snapshots/`, `engineer-worktrees/`, `state/`) | `0o700` |
+| Registry / snapshot files | `0o600` |
+
+Pre-existing directories are not re-`chmod`ed. On non-unix targets the mode is
+omitted and the umask applies.
+
+---
+
+## See also
+
+- [Multi-identity host isolation](../concepts/multi-identity-host-isolation.md)
+  — the design rationale.
+- [State-root resolution](./state-root-resolution.md) — the per-subsystem
+  ladder that `SIMARD_HOME` layers above.
+- [Write-authority posture API](./write-authority-posture-api.md) — the
+  read-only contract that pairs with isolation.
+- [How to run a second agent identity](../howto/run-a-second-agent-identity.md)
+  — the operator procedure.

--- a/docs/reference/write-authority-posture-api.md
+++ b/docs/reference/write-authority-posture-api.md
@@ -1,0 +1,318 @@
+---
+title: Write-authority posture API reference
+description: Rust and identity.toml reference for the write-authority posture contract — the IdentityAuthority manifest field, the [identities.authority] TOML block, posture-aware check_git_safety / check_ado_acl_safety / GitHub write-path enforcement, composition rules, error variants, and the `simard debug authority` verification command.
+last_updated: 2026-07-08
+owner: simard
+doc_type: reference
+related:
+  - ../concepts/write-authority-posture.md
+  - ../reference/pluggable-identity-api.md
+  - ../reference/ado-acl-self-escalation-guard.md
+  - ../reference/agent-instance-isolation.md
+---
+
+# Write-authority posture API reference
+
+!!! warning "Implementation status — this page describes the PLANNED typed API (tracking #3067)"
+    The typed `IdentityAuthority` / `WritePosture` types, the `[identities.authority]`
+    TOML block, the `*_with_authority` guardrail entry points, and the
+    `simard debug authority` verb documented on this page are **not yet implemented**;
+    they are the target design tracked in
+    [#3067](https://github.com/rysweet/Simard/issues/3067). **What ships today** is the
+    env-driven read-only floor: `SIMARD_OBSERVE_ONLY=1` activates the fail-closed
+    `read_only_guard` classifier (`observe_only_enabled`, `check_observe_only`,
+    `check_observe_only_git`, `guard_observe_only_git`, `command_is_read`,
+    `is_write_command`), which is wired into `git_guardrails::check_git_safety` and
+    `ooda_actions::advance_goal::spawn::dispatch_spawn_engineer`. The runnable guardrail
+    proof lives in the `rysweet/Crocutus` repo (`scripts/prove-guardrail.sh`).
+
+Modules: `simard::identity::toml_types`, `simard::identity::manifest`,
+`simard::git_guardrails`, `simard::ado_acl_guard`
+
+The write-authority posture contract adds a typed, per-identity policy that
+governs whether a session may write via git, Azure DevOps, or GitHub. For the
+rationale see [Write-authority posture](../concepts/write-authority-posture.md).
+
+!!! note "Planned types (tracking #3067)"
+    `IdentityAuthority` / `WritePosture` (domain) and the `TomlAuthority`
+    deserialization struct behind `[identities.authority]` are **planned, not yet
+    shipped**. The target implementation adds `TomlAuthority` to
+    `simard::identity::toml_types`, threads it into `IdentityManifest`, and maps the
+    TOML block onto `IdentityAuthority` during load. Because every pluggable-identity
+    TOML type uses `deny_unknown_fields`, a `[identities.authority]` block is a hard
+    parse error against the **current** schema until this lands — so a shipped
+    Crocutus identity today expresses its read-only mandate via the
+    `SIMARD_OBSERVE_ONLY` environment floor, not this TOML block.
+
+---
+
+## `IdentityAuthority`
+
+Module: `simard::identity::manifest`
+
+```rust
+pub struct IdentityAuthority {
+    pub posture: WritePosture,
+    pub allowed_write_repos: Vec<String>,
+    pub allow_git_push: bool,
+    pub allow_ado_writes: bool,
+    pub allow_github_writes: bool,
+}
+
+pub enum WritePosture {
+    ReadOnly,
+    ScopedWrite,
+    Full,
+}
+```
+
+`IdentityAuthority` is a field on `IdentityManifest` — the same domain type
+produced by both `BuiltinIdentityLoader` and
+[`FileIdentityLoader`](./pluggable-identity-api.md#fileidentityloader), so
+posture resolution is orthogonal to the loading mechanism.
+
+### `Default`
+
+```rust
+impl Default for IdentityAuthority {
+    fn default() -> Self {
+        Self {
+            posture: WritePosture::Full,
+            allowed_write_repos: Vec::new(),
+            allow_git_push: true,
+            allow_ado_writes: true,
+            allow_github_writes: true,
+        }
+    }
+}
+```
+
+The default is **`Full`** so built-in identities and TOML identities that omit
+`[identities.authority]` behave exactly as before this feature (backward
+compatible).
+
+### Posture semantics
+
+| `posture` | `allow_*` fields | `allowed_write_repos` |
+|-----------|------------------|-----------------------|
+| `ReadOnly` | default to `false` and may be omitted; setting any `allow_*_writes = true` under `read-only` is a **hard parse error** (rejected, never silently coerced) | must be empty; non-empty is a hard parse error |
+| `ScopedWrite` | honored per field | write is permitted **only** for repos whose canonical URL/slug is in the allowlist; all others refused |
+| `Full` | honored per field (default all `true`) | ignored |
+
+The `allow_*` **default is posture-dependent**: when `[identities.authority]`
+is omitted entirely the posture is `Full` and the `allow_*` fields default to
+`true` (the `Default` impl above); when the block is present with
+`posture = "read-only"` the `allow_*` fields default to `false`. A read-only
+manifest may thus omit the `allow_*` lines entirely — but it may not set them
+to `true`.
+
+`WritePosture` is resolved once at identity load time and threaded into the
+guardrails; a running session cannot raise its own posture.
+
+---
+
+## `identity.toml` surface
+
+```toml
+[[identities]]
+name = "crocutus"
+default_mode = "engineer"
+
+# Optional. Omit for the default `full` posture.
+[identities.authority]
+posture = "read-only"          # "read-only" | "scoped-write" | "full"
+allowed_write_repos = []       # allowlist; only meaningful for "scoped-write"
+allow_git_push = false
+allow_ado_writes = false
+allow_github_writes = false
+```
+
+The struct is deserialized with `deny_unknown_fields`, matching every other
+[pluggable-identity TOML type](./pluggable-identity-api.md); an unexpected key
+is a hard `IdentityTomlParseError`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `posture` | string | `"full"` | `"read-only"`, `"scoped-write"`, or `"full"`. |
+| `allowed_write_repos` | `[string]` | `[]` | Repo URLs/slugs writable under `scoped-write`. Must be empty unless `posture = "scoped-write"`. |
+| `allow_git_push` | bool | `true` (`full`) / `false` (`read-only`) | Permit `git push`/`git commit`. Under `read-only` it defaults to `false` and setting `true` is a parse error. |
+| `allow_ado_writes` | bool | `true` (`full`) / `false` (`read-only`) | Permit Azure DevOps write verbs (push, PR create, work-item edit). Under `read-only` it defaults to `false` and setting `true` is a parse error. |
+| `allow_github_writes` | bool | `true` (`full`) / `false` (`read-only`) | Permit GitHub writes (PR create, issue edit, comment). Under `read-only` it defaults to `false` and setting `true` is a parse error. |
+
+---
+
+## Posture-aware guardrails
+
+Posture is enforced at the **existing** guardrail seams; there is no parallel
+enforcement system.
+
+### `check_git_safety`
+
+Module: `simard::git_guardrails`
+
+```rust
+pub fn check_git_safety(workspace: &Path, args: &[&str]) -> Result<(), String>;
+
+pub fn check_git_safety_with_authority(
+    workspace: &Path,
+    args: &[&str],
+    authority: &IdentityAuthority,
+) -> Result<(), String>;
+```
+
+`check_git_safety` retains its historical signature and behavior (blocks the
+destructive `BLOCKED_PATTERNS` and, on a protected repo, restricts to the safe
+command list). `check_git_safety_with_authority` layers posture on top:
+
+| Posture | Added behavior over the existing destructive/protected checks |
+|---------|---------------------------------------------------------------|
+| `ReadOnly` | Refuses `push`, `commit`, `merge`, `tag -a`, `am`, `apply`, and any other mutating verb — returns `Err` with `GUARDRAIL BLOCKED (read-only): ...` |
+| `ScopedWrite` | Allows `push`/`commit` only when `workspace` maps to a repo in `allowed_write_repos`; otherwise refuses |
+| `Full` | No change — existing destructive/protected checks only |
+
+Read verbs (`status`, `log`, `diff`, `show`, `fetch`, `rev-parse`, ...) are
+never blocked by posture.
+
+### `check_ado_acl_safety`
+
+Module: `simard::ado_acl_guard`
+
+```rust
+pub fn check_ado_acl_safety(args: &[&str]) -> Result<(), String>;
+
+pub fn check_ado_write_safety(
+    args: &[&str],
+    authority: &IdentityAuthority,
+) -> Result<(), String>;
+```
+
+`check_ado_acl_safety` is unchanged — it still fails closed on
+[ACL self-escalation](./ado-acl-self-escalation-guard.md). `check_ado_write_safety`
+generalizes it to posture:
+
+| Posture | Behavior |
+|---------|----------|
+| `ReadOnly` | Refuses **all** Azure DevOps write verbs — `az repos pr create`, `az repos ...` writes, `az boards work-item update/create`, `git push` to an `dev.azure.com` remote, and every ACL mutation. Read verbs (`show`, `list`, `GET`, read-only clone) pass. |
+| `ScopedWrite` | ADO writes allowed only for repos in `allowed_write_repos`; ACL self-escalation still refused unless `SIMARD_ALLOW_ADO_ACL_ESCALATION` is set (see the [ADO ACL guard](./ado-acl-self-escalation-guard.md#configuration)). |
+| `Full` | Existing `check_ado_acl_safety` behavior only. |
+
+Detection **fails closed**, inheriting the ADO guard's rule that a command
+targeting a write surface is treated as a write unless it is *provably* a read
+(explicit `GET`/`HEAD`/`OPTIONS` and no body). See
+[what is detected as an ACL mutation](./ado-acl-self-escalation-guard.md#what-is-detected-as-an-acl-mutation).
+
+### GitHub write path
+
+The GitHub client refuses PR creation, issue edits, comments, and label/branch
+mutations when `posture == ReadOnly` (or the target is outside
+`allowed_write_repos` under `scoped-write`), returning a visible error rather
+than a silent no-op. Read calls (list issues, read PRs) are unaffected.
+
+### Dispatch-layer enforcement (ACT phase)
+
+Threading posture into the three guardrail functions is necessary but **not
+sufficient**. The OODA **ACT** phase (`dispatch_spawn_engineer` and the other
+`ooda_actions` dispatchers) can spawn engineer worktrees and sub-agents that
+themselves shell out to `git` / `az` / `gh`. The contract's invariant is that
+**every write path routes through a posture-aware seam**, and under `read-only`
+the dispatchers **short-circuit**: they record proposed goals but dispatch zero
+write-bearing actions. Concretely, `dispatch_spawn_engineer` (and the git write
+sites in `self_improve_executor::git_ops` and `overseer::conflict`) consult the
+resolved `IdentityAuthority` and refuse, fail-closed, before any subprocess is
+launched. This is what produces `dispatched 0 actions (read-only), 0 writes` in
+the OODA cycle summary. Implementations MUST verify this end-to-end, not only
+at the guardrail-function unit level.
+
+---
+
+## Composition
+
+Posture composes like [`memory_policy`](./pluggable-identity-api.md). When a
+composite identity merges components:
+
+- **All components must agree on `posture`.** A mismatch (e.g. one `read-only`,
+  one `full`) is a hard `InvalidIdentityComposition` error. You cannot dilute a
+  read-only component by composing it with a full one.
+- `allowed_write_repos` under `scoped-write` is the **intersection** of the
+  components' allowlists (the most restrictive wins).
+
+---
+
+## Error variants
+
+| Condition | Error |
+|-----------|-------|
+| `posture` is not one of the three known values | `IdentityTomlParseError` |
+| `allow_*_writes = true` while `posture = "read-only"` | `IdentityTomlParseError` (contradiction) |
+| `allowed_write_repos` non-empty while `posture` ≠ `"scoped-write"` | `IdentityTomlParseError` |
+| Unknown field in `[identities.authority]` | `IdentityTomlParseError` (`deny_unknown_fields`) |
+| Components disagree on `posture` | `InvalidIdentityComposition` |
+| Read-only identity attempts a git write | `Err("GUARDRAIL BLOCKED (read-only): ...")` from `check_git_safety_with_authority` |
+| Read-only identity attempts an ADO write | `Err("GUARDRAIL BLOCKED (read-only): ...")` from `check_ado_write_safety` |
+| Read-only identity attempts a GitHub write | `Err` from the GitHub client |
+
+All enforcement errors are **hard and visible** (fail-closed); none degrade to
+a silent no-op.
+
+---
+
+## `simard debug authority`
+
+Prints the resolved write-authority posture for the selected identity, without
+performing any writes — the posture analogue of
+[`simard debug instance`](./agent-instance-isolation.md#simard-debug-instance).
+
+```bash
+SIMARD_IDENTITY=crocutus \
+SIMARD_IDENTITY_PATH="$CROCUTUS/identity" \
+SIMARD_PROMPT_ROOT="$CROCUTUS" \
+simard debug authority
+```
+
+```
+identity=crocutus
+posture=read-only
+allow_git_push=false
+allow_ado_writes=false
+allow_github_writes=false
+allowed_write_repos=[]
+git_push_check=REFUSED (read-only)
+ado_write_check=REFUSED (read-only)
+github_write_check=REFUSED (read-only)
+```
+
+### Dry-run refusal probe
+
+`simard debug authority --probe-write <target>` performs a **dry-run** of the
+git/ADO/GitHub write checks against a target and reports whether each would be
+refused, executing nothing. Use it as the machine-checkable half of the
+[read-only guardrail proof](../tutorials/deploy-crocutus-read-only-observer.md#step-6-prove-the-read-only-guardrail):
+
+```bash
+simard debug authority --probe-write \
+  https://dev.azure.com/acs-mdash/acs-mdash/_git/hyenas
+```
+
+```
+probe target=https://dev.azure.com/acs-mdash/acs-mdash/_git/hyenas
+git push        => REFUSED (read-only)
+az repos pr     => REFUSED (read-only)
+work-item edit  => REFUSED (read-only)
+exit=0 (all writes refused as expected)
+```
+
+The command exits non-zero if **any** probed write would be *allowed*, so it
+can gate CI/acceptance.
+
+---
+
+## See also
+
+- [Write-authority posture](../concepts/write-authority-posture.md) — design
+  rationale and the four-layer defense-in-depth for a read-only identity.
+- [Pluggable identity API reference](./pluggable-identity-api.md) — the loader
+  and TOML types that carry `IdentityAuthority`.
+- [Azure DevOps ACL self-escalation guard](./ado-acl-self-escalation-guard.md)
+  — the pre-existing fail-closed guard that posture generalizes.
+- [Agent instance-isolation reference](./agent-instance-isolation.md) — the
+  per-instance isolation that pairs with posture.

--- a/docs/tutorials/deploy-crocutus-read-only-observer.md
+++ b/docs/tutorials/deploy-crocutus-read-only-observer.md
@@ -1,0 +1,347 @@
+---
+title: "Tutorial: Deploy Crocutus, a read-only observer of an Azure DevOps project"
+description: End-to-end walkthrough of deploying Crocutus — a second autonomous Simard identity that observes the acs-mdash/acs-mdash Azure DevOps project (the hyenas repo and its sisters) strictly read-only, articulates repo-hygiene goals, runs side-by-side with the primary simard daemon on host "dev", and is provably unable to change anything.
+last_updated: 2026-07-08
+owner: simard
+doc_type: tutorial
+related:
+  - ../concepts/multi-identity-host-isolation.md
+  - ../concepts/write-authority-posture.md
+  - ../reference/agent-instance-isolation.md
+  - ../reference/write-authority-posture-api.md
+  - ../howto/run-a-second-agent-identity.md
+  - ../howto/configure-pluggable-identity.md
+---
+
+# Tutorial: Deploy Crocutus, a read-only observer of an Azure DevOps project
+
+!!! warning "Implementation status — read before running (issue #1, tracking #3067)"
+    Some commands below use the **planned** interface (`SIMARD_HOME`,
+    `[identities.authority]` posture, `simard debug instance`/`authority`,
+    `simard install`) tracked in
+    [#3067](https://github.com/rysweet/Simard/issues/3067) and will not run as-is on the
+    shipped binary. **The shipped mechanism** is env-driven: set
+    **`SIMARD_STATE_ROOT=$HOME/.crocutus/state`** (isolation) and
+    **`SIMARD_OBSERVE_ONLY=1`** (read-only floor, enforced fail-closed by
+    `read_only_guard` wired into `git_guardrails::check_git_safety` and the OODA
+    engineer-dispatch), point the daemon's working directory at a **read-only clone**
+    of the target, and run `simard ooda run`. The concrete, runnable version of this
+    tutorial — including the guardrail proof and systemd unit — is maintained in the
+    `rysweet/Crocutus` repo (`README.md`, `scripts/`). Read this tutorial for the design
+    intent; run the Crocutus repo for the working procedure.
+
+By the end of this tutorial you will have **Crocutus** running as a distinct,
+read-only autonomous identity next to the primary `simard` daemon on host
+`dev`. Crocutus observes the Azure DevOps project
+`acs-mdash/acs-mdash` — the `hyenas` repository and its sister repos — learns
+their structure and health **read-only**, and articulates repo-hygiene goals
+(stale branches, missing CI, docs drift, dependency hygiene). It **never**
+changes anything in that project, and you will prove that.
+
+Crocutus is not a fork of Simard. It is a downstream **private** repository
+(`rysweet/Crocutus`) that *depends on* Simard and is almost entirely
+configuration: an `identity.toml` persona, prompt assets, an environment
+profile, and a systemd unit. The behavior comes from two Simard abstractions
+you already have references for:
+
+- [Multi-identity host isolation](../concepts/multi-identity-host-isolation.md)
+  (`SIMARD_HOME`) — so Crocutus and Simard do not collide.
+- [Write-authority posture](../concepts/write-authority-posture.md)
+  (`posture = "read-only"`) — so Crocutus cannot write.
+
+!!! danger "The one non-negotiable guarantee"
+    Crocutus must not make **any** change to the target repos or their Azure
+    DevOps project — no commit, push, branch, PR, work-item edit, comment, or
+    ACL change, anywhere. This is enforced in depth (credential, capability,
+    mandate, isolation). If any layer is uncertain, Crocutus **fails closed**
+    (does nothing). Getting this right matters more than any feature.
+
+## Prerequisites
+
+- Host `dev` reachable, with the primary `simard` daemon already running.
+- `rysweet` GitHub identity (`gh auth status` green) and `az login` completed
+  on host `dev`.
+- The `rysweet/Crocutus` repo cloned to `~/crocutus` on host `dev`.
+- A **read-only** Azure DevOps credential for `acs-mdash` — a read-scoped PAT
+  (Code: Read; Work Items: Read) **or** an anonymous read-only clone path.
+  **Never** a write-capable token to this project.
+
+## Step 0 — Confirm which host `dev` is
+
+`dev` may be the current box under another name, or a separate azlin VM. Do not
+install anything until you know. Confirm the mapping first:
+
+```bash
+hostname
+grep -E '\bdev\b' /etc/hosts ~/.ssh/config 2>/dev/null
+az vm list -d -o table 2>/dev/null | grep -i dev
+```
+
+If `dev` is a separate VM, `ssh dev` and run the rest of this tutorial there.
+If `dev` is the current host under another name, proceed locally.
+
+## Step 1 — Provision the read-only credential (or none)
+
+Store the read-only PAT so only Crocutus's environment sees it, and confirm it
+carries **no** write scope:
+
+```bash
+# Read-only PAT: Code (Read), Work Items (Read). No write scopes.
+install -m 600 /dev/stdin ~/.crocutus/ado_readonly.pat <<< "$ADO_READONLY_PAT"
+
+# Prove the token cannot write: a read succeeds, a write is denied by AzDO.
+az repos ref list \
+  --org https://dev.azure.com/acs-mdash --project acs-mdash \
+  --repository hyenas >/dev/null && echo "read OK"
+```
+
+!!! warning "Fail closed on credentials"
+    If you cannot obtain a genuinely read-only credential, give Crocutus
+    **zero** Azure DevOps credentials and rely on anonymous read (or have it do
+    nothing). Never substitute a write-capable token. Absence of a write token
+    is itself a guardrail layer.
+
+## Step 2 — Author the Crocutus identity (config, not code)
+
+In `~/crocutus/identity/identity.toml`, declare the read-only persona. This is
+the whole "identity" — a persona plus a posture:
+
+```toml
+[package]
+name = "crocutus-identity"
+version = "0.1.0"
+description = "Read-only observer of the acs-mdash Azure DevOps project"
+
+[[identities]]
+name = "crocutus"
+default_mode = "engineer"
+supported_base_types = ["local-harness", "rusty-clawd"]
+required_capabilities = ["prompt-assets", "session-lifecycle", "memory", "reflection"]
+
+[[identities.prompt_assets]]
+id = "crocutus-system"
+path = "crocutus_system.md"
+
+[identities.memory_policy]
+allow_project_writes = false
+summary_scope = "session-summary"
+
+[identities.authority]
+posture = "read-only"
+allowed_write_repos = []
+allow_git_push = false
+allow_ado_writes = false
+allow_github_writes = false
+```
+
+The prompt asset `crocutus_system.md` states the mandate in the identity's own
+voice — "You are Crocutus, a read-only observer of the acs-mdash Azure DevOps
+project. You never commit, push, open PRs, edit work items, or change anything
+in these repos. You only read, reason, and propose repo-hygiene goals." This is
+the *mandate* layer; it is backed by the *capability* layer (`posture`) and the
+*credential* layer (read-only PAT), so the guarantee holds even if the prompt
+were wrong.
+
+See [How to configure pluggable identities](../howto/configure-pluggable-identity.md)
+for the full `identity.toml` schema and
+[the posture API](../reference/write-authority-posture-api.md#identitytoml-surface)
+for the `[identities.authority]` block.
+
+## Step 3 — Define the Crocutus instance environment
+
+Give Crocutus its own instance root and non-colliding endpoints
+([env matrix](../reference/agent-instance-isolation.md#per-instance-environment-matrix)):
+
+```bash
+cat > ~/crocutus/crocutus.env <<'EOF'
+SIMARD_HOME=%h/.crocutus
+SIMARD_INSTANCE=crocutus
+SIMARD_STATE_ROOT=%h/.crocutus/state
+SIMARD_DASHBOARD_PORT=8090
+SIMARD_MEMORY_SOCKET=%h/.crocutus/state/crocutus-memory.sock
+SIMARD_AGENT_NAME=crocutus-ooda
+SIMARD_IDENTITY=crocutus
+SIMARD_IDENTITY_PATH=%h/crocutus/identity
+SIMARD_PROMPT_ROOT=%h/crocutus
+SIMARD_TARGET_ADO_ORG=https://dev.azure.com/acs-mdash
+SIMARD_TARGET_ADO_PROJECT=acs-mdash
+SIMARD_TARGET_REPO_URL=https://dev.azure.com/acs-mdash/acs-mdash/_git/hyenas
+SIMARD_ADO_PAT_FILE=%h/.crocutus/ado_readonly.pat
+EOF
+```
+
+`SIMARD_TARGET_REPO_URL` is the concrete write target the guardrail probe
+checks in Step 7. `SIMARD_ADO_PAT_FILE` points Simard at the **read-only** PAT
+file from Step 1; Simard loads it as a read credential and is never given a
+write token (it is a Simard-owned variable, not the `az`-native
+`AZURE_DEVOPS_EXT_PAT`).
+
+## Step 4 — Build and install Crocutus's own binary copy
+
+Crocutus depends on Simard; it does not vendor Simard's source. Build the
+downstream crate (which pulls Simard as a git dependency) and install into the
+Crocutus instance root:
+
+```bash
+cd ~/crocutus && cargo build --release --quiet
+SIMARD_HOME=$HOME/.crocutus SIMARD_INSTANCE=crocutus \
+  ./target/release/simard install     # → ~/.crocutus/bin/simard
+```
+
+## Step 5 — Verify isolation and posture BEFORE starting
+
+This is the gate. Both checks must pass; if either is uncertain, stop.
+
+```bash
+set -a; . <(sed 's/%h/'"$HOME"'/g' ~/crocutus/crocutus.env); set +a
+
+simard debug instance --check-collision
+simard debug authority
+```
+
+Expected — disjoint paths from the primary, and a read-only posture:
+
+```
+instance_name=crocutus
+instance_home=/home/azureuser/.crocutus
+state_root=/home/azureuser/.crocutus/state
+dashboard_port=8090
+ooda_unit=crocutus-ooda.service
+...
+posture=read-only
+git_push_check=REFUSED (read-only)
+ado_write_check=REFUSED (read-only)
+github_write_check=REFUSED (read-only)
+```
+
+## Step 6 — Prove the read-only guardrail
+
+Before running the daemon against the real project, prove — mechanically —
+that every write path to `hyenas` is refused. This is a required acceptance
+artifact.
+
+### 6a. No write credential
+
+```bash
+# The only ADO credential in Crocutus's environment is the read-only PAT file.
+ls -l ~/.crocutus/*.pat                 # ~/.crocutus/ado_readonly.pat only
+# Prove it: a write via this token is denied by Azure DevOps itself.
+az repos pr create --org "$SIMARD_TARGET_ADO_ORG" --project acs-mdash \
+  --repository hyenas --source-branch x --target-branch main 2>&1 \
+  | grep -qi 'denied\|forbidden\|unauthorized' && echo "write DENIED by ADO (expected)"
+```
+
+### 6b. Capability refuses the write
+
+The posture dry-run probe (executes nothing) confirms Simard's own code paths
+refuse writes to the target and exits non-zero if any write would be allowed:
+
+```bash
+simard debug authority --probe-write \
+  "$SIMARD_TARGET_ADO_ORG/acs-mdash/_git/hyenas"
+```
+
+```
+probe target=https://dev.azure.com/acs-mdash/acs-mdash/_git/hyenas
+git push        => REFUSED (read-only)
+az repos pr     => REFUSED (read-only)
+work-item edit  => REFUSED (read-only)
+exit=0 (all writes refused as expected)
+```
+
+With 6a and 6b together you have proven the guarantee at two independent
+layers: the credential cannot write, and even with a credential the capability
+layer refuses. That is defense in depth, failing closed.
+
+## Step 7 — Launch the Crocutus daemon
+
+Install the user unit (its name never clashes with `simard-ooda.service`) with
+the collision check as a start gate:
+
+```ini
+# ~/.config/systemd/user/crocutus-ooda.service
+[Unit]
+Description=Crocutus — read-only observer of acs-mdash (side-by-side with simard)
+After=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=%h/crocutus/crocutus.env
+ExecStartPre=%h/.crocutus/bin/simard debug instance --check-collision
+ExecStartPre=%h/.crocutus/bin/simard debug authority --probe-write ${SIMARD_TARGET_REPO_URL}
+ExecStart=%h/.crocutus/bin/simard ooda run
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now crocutus-ooda.service
+```
+
+The two `ExecStartPre` gates mean the daemon **refuses to start** if it would
+collide with the primary or if any write path to the target is not refused — a
+systemd-level fail-closed. The probe target `${SIMARD_TARGET_REPO_URL}` and the
+read-only credential `${SIMARD_ADO_PAT_FILE}` are both expanded from the
+`EnvironmentFile` loaded above (this is a plain, non-templated unit, so the
+`%i` instance specifier is *not* used).
+
+## Step 8 — Verify the end state
+
+**Both daemons running, isolated:**
+
+```bash
+systemctl --user status simard-ooda.service crocutus-ooda.service --no-pager
+ss -ltnp | grep -E ':8080|:8090'
+ls ~/.simard/state ~/.crocutus/state
+```
+
+**Crocutus thinking about hyenas, read-only:**
+
+```bash
+journalctl --user -u crocutus-ooda.service -n 40 --no-pager
+SIMARD_STATE_ROOT=$HOME/.crocutus/state simard goal list
+```
+
+You should see hygiene goals referencing the `acs-mdash` repos, for example:
+
+```
+[crocutus] OODA cycle 7: observed 4 repos, 3 priorities, dispatched 0 actions (read-only), 0 writes
+goal: "hyenas: 6 stale branches (>90d) — propose pruning policy"    status: not-started
+goal: "sister repo 'dens': no CI workflow — propose pipeline"        status: not-started
+goal: "hyenas: README drift vs. src layout — propose docs refresh"   status: not-started
+```
+
+Note `dispatched 0 actions (read-only), 0 writes` — Crocutus proposes goals but
+takes no acting/writing steps against the target.
+
+## What you have
+
+- `rysweet/Crocutus` (private) exists and **depends on** Simard (no copied
+  source).
+- The Crocutus daemon runs on host `dev` as a **distinct** read-only identity,
+  with its own home, memory, goal board, ports, socket, and systemd unit —
+  side-by-side with `simard`, no interference.
+- It articulates `hyenas` repo-hygiene goals and is **provably** unable to
+  change anything: no write credential (6a) and capability refuses writes (6b),
+  both failing closed.
+
+## Abstraction-gap note
+
+If deploying Crocutus required duplicating large amounts of Simard Rust rather
+than the two small parameterizations
+([instance isolation](../concepts/multi-identity-host-isolation.md) and
+[write-authority posture](../concepts/write-authority-posture.md)), that is an
+abstraction gap. Record it as a Simard issue and fix the abstraction upstream —
+do not fork. A correctly abstracted Simard makes a second identity *mostly
+configuration*, which is exactly what this tutorial demonstrates.
+
+## See also
+
+- [Multi-identity host isolation](../concepts/multi-identity-host-isolation.md)
+- [Write-authority posture](../concepts/write-authority-posture.md)
+- [How to run a second agent identity](../howto/run-a-second-agent-identity.md)
+- [How to configure pluggable identities](../howto/configure-pluggable-identity.md)
+- [Write-authority posture API reference](../reference/write-authority-posture-api.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,8 @@ nav:
     - Operational Autonomy Model: concepts/operational-autonomy-model.md
     - Adaptive Scaling: concepts/adaptive-scaling.md
     - Pluggable Identity: concepts/pluggable-identity.md
+    - Multi-Identity Host Isolation: concepts/multi-identity-host-isolation.md
+    - Write-Authority Posture: concepts/write-authority-posture.md
     - OODA Loop Self-Detection: concepts/ooda-loop-self-detection.md
     - Unified RecipeBrain: concepts/unified-recipe-brain.md
     - Prompt-Driven OODA Brain: concepts/prompt-driven-ooda-brain.md
@@ -148,6 +150,7 @@ nav:
     - First Local Session: tutorials/run-your-first-local-session.md
     - First Benchmark Suite: tutorials/run-your-first-benchmark-gym.md
     - Read Simard's Daily Journal: tutorials/read-simards-daily-journal.md
+    - Deploy Crocutus (Read-Only Observer): tutorials/deploy-crocutus-read-only-observer.md
   - How-To Guides:
     - Fix a No-`bridge` Naming Guard Failure: howto/fix-a-no-bridge-naming-guard-failure.md
     - Run the LOCAL COIN Gym Harness: howto/run-the-coin-gym-harness.md
@@ -207,6 +210,7 @@ nav:
     - Respond to a Proactive Advisory Remediation: howto/respond-to-a-proactive-advisory-remediation.md
     - Configure Adaptive Scaling: howto/configure-adaptive-scaling.md
     - Configure Pluggable Identity: howto/configure-pluggable-identity.md
+    - Run a Second Agent Identity: howto/run-a-second-agent-identity.md
     - Configure Episode Hygiene and Promotion: howto/configure-episode-hygiene-and-promotion.md
     - Inspect Improvement Curation State: howto/inspect-improvement-curation-state.md
     - Inspect the Procedural-Learning Loop: howto/inspect-the-procedural-learning-loop.md
@@ -370,6 +374,8 @@ nav:
     - Meeting Handoff Schema: reference/meeting-handoff-schema.md
     - Handoff Lifecycle API: reference/handoff-lifecycle-api.md
     - Pluggable Identity API: reference/pluggable-identity-api.md
+    - Agent Instance Isolation: reference/agent-instance-isolation.md
+    - Write-Authority Posture API: reference/write-authority-posture-api.md
     - Adaptive Scaling API: reference/adaptive-scaling-api.md
     - Brain Introspection API: reference/brain-introspection-api.md
     - Self-Quality-Audit API: reference/self-quality-audit-api.md

--- a/src/git_guardrails.rs
+++ b/src/git_guardrails.rs
@@ -39,6 +39,15 @@ fn protected_roots() -> Vec<String> {
 /// Returns `Err` with a descriptive message if the proposed git command would
 /// violate guardrails. Returns `Ok(())` if the command is safe to execute.
 pub fn check_git_safety(workspace: &Path, args: &[&str]) -> Result<(), String> {
+    // Observe-only floor (issue #1, Crocutus): a read-only identity sets
+    // `SIMARD_OBSERVE_ONLY=1`; under it, EVERY mutating git verb (push, commit,
+    // branch, tag, merge, rebase, reset, checkout -b, am, apply, update-ref, …)
+    // is refused here at the shared write seam. This runs BEFORE the
+    // `guardrails_enabled()` gate on purpose: the observe-only guarantee must
+    // hold even if `SIMARD_GIT_GUARDRAILS` is disabled — fail closed. It is a
+    // no-op for the engineer identity (env unset).
+    crate::read_only_guard::guard_observe_only_git(args)?;
+
     if !guardrails_enabled() {
         return Ok(());
     }
@@ -108,6 +117,8 @@ mod tests {
         unsafe {
             std::env::remove_var("SIMARD_GIT_GUARDRAILS");
             std::env::remove_var("SIMARD_GIT_PROTECTED_REPOS");
+            // Ensure the observe-only floor does not leak between tests.
+            std::env::remove_var(crate::read_only_guard::OBSERVE_ONLY_ENV);
         }
     }
 
@@ -482,5 +493,84 @@ mod tests {
         reset_env();
         let result = check_git_safety(&PathBuf::from("/tmp/repo"), &[]);
         assert!(result.is_ok(), "{result:?}");
+    }
+
+    // ── Observe-only floor (issue #1, Crocutus) ─────────────────────────────
+    // With SIMARD_OBSERVE_ONLY set, the shared git write seam refuses every
+    // mutating verb — even ordinary push/commit that the engineer identity is
+    // allowed to run — and even when SIMARD_GIT_GUARDRAILS is disabled.
+
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn observe_only_blocks_ordinary_push_and_commit() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_env();
+        unsafe { std::env::set_var(crate::read_only_guard::OBSERVE_ONLY_ENV, "1") };
+        for args in [
+            vec!["push", "origin", "feature-branch"],
+            vec!["commit", "-m", "hygiene fix"],
+            vec!["checkout", "-b", "hygiene"],
+            vec!["tag", "v1.0"],
+            vec!["merge", "feature"],
+        ] {
+            let result = check_git_safety(&PathBuf::from("/tmp/clone"), &args);
+            assert!(
+                result.is_err(),
+                "observe-only must refuse the write `git {}`",
+                args.join(" ")
+            );
+            assert!(result.unwrap_err().contains("GUARDRAIL BLOCKED"));
+        }
+        reset_env();
+    }
+
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn observe_only_still_allows_reads() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_env();
+        unsafe { std::env::set_var(crate::read_only_guard::OBSERVE_ONLY_ENV, "1") };
+        for args in [
+            vec!["fetch", "--all", "--prune"],
+            vec!["log", "--oneline", "-20"],
+            vec!["status"],
+            vec!["branch", "-a"],
+            vec!["for-each-ref", "refs/remotes"],
+        ] {
+            assert!(
+                check_git_safety(&PathBuf::from("/tmp/clone"), &args).is_ok(),
+                "observe-only must permit the read `git {}`",
+                args.join(" ")
+            );
+        }
+        reset_env();
+    }
+
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn observe_only_floor_holds_even_when_git_guardrails_disabled() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_env();
+        unsafe {
+            std::env::set_var("SIMARD_GIT_GUARDRAILS", "disabled");
+            std::env::set_var(crate::read_only_guard::OBSERVE_ONLY_ENV, "1");
+        }
+        // Even with the destructive-op guardrails switched off, the observe-only
+        // floor must fail closed on a push (defense in depth).
+        assert!(
+            check_git_safety(&PathBuf::from("/tmp/clone"), &["push", "origin", "main"]).is_err()
+        );
+        reset_env();
+    }
+
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn engineer_identity_unaffected_by_floor_when_env_unset() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_env();
+        // Env unset ⇒ the observe-only floor is a no-op; ordinary push allowed.
+        assert!(
+            check_git_safety(&PathBuf::from("/tmp/repo"), &["push", "origin", "feature"]).is_ok()
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,7 @@ pub mod overseer;
 mod persistence;
 pub mod prompt_assets;
 pub mod prompt_delivery;
+pub mod read_only_guard;
 // Issues #2640/#2692: shared "path-in-argv, content-in-file" transport for
 // unbounded recipe context values, so a large payload never overflows ARG_MAX
 // (the live journal E2BIG recipe-spawn failure).

--- a/src/ooda_actions/advance_goal/spawn.rs
+++ b/src/ooda_actions/advance_goal/spawn.rs
@@ -75,6 +75,32 @@ pub(crate) fn lock_state<'g, 'a>(
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+/// Observe-only dispatch floor (issue #1, Crocutus).
+///
+/// Returns `Some(refusal_outcome)` when the process runs under a read-only
+/// identity (`SIMARD_OBSERVE_ONLY` truthy), signalling that no write-bearing
+/// engineer may be dispatched; returns `None` for the ordinary engineer
+/// identity so dispatch proceeds unchanged. Extracted as a pure function so the
+/// short-circuit is unit-testable without constructing a full brain/session.
+///
+/// The outcome is `success = true`: for an observer, *declining to act* is the
+/// correct behaviour, not a failure — it must not bump goal-failure counters or
+/// trip the no-progress breaker.
+fn observe_only_dispatch_refusal(action: &PlannedAction, goal_id: &str) -> Option<ActionOutcome> {
+    if !crate::read_only_guard::observe_only_enabled() {
+        return None;
+    }
+    Some(make_outcome(
+        action,
+        true,
+        format!(
+            "observe-only: refused to dispatch a write-bearing engineer for goal '{goal_id}'. \
+             This read-only identity proposes repo-hygiene goals but dispatches 0 write \
+             actions (no clone-and-push, no PR). Guardrail: SIMARD_OBSERVE_ONLY."
+        ),
+    ))
+}
+
 /// Spawn a subordinate engineer for a goal that the LLM picked
 /// `spawn_engineer` for, then mutate the active board to record the
 /// assignment.
@@ -100,6 +126,18 @@ pub fn dispatch_spawn_engineer(
     brain: &dyn OodaBrain,
     repo_root: &Path,
 ) -> ActionOutcome {
+    // ── Observe-only floor (issue #1, Crocutus) ─────────────────────────────
+    // A read-only identity (SIMARD_OBSERVE_ONLY=1) is a bounded OBSERVER: it may
+    // reason about goals but must never dispatch a write-bearing engineer, which
+    // would clone-and-push/PR against a target repo. Short-circuit BEFORE any
+    // worktree is allocated or subprocess launched — fail closed. This is the
+    // capability layer that makes "proposes goals, changes nothing anywhere"
+    // structural, not merely prompt-deep. The engineer identity (env unset) is
+    // unaffected.
+    if let Some(refusal) = observe_only_dispatch_refusal(action, goal_id) {
+        return refusal;
+    }
+
     // Re-check assignment under a short exclusive state lock to prevent a
     // double-spawn race (two cycles/threads parsing spawn_engineer for the
     // same goal). The per-round claim set in the dispatcher is the primary
@@ -980,5 +1018,56 @@ mod tests {
         let tmp2 = tempfile::tempdir().unwrap();
         write_claim(tmp2.path(), "not-a-pid\n0\n");
         assert_eq!(read_sentinel_pid(tmp2.path()), None);
+    }
+
+    // ── observe_only_dispatch_refusal (issue #1, Crocutus) ──────────────────
+    // Serialize env mutation: cargo runs unit tests in parallel.
+    static OBSERVE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn advance_action(goal_id: &str) -> PlannedAction {
+        PlannedAction {
+            kind: crate::ooda_loop::ActionKind::AdvanceGoal,
+            goal_id: Some(goal_id.to_string()),
+            description: format!("advance {goal_id}"),
+        }
+    }
+
+    #[test]
+    fn observe_only_refuses_engineer_dispatch_when_enabled() {
+        let _g = OBSERVE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::set_var(crate::read_only_guard::OBSERVE_ONLY_ENV, "1");
+        }
+        let action = advance_action("tidy-stale-branches");
+        let refusal = observe_only_dispatch_refusal(&action, "tidy-stale-branches");
+        unsafe {
+            std::env::remove_var(crate::read_only_guard::OBSERVE_ONLY_ENV);
+        }
+        let outcome = refusal.expect("read-only identity must refuse engineer dispatch");
+        // Declining to act is correct behaviour, not a failure.
+        assert!(
+            outcome.success,
+            "observer refusal must not count as a failure"
+        );
+        assert!(
+            outcome.detail.contains("observe-only")
+                && outcome.detail.contains("0 write")
+                && outcome.detail.contains("SIMARD_OBSERVE_ONLY"),
+            "refusal detail must be explicit and auditable, got: {}",
+            outcome.detail
+        );
+    }
+
+    #[test]
+    fn engineer_identity_dispatches_normally_when_env_unset() {
+        let _g = OBSERVE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::remove_var(crate::read_only_guard::OBSERVE_ONLY_ENV);
+        }
+        let action = advance_action("ship-feature");
+        assert!(
+            observe_only_dispatch_refusal(&action, "ship-feature").is_none(),
+            "engineer identity (env unset) must not be short-circuited"
+        );
     }
 }

--- a/src/ooda_actions/advance_goal/spawn.rs
+++ b/src/ooda_actions/advance_goal/spawn.rs
@@ -1021,8 +1021,9 @@ mod tests {
     }
 
     // ── observe_only_dispatch_refusal (issue #1, Crocutus) ──────────────────
-    // Serialize env mutation: cargo runs unit tests in parallel.
-    static OBSERVE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // These tests mutate the process-global OBSERVE_ONLY_ENV var; they carry the
+    // `cognitive_memory` serial key so env mutation is never concurrent with an
+    // env read (enforced by test_support::serial_guard).
 
     fn advance_action(goal_id: &str) -> PlannedAction {
         PlannedAction {
@@ -1032,9 +1033,9 @@ mod tests {
         }
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn observe_only_refuses_engineer_dispatch_when_enabled() {
-        let _g = OBSERVE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         unsafe {
             std::env::set_var(crate::read_only_guard::OBSERVE_ONLY_ENV, "1");
         }
@@ -1058,9 +1059,9 @@ mod tests {
         );
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn engineer_identity_dispatches_normally_when_env_unset() {
-        let _g = OBSERVE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         unsafe {
             std::env::remove_var(crate::read_only_guard::OBSERVE_ONLY_ENV);
         }

--- a/src/read_only_guard.rs
+++ b/src/read_only_guard.rs
@@ -875,6 +875,7 @@ mod tests {
 
     // --- env gate ---
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn env_gate_only_enforces_when_enabled() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());

--- a/src/read_only_guard.rs
+++ b/src/read_only_guard.rs
@@ -1,0 +1,904 @@
+//! Observe-only (read-only) guardrail — a hard, fail-closed command floor for
+//! an observe-only identity such as **Crocutus** (issue #1).
+//!
+//! ## Why a new guard (abstraction gap)
+//!
+//! Simard already ships two command guards, but neither expresses an
+//! *observe-only* posture:
+//!
+//! - [`crate::git_guardrails`] blocks only *destructive* git operations
+//!   (`push --force`, `reset --hard`, …) and **allows** ordinary
+//!   `push`/`commit`. That is correct for the engineering identity (Simard),
+//!   which is *meant* to write.
+//! - [`crate::ado_acl_guard`] blocks only Azure DevOps **ACL self-escalation**
+//!   and allows every other `az` command.
+//!
+//! Crocutus is a second identity on the same codebase whose entire mandate is
+//! to **observe target repositories read-only and never change anything,
+//! anywhere** — no commit, push, branch, PR, work-item edit, comment, or ACL
+//! change. That posture cannot be expressed by the existing guards, so this
+//! module adds it. It is the identity-level "READ-ONLY mode flag" the Crocutus
+//! task calls for, implemented as *one* shared-codebase capability rather than
+//! a fork.
+//!
+//! ## Design: default-DENY, fail-closed
+//!
+//! Unlike the other guards (which allow-by-default and block specific bad
+//! patterns), this guard **denies by default** for the tools that can mutate a
+//! remote target (`git`, `az`, `gh`, `curl`, `wget`) and permits a command only
+//! when it is *provably* a read. Anything ambiguous is treated as a write and
+//! refused. If any layer is uncertain, it FAILS CLOSED (blocks) rather than risk
+//! a write — exactly the guarantee the Crocutus guardrail demands.
+//!
+//! ## Scope
+//!
+//! This screens `git`/`az`/`gh`/`curl`/`wget` command lines. Writes embedded in
+//! opaque interpreters (`python foo.py`, `bash -c …`) cannot be classified here
+//! and are the responsibility of the *other* guardrail layers Crocutus stacks:
+//! (a) no write-capable credential to the target project, and (b) disabled
+//! act/engineer-dispatch capabilities. This command guard is one layer of that
+//! defense in depth, not the whole of it.
+
+/// Environment flag that puts the shared binary into observe-only mode.
+///
+/// When set to a truthy value (`1`/`true`/`enabled`/`yes`/`on`), the env-gated
+/// entry point [`guard_observe_only`] enforces the read-only floor. The Crocutus
+/// identity sets this; the Simard (engineer) identity leaves it unset.
+pub const OBSERVE_ONLY_ENV: &str = "SIMARD_OBSERVE_ONLY";
+
+/// Returns `true` when observe-only mode is enabled via [`OBSERVE_ONLY_ENV`].
+///
+/// Defaults to `false` (the engineer identity is not observe-only).
+#[must_use]
+pub fn observe_only_enabled() -> bool {
+    std::env::var(OBSERVE_ONLY_ENV)
+        .map(|v| matches!(v.as_str(), "1" | "true" | "enabled" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+/// Env-gated chokepoint: enforce the observe-only floor **only** when
+/// [`observe_only_enabled`] is true, otherwise allow (the other identities are
+/// free to write).
+///
+/// This is what an in-crate command-execution chokepoint calls so a single
+/// shared binary serves both identities.
+pub fn guard_observe_only(argv: &[&str]) -> Result<(), String> {
+    if observe_only_enabled() {
+        check_observe_only(argv)
+    } else {
+        Ok(())
+    }
+}
+
+/// Env-gated chokepoint using the git-argument convention (arguments **after**
+/// the `git` program name, e.g. `["push", "origin", "main"]`).
+///
+/// This is the seam wired into [`crate::git_guardrails::check_git_safety`]: it
+/// enforces the observe-only floor **only** when [`observe_only_enabled`] is
+/// true, so the engineer identity (Simard) is unaffected while the Crocutus
+/// identity — which sets [`OBSERVE_ONLY_ENV`] — has every mutating git verb
+/// refused at the shared write seam, fail-closed.
+pub fn guard_observe_only_git(git_args: &[&str]) -> Result<(), String> {
+    if observe_only_enabled() {
+        check_observe_only_git(git_args)
+    } else {
+        Ok(())
+    }
+}
+
+/// Always-on observe-only check (independent of the env flag).
+///
+/// Returns `Ok(())` if `argv` is provably a read (or an out-of-scope tool this
+/// guard does not screen), and `Err(message)` if it is — or *might be* — a
+/// write. The Crocutus identity, which is observe-only by construction, calls
+/// this directly regardless of the env flag.
+///
+/// `argv` is the full command line including the tool (e.g.
+/// `["git", "push", …]`, `["az", "repos", "pr", "create", …]`).
+pub fn check_observe_only(argv: &[&str]) -> Result<(), String> {
+    if command_is_read(argv) {
+        Ok(())
+    } else {
+        Err(blocked_message(argv))
+    }
+}
+
+/// Git-argument convention mirroring [`crate::git_guardrails::check_git_safety`]:
+/// `git_args` are the arguments **after** the `git` program name
+/// (e.g. `["push", "--force", "origin", "main"]`).
+pub fn check_observe_only_git(git_args: &[&str]) -> Result<(), String> {
+    if git_command_is_read(git_args) {
+        Ok(())
+    } else {
+        let mut full = Vec::with_capacity(git_args.len() + 1);
+        full.push("git");
+        full.extend_from_slice(git_args);
+        Err(blocked_message(&full))
+    }
+}
+
+/// Classification helper: `true` when `argv` would mutate a target under
+/// observe-only rules (the inverse of [`command_is_read`] for in-scope tools).
+#[must_use]
+pub fn is_write_command(argv: &[&str]) -> bool {
+    !command_is_read(argv)
+}
+
+/// The block message. Includes a stable `GUARDRAIL BLOCKED` marker and the
+/// `observe-only` posture so logs and tests can assert on it.
+fn blocked_message(argv: &[&str]) -> String {
+    format!(
+        "GUARDRAIL BLOCKED: observe-only (read-only) identity refuses to run a \
+         potentially mutating command `{}`. This identity may only OBSERVE target \
+         repositories — no commit, push, branch, PR, work-item edit, comment, or \
+         ACL change is permitted anywhere. If this command is genuinely read-only \
+         and was refused, it was refused by design (fail-closed): use an explicit \
+         read form (e.g. `git fetch`/`git log`, `az ... list|show`, `az rest \
+         --method GET`, `gh ... list|view`, `curl -X GET`).",
+        argv.join(" ")
+    )
+}
+
+/// Top-level classifier: is `argv` provably a read for the tool it invokes?
+///
+/// Tools this guard does not screen (anything other than `git`/`az`/`gh`/
+/// `curl`/`wget`) return `true` here — command-level screening is out of scope
+/// for them and the credential/capability layers cover them.
+#[must_use]
+pub fn command_is_read(argv: &[&str]) -> bool {
+    let Some(tool) = argv.first().copied() else {
+        return true; // empty command mutates nothing
+    };
+    let base = tool.rsplit(['/', '\\']).next().unwrap_or(tool);
+    match base {
+        "git" => git_command_is_read(&argv[1..]),
+        "az" => az_command_is_read(&argv[1..]),
+        "gh" => gh_command_is_read(&argv[1..]),
+        "curl" => http_is_read(&argv[1..], HttpDialect::Curl),
+        "wget" => http_is_read(&argv[1..], HttpDialect::Wget),
+        _ => true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// git
+// ---------------------------------------------------------------------------
+
+/// Git subcommands that are always pure reads.
+const GIT_READ_SUBCOMMANDS: &[&str] = &[
+    "status",
+    "log",
+    "diff",
+    "show",
+    "fetch",
+    "clone",
+    "ls-remote",
+    "ls-files",
+    "ls-tree",
+    "rev-parse",
+    "rev-list",
+    "cat-file",
+    "for-each-ref",
+    "describe",
+    "blame",
+    "shortlog",
+    "grep",
+    "whatchanged",
+    "name-rev",
+    "cherry",
+    "show-ref",
+    "show-branch",
+    "merge-base",
+    "count-objects",
+    "verify-pack",
+    "verify-commit",
+    "verify-tag",
+    "annotate",
+    "version",
+    "help",
+];
+
+/// Git global options (that appear *before* the subcommand) which take a value.
+const GIT_VALUE_GLOBALS: &[&str] = &[
+    "-C",
+    "-c",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--exec-path",
+    "--super-prefix",
+];
+
+/// Git global boolean options that appear before the subcommand.
+const GIT_BOOL_GLOBALS: &[&str] = &[
+    "-p",
+    "--paginate",
+    "-P",
+    "--no-pager",
+    "--bare",
+    "--no-replace-objects",
+    "--literal-pathspecs",
+    "--glob-pathspecs",
+    "--noglob-pathspecs",
+    "--icase-pathspecs",
+    "--no-optional-locks",
+];
+
+/// Skip any leading git global options and return the slice starting at the
+/// subcommand. Unknown leading `-`-options are left in place so the caller
+/// treats them as an (unrecognized) subcommand and fails closed.
+fn strip_git_globals<'a>(args: &'a [&'a str]) -> &'a [&'a str] {
+    let mut i = 0;
+    while i < args.len() {
+        let a = args[i];
+        if GIT_VALUE_GLOBALS.contains(&a) {
+            i += 2;
+            continue;
+        }
+        if GIT_BOOL_GLOBALS.contains(&a)
+            || a.starts_with("--git-dir=")
+            || a.starts_with("--work-tree=")
+            || a.starts_with("--namespace=")
+            || a.starts_with("--exec-path=")
+            || (a.starts_with("-c") && a.len() > 2)
+        {
+            i += 1;
+            continue;
+        }
+        break;
+    }
+    &args[i..]
+}
+
+/// `true` when the git argument vector (after the `git` program name) is a read.
+#[must_use]
+pub fn git_command_is_read(git_args: &[&str]) -> bool {
+    let args = strip_git_globals(git_args);
+    let Some((sub, rest)) = args.split_first() else {
+        return true; // bare `git` prints help; mutates nothing
+    };
+    let sub = *sub;
+
+    if GIT_READ_SUBCOMMANDS.contains(&sub) {
+        return true;
+    }
+
+    match sub {
+        "branch" => git_branch_is_read(rest),
+        "tag" => git_tag_is_read(rest),
+        "config" => git_config_is_read(rest),
+        "remote" => git_remote_is_read(rest),
+        "reflog" => matches!(rest.first().copied(), None | Some("show")),
+        "stash" => matches!(rest.first().copied(), Some("list") | Some("show")),
+        "notes" => matches!(rest.first().copied(), None | Some("list") | Some("show")),
+        "worktree" => matches!(rest.first().copied(), Some("list")),
+        "submodule" => matches!(rest.first().copied(), Some("status") | Some("summary")),
+        // Everything else (push, pull, commit, add, rm, mv, merge, rebase,
+        // cherry-pick, revert, reset, checkout, switch, restore, clean, gc,
+        // am, apply, format-patch-send, update-ref, fast-import, init, …) is
+        // refused: fail closed.
+        _ => false,
+    }
+}
+
+fn git_branch_is_read(rest: &[&str]) -> bool {
+    const WRITE_FLAGS: &[&str] = &[
+        "-d",
+        "-D",
+        "--delete",
+        "-m",
+        "-M",
+        "--move",
+        "-c",
+        "-C",
+        "--copy",
+        "--set-upstream-to",
+        "-u",
+        "--unset-upstream",
+        "--edit-description",
+        "-f",
+        "--force",
+        "--track",
+        "--set-upstream",
+    ];
+    if rest.iter().any(|a| WRITE_FLAGS.contains(a)) {
+        return false;
+    }
+    const FILTER_FLAGS: &[&str] = &[
+        "--contains",
+        "--no-contains",
+        "--points-at",
+        "--merged",
+        "--no-merged",
+    ];
+    let has_positional = rest.iter().any(|a| !a.starts_with('-'));
+    let has_filter = rest.iter().any(|a| FILTER_FLAGS.contains(a));
+    !has_positional || has_filter
+}
+
+fn git_tag_is_read(rest: &[&str]) -> bool {
+    const WRITE_FLAGS: &[&str] = &[
+        "-d",
+        "--delete",
+        "-a",
+        "--annotate",
+        "-s",
+        "--sign",
+        "-f",
+        "--force",
+        "-m",
+        "--message",
+        "-F",
+        "--file",
+        "-e",
+        "--edit",
+        "-u",
+    ];
+    if rest.iter().any(|a| WRITE_FLAGS.contains(a)) {
+        return false;
+    }
+    const LIST_FLAGS: &[&str] = &[
+        "-l",
+        "--list",
+        "--contains",
+        "--no-contains",
+        "--points-at",
+        "--merged",
+        "--no-merged",
+        "--format",
+        "--sort",
+        "--column",
+        "-i",
+        "--ignore-case",
+    ];
+    let has_positional = rest.iter().any(|a| !a.starts_with('-'));
+    let has_list_flag = rest
+        .iter()
+        .any(|a| LIST_FLAGS.contains(a) || a.starts_with("-n"));
+    !has_positional || has_list_flag
+}
+
+fn git_config_is_read(rest: &[&str]) -> bool {
+    // Refuse unless an explicit read flag is present. `git config x y`,
+    // `git config --add`, `git config --unset` all lack a read flag → blocked.
+    const READ_FLAGS: &[&str] = &[
+        "--get",
+        "--get-all",
+        "--get-regexp",
+        "--get-urlmatch",
+        "-l",
+        "--list",
+        "--get-color",
+        "--get-colorbool",
+    ];
+    rest.iter().any(|a| READ_FLAGS.contains(a))
+}
+
+fn git_remote_is_read(rest: &[&str]) -> bool {
+    match rest.first().copied() {
+        None => true,
+        Some("-v" | "--verbose" | "show" | "get-url") => true,
+        // add, remove, rename, set-url, set-head, set-branches, prune, update → block
+        _ => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// az (Azure CLI / Azure DevOps)
+// ---------------------------------------------------------------------------
+
+/// `az` verb tokens that mutate state. Presence of any of these anywhere in the
+/// command makes it a write.
+const AZ_WRITE_VERBS: &[&str] = &[
+    "create", "update", "delete", "set", "add", "remove", "import", "restore", "abandon",
+    "complete", "vote", "publish", "merge", "reset", "approve", "reject", "link", "unlink", "edit",
+    "push", "upload", "purge", "enable", "disable", "grant", "revoke", "clone", "init", "move",
+    "rename", "promote", "unshelve", "apply", "run", "queue", "cancel", "retain", "unmark", "mark",
+];
+
+/// `az` verb tokens that read state.
+const AZ_READ_VERBS: &[&str] = &["list", "show", "get"];
+
+/// Neutral `az` subcommands (auth/version/context) that mutate no target and
+/// are permitted so observe-only setup is not broken.
+const AZ_NEUTRAL_HEADS: &[&str] = &["login", "logout", "version", "account", "--version", "-v"];
+
+fn az_command_is_read(args: &[&str]) -> bool {
+    if args.first().copied() == Some("rest") {
+        return http_is_read(&args[1..], HttpDialect::AzRest);
+    }
+    // A write verb anywhere ⇒ write.
+    if args.iter().any(|a| AZ_WRITE_VERBS.contains(a)) {
+        return false;
+    }
+    // Neutral heads (login/logout/account/version) are allowed once we know no
+    // write verb is present.
+    if matches!(args.first().copied(), Some(h) if AZ_NEUTRAL_HEADS.contains(&h)) {
+        return true;
+    }
+    // Otherwise require an explicit read verb; anything unrecognized fails closed.
+    args.iter()
+        .any(|a| AZ_READ_VERBS.contains(a) || a.starts_with("list-"))
+}
+
+// ---------------------------------------------------------------------------
+// gh (GitHub CLI)
+// ---------------------------------------------------------------------------
+
+const GH_WRITE_VERBS: &[&str] = &[
+    "create",
+    "merge",
+    "close",
+    "reopen",
+    "edit",
+    "delete",
+    "comment",
+    "review",
+    "approve",
+    "request-changes",
+    "ready",
+    "lock",
+    "unlock",
+    "pin",
+    "unpin",
+    "transfer",
+    "develop",
+    "rename",
+    "add",
+    "remove",
+    "set",
+    "sync",
+    "push",
+    "fork",
+    "clone",
+    "rerun",
+    "cancel",
+    "disable",
+    "enable",
+    "import",
+    "restore",
+    "upload",
+    "release",
+];
+
+const GH_READ_VERBS: &[&str] = &[
+    "list", "view", "status", "diff", "checks", "search", "browse",
+];
+
+fn gh_command_is_read(args: &[&str]) -> bool {
+    if args.first().copied() == Some("api") {
+        return !gh_api_has_write(&args[1..]);
+    }
+    if args.iter().any(|a| GH_WRITE_VERBS.contains(a)) {
+        return false;
+    }
+    args.iter().any(|a| GH_READ_VERBS.contains(a))
+        || matches!(
+            args.first().copied(),
+            Some("auth" | "version" | "--version")
+        )
+}
+
+/// `gh api` defaults to GET; it becomes a write when an explicit non-read
+/// method is given, or when any field/body flag forces a POST.
+fn gh_api_has_write(args: &[&str]) -> bool {
+    let mut i = 0;
+    while i < args.len() {
+        let a = args[i];
+        match a {
+            "-X" | "--method" => {
+                if let Some(m) = args.get(i + 1)
+                    && !is_read_method(m)
+                {
+                    return true;
+                }
+                i += 2;
+                continue;
+            }
+            "-f" | "--raw-field" | "-F" | "--field" | "--input" => return true,
+            _ => {}
+        }
+        if let Some(m) = a.strip_prefix("--method=")
+            && !is_read_method(m)
+        {
+            return true;
+        }
+        if let Some(m) = a.strip_prefix("-X")
+            && !m.is_empty()
+            && !is_read_method(m)
+        {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// HTTP (curl / wget / az rest) — provably-read detection, fail-closed
+// ---------------------------------------------------------------------------
+
+/// Which HTTP client dialect a command line uses. Method/body flags differ.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HttpDialect {
+    Curl,
+    Wget,
+    AzRest,
+}
+
+fn is_read_method(m: &str) -> bool {
+    matches!(
+        strip_quotes(m).to_ascii_lowercase().as_str(),
+        "get" | "head" | "options"
+    )
+}
+
+fn strip_quotes(s: &str) -> &str {
+    s.trim_matches(|c| c == '"' || c == '\'')
+}
+
+/// `true` only when the HTTP command is *provably* a read: it carries no request
+/// body/upload and every explicit method (if any) is a read method. No explicit
+/// method means the default `GET`. Fails closed against repeated-method decoys
+/// (`-X GET -X POST`) because *all* methods must be reads.
+fn http_is_read(args: &[&str], dialect: HttpDialect) -> bool {
+    if http_carries_body(args, dialect) {
+        return false;
+    }
+    http_methods(args, dialect)
+        .iter()
+        .all(|m| is_read_method(m))
+}
+
+fn http_carries_body(args: &[&str], dialect: HttpDialect) -> bool {
+    match dialect {
+        HttpDialect::Curl => args.iter().any(|a| {
+            let a = *a;
+            matches!(a, "-d" | "-F" | "-T")
+                || (a.starts_with("-d") && a.len() > 2)
+                || (a.starts_with("-F") && a.len() > 2)
+                || (a.starts_with("-T") && a.len() > 2)
+                || a.starts_with("--data")
+                || a.starts_with("--form")
+                || a == "--upload-file"
+                || a.starts_with("--upload-file=")
+                || a == "--json"
+                || a.starts_with("--json=")
+        }),
+        HttpDialect::Wget => args.iter().any(|a| {
+            let a = *a;
+            matches!(
+                a,
+                "--post-data" | "--post-file" | "--body-data" | "--body-file"
+            ) || a.starts_with("--post-data=")
+                || a.starts_with("--post-file=")
+                || a.starts_with("--body-data=")
+                || a.starts_with("--body-file=")
+        }),
+        HttpDialect::AzRest => args.iter().any(|a| {
+            let a = *a;
+            matches!(a, "--body" | "-b" | "--in-file" | "--input-file")
+                || a.starts_with("--body=")
+                || a.starts_with("--in-file=")
+                || (a.starts_with("-b") && a.len() > 2)
+        }),
+    }
+}
+
+fn http_methods(args: &[&str], dialect: HttpDialect) -> Vec<String> {
+    let mut methods = Vec::new();
+    let long_flags: &[&str] = match dialect {
+        HttpDialect::Curl => &["-X", "--request"],
+        HttpDialect::Wget => &["--method"],
+        HttpDialect::AzRest => &["-m", "--method", "--http-method"],
+    };
+    for (i, tok) in args.iter().enumerate() {
+        let tok = *tok;
+        if long_flags.contains(&tok)
+            && let Some(v) = args.get(i + 1)
+        {
+            methods.push(strip_quotes(v).to_string());
+        }
+        for pfx in long_flags {
+            let eq = format!("{pfx}=");
+            if let Some(rest) = tok.strip_prefix(eq.as_str())
+                && !rest.is_empty()
+            {
+                methods.push(strip_quotes(rest).to_string());
+            }
+        }
+        // Glued short forms: curl `-XPOST`, az rest `-mPUT`.
+        match dialect {
+            HttpDialect::Curl => {
+                if let Some(rest) = tok.strip_prefix("-X")
+                    && !rest.is_empty()
+                {
+                    methods.push(strip_quotes(rest).to_string());
+                }
+            }
+            HttpDialect::AzRest => {
+                if let Some(rest) = tok.strip_prefix("-m")
+                    && !rest.is_empty()
+                {
+                    methods.push(strip_quotes(rest).to_string());
+                }
+            }
+            HttpDialect::Wget => {}
+        }
+    }
+    methods
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Tests mutate the process-global OBSERVE_ONLY_ENV var; serialize them.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn set_observe(on: bool) {
+        unsafe {
+            if on {
+                std::env::set_var(OBSERVE_ONLY_ENV, "1");
+            } else {
+                std::env::remove_var(OBSERVE_ONLY_ENV);
+            }
+        }
+    }
+
+    // --- git writes are blocked ---
+
+    #[test]
+    fn blocks_git_push() {
+        assert!(check_observe_only(&["git", "push", "origin", "main"]).is_err());
+        assert!(check_observe_only_git(&["push", "origin", "main"]).is_err());
+    }
+
+    #[test]
+    fn blocks_git_force_push_and_commit_and_mutations() {
+        for argv in [
+            vec!["git", "push", "--force", "origin", "main"],
+            vec!["git", "commit", "-m", "x"],
+            vec!["git", "add", "."],
+            vec!["git", "merge", "feature"],
+            vec!["git", "rebase", "main"],
+            vec!["git", "reset", "--hard", "HEAD~1"],
+            vec!["git", "checkout", "-b", "new"],
+            vec!["git", "switch", "-c", "new"],
+            vec!["git", "restore", "file"],
+            vec!["git", "cherry-pick", "abc"],
+            vec!["git", "revert", "abc"],
+            vec!["git", "clean", "-fdx"],
+            vec!["git", "tag", "v1.0"],
+            vec!["git", "tag", "-d", "v1.0"],
+            vec!["git", "branch", "newbranch"],
+            vec!["git", "branch", "-D", "main"],
+            vec!["git", "config", "user.name", "x"],
+            vec!["git", "remote", "add", "origin", "url"],
+            vec!["git", "remote", "set-url", "origin", "url"],
+            vec!["git", "pull"],
+            vec!["git", "am", "patch"],
+            vec!["git", "apply", "patch"],
+            vec!["git", "update-ref", "refs/heads/x", "abc"],
+            vec!["git", "init"],
+        ] {
+            assert!(
+                check_observe_only(&argv).is_err(),
+                "expected BLOCK for {argv:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn blocks_git_push_with_leading_global_options() {
+        assert!(check_observe_only(&["git", "-C", "/repo", "push", "origin", "main"]).is_err());
+        assert!(
+            check_observe_only(&["git", "-c", "user.name=x", "push", "origin", "main"]).is_err()
+        );
+    }
+
+    // --- git reads are allowed ---
+
+    #[test]
+    fn allows_git_reads() {
+        for argv in [
+            vec!["git", "fetch", "origin"],
+            vec!["git", "clone", "https://example/repo.git"],
+            vec!["git", "log", "--oneline"],
+            vec!["git", "status"],
+            vec!["git", "diff", "HEAD~1"],
+            vec!["git", "show", "HEAD"],
+            vec!["git", "ls-remote", "origin"],
+            vec!["git", "for-each-ref"],
+            vec!["git", "branch"],
+            vec!["git", "branch", "-a"],
+            vec!["git", "branch", "--contains", "HEAD"],
+            vec!["git", "tag"],
+            vec!["git", "tag", "-l", "v*"],
+            vec!["git", "config", "--get", "user.name"],
+            vec!["git", "config", "--list"],
+            vec!["git", "remote", "-v"],
+            vec!["git", "remote", "show", "origin"],
+            vec!["git", "rev-parse", "HEAD"],
+            vec!["git", "-C", "/repo", "log"],
+        ] {
+            assert!(
+                check_observe_only(&argv).is_ok(),
+                "expected ALLOW for {argv:?}"
+            );
+        }
+    }
+
+    // --- az ---
+
+    #[test]
+    fn blocks_az_writes() {
+        for argv in [
+            vec!["az", "repos", "pr", "create", "--title", "x"],
+            vec!["az", "boards", "work-item", "update", "--id", "1"],
+            vec!["az", "boards", "work-item", "create"],
+            vec!["az", "repos", "import", "create"],
+            vec!["az", "pipelines", "run", "--name", "ci"],
+            vec!["az", "repos", "policy", "create"],
+            vec!["az", "devops", "security", "permission", "update"],
+            vec!["az", "repos", "ref", "delete"],
+        ] {
+            assert!(
+                check_observe_only(&argv).is_err(),
+                "expected BLOCK for {argv:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_az_reads() {
+        for argv in [
+            vec!["az", "repos", "list"],
+            vec!["az", "repos", "pr", "list"],
+            vec!["az", "boards", "work-item", "show", "--id", "1"],
+            vec!["az", "repos", "ref", "list"],
+            vec!["az", "account", "show"],
+            vec!["az", "rest", "--method", "GET", "--url", "https://x"],
+            vec!["az", "rest", "--url", "https://x"],
+        ] {
+            assert!(
+                check_observe_only(&argv).is_ok(),
+                "expected ALLOW for {argv:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn blocks_az_rest_writes() {
+        assert!(check_observe_only(&["az", "rest", "--method", "POST", "--url", "u"]).is_err());
+        assert!(
+            check_observe_only(&["az", "rest", "-m", "put", "--url", "u", "--body", "@b"]).is_err()
+        );
+        assert!(check_observe_only(&["az", "rest", "--url", "u", "--body", "@b"]).is_err());
+        assert!(check_observe_only(&["az", "rest", "-mPATCH", "--url", "u"]).is_err());
+    }
+
+    #[test]
+    fn az_unrecognized_command_fails_closed() {
+        // No read verb, no neutral head, no write verb → fail closed (block).
+        assert!(check_observe_only(&["az", "repos", "pr"]).is_err());
+    }
+
+    // --- gh ---
+
+    #[test]
+    fn blocks_gh_writes() {
+        for argv in [
+            vec!["gh", "pr", "create"],
+            vec!["gh", "pr", "merge", "1"],
+            vec!["gh", "issue", "create"],
+            vec!["gh", "issue", "comment", "1"],
+            vec!["gh", "release", "create", "v1"],
+            vec!["gh", "api", "-X", "POST", "/repos/x"],
+            vec!["gh", "api", "--method", "DELETE", "/repos/x"],
+            vec!["gh", "api", "-f", "name=x", "/repos/x"],
+            vec!["gh", "api", "-XPATCH", "/repos/x"],
+        ] {
+            assert!(
+                check_observe_only(&argv).is_err(),
+                "expected BLOCK for {argv:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_gh_reads() {
+        for argv in [
+            vec!["gh", "pr", "list"],
+            vec!["gh", "pr", "view", "1"],
+            vec!["gh", "issue", "list"],
+            vec!["gh", "api", "/repos/x"],
+            vec!["gh", "api", "-X", "GET", "/repos/x"],
+        ] {
+            assert!(
+                check_observe_only(&argv).is_ok(),
+                "expected ALLOW for {argv:?}"
+            );
+        }
+    }
+
+    // --- curl / wget ---
+
+    #[test]
+    fn blocks_http_writes() {
+        for argv in [
+            vec!["curl", "-X", "POST", "https://x"],
+            vec!["curl", "-XPUT", "https://x"],
+            vec!["curl", "-d", "@body", "https://x"],
+            vec!["curl", "--data", "a=b", "https://x"],
+            vec!["curl", "-T", "file", "https://x"],
+            vec!["curl", "-X", "GET", "-X", "POST", "https://x"],
+            vec!["wget", "--post-data", "a=b", "https://x"],
+            vec!["wget", "--method=PUT", "https://x"],
+        ] {
+            assert!(
+                check_observe_only(&argv).is_err(),
+                "expected BLOCK for {argv:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_http_reads() {
+        for argv in [
+            vec!["curl", "https://x"],
+            vec!["curl", "-X", "GET", "https://x"],
+            vec!["curl", "-sSL", "https://x"],
+            vec!["curl", "-m", "5", "https://x"], // -m is max-time for curl, not a method
+            vec!["wget", "https://x"],
+            vec!["wget", "-O", "out", "https://x"],
+        ] {
+            assert!(
+                check_observe_only(&argv).is_ok(),
+                "expected ALLOW for {argv:?}"
+            );
+        }
+    }
+
+    // --- out of scope tools ---
+
+    #[test]
+    fn unknown_tools_are_out_of_scope() {
+        // Command-level screening does not classify opaque interpreters; other
+        // guardrail layers (no write credential, disabled capabilities) cover
+        // them. This guard neither blocks nor claims to screen them.
+        assert!(check_observe_only(&["python", "analyze.py"]).is_ok());
+        assert!(check_observe_only(&["bash", "-c", "echo hi"]).is_ok());
+        assert!(check_observe_only(&[]).is_ok());
+    }
+
+    // --- env gate ---
+
+    #[test]
+    fn env_gate_only_enforces_when_enabled() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        set_observe(false);
+        // Not observe-only: even a push is allowed by the env-gated entry point.
+        assert!(guard_observe_only(&["git", "push", "origin", "main"]).is_ok());
+        set_observe(true);
+        assert!(guard_observe_only(&["git", "push", "origin", "main"]).is_err());
+        // The always-on check ignores the env flag entirely.
+        set_observe(false);
+        assert!(check_observe_only(&["git", "push", "origin", "main"]).is_err());
+        set_observe(false);
+    }
+
+    #[test]
+    fn block_message_is_stable_and_marks_observe_only() {
+        let err = check_observe_only(&["git", "push"]).unwrap_err();
+        assert!(err.contains("GUARDRAIL BLOCKED"));
+        assert!(err.contains("observe-only"));
+    }
+
+    #[test]
+    fn is_write_command_matches_check() {
+        assert!(is_write_command(&["git", "push"]));
+        assert!(!is_write_command(&["git", "fetch"]));
+    }
+}

--- a/tests/crocutus_read_only_guard.rs
+++ b/tests/crocutus_read_only_guard.rs
@@ -1,0 +1,265 @@
+//! Crocutus read-only guardrail — outside-in proof of the #1 non-negotiable
+//! guardrail (issue #1) plus the identity-isolation contract that lets a second
+//! identity share Simard's binary.
+//!
+//! These tests are written FIRST (TDD). They exercise Simard's PUBLIC surface
+//! only — no Crocutus code is copied. Crocutus is meant to be a distinct
+//! *identity* over this same shared codebase, so the observe-only floor and the
+//! state-root-relative goal board MUST hold here.
+//!
+//! ## What is proven
+//!
+//! 1. **Fail-closed observe-only floor.** For an observe-only identity, EVERY
+//!    mutating command against a target repo / AzDO project is refused —
+//!    `git push`, `commit`, `branch`, PR creation (`az repos pr create` /
+//!    `gh pr create`), work-item edits (`az boards work-item update`), ACL
+//!    changes, and raw HTTP writes (`az rest --method POST`, `curl -d`). Reads
+//!    are permitted. Ambiguity fails closed.
+//!
+//! 2. **Identity isolation.** The goal board is resolved *relative to the state
+//!    root*, so a Crocutus home (`~/.crocutus`) yields a goal board distinct
+//!    from Simard's (`~/.simard`) — the two identities do not share state.
+
+use std::path::{Path, PathBuf};
+
+use simard::read_only_guard::{
+    OBSERVE_ONLY_ENV, check_observe_only, check_observe_only_git, command_is_read,
+    guard_observe_only, is_write_command, observe_only_enabled,
+};
+
+/// The exhaustive set of TARGET-mutating command shapes that Crocutus must
+/// never be able to run against the hyenas repos or their AzDO project.
+///
+/// If a NEW write path is added to the framework, add it here first (it must be
+/// refused) — this list is the executable specification of "changes nothing,
+/// anywhere".
+const MUST_BLOCK: &[&[&str]] = &[
+    // --- git: commit / push / branch / history rewrite ---
+    &["git", "push", "origin", "main"],
+    &["git", "push", "--force", "origin", "main"],
+    &["git", "push", "--force-with-lease", "origin", "main"],
+    &["git", "commit", "-m", "hygiene fix"],
+    &["git", "commit", "--amend", "--no-edit"],
+    &["git", "add", "-A"],
+    &["git", "merge", "feature"],
+    &["git", "rebase", "-i", "main"],
+    &["git", "reset", "--hard", "HEAD~1"],
+    &["git", "cherry-pick", "deadbeef"],
+    &["git", "revert", "deadbeef"],
+    &["git", "checkout", "-b", "hygiene"],
+    &["git", "switch", "-c", "hygiene"],
+    &["git", "branch", "hygiene"],
+    &["git", "branch", "-D", "stale-branch"],
+    &["git", "tag", "v9.9.9"],
+    &["git", "tag", "-d", "v1"],
+    &["git", "remote", "add", "mirror", "https://x"],
+    &["git", "remote", "set-url", "origin", "https://x"],
+    &["git", "config", "user.email", "x@y.z"],
+    &["git", "pull", "origin", "main"],
+    &["git", "am", "patch.mbox"],
+    &["git", "apply", "patch.diff"],
+    &["git", "update-ref", "refs/heads/main", "deadbeef"],
+    // leading git globals must not smuggle a write past the guard
+    &["git", "-C", "/clone", "push", "origin", "main"],
+    // --- Azure DevOps: PRs, work items, policies, ACLs ---
+    &["az", "repos", "pr", "create", "--title", "x"],
+    &["az", "repos", "pr", "update", "--id", "1"],
+    &[
+        "az", "repos", "pr", "set-vote", "--id", "1", "--vote", "approve",
+    ],
+    &["az", "repos", "pr", "reviewer", "add", "--id", "1"],
+    &["az", "repos", "ref", "create", "--name", "refs/heads/x"],
+    &["az", "repos", "ref", "delete", "--name", "refs/heads/x"],
+    &[
+        "az",
+        "repos",
+        "import",
+        "create",
+        "--git-source-url",
+        "https://x",
+    ],
+    &["az", "repos", "policy", "create"],
+    &["az", "boards", "work-item", "create", "--type", "Bug"],
+    &["az", "boards", "work-item", "update", "--id", "1"],
+    &["az", "boards", "work-item", "delete", "--id", "1"],
+    &["az", "boards", "work-item", "relation", "add", "--id", "1"],
+    &["az", "pipelines", "run", "--name", "ci"],
+    &["az", "pipelines", "create", "--name", "ci"],
+    &["az", "devops", "security", "permission", "update"],
+    &["az", "devops", "security", "group", "membership", "add"],
+    // az rest raw writes
+    &[
+        "az",
+        "rest",
+        "--method",
+        "POST",
+        "--url",
+        "https://dev.azure.com/x",
+    ],
+    &[
+        "az",
+        "rest",
+        "-m",
+        "patch",
+        "--url",
+        "https://dev.azure.com/x",
+    ],
+    &[
+        "az",
+        "rest",
+        "--url",
+        "https://dev.azure.com/x",
+        "--body",
+        "@payload.json",
+    ],
+    // --- GitHub CLI writes (Crocutus must not act on GitHub either) ---
+    &["gh", "pr", "create"],
+    &["gh", "pr", "merge", "1"],
+    &["gh", "issue", "create"],
+    &["gh", "issue", "comment", "1", "--body", "x"],
+    &["gh", "api", "-X", "POST", "/repos/x/pulls"],
+    &["gh", "api", "-f", "title=x", "/repos/x/issues"],
+    // --- raw HTTP writes ---
+    &["curl", "-X", "POST", "https://dev.azure.com/x"],
+    &["curl", "-d", "@payload", "https://dev.azure.com/x"],
+    &["curl", "-XPUT", "https://dev.azure.com/x"],
+    &["wget", "--post-data", "a=b", "https://dev.azure.com/x"],
+];
+
+/// Read-only command shapes Crocutus MUST be able to run so it can actually
+/// observe the target repos.
+const MUST_ALLOW: &[&[&str]] = &[
+    &[
+        "git",
+        "clone",
+        "https://dev.azure.com/acs-mdash/acs-mdash/_git/hyenas",
+    ],
+    &["git", "fetch", "--all", "--prune"],
+    &["git", "log", "--oneline", "-20"],
+    &["git", "status"],
+    &["git", "diff", "origin/main...HEAD"],
+    &["git", "show", "HEAD:README.md"],
+    &["git", "ls-remote", "--heads", "origin"],
+    &[
+        "git",
+        "for-each-ref",
+        "--sort=-committerdate",
+        "refs/remotes",
+    ],
+    &["git", "branch", "-a"],
+    &["git", "branch", "--merged", "origin/main"],
+    &["git", "tag", "-l"],
+    &["git", "rev-parse", "HEAD"],
+    &["git", "config", "--get", "remote.origin.url"],
+    &["git", "-C", "/clone", "log"],
+    &["az", "repos", "list", "--project", "acs-mdash"],
+    &["az", "repos", "pr", "list", "--status", "active"],
+    &["az", "boards", "work-item", "show", "--id", "1"],
+    &["az", "repos", "ref", "list", "--repository", "hyenas"],
+    &[
+        "az",
+        "rest",
+        "--method",
+        "GET",
+        "--url",
+        "https://dev.azure.com/x",
+    ],
+    &["az", "rest", "--url", "https://dev.azure.com/x"],
+    &["gh", "pr", "list"],
+    &["gh", "api", "/repos/x/pulls"],
+    &["curl", "https://dev.azure.com/x"],
+    &["curl", "-sSL", "-X", "GET", "https://dev.azure.com/x"],
+];
+
+#[test]
+fn every_mutating_command_is_refused() {
+    for argv in MUST_BLOCK {
+        let result = check_observe_only(argv);
+        assert!(
+            result.is_err(),
+            "GUARDRAIL HOLE: observe-only identity was allowed to run a mutating \
+             command {argv:?} — this could change the target repos. Must fail closed."
+        );
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("GUARDRAIL BLOCKED"),
+            "block message for {argv:?} must carry the GUARDRAIL BLOCKED marker, got: {msg}"
+        );
+        assert!(
+            is_write_command(argv),
+            "is_write_command must agree that {argv:?} is a write"
+        );
+    }
+}
+
+#[test]
+fn every_read_command_is_permitted() {
+    for argv in MUST_ALLOW {
+        assert!(
+            check_observe_only(argv).is_ok(),
+            "observe-only identity must be able to READ: {argv:?} was refused, \
+             which would prevent Crocutus from observing the target repos."
+        );
+        assert!(
+            command_is_read(argv),
+            "command_is_read must agree that {argv:?} is a read"
+        );
+    }
+}
+
+#[test]
+fn git_arg_convention_matches_full_argv() {
+    // The git-args-without-"git" convention (mirroring git_guardrails) must
+    // agree with the full-argv path.
+    assert!(check_observe_only_git(&["push", "origin", "main"]).is_err());
+    assert!(check_observe_only_git(&["fetch", "origin"]).is_ok());
+    assert!(check_observe_only_git(&["commit", "-m", "x"]).is_err());
+    assert!(check_observe_only_git(&["log"]).is_ok());
+}
+
+#[test]
+fn env_gate_defaults_off_and_can_be_forced_on() {
+    // With the env unset, the env-gated entry point does not enforce (Simard,
+    // the engineering identity, is free to write). The always-on check still
+    // refuses. The Crocutus deployment sets OBSERVE_ONLY_ENV to force the gate.
+    //
+    // We only READ the env default here (do not mutate process-global env in a
+    // parallel integration test): default must be "not observe-only".
+    assert!(
+        !observe_only_enabled(),
+        "{OBSERVE_ONLY_ENV} must default to disabled so the engineer identity is unaffected"
+    );
+    // Env-gated path is a no-op when disabled …
+    assert!(guard_observe_only(&["git", "push", "origin", "main"]).is_ok());
+    // … but the always-on path (used by the Crocutus identity) always refuses.
+    assert!(check_observe_only(&["git", "push", "origin", "main"]).is_err());
+}
+
+#[test]
+fn identity_isolation_goal_board_is_state_root_relative() {
+    // Crocutus runs with its own home (~/.crocutus) via SIMARD_STATE_ROOT.
+    // The goal board is resolved relative to that root, so the two identities'
+    // goal boards are DISTINCT files — no shared mutable state.
+    let crocutus_home: PathBuf = Path::new("/home/agent/.crocutus").to_path_buf();
+    let simard_home: PathBuf = Path::new("/home/agent/.simard").to_path_buf();
+
+    let crocutus_board = simard::goal_board_store::store_path(&crocutus_home);
+    let simard_board = simard::goal_board_store::store_path(&simard_home);
+
+    assert_ne!(
+        crocutus_board, simard_board,
+        "Crocutus and Simard must not share a goal board"
+    );
+    assert!(
+        crocutus_board.starts_with(&crocutus_home),
+        "Crocutus goal board must live under its own home, got {crocutus_board:?}"
+    );
+    assert!(
+        crocutus_board.to_string_lossy().contains(".crocutus"),
+        "Crocutus goal board path must be scoped to .crocutus, got {crocutus_board:?}"
+    );
+    assert!(
+        !crocutus_board.to_string_lossy().contains(".simard"),
+        "Crocutus goal board must not touch the Simard home, got {crocutus_board:?}"
+    );
+}


### PR DESCRIPTION
## What & why

Parameterizes Simard *by identity* so a second, **read-only** observer identity (**Crocutus**, issue #1) runs on the shared codebase with almost no new code — via **environment**, not a fork. Validates the "second identity = mostly config" thesis.

## The #1 guardrail (structural, fail-closed)

A read-only identity must be **structurally unable** to change anything, anywhere. Shipped enforcement, in depth:

- **`read_only_guard`** — a default-DENY, fail-closed command classifier for `git`/`az`/`gh`/`curl`/`wget`. Reads permitted; every mutating shape (push, commit, branch, tag, PR create, work-item edit, ACL change, raw HTTP writes) refused; **ambiguity fails closed**.
- **Wired into `git_guardrails::check_git_safety`** (the shared git write seam) — under `SIMARD_OBSERVE_ONLY=1` every existing write path refuses, **even when `SIMARD_GIT_GUARDRAILS` is disabled** (independent floor).
- **Wired into `ooda_actions::advance_goal::spawn::dispatch_spawn_engineer`** — the OODA ACT phase short-circuits, so a read-only identity **proposes goals but dispatches 0 write-bearing engineers**.

Isolation reuses the pre-existing **`SIMARD_STATE_ROOT`** (distinct goal board + cognitive-memory `flock` per identity), proven state-root-relative in `tests/crocutus_read_only_guard.rs`.

## Tests

- `read_only_guard` unit tests (16) + `tests/crocutus_read_only_guard.rs` (outside-in guardrail + isolation, 5).
- New `git_guardrails` observe-only-floor tests (refuses ordinary push/commit under the floor; still allows reads; holds when git-guardrails disabled; engineer identity unaffected when env unset).
- New `dispatch_spawn_engineer` observe-only short-circuit tests.

## Docs honesty

The docs added here describe the **target** design (typed `IdentityAuthority` posture, `SIMARD_HOME` instance root, `simard debug` verbs). Each now carries an explicit **implementation-status admonition** marking *shipped* (env-driven: `SIMARD_STATE_ROOT` + `SIMARD_OBSERVE_ONLY`) vs. *planned*, tracked in **#3067**. `mkdocs --strict` passes.

## Abstraction-gap findings (see #3067)

- No single command-execution chokepoint (git/az/gh spawned in ~40 sites; `ado_acl_guard::check_ado_acl_safety` had **zero callers**). The floor was wired at the git seam + ACT dispatch; a universal chokepoint would let posture be enforced once.
- Env-driven parameterization was sufficient for a read-only observer — little/no new code.

## Guardrail: no `--admin` / `--no-verify`

Committed and pushed through full pre-commit + pre-push (fmt, release clippy `-D warnings`, release test subset). Not merging; CI to run.

Refs #1
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>