### PR TITLE
feat(coin-gym): Phase-5 skwaq-style self-improvement loop (#2825)

### DIFF
--- a/docs/howto/run-the-coin-gym-harness.md
+++ b/docs/howto/run-the-coin-gym-harness.md
@@ -17,17 +17,20 @@ target line, grades the result, scores reach/precision against the published
 leaderboard, and compares a **single-model baseline** against a **multi-agent
 team** — mirroring skwaq's failure-analysis + overfitting-reviewer gating.
 
-This guide covers **Phase 4** (the local scaffold). The full design and the
-phase plan live in
-[COIN benchmark & skwaq gym study](../research/coin-benchmark-and-skwaq-study.md)
-and are tracked in issue #2713.
+This guide covers **Phase 4** (the local scaffold) and the **Phase 5**
+self-improvement loop (`improve --holdout fresh`). The full design and the phase
+plan live in
+[COIN benchmark & skwaq gym study](../research/coin-benchmark-and-skwaq-study.md);
+Phase 5 is tracked in issue #2825.
 
 > **Offline by default.** In Phase 4 the harness grades against a **mock oracle**
 > so the whole pipeline runs without a VM. Runs are clearly labelled
 > `OFFLINE SCAFFOLD`. Real grading delegates to `coin evaluate` (Docker +
-> instrumented replay) and needs a provisioned host — that is **Phase 3**. The
-> live self-improvement loop (apply → verify on held-out fresh targets →
-> keep-or-roll-back) is **Phase 5**.
+> instrumented replay) and needs a provisioned host — that is **Phase 3**
+> (#2823). The **Phase 5** self-improvement loop (apply → verify on held-out
+> fresh targets → keep-or-roll-back, with durable tactic memory) runs the same
+> way — offline against the mock oracle — behind `improve --holdout fresh`; a
+> real held-out grade comes from `coin verify` on the Phase-3 VM.
 
 ## Build the CLI
 
@@ -44,7 +47,7 @@ default, overridable with the `COIN_GYM_HOME` environment variable.
 coin-gym run <model> [--strategy baseline|team] [--profile <name>] [--targets <path>]
 coin-gym score   <run-id> [--profile <name>]
 coin-gym compare <run-id> [--profile <name>]
-coin-gym improve <run-id> [--profile <name>]
+coin-gym improve <run-id> [--profile <name>] [--holdout fresh]
 coin-gym contract [--dataset <repo>] [--revision <tag>] [--split a,b] [--project x,y] [--source rebuild|image]
 coin-gym profiles
 ```
@@ -106,7 +109,7 @@ reproduce leaderboard numbers).
 coin-gym improve <run-id>
 ```
 
-Runs the **Phase-4 slice** of the self-improvement loop over a saved run:
+Runs the **offline slice** of the self-improvement loop over a saved run:
 
 1. **Failure-analyst** turns each unreached target (`W`/`T`/`N`) into a
    **general** reachability tactic (e.g. "for format-gated decoders, satisfy the
@@ -115,9 +118,65 @@ Runs the **Phase-4 slice** of the self-improvement loop over a saved run:
    input or keys off a specific target id / project / locator, accepting only
    tactics that plausibly generalise.
 
-Applying an accepted tactic, re-running on held-out **fresh** targets, and
-keeping it only if reach improves without a precision regression (else rolling
-back) requires live grading and is **Phase 5**.
+This is the analysis-only view; it does **not** apply, verify, or roll back
+tactics. For that, add `--holdout fresh`.
+
+### `improve --holdout fresh` — the Phase-5 self-improvement loop
+
+```bash
+# A run persists its offline scaffold (oracle + script), which the loop needs.
+coin-gym run "Claude Opus 4.6" --targets my_snapshot.json --profile loop
+coin-gym improve <run-id> --profile loop --holdout fresh
+```
+
+Runs the **live loop** (Phase 5, #2825), mirroring skwaq's
+`failure-analyst → overfitting-reviewer → verify` cycle:
+
+1. **Analyse + gate** the run's failures into general tactics (as above);
+   memorising / target-specific tactics are rejected *before* verification.
+2. **Apply + measure on held-out fresh targets.** Each accepted tactic is applied
+   and the agent is re-run on the snapshot's **held-out fresh** slice — targets
+   the tactic's motivating failure never saw. The tactic is **kept iff held-out
+   reach improves and precision does not drop**; otherwise it is **rolled back**.
+   (Offline, the held-out grade is synthesised from the mock oracle — see the
+   note below.)
+3. **Train/held-out-gap warning** (the issue's "overfitting-warning"). If a tactic
+   lifts *training* reach but not *held-out* reach, the gap is flagged and the
+   tactic is rolled back as **UNPROVEN**; a definitive overfit-vs-coverage verdict
+   is left to the Phase-3 verifier.
+4. **Durable tactic memory.** Kept tactics are persisted per **general family**
+   (never per project/target — that would be overfitting) to
+   `<home>/profiles/<name>/tactics.json` and **reused** on subsequent runs.
+
+On the bundled `improve_loop_snapshot.json` fixture — pinned failures across a
+decoder, a crypto state machine, and a generic guard, with a held-out slice that
+covers the decoder + crypto families but **not** the generic one — one cycle
+keeps the two decoder/crypto tactics, rolls back the generic one, and warns:
+
+```text
+gate:     3 accepted  0 rejected
+holdout:  reach 0.0% → 100.0%   (kept 2, rolled back 1, train/held-out-gap warnings 1)
+memory:   0 → 2 durable tactic(s)
+  [KEEP]     dec-a (format-gated-decoder) — held-out reach 0.0% → 50.0% …
+  [KEEP]     cry-a (crypto-state-machine) — held-out reach 50.0% → 100.0% …
+  [ROLLBACK] gen-a (generic) — train/held-out reach GAP: lifts TRAINING reach but no held-out gain; rolled back as UNPROVEN
+```
+
+A second `improve --holdout fresh` **reuses** the banked tactics: the held-out
+baseline already reaches 100%, nothing new is banked (`memory: 2 → 2`), and the
+memorisation-resistant design never double-counts a family.
+
+> **Offline scaffold — an *idealized* effect model, honestly.** The held-out
+> grade here is synthesised from the **same mock oracle**: applying a tactic of
+> family `F` is *assumed* to produce the oracle's reaching input for every
+> in-scope target of `F` (including held-out ones). This exercises the loop's
+> **control flow** — analyse → gate → apply → measure held-out → keep/rollback +
+> durable memory — but it does **not** prove the tactic *text* would solve fresh
+> targets. A train/held-out gap is therefore reported as **UNPROVEN** (a coverage
+> gap), not a definitive overfit verdict. **Real** empirical held-out
+> verification — a live model graded by `coin verify` — is **Phase 3** (#2823).
+> **LOCAL-ONLY**: nothing is ever submitted externally, and the stored oracle is
+> a test double, never a real verdict source.
 
 ### `contract` — show the real `coin evaluate` / `coin verify` wiring
 
@@ -178,6 +237,9 @@ cross-contaminate.
 
 The `oracle` and `script` sections drive the **offline** demo run only. A real
 run gets its oracle from `coin evaluate` and its candidates from a live model.
+For `improve --holdout fresh`, include a non-empty `held_out_fresh` slice **and**
+`oracle` entries covering it, so the loop has fresh lines to verify tactics
+against (see `src/coin_gym/fixtures/improve_loop_snapshot.json`).
 
 > **Real COIN dataset schema.** The compact manifest above is the offline-demo
 > shape. The library also parses COIN's **published** dataset schema — rows with
@@ -192,10 +254,13 @@ run gets its oracle from `coin evaluate` and its candidates from a live model.
 | Phase | Work | Status |
 |-------|------|--------|
 | 3 | Provision an `azlin` VM + Docker host and pull a COIN snapshot, then run the **already-wired** `coin evaluate` / `coin verify` executor live (see `contract`) | follow-up (HIGH-RISK, operator-gated; #2823) |
-| 5 | Live self-improvement loop: apply tactic → verify on held-out fresh targets → keep-or-roll-back; durable tactic memory | follow-up (#2825) |
+| 5 | Live self-improvement loop: apply tactic → verify on held-out fresh targets → keep-or-roll-back; durable tactic memory | **implemented offline** (`improve --holdout fresh`, #2825) |
 
-Both remain unchecked on issue #2713. The **executor contract** itself — the
-`coin evaluate` / `coin verify` argv, the `/answer/blob.bin` +
-`/answer/blob.harness` (or `/answer/UNREACHABLE.md`) submission, and reading
-`reached` from each `result.json` — is implemented and unit-tested offline
-(issue #3001); only the live Docker invocation is gated behind Phase 3.
+Phase 5 lands the loop **offline** against the mock oracle; a **real** held-out
+grade (and therefore a real leaderboard delta) depends on the Phase-3 `azlin` VM
+(#2823), which stays the critical path for the final done-gate. The **executor
+contract** itself — the `coin evaluate` / `coin verify` argv, the
+`/answer/blob.bin` + `/answer/blob.harness` (or `/answer/UNREACHABLE.md`)
+submission, and reading `reached` from each `result.json` — is implemented and
+unit-tested offline (issue #3001); only the live Docker invocation is gated
+behind Phase 3.

--- a/src/coin_gym/fixtures/improve_loop_snapshot.json
+++ b/src/coin_gym/fixtures/improve_loop_snapshot.json
@@ -1,0 +1,67 @@
+{
+  "snapshot": "you/coin@v1-improve-loop",
+  "note": "Phase-5 self-improvement loop fixture (offline scaffold, mock oracle; placeholder UTF-8 inputs, not real COIN bytes). Pinned failures span three tactic families (format-gated decoder, crypto state machine, generic). The held-out fresh slice covers decoder + crypto but NOT generic, so the decoder/crypto tactics generalise (held-out reach improves → kept + banked) while the generic tactic lifts training reach without held-out reach (train/held-out gap → overfitting-warning → rolled back). Drives the improve_loop unit tests and the `run` + `improve --holdout fresh` CLI demo.",
+  "targets": {
+    "pinned": [
+      {
+        "id": "dec-a",
+        "project": "acme",
+        "commit": "c1a2b3d",
+        "harness": "png_decode_fuzzer",
+        "file": "src/decode/reader.c",
+        "line": 120,
+        "family": "frontier"
+      },
+      {
+        "id": "cry-a",
+        "project": "beta",
+        "commit": "c2b3c4e",
+        "harness": "tls_handshake_fuzzer",
+        "file": "src/ssl/state.c",
+        "line": 88,
+        "family": "non-trivial-reachable"
+      },
+      {
+        "id": "gen-a",
+        "project": "gamma",
+        "commit": "c3c4d5f",
+        "harness": "logic_fuzzer",
+        "file": "src/core/logic.c",
+        "line": 42,
+        "family": "non-trivial-reachable"
+      }
+    ],
+    "held_out_fresh": [
+      {
+        "id": "dec-h",
+        "project": "delta",
+        "commit": "c4d5e6a",
+        "harness": "jpeg_decode_fuzzer",
+        "file": "src/decode/jpg.c",
+        "line": 200,
+        "family": "frontier"
+      },
+      {
+        "id": "cry-h",
+        "project": "epsilon",
+        "commit": "c5e6f7b",
+        "harness": "kem_fuzzer",
+        "file": "src/kem/kem.c",
+        "line": 64,
+        "family": "non-trivial-reachable"
+      }
+    ]
+  },
+  "oracle": {
+    "dec-a": "MAGIC+deep-branch-a",
+    "cry-a": "handshake:state-2",
+    "gen-a": "guard-true+payload",
+    "dec-h": "MAGIC+deep-branch-h",
+    "cry-h": "kem-seed:decaps"
+  },
+  "script": {
+    "dec-a": { "input": "no-magic-header", "confidence": 0.5, "rationale": "did not satisfy the container header validator" },
+    "cry-a": { "input": "handshake:state-0", "confidence": 0.5, "rationale": "wrong protocol state; never reached the decapsulation branch" },
+    "gen-a": { "input": "guard-false", "confidence": 0.5, "rationale": "guard predicate left unsatisfied" }
+  }
+}

--- a/src/coin_gym/improve.rs
+++ b/src/coin_gym/improve.rs
@@ -8,10 +8,11 @@
 //!
 //! The **live** part of the loop — apply an accepted tactic, re-run on held-out
 //! *fresh* targets, and keep it iff reach improves without a precision
-//! regression (else roll back) — needs real grading and is **Phase 5**
-//! (tracked on issue #2713). It is intentionally NOT implemented here.
+//! regression (else roll back), plus durable tactic memory — is **Phase 5**
+//! (issue #2825) and lives in [`super::improve_loop`]. It composes the
+//! analyst + gate defined here.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::target_loader::TargetSet;
 use super::types::{OutcomeCode, RunReport, Target, TargetFamily};
@@ -79,14 +80,43 @@ pub struct ImproveReport {
 }
 
 /// Broad heuristic class a target falls into, used to pick a *general* tactic.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum TacticCategory {
+///
+/// The class is a **general** target family (format-gated decoder,
+/// cryptographic state machine, or a generic guard) — never a specific project
+/// or target id — so tactics keyed to it stay generalisable and durable-memory
+/// entries are shared across projects. Exposed to the live self-improvement loop
+/// ([`super::improve_loop`]) which keys accepted tactics by this category.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum TacticCategory {
     FormatGatedDecoder,
     CryptoStateMachine,
     Generic,
 }
 
-fn categorize(target: &Target) -> TacticCategory {
+impl TacticCategory {
+    /// Stable kebab-case label used in reports, memory keys, and CLI output.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::FormatGatedDecoder => "format-gated-decoder",
+            Self::CryptoStateMachine => "crypto-state-machine",
+            Self::Generic => "generic",
+        }
+    }
+
+    /// Parse a [`Self::label`] back into a category (used to rehydrate durable
+    /// tactic memory). Returns `None` for an unrecognised label.
+    pub(crate) fn from_label(label: &str) -> Option<Self> {
+        match label {
+            "format-gated-decoder" => Some(Self::FormatGatedDecoder),
+            "crypto-state-machine" => Some(Self::CryptoStateMachine),
+            "generic" => Some(Self::Generic),
+            _ => None,
+        }
+    }
+}
+
+pub(crate) fn categorize(target: &Target) -> TacticCategory {
     let hay = format!(
         "{} {} {}",
         target.project.to_ascii_lowercase(),
@@ -120,7 +150,7 @@ fn categorize(target: &Target) -> TacticCategory {
     }
 }
 
-fn tactic_text(category: TacticCategory) -> &'static str {
+pub(crate) fn tactic_text(category: TacticCategory) -> &'static str {
     match category {
         TacticCategory::FormatGatedDecoder => {
             "For format-gated decoders, first satisfy the container's magic-byte / header \
@@ -259,8 +289,9 @@ fn reject(proposal: &TacticProposal, reason: String) -> ReviewedProposal {
 }
 
 /// Run one **offline** analysis cycle: failure-analysis → overfitting-review.
-/// This does NOT apply, verify, or roll back tactics — that live loop needs real
-/// grading on held-out fresh targets and is Phase 5 (issue #2713).
+/// This does NOT apply, verify, or roll back tactics — that live loop lives in
+/// [`super::improve_loop`] (`improve --holdout fresh`, Phase 5, issue #2825),
+/// which composes this analyst + gate with held-out verification.
 #[must_use]
 pub fn analyze_and_review(report: &RunReport, targets: &TargetSet) -> ImproveReport {
     let reviewed: Vec<ReviewedProposal> = analyze_failures(report, targets)
@@ -280,7 +311,8 @@ pub fn analyze_and_review(report: &RunReport, targets: &TargetSet) -> ImproveRep
         rejected,
         note: "offline analysis only — applying an accepted tactic, re-running on held-out \
                fresh targets, and keeping it iff reach improves without a precision regression \
-               (else roll back) requires live `coin evaluate` grading and is Phase 5 (issue #2713)"
+               (else roll back) is the live loop `improve --holdout fresh` (Phase 5, issue \
+               #2825); real `coin evaluate` grading still needs the Phase-3 VM (issue #2823)"
             .to_string(),
     }
 }

--- a/src/coin_gym/improve_loop.rs
+++ b/src/coin_gym/improve_loop.rs
@@ -1,0 +1,556 @@
+//! Live self-improvement loop (Phase 5, issue #2825).
+//!
+//! This is the **live** half of the skwaq-style loop whose offline half lives in
+//! [`super::improve`] (failure-analyst + overfitting-reviewer gate). It composes
+//! that analyst + gate with a *verify-on-held-out* step and durable memory,
+//! mirroring skwaq's `failure-analyst → overfitting-reviewer → verify` cycle
+//! (`~/src/skwaq/crates/gym/src/improve.rs`):
+//!
+//! 1. **Analyse + gate** the run's failures into *general* reachability tactics
+//!    (reused from [`super::improve`]); memorising / target-specific tactics are
+//!    rejected before they are ever verified.
+//! 2. **Apply** an accepted tactic and **re-run on held-out *fresh* targets**
+//!    (targets the tactic's motivating failure never saw). Keep it **iff** reach
+//!    improves and precision does not drop; otherwise **roll back**.
+//! 3. **Overfitting-warning**: if a tactic lifts *training* reach but not
+//!    *held-out* reach, that train/held-out gap is flagged — the empirical
+//!    complement to the static gate.
+//! 4. **Durable memory**: kept tactics are persisted per *general family* (never
+//!    per project/target — that would be overfitting) under the profile and
+//!    **reused** on subsequent runs.
+//!
+//! ## Offline scaffold — an *idealized* effect model, honestly
+//! Like the rest of the Gym (Phase 4), this runs **offline against a mock
+//! oracle** so it is exercised in CI without a VM. It models a tactic's effect
+//! **idealistically**: an accepted tactic of family `F` is *assumed* to produce
+//! the objective grader's reaching input for **every** in-scope target of `F`,
+//! including held-out ones. This exercises the loop's **control flow** —
+//! analyse → gate → apply → measure held-out → keep/rollback + memory — but it
+//! does **not** prove the tactic *text* would solve fresh targets: the held-out
+//! grade is synthesised from the same oracle, so it is illustrative, not
+//! empirical. The static gate still rejects tactics that *name* a specific
+//! target/project/input, and the held-out **coverage** check distinguishes a
+//! genuine train/held-out gap from a mere "no held-out target of this family to
+//! confirm against". **Real** empirical held-out verification — running the
+//! tactic through a live model and grading with `coin verify` — is **Phase 3**
+//! (issue #2823). **LOCAL-ONLY**: nothing here is submitted externally, and the
+//! stored oracle is a test double, never a real verdict source.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use super::agent_runner::Candidate;
+use super::execute_run;
+use super::improve::{
+    ReviewVerdict, ReviewedProposal, TacticCategory, analyze_failures, categorize, review_proposal,
+};
+use super::profiles::{PersistedRun, profile_dir};
+use super::scorer::ReachPrecision;
+use super::target_loader::{DemoScenario, TargetSet};
+use super::types::{CoinGymError, CoinGymResult, RunReport, Strategy, Target};
+
+/// Filename of a profile's durable tactic memory.
+pub const TACTIC_MEMORY_FILE: &str = "tactics.json";
+
+/// Float slack when comparing precision percentages (avoid FP jitter).
+const PRECISION_EPS: f64 = 1e-9;
+
+// ── Reach/precision snapshot ─────────────────────────────────────────────────
+
+/// A reach/precision measurement over one slice (training or held-out).
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+pub struct SliceMeasurement {
+    /// Targets reached.
+    pub reached: usize,
+    /// Inputs submitted (precision denominator).
+    pub submitted: usize,
+    /// Total targets in the slice.
+    pub total: usize,
+    /// reached / total, as a percentage.
+    pub reach_pct: f64,
+    /// reached / submitted, as a percentage (0 when nothing submitted).
+    pub precision_pct: f64,
+}
+
+impl SliceMeasurement {
+    fn from_rp(rp: &ReachPrecision) -> Self {
+        Self {
+            reached: rp.reached,
+            submitted: rp.submitted,
+            total: rp.total,
+            reach_pct: rp.reach_pct(),
+            precision_pct: rp.precision_pct(),
+        }
+    }
+}
+
+/// Keep-or-rollback verdict for a verified tactic.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TacticDecision {
+    /// Held-out reach improved without a precision drop — keep the tactic.
+    Keep,
+    /// No held-out gain (or a precision regression / already banked) — roll back.
+    Rollback,
+}
+
+impl TacticDecision {
+    /// Uppercase label (`KEEP` / `ROLLBACK`).
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Keep => "KEEP",
+            Self::Rollback => "ROLLBACK",
+        }
+    }
+}
+
+/// One accepted tactic after held-out verification.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct VerifiedTactic {
+    /// The tactic that was verified.
+    pub tactic: String,
+    /// The general family the tactic was keyed to.
+    pub category: String,
+    /// The failing target whose analysis motivated the tactic.
+    pub source_target_id: String,
+    /// Training-slice reach/precision before applying the tactic.
+    pub train_before: SliceMeasurement,
+    /// Training-slice reach/precision after applying the tactic.
+    pub train_after: SliceMeasurement,
+    /// Held-out-slice reach/precision before applying the tactic.
+    pub holdout_before: SliceMeasurement,
+    /// Held-out-slice reach/precision after applying the tactic.
+    pub holdout_after: SliceMeasurement,
+    /// Keep vs roll back.
+    pub decision: TacticDecision,
+    /// Set when a train/held-out reach GAP was detected (the issue's
+    /// "overfitting-warning"): training reach lifted but held-out reach did not.
+    /// In the offline idealized model this provably means "no unreached held-out
+    /// target of the family to confirm against" (a coverage gap); the definitive
+    /// overfit-vs-coverage verdict is the Phase-3 verifier's.
+    pub overfitting_warning: Option<String>,
+    /// Whether this tactic was newly banked to durable memory this cycle.
+    pub newly_persisted: bool,
+    /// Human-readable justification.
+    pub reason: String,
+}
+
+/// The result of one live self-improvement cycle.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SelfImproveReport {
+    /// The run analysed.
+    pub run_id: String,
+    /// Model under test.
+    pub model: String,
+    /// Snapshot the targets came from.
+    pub snapshot: String,
+    /// Tactics accepted by the overfitting-reviewer gate (candidates to verify).
+    pub gate_accepted: usize,
+    /// Tactics rejected by the gate (never verified).
+    pub gate_rejected: usize,
+    /// Full gate output, for transparency.
+    pub reviewed: Vec<ReviewedProposal>,
+    /// Held-out verification results, one per gate-accepted tactic.
+    pub verified: Vec<VerifiedTactic>,
+    /// Tactics kept (held-out reach improved) and newly banked.
+    pub kept: usize,
+    /// Tactics rolled back (no held-out gain, precision drop, or already banked).
+    pub rolled_back: usize,
+    /// Number of overfitting warnings fired.
+    pub overfitting_warnings: usize,
+    /// Held-out reach at cycle start (with remembered tactics already applied).
+    pub holdout_reach_before_pct: f64,
+    /// Held-out reach after banking this cycle's kept tactics.
+    pub holdout_reach_after_pct: f64,
+    /// Durable-memory size before the cycle.
+    pub memory_before: usize,
+    /// Durable-memory size after the cycle.
+    pub memory_after: usize,
+    /// Provenance / guardrail note.
+    pub note: String,
+}
+
+// ── Durable tactic memory ────────────────────────────────────────────────────
+
+/// A durable, accepted tactic keyed by *general family* (never a project or
+/// target id). Persisted so a win carries across runs.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AcceptedTactic {
+    /// The general family label (`format-gated-decoder`, …).
+    pub category: String,
+    /// The general tactic text.
+    pub tactic: String,
+    /// The failing target whose analysis first motivated the tactic.
+    pub source_target_id: String,
+    /// When the tactic was accepted (unix epoch milliseconds).
+    pub accepted_at_unix_ms: u128,
+    /// Held-out reach before the tactic was applied (percentage).
+    pub holdout_reach_before_pct: f64,
+    /// Held-out reach after the tactic was applied (percentage).
+    pub holdout_reach_after_pct: f64,
+}
+
+/// A profile's durable tactic memory.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct TacticMemory {
+    /// Accepted tactics, one per general family.
+    pub tactics: Vec<AcceptedTactic>,
+}
+
+impl TacticMemory {
+    /// Whether a tactic for `category` is already banked.
+    #[must_use]
+    pub(crate) fn has_category(&self, category: TacticCategory) -> bool {
+        let label = category.label();
+        self.tactics.iter().any(|t| t.category == label)
+    }
+}
+
+/// Path to a profile's tactic memory file.
+#[must_use]
+pub fn tactic_memory_path(home: &Path, profile: &str) -> PathBuf {
+    profile_dir(home, profile).join(TACTIC_MEMORY_FILE)
+}
+
+/// Load a profile's durable tactic memory. A missing file is an empty memory.
+///
+/// # Errors
+/// Returns [`CoinGymError::Parse`] if the file exists but is malformed.
+pub fn load_tactic_memory(home: &Path, profile: &str) -> CoinGymResult<TacticMemory> {
+    let path = tactic_memory_path(home, profile);
+    match std::fs::read_to_string(&path) {
+        Ok(raw) => serde_json::from_str(&raw)
+            .map_err(|e| CoinGymError::Parse(format!("tactic memory {}: {e}", path.display()))),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(TacticMemory::default()),
+        Err(e) => Err(CoinGymError::Io(format!("read {}: {e}", path.display()))),
+    }
+}
+
+/// Persist a profile's durable tactic memory.
+///
+/// # Errors
+/// Returns [`CoinGymError::Io`] on directory-creation or write failure.
+pub fn save_tactic_memory(home: &Path, profile: &str, memory: &TacticMemory) -> CoinGymResult<()> {
+    let dir = profile_dir(home, profile);
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| CoinGymError::Io(format!("create {}: {e}", dir.display())))?;
+    let path = tactic_memory_path(home, profile);
+    let body = serde_json::to_string_pretty(memory)
+        .map_err(|e| CoinGymError::Parse(format!("serialize tactic memory: {e}")))?;
+    std::fs::write(&path, body)
+        .map_err(|e| CoinGymError::Io(format!("write {}: {e}", path.display())))
+}
+
+// ── Tactic application (offline scaffold model) ──────────────────────────────
+
+/// Apply a tactic of `category` to a slice under the **idealized effect model**:
+/// for every in-scope target of that family, *assume* the tactic drives the
+/// agent's candidate to the objective oracle's reaching input. Targets outside
+/// the family keep their base candidate. Returns the resulting
+/// `target_id -> Candidate` script. This is a **simulation of an assumed
+/// family-wide effect**, not proof the tactic text would solve fresh targets;
+/// see the module docs.
+fn apply_tactic_to_slice(
+    category: TacticCategory,
+    targets: &[Target],
+    oracle: &HashMap<String, String>,
+    base_script: &HashMap<String, Candidate>,
+) -> HashMap<String, Candidate> {
+    let mut script = base_script.clone();
+    for target in targets {
+        if categorize(target) != category {
+            continue;
+        }
+        if let Some(reaching) = oracle.get(&target.id) {
+            script.insert(
+                target.id.clone(),
+                Candidate {
+                    input: reaching.clone(),
+                    confidence: 0.9,
+                    rationale: format!("applied general '{}' tactic", category.label()),
+                },
+            );
+        }
+    }
+    script
+}
+
+/// Apply every remembered tactic to a slice (cumulative), reconstructing the
+/// current agent's script so prior wins carry into this run's baseline.
+fn apply_remembered_tactics(
+    memory: &TacticMemory,
+    targets: &[Target],
+    oracle: &HashMap<String, String>,
+    base_script: &HashMap<String, Candidate>,
+) -> HashMap<String, Candidate> {
+    let mut script = base_script.clone();
+    for tactic in &memory.tactics {
+        if let Some(category) = TacticCategory::from_label(&tactic.category) {
+            script = apply_tactic_to_slice(category, targets, oracle, &script);
+        }
+    }
+    script
+}
+
+/// Measure baseline reach/precision over `targets` given an oracle + script, by
+/// replaying the offline agent through the mock grader.
+fn measure_slice(
+    model: &str,
+    snapshot: &str,
+    targets: &[Target],
+    oracle: &HashMap<String, String>,
+    script: &HashMap<String, Candidate>,
+) -> CoinGymResult<SliceMeasurement> {
+    if targets.is_empty() {
+        let empty: Vec<super::types::Outcome> = Vec::new();
+        return Ok(SliceMeasurement::from_rp(&ReachPrecision::compute(&empty)));
+    }
+    let scenario = DemoScenario {
+        targets: TargetSet {
+            snapshot: snapshot.to_string(),
+            pinned: targets.to_vec(),
+            held_out_fresh: Vec::new(),
+        },
+        oracle: oracle.clone(),
+        script: script.clone(),
+    };
+    let report: RunReport = execute_run(model, Strategy::Baseline, &scenario)?;
+    Ok(SliceMeasurement::from_rp(&ReachPrecision::compute(
+        &report.outcomes,
+    )))
+}
+
+/// Keep decision: held-out reach must strictly improve **and** precision must
+/// not drop. Exposed for direct testing of the regression (rollback) path.
+#[must_use]
+pub(crate) fn improves_holdout(before: &SliceMeasurement, after: &SliceMeasurement) -> bool {
+    after.reached > before.reached && after.precision_pct + PRECISION_EPS >= before.precision_pct
+}
+
+// ── The live loop ────────────────────────────────────────────────────────────
+
+/// Run one live self-improvement cycle against a persisted **offline scaffold**
+/// run, verifying each gate-accepted tactic on the held-out fresh slice and
+/// persisting kept tactics to `profile`'s durable memory.
+///
+/// # Errors
+/// Returns [`CoinGymError::Usage`] if the run is not an offline scaffold run or
+/// has no held-out fresh slice to verify against, or any underlying I/O error.
+pub fn run_self_improvement(
+    home: &Path,
+    profile: &str,
+    persisted: &PersistedRun,
+) -> CoinGymResult<SelfImproveReport> {
+    if persisted.offline.is_empty() || !persisted.report.offline_scaffold {
+        return Err(CoinGymError::Usage(
+            "improve --holdout fresh needs an OFFLINE SCAFFOLD run (with its mock oracle + \
+             script persisted); this run has none. A real held-out grade comes from `coin \
+             verify` on the Phase-3 VM (issue #2823)"
+                .to_string(),
+        ));
+    }
+    let holdout = persisted.targets.held_out_fresh.clone();
+    if holdout.is_empty() {
+        return Err(CoinGymError::Usage(
+            "improve --holdout fresh needs a held-out fresh slice to verify against; this run's \
+             target set reserved none"
+                .to_string(),
+        ));
+    }
+    let pinned = persisted.targets.pinned.clone();
+    let model = persisted.report.model.clone();
+    let snapshot = persisted.targets.snapshot.clone();
+    let oracle = persisted.offline.oracle.clone();
+    let base_script = persisted.offline.base_candidates();
+
+    let mut memory = load_tactic_memory(home, profile)?;
+    let memory_before = memory.tactics.len();
+
+    // Baseline slices with remembered tactics already applied (prior wins reused).
+    let mut running_holdout_script =
+        apply_remembered_tactics(&memory, &holdout, &oracle, &base_script);
+    let mut running_train_script =
+        apply_remembered_tactics(&memory, &pinned, &oracle, &base_script);
+    let mut running_holdout = measure_slice(
+        &model,
+        &snapshot,
+        &holdout,
+        &oracle,
+        &running_holdout_script,
+    )?;
+    let mut running_train =
+        measure_slice(&model, &snapshot, &pinned, &oracle, &running_train_script)?;
+    let holdout_reach_before_pct = running_holdout.reach_pct;
+
+    // Failure-analyst → overfitting-reviewer gate (reuse the offline slice).
+    let proposals = analyze_failures(&persisted.report, &persisted.targets);
+    let reviewed: Vec<ReviewedProposal> = proposals
+        .iter()
+        .map(|p| review_proposal(p, &persisted.targets))
+        .collect();
+    let gate_accepted = reviewed
+        .iter()
+        .filter(|r| r.verdict == ReviewVerdict::Accept)
+        .count();
+    let gate_rejected = reviewed.len() - gate_accepted;
+
+    let all_targets: Vec<Target> = pinned.iter().chain(holdout.iter()).cloned().collect();
+    let mut verified = Vec::new();
+    let mut kept = 0usize;
+    let mut rolled_back = 0usize;
+    let mut overfitting_warnings = 0usize;
+
+    for r in reviewed
+        .iter()
+        .filter(|r| r.verdict == ReviewVerdict::Accept)
+    {
+        let Some(source) = all_targets.iter().find(|t| t.id == r.proposal.target_id) else {
+            continue;
+        };
+        let category = categorize(source);
+
+        let holdout_before = running_holdout;
+        let train_before = running_train;
+
+        let candidate_holdout_script =
+            apply_tactic_to_slice(category, &holdout, &oracle, &running_holdout_script);
+        let holdout_after = measure_slice(
+            &model,
+            &snapshot,
+            &holdout,
+            &oracle,
+            &candidate_holdout_script,
+        )?;
+        let candidate_train_script =
+            apply_tactic_to_slice(category, &pinned, &oracle, &running_train_script);
+        let train_after =
+            measure_slice(&model, &snapshot, &pinned, &oracle, &candidate_train_script)?;
+
+        let train_lifted = train_after.reached > train_before.reached;
+        let holdout_lifted = holdout_after.reached > holdout_before.reached;
+        // A train-but-not-held-out lift is the issue's "overfitting-warning".
+        // In the offline idealized model, `!holdout_lifted` provably means there
+        // was no *unreached* held-out target of this family to confirm against —
+        // i.e. a coverage gap — so we roll back as UNPROVEN rather than
+        // asserting overfit; the definitive verdict is the Phase-3 verifier's.
+        let overfitting_warning = if train_lifted && !holdout_lifted {
+            overfitting_warnings += 1;
+            Some(format!(
+                "train/held-out reach GAP: lifts TRAINING reach (+{} target(s)) but produced no \
+                 held-out gain — no unreached held-out '{}' target to confirm generalisation; \
+                 rolled back as UNPROVEN (a real overfit-vs-coverage verdict needs the Phase-3 \
+                 verifier, #2823)",
+                train_after.reached - train_before.reached,
+                category.label()
+            ))
+        } else {
+            None
+        };
+
+        let already_banked = memory.has_category(category);
+        let keep = !already_banked && improves_holdout(&holdout_before, &holdout_after);
+
+        let (decision, reason, newly_persisted) = if keep {
+            memory.tactics.push(AcceptedTactic {
+                category: category.label().to_string(),
+                tactic: r.proposal.tactic.clone(),
+                source_target_id: r.proposal.target_id.clone(),
+                accepted_at_unix_ms: now_unix_ms(),
+                holdout_reach_before_pct: holdout_before.reach_pct,
+                holdout_reach_after_pct: holdout_after.reach_pct,
+            });
+            running_holdout_script = candidate_holdout_script;
+            running_train_script = candidate_train_script;
+            running_holdout = holdout_after;
+            running_train = train_after;
+            kept += 1;
+            (
+                TacticDecision::Keep,
+                format!(
+                    "held-out reach {:.1}% → {:.1}% (precision {:.1}% → {:.1}%); kept and banked \
+                     for family '{}'",
+                    holdout_before.reach_pct,
+                    holdout_after.reach_pct,
+                    holdout_before.precision_pct,
+                    holdout_after.precision_pct,
+                    category.label()
+                ),
+                true,
+            )
+        } else {
+            rolled_back += 1;
+            let reason = if already_banked {
+                format!(
+                    "family '{}' already in durable memory (reused); no new held-out reach to bank",
+                    category.label()
+                )
+            } else if overfitting_warning.is_some() {
+                format!(
+                    "train/held-out reach gap for family '{}'; rolled back as UNPROVEN (see warning)",
+                    category.label()
+                )
+            } else {
+                format!(
+                    "no held-out reach improvement ({:.1}% → {:.1}%) or precision dropped \
+                     ({:.1}% → {:.1}%); rolled back",
+                    holdout_before.reach_pct,
+                    holdout_after.reach_pct,
+                    holdout_before.precision_pct,
+                    holdout_after.precision_pct
+                )
+            };
+            (TacticDecision::Rollback, reason, false)
+        };
+
+        verified.push(VerifiedTactic {
+            tactic: r.proposal.tactic.clone(),
+            category: category.label().to_string(),
+            source_target_id: r.proposal.target_id.clone(),
+            train_before,
+            train_after,
+            holdout_before,
+            holdout_after,
+            decision,
+            overfitting_warning,
+            newly_persisted,
+            reason,
+        });
+    }
+
+    save_tactic_memory(home, profile, &memory)?;
+    let memory_after = memory.tactics.len();
+
+    Ok(SelfImproveReport {
+        run_id: persisted.report.run_id.clone(),
+        model,
+        snapshot,
+        gate_accepted,
+        gate_rejected,
+        reviewed,
+        verified,
+        kept,
+        rolled_back,
+        overfitting_warnings,
+        holdout_reach_before_pct,
+        holdout_reach_after_pct: running_holdout.reach_pct,
+        memory_before,
+        memory_after,
+        note: "offline scaffold (mock oracle), IDEALIZED effect model — the held-out grade is \
+               synthesised from the same oracle, so keep/rollback demonstrates the loop's \
+               control flow, not empirical generalisation. Real held-out verification (a live \
+               model + `coin verify`) needs the Phase-3 VM (issue #2823). LOCAL-ONLY: nothing \
+               submitted externally."
+            .to_string(),
+    })
+}
+
+fn now_unix_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}

--- a/src/coin_gym/mod.rs
+++ b/src/coin_gym/mod.rs
@@ -15,12 +15,14 @@
 //! overfitting-reviewer gate, profiles, and the
 //! `coin-gym run|score|compare|improve|profiles` CLI. The whole pipeline runs
 //! offline against a mock oracle so it is exercised without a VM. Live grading
-//! (Phase 3 VM) and the live self-improvement loop with verify/rollback
-//! (Phase 5) remain follow-ups on issue #2713.
+//! (Phase 3 VM) remains a follow-up on issue #2823; the live self-improvement
+//! loop with verify/rollback (Phase 5, issue #2825) is implemented offline in
+//! [`improve_loop`] behind `coin-gym improve --holdout fresh`.
 
 pub mod agent_runner;
 pub mod executor;
 pub mod improve;
+pub mod improve_loop;
 pub mod leaderboard;
 pub mod profiles;
 pub mod scorer;
@@ -35,6 +37,8 @@ mod tests_cli;
 mod tests_executor;
 #[cfg(test)]
 mod tests_improve;
+#[cfg(test)]
+mod tests_improve_loop;
 #[cfg(test)]
 mod tests_leaderboard;
 #[cfg(test)]
@@ -55,6 +59,7 @@ use executor::{
     CoinEvaluateExecutor, EvaluateSource, LOCAL_ONLY, MockHarnessExecutor,
 };
 use improve::analyze_and_review;
+use improve_loop::{SelfImproveReport, run_self_improvement};
 use leaderboard::compare_to_leaderboard;
 use profiles::{PersistedRun, default_home, ensure_profile, list_profiles, load_run, save_run};
 use scorer::{Score, score_run};
@@ -70,14 +75,16 @@ pub fn coin_gym_usage() -> &'static str {
      \x20 run <model> [--strategy baseline|team] [--profile <name>] [--targets <path>]\n\
      \x20 score <run-id> [--profile <name>]\n\
      \x20 compare <run-id> [--profile <name>]\n\
-     \x20 improve <run-id> [--profile <name>]\n\
+     \x20 improve <run-id> [--profile <name>] [--holdout fresh]\n\
      \x20 contract [--dataset <repo>] [--revision <tag>] [--split a,b] [--project x,y] [--source rebuild|image]\n\
      \x20 profiles\n\
      \n\
      Offline scaffold (Phase 4): runs grade against a mock oracle. Live grading\n\
-     needs `coin evaluate` on a Docker host (Phase 3); the self-improvement\n\
-     verify/rollback loop is Phase 5. `contract` prints the real coin\n\
-     evaluate/verify wiring without running anything (LOCAL-ONLY). See\n\
+     needs `coin evaluate` on a Docker host (Phase 3, issue #2823). `improve\n\
+     --holdout fresh` runs the Phase-5 self-improvement loop (failure-analyst →\n\
+     overfitting gate → verify on held-out fresh → keep/rollback + durable tactic\n\
+     memory) offline. `contract` prints the real coin evaluate/verify wiring\n\
+     without running anything (LOCAL-ONLY). See\n\
      docs/howto/run-the-coin-gym-harness.md."
 }
 
@@ -175,6 +182,7 @@ fn cmd_run(home: &Path, rest: &[String]) -> CoinGymResult<()> {
     let persisted = PersistedRun {
         report: report.clone(),
         targets: scenario.targets.clone(),
+        offline: scenario.offline_scaffold(),
     };
     let path = save_run(home, &profile_name, &persisted)?;
     let score = score_run(&report);
@@ -312,10 +320,26 @@ fn cmd_compare(home: &Path, rest: &[String]) -> CoinGymResult<()> {
 // ── improve ──────────────────────────────────────────────────────────────────
 
 fn cmd_improve(home: &Path, rest: &[String]) -> CoinGymResult<()> {
-    let parsed = parse_args(rest, &["profile"])?;
+    let parsed = parse_args(rest, &["profile", "holdout"])?;
     let run_id = require_run_id(&parsed, "improve")?;
     let profile = sanitized_profile(&parsed);
     let persisted = load_run(home, profile.as_deref(), &run_id)?;
+
+    if let Some(holdout) = parsed.flags.get("holdout") {
+        if holdout != "fresh" {
+            return Err(CoinGymError::Usage(format!(
+                "improve --holdout only supports 'fresh' (got '{holdout}')"
+            )));
+        }
+        // Tactic memory is banked under a concrete profile: the explicit
+        // `--profile`, else the run's model-derived default (matching `run`).
+        let mem_profile =
+            profile.unwrap_or_else(|| profiles::sanitize_name(&persisted.report.model));
+        let report = run_self_improvement(home, &mem_profile, &persisted)?;
+        print_self_improve(&mem_profile, &report);
+        return Ok(());
+    }
+
     let report = analyze_and_review(&persisted.report, &persisted.targets);
     println!("run-id:   {run_id}");
     println!("analyzed: {} unreached target(s)", report.analyzed);
@@ -334,6 +358,42 @@ fn cmd_improve(home: &Path, rest: &[String]) -> CoinGymResult<()> {
     }
     println!("note: {}", report.note);
     Ok(())
+}
+
+/// Render a live self-improvement (`improve --holdout fresh`) report.
+fn print_self_improve(profile: &str, report: &SelfImproveReport) {
+    println!("run-id:   {}", report.run_id);
+    println!("model:    {}", report.model);
+    println!("profile:  {profile}");
+    println!(
+        "gate:     {} accepted  {} rejected",
+        report.gate_accepted, report.gate_rejected
+    );
+    println!(
+        "holdout:  reach {:.1}% → {:.1}%   (kept {}, rolled back {}, train/held-out-gap warnings {})",
+        report.holdout_reach_before_pct,
+        report.holdout_reach_after_pct,
+        report.kept,
+        report.rolled_back,
+        report.overfitting_warnings
+    );
+    println!(
+        "memory:   {} → {} durable tactic(s)",
+        report.memory_before, report.memory_after
+    );
+    for v in &report.verified {
+        println!(
+            "  [{}] {} ({}) — {}",
+            v.decision.label(),
+            v.source_target_id,
+            v.category,
+            v.reason
+        );
+        if let Some(w) = &v.overfitting_warning {
+            println!("        ⚠ train/held-out gap: {w}");
+        }
+    }
+    println!("note: {}", report.note);
 }
 
 // ── contract ─────────────────────────────────────────────────────────────────

--- a/src/coin_gym/profiles.rs
+++ b/src/coin_gym/profiles.rs
@@ -19,7 +19,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-use super::target_loader::TargetSet;
+use super::target_loader::{OfflineScaffold, TargetSet};
 use super::types::{CoinGymError, CoinGymResult, RunReport};
 
 /// Default (relative) home when `COIN_GYM_HOME` is unset.
@@ -49,6 +49,13 @@ pub struct PersistedRun {
     pub report: RunReport,
     /// The target set the run was evaluated against.
     pub targets: TargetSet,
+    /// The offline mock context (oracle + base script) that graded this run,
+    /// persisted so the offline self-improvement loop (`improve --holdout
+    /// fresh`) can re-grade held-out fresh targets without the manifest. Empty
+    /// (and omitted) for real (`coin verify`-graded) runs. `#[serde(default)]`
+    /// keeps runs written before this field was added loadable.
+    #[serde(default, skip_serializing_if = "OfflineScaffold::is_empty")]
+    pub offline: OfflineScaffold,
 }
 
 /// Directory for a named profile under `home`.

--- a/src/coin_gym/target_loader.rs
+++ b/src/coin_gym/target_loader.rs
@@ -207,6 +207,89 @@ impl DemoScenario {
             .map_err(|e| CoinGymError::Io(format!("read {}: {e}", path.display())))?;
         Self::from_manifest(&raw)
     }
+
+    /// The serialisable offline mock context (oracle + script) this scenario
+    /// grades against, so a persisted run stays self-contained for the offline
+    /// self-improvement loop (`improve --holdout fresh`). This is **mock
+    /// ground-truth only** (a test double); real runs get their verdicts from
+    /// `coin verify`, never from a stored oracle.
+    #[must_use]
+    pub fn offline_scaffold(&self) -> OfflineScaffold {
+        let script = self
+            .script
+            .iter()
+            .map(|(id, c)| {
+                (
+                    id.clone(),
+                    OfflineScriptEntry {
+                        input: c.input.clone(),
+                        confidence: c.confidence,
+                        rationale: c.rationale.clone(),
+                    },
+                )
+            })
+            .collect();
+        OfflineScaffold {
+            oracle: self.oracle.clone(),
+            script,
+        }
+    }
+}
+
+/// The offline mock context (oracle + scripted candidates) that graded an
+/// offline scaffold run. Persisted alongside a run so the offline
+/// self-improvement loop can re-grade held-out fresh targets and reconstruct the
+/// agent's base candidates without re-reading the manifest. **Mock ground-truth
+/// only**: empty for real (`coin verify`-graded) runs.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct OfflineScaffold {
+    /// Ground-truth reaching input per target id (the mock oracle).
+    #[serde(default)]
+    pub oracle: HashMap<String, String>,
+    /// The agent's base scripted candidate per target id.
+    #[serde(default)]
+    pub script: HashMap<String, OfflineScriptEntry>,
+}
+
+impl OfflineScaffold {
+    /// Whether this scaffold carries no mock context (a real run, or an empty
+    /// scenario). The self-improvement loop refuses to run on such a run.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.oracle.is_empty() && self.script.is_empty()
+    }
+
+    /// Reconstruct the base scripted candidates as a `target_id -> Candidate`
+    /// map (the reasoner's script), so the loop can replay the agent offline.
+    #[must_use]
+    pub fn base_candidates(&self) -> HashMap<String, Candidate> {
+        self.script
+            .iter()
+            .map(|(id, e)| {
+                (
+                    id.clone(),
+                    Candidate {
+                        input: e.input.clone(),
+                        confidence: e.confidence,
+                        rationale: e.rationale.clone(),
+                    },
+                )
+            })
+            .collect()
+    }
+}
+
+/// A serialisable scripted candidate (the persistable twin of
+/// [`Candidate`], which is intentionally not `serde`-derived).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct OfflineScriptEntry {
+    /// The candidate input (placeholder UTF-8 in the scaffold).
+    pub input: String,
+    /// The agent's self-reported confidence in `0.0..=1.0`.
+    pub confidence: f64,
+    /// Free-text rationale.
+    #[serde(default)]
+    pub rationale: String,
 }
 
 // ── Real COIN dataset schema (Hugging Face rows) ─────────────────────────────

--- a/src/coin_gym/tests_cli.rs
+++ b/src/coin_gym/tests_cli.rs
@@ -70,6 +70,7 @@ fn score_compare_improve_load_a_saved_run() {
         &PersistedRun {
             report: report.clone(),
             targets: scenario.targets.clone(),
+            offline: scenario.offline_scaffold(),
         },
     )
     .unwrap();
@@ -279,4 +280,78 @@ fn contract_rejects_unknown_source() {
     let dir = tempfile::tempdir().unwrap();
     let err = dispatch_with_home(dir.path(), args(&["contract", "--source", "magic"])).unwrap_err();
     assert!(err.to_string().contains("unknown --source"));
+}
+
+/// The Phase-5 loop fixture (decoder+crypto generalise; generic overfits).
+const LOOP_SNAPSHOT: &str = include_str!("fixtures/improve_loop_snapshot.json");
+
+/// The single run-id under a profile's runs directory.
+fn only_run_id(home: &std::path::Path, profile: &str) -> String {
+    let runs = runs_dir(home, profile);
+    let mut ids: Vec<String> = std::fs::read_dir(&runs)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .map(|e| e.path().file_stem().unwrap().to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(ids.len(), 1, "expected exactly one run under {profile}");
+    ids.pop().unwrap()
+}
+
+#[test]
+fn improve_holdout_fresh_runs_full_cycle_via_cli() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let manifest = write_manifest(home, "loop.json", LOOP_SNAPSHOT);
+
+    // A baseline run persists the offline scaffold (oracle + script) the loop needs.
+    dispatch_with_home(
+        home,
+        args(&["run", "m", "--targets", &manifest, "--profile", "loop"]),
+    )
+    .unwrap();
+    let run_id = only_run_id(home, "loop");
+
+    // The live self-improvement cycle runs end-to-end and banks durable tactics.
+    dispatch_with_home(
+        home,
+        args(&[
+            "improve",
+            &run_id,
+            "--profile",
+            "loop",
+            "--holdout",
+            "fresh",
+        ]),
+    )
+    .unwrap();
+
+    let tactics = super::improve_loop::load_tactic_memory(home, "loop").unwrap();
+    assert_eq!(tactics.tactics.len(), 2, "decoder + crypto tactics banked");
+}
+
+#[test]
+fn improve_holdout_rejects_unknown_mode() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let manifest = write_manifest(home, "loop.json", LOOP_SNAPSHOT);
+    dispatch_with_home(
+        home,
+        args(&["run", "m", "--targets", &manifest, "--profile", "loop"]),
+    )
+    .unwrap();
+    let run_id = only_run_id(home, "loop");
+    let err = dispatch_with_home(
+        home,
+        args(&[
+            "improve",
+            &run_id,
+            "--profile",
+            "loop",
+            "--holdout",
+            "stale",
+        ]),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("only supports 'fresh'"));
 }

--- a/src/coin_gym/tests_improve_loop.rs
+++ b/src/coin_gym/tests_improve_loop.rs
@@ -1,0 +1,202 @@
+use super::execute_run;
+use super::improve_loop::{
+    SliceMeasurement, TacticDecision, improves_holdout, load_tactic_memory, run_self_improvement,
+    save_tactic_memory,
+};
+use super::profiles::PersistedRun;
+use super::target_loader::{DemoScenario, OfflineScaffold, TargetSet};
+use super::types::Strategy;
+
+/// The Phase-5 loop fixture: pinned decoder+crypto+generic failures; held-out
+/// fresh covers decoder+crypto but NOT generic.
+const LOOP_SNAPSHOT: &str = include_str!("fixtures/improve_loop_snapshot.json");
+
+fn approx(a: f64, b: f64) -> bool {
+    (a - b).abs() < 1e-6
+}
+
+/// Build a persisted offline scaffold run (baseline on pinned) from the loop
+/// fixture, ready for `run_self_improvement`.
+fn persisted_loop_run() -> PersistedRun {
+    let scenario = DemoScenario::from_manifest(LOOP_SNAPSHOT).unwrap();
+    let report = execute_run("claude-opus-4.6", Strategy::Baseline, &scenario).unwrap();
+    PersistedRun {
+        report,
+        targets: scenario.targets.clone(),
+        offline: scenario.offline_scaffold(),
+    }
+}
+
+#[test]
+fn full_cycle_keeps_generalising_and_rolls_back_overfit() {
+    let home = tempfile::tempdir().unwrap();
+    let persisted = persisted_loop_run();
+
+    let report = run_self_improvement(home.path(), "loop", &persisted).unwrap();
+
+    // All three analyst tactics are general → accepted by the gate.
+    assert_eq!(report.gate_accepted, 3);
+    assert_eq!(report.gate_rejected, 0);
+
+    // Decoder + crypto generalise to held-out fresh → kept; generic does not.
+    assert_eq!(report.kept, 2, "decoder + crypto tactics generalise");
+    assert_eq!(report.rolled_back, 1, "generic tactic rolls back");
+    assert_eq!(report.overfitting_warnings, 1);
+
+    // Held-out reach lifts from 0% (fresh lines unsolved) to 100% after banking.
+    assert!(approx(report.holdout_reach_before_pct, 0.0));
+    assert!(approx(report.holdout_reach_after_pct, 100.0));
+
+    // Durable memory grows by the two kept tactics.
+    assert_eq!(report.memory_before, 0);
+    assert_eq!(report.memory_after, 2);
+
+    // Per-tactic decisions.
+    let dec = report
+        .verified
+        .iter()
+        .find(|v| v.source_target_id == "dec-a")
+        .unwrap();
+    assert_eq!(dec.decision, TacticDecision::Keep);
+    assert_eq!(dec.category, "format-gated-decoder");
+    assert!(dec.newly_persisted);
+    assert!(dec.overfitting_warning.is_none());
+
+    let cry = report
+        .verified
+        .iter()
+        .find(|v| v.source_target_id == "cry-a")
+        .unwrap();
+    assert_eq!(cry.decision, TacticDecision::Keep);
+    assert_eq!(cry.category, "crypto-state-machine");
+
+    let generic = report
+        .verified
+        .iter()
+        .find(|v| v.source_target_id == "gen-a")
+        .unwrap();
+    assert_eq!(generic.decision, TacticDecision::Rollback);
+    assert_eq!(generic.category, "generic");
+    assert!(!generic.newly_persisted);
+    // The train/held-out gap fires the "overfitting-warning", worded honestly as
+    // a coverage gap (UNPROVEN) rather than a definitive overfit claim.
+    let warning = generic.overfitting_warning.as_ref().unwrap();
+    assert!(warning.contains("GAP"), "warning: {warning}");
+    assert!(warning.contains("UNPROVEN"), "warning: {warning}");
+    assert!(generic.train_after.reached > generic.train_before.reached);
+    assert_eq!(
+        generic.holdout_after.reached,
+        generic.holdout_before.reached
+    );
+}
+
+#[test]
+fn kept_tactics_persist_to_memory_and_are_reused_next_run() {
+    let home = tempfile::tempdir().unwrap();
+    let persisted = persisted_loop_run();
+
+    // First cycle banks decoder + crypto.
+    let first = run_self_improvement(home.path(), "loop", &persisted).unwrap();
+    assert_eq!(first.kept, 2);
+
+    // The tactics are on disk, keyed by general family (never per project/target).
+    let memory = load_tactic_memory(home.path(), "loop").unwrap();
+    assert_eq!(memory.tactics.len(), 2);
+    let families: Vec<&str> = memory.tactics.iter().map(|t| t.category.as_str()).collect();
+    assert!(families.contains(&"format-gated-decoder"));
+    assert!(families.contains(&"crypto-state-machine"));
+    assert!(
+        !families
+            .iter()
+            .any(|f| f.contains("acme") || f.contains("delta"))
+    );
+
+    // Second cycle reuses them: the held-out baseline already reaches 100%, so
+    // nothing new is banked and memory does not double-count.
+    let second = run_self_improvement(home.path(), "loop", &persisted).unwrap();
+    assert_eq!(second.memory_before, 2, "prior cycle's tactics are loaded");
+    assert!(
+        approx(second.holdout_reach_before_pct, 100.0),
+        "reused wins"
+    );
+    assert_eq!(second.kept, 0, "no new tactics banked on the reuse run");
+    assert_eq!(second.memory_after, 2, "memory is not double-banked");
+}
+
+#[test]
+fn improves_holdout_requires_reach_up_and_no_precision_drop() {
+    let m = |reached, submitted, total, reach, precision| SliceMeasurement {
+        reached,
+        submitted,
+        total,
+        reach_pct: reach,
+        precision_pct: precision,
+    };
+
+    // reach up, precision steady → keep.
+    assert!(improves_holdout(
+        &m(1, 1, 4, 25.0, 100.0),
+        &m(2, 2, 4, 50.0, 100.0)
+    ));
+
+    // reach up but precision drops (added a wrong submission) → roll back.
+    assert!(!improves_holdout(
+        &m(2, 2, 4, 50.0, 100.0),
+        &m(3, 6, 4, 75.0, 50.0)
+    ));
+
+    // reach flat → roll back.
+    assert!(!improves_holdout(
+        &m(2, 2, 4, 50.0, 100.0),
+        &m(2, 3, 4, 50.0, 66.7)
+    ));
+}
+
+#[test]
+fn rejects_real_run_without_offline_scaffold() {
+    let home = tempfile::tempdir().unwrap();
+    let scenario = DemoScenario::from_manifest(LOOP_SNAPSHOT).unwrap();
+    let report = execute_run("m", Strategy::Baseline, &scenario).unwrap();
+    // A run with no persisted mock context (as a real `coin verify` run would be).
+    let persisted = PersistedRun {
+        report,
+        targets: scenario.targets.clone(),
+        offline: OfflineScaffold::default(),
+    };
+    let err = run_self_improvement(home.path(), "loop", &persisted).unwrap_err();
+    assert!(err.to_string().contains("OFFLINE SCAFFOLD"));
+}
+
+#[test]
+fn rejects_run_without_a_held_out_slice() {
+    let home = tempfile::tempdir().unwrap();
+    let mut scenario = DemoScenario::from_manifest(LOOP_SNAPSHOT).unwrap();
+    // Drop the held-out slice: there is nothing fresh to verify against.
+    scenario.targets = TargetSet {
+        snapshot: scenario.targets.snapshot.clone(),
+        pinned: scenario.targets.pinned.clone(),
+        held_out_fresh: Vec::new(),
+    };
+    let report = execute_run("m", Strategy::Baseline, &scenario).unwrap();
+    let persisted = PersistedRun {
+        report,
+        targets: scenario.targets.clone(),
+        offline: scenario.offline_scaffold(),
+    };
+    let err = run_self_improvement(home.path(), "loop", &persisted).unwrap_err();
+    assert!(err.to_string().contains("held-out fresh slice"));
+}
+
+#[test]
+fn tactic_memory_round_trips_on_disk() {
+    let home = tempfile::tempdir().unwrap();
+    let persisted = persisted_loop_run();
+    let report = run_self_improvement(home.path(), "loop", &persisted).unwrap();
+    assert_eq!(report.memory_after, 2);
+
+    let loaded = load_tactic_memory(home.path(), "loop").unwrap();
+    // Re-save then reload is stable.
+    save_tactic_memory(home.path(), "loop", &loaded).unwrap();
+    let reloaded = load_tactic_memory(home.path(), "loop").unwrap();
+    assert_eq!(loaded, reloaded);
+}

--- a/src/coin_gym/tests_profiles.rs
+++ b/src/coin_gym/tests_profiles.rs
@@ -21,6 +21,7 @@ fn persisted(run_id: &str) -> PersistedRun {
             pinned: Vec::new(),
             held_out_fresh: Vec::new(),
         },
+        offline: super::target_loader::OfflineScaffold::default(),
     }
 }
 

--- a/tests/gadugi/coin-gym-self-improve.sh
+++ b/tests/gadugi/coin-gym-self-improve.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Outside-in gadugi scenario for the COIN Gym **Phase-5 self-improvement loop**
+# (`coin-gym improve --holdout fresh`, issue #2825).
+#
+# GUARANTEES UNDER TEST (all offline; no VM, no Docker, no network):
+#   1. A `run` against the bundled improve-loop snapshot persists the offline
+#      scaffold (mock oracle + script) that the live loop needs.
+#   2. `improve --holdout fresh` runs a full cycle: failure-analyst →
+#      overfitting-reviewer gate → apply → verify on held-out fresh targets →
+#      keep-or-roll-back.
+#   3. Tactics that GENERALISE to held-out fresh targets (a format-gated decoder
+#      and a crypto state machine) are KEPT and banked; a tactic that lifts only
+#      TRAINING reach (generic guard, no held-out member) is ROLLED BACK with an
+#      overfitting-warning (train/held-out gap).
+#   4. Kept tactics are persisted to durable memory keyed by GENERAL FAMILY
+#      (never per project/target), and are REUSED on a second cycle (no
+#      double-banking; held-out baseline already at 100%).
+#   5. `--holdout` only accepts `fresh`.
+#
+# Hermetic: COIN_GYM_HOME is a throwaway temp dir; nothing touches the real
+# ~/.simard state or the network.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+HOME_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$HOME_DIR"; }
+trap cleanup EXIT
+export COIN_GYM_HOME="$HOME_DIR"
+
+FIXTURE="src/coin_gym/fixtures/improve_loop_snapshot.json"
+run_gym() { cargo run --quiet --bin coin-gym -- "$@"; }
+
+# --- 1. run persists the offline scaffold the loop verifies against -----------
+RUN_OUT="$(run_gym run "Claude Opus 4.6" --targets "$FIXTURE" --profile loop)"
+printf '%s\n' "$RUN_OUT"
+printf '%s\n' "$RUN_OUT" | grep -F "OFFLINE SCAFFOLD" >/dev/null
+RUN_ID="$(printf '%s\n' "$RUN_OUT" | awk '/^run-id:/ { print $2; exit }')"
+test -n "$RUN_ID"
+# The persisted run carries the mock oracle + script (needed for held-out grading).
+test -f "$HOME_DIR/profiles/loop/runs/$RUN_ID.json"
+grep -F '"offline"' "$HOME_DIR/profiles/loop/runs/$RUN_ID.json" >/dev/null
+
+# --- 2/3. cycle 1: keep generalising tactics, roll back the overfit one --------
+CYCLE1="$(run_gym improve "$RUN_ID" --profile loop --holdout fresh)"
+printf '%s\n' "$CYCLE1"
+printf '%s\n' "$CYCLE1" | grep -F "3 accepted" >/dev/null
+printf '%s\n' "$CYCLE1" | grep -F "0 rejected" >/dev/null
+printf '%s\n' "$CYCLE1" | grep -F "kept 2, rolled back 1, train/held-out-gap warnings 1" >/dev/null
+printf '%s\n' "$CYCLE1" | grep -F "2 durable tactic(s)" >/dev/null
+printf '%s\n' "$CYCLE1" | grep -F "[KEEP] dec-a (format-gated-decoder)" >/dev/null
+printf '%s\n' "$CYCLE1" | grep -F "[KEEP] cry-a (crypto-state-machine)" >/dev/null
+printf '%s\n' "$CYCLE1" | grep -F "[ROLLBACK] gen-a (generic)" >/dev/null
+printf '%s\n' "$CYCLE1" | grep -F "train/held-out gap:" >/dev/null
+
+# --- 4. durable memory: banked by general family, never per project/target -----
+TACTICS="$HOME_DIR/profiles/loop/tactics.json"
+test -f "$TACTICS"
+COUNT="$(grep -c '"category"' "$TACTICS")"
+test "$COUNT" -eq 2
+grep -F '"format-gated-decoder"' "$TACTICS" >/dev/null
+grep -F '"crypto-state-machine"' "$TACTICS" >/dev/null
+# The general (rolled-back) tactic must NOT have been banked.
+if grep -F '"generic"' "$TACTICS" >/dev/null; then
+  echo "ERROR: rolled-back generic tactic was banked to durable memory" >&2
+  exit 1
+fi
+
+# --- 4 (cont). cycle 2 reuses banked tactics without double-banking ------------
+CYCLE2="$(run_gym improve "$RUN_ID" --profile loop --holdout fresh)"
+printf '%s\n' "$CYCLE2"
+printf '%s\n' "$CYCLE2" | grep -F "kept 0, rolled back 3" >/dev/null
+printf '%s\n' "$CYCLE2" | grep -F "already in durable memory (reused)" >/dev/null
+# Memory did not grow.
+COUNT2="$(grep -c '"category"' "$TACTICS")"
+test "$COUNT2" -eq 2
+
+# --- 5. --holdout only accepts 'fresh' ----------------------------------------
+if run_gym improve "$RUN_ID" --profile loop --holdout stale >/tmp/coin-gym-holdout.out 2>&1; then
+  echo "ERROR: --holdout stale should have failed" >&2
+  exit 1
+fi
+grep -F "only supports 'fresh'" /tmp/coin-gym-holdout.out >/dev/null
+rm -f /tmp/coin-gym-holdout.out
+
+echo "coin-gym-self-improve gadugi scenario: PASS"

--- a/tests/gadugi/coin-gym-self-improve.yaml
+++ b/tests/gadugi/coin-gym-self-improve.yaml
@@ -1,0 +1,55 @@
+name: "COIN Gym Phase-5 self-improvement loop (#2825)"
+description: "Outside-in coverage for `coin-gym improve --holdout fresh`: a full self-improvement cycle (failure-analyst → overfitting-reviewer gate → apply → verify on held-out fresh targets → keep-or-roll-back). Tactics that generalise to held-out fresh targets are kept and banked to durable memory keyed by general family; a tactic that lifts only training reach is rolled back with an overfitting-warning; banked tactics are reused on a second cycle without double-banking. Hermetic and network-free; held-out grading uses a mock oracle (a real held-out grade is Phase 3, #2823)."
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "COIN Gym self-improvement loop end-to-end"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/coin-gym-self-improve.sh"
+    timeout: 300000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "behavior"
+    - "simard"
+    - "coin-gym"
+    - "self-improvement"
+    - "overfitting-gate"
+    - "held-out-verification"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Phase 5 — COIN Gym skwaq-style self-improvement loop

Closes #2825.

Adds the **live** half of the COIN Gym self-improvement loop behind
`coin-gym improve --holdout fresh`, composing the existing offline
failure-analyst + overfitting-reviewer gate (`src/coin_gym/improve.rs`) with
apply → verify-on-held-out-fresh → keep/rollback, durable tactic memory, and a
train/held-out-gap warning. Builds directly on the merged Phase-4 harness
(executor PR #3038; issues #2752/#2824/#3001 closed).

### Done-when (issue #2825)
- [x] `coin-gym improve --holdout fresh` runs ≥1 full cycle end-to-end.
- [x] The cycle **accepts or rolls back** a tactic based on **held-out** reach, and rolls back on regression (reach↓ or precision↓).
- [x] ≥1 accepted tactic is persisted to durable tactic memory (`<home>/profiles/<name>/tactics.json`) and reused on a subsequent run.
- [x] A train/held-out-gap warning (the issue's "overfitting-warning") fires when training reach lifts but held-out reach does not.
- [x] qa-team scenarios + docs land; six merge-ready gates below.

### Honesty / scope
Runs **offline against the mock oracle** (LOCAL-ONLY). The held-out grade is
synthesised from the same oracle — an **idealized family-wide effect model** — so
the loop demonstrates the *control flow* (analyse → gate → apply → measure
held-out → keep/rollback + memory), **not** empirical semantic generalisation. A
train/held-out gap is reported as **UNPROVEN** (a coverage gap), not a definitive
overfit verdict. A **real** `coin evaluate` score / leaderboard delta depends on
the parallel **Phase-3 azlin VM (#2823)**, which stays the critical path for the
final done-gate. (This framing was tightened after a rubber-duck design-honesty
review.)

### Baseline vs multi-agent-team measurement (first local delta artifact)
Produced via the `coin-gym` CLI against the current (mock) oracle on the bundled
sample:

| strategy | reach | precision | histogram |
|---|---|---|---|
| baseline (single model) | 60.0% (3/5) | 60.0% (3/5) | R:3/W:2/A:0/T:0/N:0/E:0 |
| team (multi-agent debate) | 60.0% (3/5) | **100.0%** (3/3) | R:3/W:0/A:2/T:0/N:0/E:0 |

**Delta baseline→team: precision +40.0 pts at equal reach** — the team's
skeptic/synthesizer abstention gate declines the two low-confidence (wrong)
submissions instead of over-claiming. Offline/illustrative; a real delta needs
Phase-3. (Objective also asked to post this to the Signal self-notes channel
#2989; no Signal tooling is available in this environment, so the delta lives
here — #2989 remains the intended posting mechanism.)

### Phase-5 loop demo (bundled `improve_loop_snapshot.json`)
```
gate:     3 accepted  0 rejected
holdout:  reach 0.0% → 100.0%   (kept 2, rolled back 1, train/held-out-gap warnings 1)
memory:   0 → 2 durable tactic(s)
  [KEEP]     dec-a (format-gated-decoder) — held-out reach 0.0% → 50.0% …
  [KEEP]     cry-a (crypto-state-machine) — held-out reach 50.0% → 100.0% …
  [ROLLBACK] gen-a (generic) — train/held-out reach gap; rolled back as UNPROVEN
```
A second `improve --holdout fresh` reuses the banked tactics (`memory: 2 → 2`,
kept 0) — no double-banking, keyed by general family (never per project/target).

---

## Merge-ready criteria (with evidence)

### 1. qa-team scenarios (gadugi)
- New outside-in scenario `tests/gadugi/coin-gym-self-improve.{yaml,sh}`: run persists offline scaffold → full improve cycle → keep×2 / rollback×1 with gap warning → durable memory keyed by general family (asserts the rolled-back generic tactic is NOT banked) → reuse without double-banking → `--holdout` only accepts `fresh`.
- `gadugi-test validate -f tests/gadugi/coin-gym-self-improve.yaml` → `✓ is valid` (1 valid, 0 invalid).
- `gadugi-test run -d tests/gadugi -s coin-gym-self-improve` → `✓ Passed: 1  ✗ Failed: 0`.
- Existing `coin-gym-harness` scenario re-run → `✓ Passed: 1  ✗ Failed: 0` (no regression).

### 2. Docs
- `docs/howto/run-the-coin-gym-harness.md`: new `improve --holdout fresh` section (loop steps, durable tactic memory, honest idealized-effect callout, worked example), custom-snapshot note (needs `held_out_fresh` + covering `oracle`), and the deferred-work table (Phase 5 = implemented offline; Phase 3 = follow-up, #2823). Only user-facing surface is the `coin-gym` CLI, which is documented.

### 3. quality-audit (≥3 SEEK→VALIDATE→FIX cycles, clean final)
- **Cycle 1 — SEEK (self-review):** verified keep/rollback invariants (`keep ⟹ holdout_lifted ⟹ no warning`; `warning ⟹ rollback`); no baseline-threading off-by-one. No issues.
- **Cycle 2 — VALIDATE (independent code-review agent):** traced grading data flow, hand-verified keep/rollback + running-baseline threading + serde backward-compat + tactic-memory path-safety + panic paths, and ran the full `coin_gym` suite (112 passing). **No significant issues found.**
- **Cycle 3 — SEEK (rubber-duck design-honesty) → FIX:** flagged over-strong "generalisation"/"verify" wording as self-fulfilling under the oracle-driven effect model. **Fixed:** reframed to an idealized effect model in module docs/CLI note/howto; changed the overfit claim to a coverage-gap **UNPROVEN** verdict; fenced `improve --holdout fresh` to require `offline_scaffold` runs; de-duplicated the rollback reason vs. warning line. Re-validated clean.
- **Final cycle clean:** zero critical/high; zero medium correctness/security findings.

### 4. CI green (local)
- `cargo fmt --all -- --check` → clean.
- `cargo clippy --all-targets --all-features --locked -- -D warnings` → clean.
- `cargo test --lib coin_gym` → **112 passed; 0 failed** (104 pre-existing + 8 new).
- Pre-commit (rust-only gate, fmt, clippy-release) and pre-push (fmt, release test subset, full clippy) hooks passed on push.

### 5. PR description
- This description carries concrete evidence for criteria 1–4 and 6.

### 6. Focused diff
- Touches only `src/coin_gym/*` (module + bundled fixture), `docs/howto/run-the-coin-gym-harness.md`, and `tests/gadugi/coin-gym-self-improve.*`. No unrelated edits.

---

## Implementation notes
- New module `src/coin_gym/improve_loop.rs` (live loop + durable `TacticMemory`); reuses `improve.rs`'s analyst + overfitting gate.
- `PersistedRun` gains an `offline` field (mock oracle + script) so the loop is self-contained; backward-compatible via `#[serde(default, skip_serializing_if)]`.
- Tactic memory is keyed by **general family** (`format-gated-decoder` / `crypto-state-machine` / `generic`), never per project/target.

Depends-on (not blocking this PR, blocks the real done-gate): **#2823** (Phase-3 azlin VM) for a real `coin evaluate` score vs the mock oracle.
