### PR TITLE
feat(installer): `simard platform` rail + remove stale kuzu check + installer docs (#3119)

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: issue-2323-eliminate-the-private-gymeval-fork-in-simard-by-ad
+## Project: Simard
 
 ## Overview
 

--- a/docs/concepts/lbug-portability-libstdcxx-abi.md
+++ b/docs/concepts/lbug-portability-libstdcxx-abi.md
@@ -1,0 +1,208 @@
+---
+title: lbug portability across libstdc++ ABIs — the std::format SIGSEGV and its fix
+description: Root cause and fix for the cognitive-memory SIGSEGV seen on newer Linux hosts — a prebuilt lbug (LadybugDB) binary compiled against an older libstdc++ std::format ABI crashes in std::vformat during Database::initBufferManager when linked into a binary running on a host with a newer libstdc++. The fix forces lbug to build from source against the host toolchain, lands in amplihack-memory-lib, and is verified by the installer's ABI probe.
+last_updated: 2026-07-08
+review_schedule: as-needed
+owner: simard
+doc_type: concept
+related:
+  - ./platform-installer.md
+  - ../howto/run-the-installer-preflight-doctor.md
+  - ../howto/install-a-simard-family-agent.md
+  - ../reference/platform-installer-cli.md
+  - ../memory.md
+---
+
+# lbug portability across libstdc++ ABIs — the std::format SIGSEGV and its fix
+
+## Summary
+
+On host `dev` (Ubuntu 26.04 LTS, g++ 15.2.0, libstdc++ exposing
+`GLIBCXX_3.4.35`), the Simard/Crocutus binary **segfaulted during
+cognitive-memory initialization**. The same binary source runs cleanly on host
+`ia2` (Ubuntu 25.10, libstdc++ 3.4.34). The crash is a **C++ standard-library
+ABI mismatch**: a *prebuilt* lbug (LadybugDB) artifact compiled against an older
+libstdc++'s `std::format` machinery is loaded into a process running on a host
+with a **newer** libstdc++, and the two disagree about the `std::format` ABI.
+The fix is to stop consuming the prebuilt on such hosts and **build lbug from
+source against the host's own toolchain**, so there is exactly one libstdc++ ABI
+in play. The fix lands in **`amplihack-memory-lib`** (the engine library),
+Simard consumes it by bumping its pin, and the
+[platform installer](./platform-installer.md) verifies it with an ABI probe.
+
+## The observed crash
+
+Simard's persistent cognitive memory is the embedded **lbug** engine (LadybugDB,
+the `lbug = "=0.17.1"` crate), compiled and statically linked into the binary
+through `amplihack-memory-lib`'s `persistent` feature. Opening the store walks
+this path:
+
+```
+crocutus::main
+  └─ simard::…run_ooda_daemon
+       └─ LibraryCognitiveMemory::open
+            └─ amplihack_memory::graph::lbug_store::open_database
+                 └─ lbug::main::Database::initBufferManager
+                      └─ std::vformat / std::__format::__formatter_str   ← SIGSEGV
+```
+
+The fault is inside `std::vformat` — C++20 `std::format` — during buffer-manager
+initialization. It is deterministic on 26.04 and absent on 25.10.
+
+## Root cause: two libstdc++ ABIs in one process
+
+`std::format` was added in C++20 and its libstdc++ implementation details
+(the `std::__format` internals, formatter symbols, and the layout of the types
+passed through `std::vformat`) **changed across libstdc++ releases**. libstdc++
+tags these with `GLIBCXX_3.4.NN` version nodes; Ubuntu 25.10 ships `3.4.34` and
+26.04 ships `3.4.35`.
+
+The published `lbug` crate's `build.rs` **prefers a prebuilt binary artifact by
+default** (in static link mode) rather than compiling the C++ engine locally. It
+selects and caches one via a set of environment knobs, and — critically — honors
+a switch that forces a source build instead:
+
+| Env knob | Role |
+|----------|------|
+| `LBUG_BUILD_FROM_SOURCE` (alias `LBUG_RUST_BUILD_FROM_SOURCE`) | **The fix's lever.** When set, `build.rs` skips the prebuilt ("Skipping prebuilt liblbug because source build was requested") and falls through to the bundled cmake build. |
+| `LBUG_PRECOMPILED_RUN_ID` | Which prebuilt CI run to fetch |
+| `LBUG_VERSION` | Engine version/tag to resolve |
+| `LBUG_GITHUB_REPOSITORY` | Where prebuilts are published (default `LadybugDB/ladybug`) |
+| `LBUG_LINUX_VARIANT` | Which Linux/libstdc++ variant of the prebuilt to use |
+| `LBUG_LIB_KIND` | Static vs shared artifact |
+| `LBUG_SHARED` | Force the shared-library link mode |
+
+with the artifact cached under `PREBUILT_CACHE_DIR=".cache/lbug-prebuilt"`. The
+prebuilt download path applies only under static link mode; all of these knob
+names and the cache path are the crate's real behavior (verified against
+`lbug-0.17.1/build.rs`), not invented for this document.
+
+That prebuilt is compiled on **some** builder image, against **that image's**
+libstdc++. When it is linked into the agent binary and that binary runs on a host
+with a **newer** libstdc++ (26.04's `3.4.35`), the `std::format` code paths
+baked into the prebuilt no longer match the host's runtime `std::format` ABI.
+`Database::initBufferManager` uses `std::format` to build its diagnostic/format
+strings, reaches `std::vformat`, and dereferences a mismatched formatter layout —
+a segfault, not a clean error. On 25.10 the prebuilt's assumed ABI happens to
+match the host, so the same code path is fine.
+
+This is a classic **"do not mix C++ standard-library ABIs in one process"**
+failure. The trigger is `std::format` because that is the part of libstdc++ whose
+ABI moved between the two Ubuntu releases; the underlying rule is general.
+
+### "But newer libstdc++ is backward-compatible" — why that doesn't save you
+
+The obvious objection is that libstdc++ is backward-compatible, so an
+older-compiled artifact should run against a newer runtime. That guarantee is
+real but **narrow**: symbol versioning (`GLIBCXX_3.4.NN`) only protects
+*exported, versioned symbols*. `std::format` arrived in C++20 and much of its
+machinery is **header-only, inlined, and templated** — the `std::__format`
+formatter types and the argument-store layout are *instantiated into the
+prebuilt at its own compile time* against its own libstdc++ headers. Those
+instantiations are not exported symbols and are not covered by the backward-compat
+guarantee. When the host's libstdc++ changed the internal layout between `3.4.34`
+and `3.4.35`, the prebuilt's baked-in instantiations no longer agree with the
+host runtime, and the usual "just link against the newer lib" contract simply
+does not apply. That is precisely why detection-and-retry at the application
+layer cannot help — the mismatch is frozen into the binary at build time.
+
+### Why it presents as a hard SIGSEGV (not an error)
+
+A `dlopen`/link-time symbol-version mismatch on an *exported* symbol would fail
+loudly at load. Here the mismatch is in **inlined/templated `std::format`
+internals** that were resolved at the prebuilt's compile time against the older
+libstdc++ headers. Nothing checks them at runtime; the first call that relies on
+the changed layout corrupts or misreads memory and crashes. That is exactly why
+the installer cannot "catch and retry" this at the application layer — it has to
+prevent the mismatch from existing in the first place.
+
+## The fix: one toolchain, built from source
+
+The durable fix is to **build lbug from source against the host's toolchain**, so
+the engine is compiled with the same `g++`/libstdc++ the binary runs against.
+Then there is exactly one `std::format` ABI in the process and
+`initBufferManager` runs cleanly. Building from source is the **unconditional
+choice at deploy time** — not a per-host heuristic — so a fast-path prebuilt can
+never silently reintroduce the crash on the next new OS.
+
+Ownership is split cleanly, because of a hard Cargo ordering fact: Cargo runs a
+dependency's build script (`lbug`) **before** its dependent's
+(`amplihack-memory`), and `lbug` exposes no Cargo *feature* to force a source
+build — only the `LBUG_BUILD_FROM_SOURCE` environment variable. So
+`amplihack-memory` cannot flip the switch for `lbug` from its own build script.
+The fix is therefore realized in two coordinated places:
+
+- **`amplihack-memory-lib` owns the from-source *contract*.** Its
+  `rust/amplihack-memory/build.rs` (active only under the `persistent` feature)
+  emits a prominent `cargo:warning` at **every consumer build** when a prebuilt
+  lbug is being linked without `LBUG_BUILD_FROM_SOURCE` set — naming the SIGSEGV
+  and the remedy — so a prebuilt can never slip in silently. A dedicated CI job
+  (`lbug-from-source`) compiles lbug from source and **opens a real persistent
+  store**, proving `initBufferManager` initializes cleanly from source.
+  **Simard consumes this by bumping its `amplihack-memory` pin.** No
+  memory-engine logic is forked into Simard; the engine library remains the
+  single source of truth, per the de-fork rule recorded in `Cargo.toml`.
+- **The platform installer sets the variable where the binary is built.** The
+  installer's build phase exports `LBUG_BUILD_FROM_SOURCE=1`
+  (`scripts/install.sh`, `installer_build_env`) and its preflight doctor
+  provisions the native toolchain the source build needs, so the *produced
+  daemon binary* never contains a mismatched prebuilt.
+
+Building from source is why the platform installer's
+[preflight doctor](../howto/run-the-installer-preflight-doctor.md) insists on the
+native build toolchain (`build-essential`, `cmake`, `clang`, `pkg-config`,
+`libssl-dev`) — those are the inputs the from-source lbug build needs.
+
+### Why not "just pick a matching prebuilt"?
+
+Selecting a prebuilt `LBUG_LINUX_VARIANT` that matches the host's libstdc++ is a
+*conceivable* remediation, but it is brittle: it requires a published variant for
+every host libstdc++ the fleet will ever run on, and it fails closed with no
+recourse the day a host ships a libstdc++ newer than any published variant
+(exactly the 26.04 situation). Building from source needs only the toolchain the
+installer already provisions, and it is correct for **any** host libstdc++,
+including future ones. Source-build is therefore the unconditional fix; a
+variant-match is at best a non-relied-upon fallback.
+
+## How the installer guarantees a working store on both 25.10 and 26.04
+
+The [platform installer](./platform-installer.md) makes the guarantee concrete:
+
+1. **Detect.** The preflight doctor reads the host's libstdc++ version
+   (`GLIBCXX_3.4.NN`) and confirms the source-build toolchain is present. Its
+   `lbug-source` check **verifies the from-source prerequisites** and informs the
+   operator; it does not choose prebuilt-vs-source (source is unconditional).
+2. **Prevent.** The build phase compiles lbug from source against the host
+   toolchain — the installer exports `LBUG_BUILD_FROM_SOURCE=1` (and
+   `amplihack-memory-lib`'s guard warns if it were ever missing). There is no
+   prebuilt in the process to mismatch.
+3. **Verify.** After start, the installer confirms cognitive memory **opened**
+   (a positive store-opened / first-OODA-cycle log marker) with no
+   `initBufferManager`/`std::vformat` SIGSEGV and a stable PID. If the store
+   still cannot open cleanly, the install fails closed at the verify phase with
+   the ABI diagnosis rather than shipping a crash-loop.
+
+The net result: a **working cognitive-memory store on both Ubuntu 25.10 and
+26.04** from the same install command.
+
+## Boundaries and ownership
+
+- **Engine/portability *contract* → `amplihack-memory-lib`.** The persistent
+  build guard (`build.rs`), the from-source ABI proof CI job, and the root-cause
+  documentation live in the memory library. It cannot flip lbug's build mode
+  itself (Cargo build-script ordering + no lbug feature), so it makes the
+  requirement loud and proves the from-source path.
+- **Simard → pin bump only.** Simard changes its `amplihack-memory` revision to
+  pull the guard/proof. Nothing about lbug is duplicated in Simard.
+- **Installer → set the variable, provision the toolchain, and verify.** The
+  installer exports `LBUG_BUILD_FROM_SOURCE=1` for the deployment build,
+  provisions the native toolchain the from-source build needs, and *proves* the
+  store opens cleanly on the target host.
+
+## See also
+
+- [The Simard platform installer](./platform-installer.md) — how detect →
+  build-from-source → verify fits into the install phase machine.
+- [Run the preflight doctor](../howto/run-the-installer-preflight-doctor.md) —
+  the libstdc++/toolchain/ABI checks.
+- [Cognitive memory](../memory.md) — the embedded lbug store Simard depends on.

--- a/docs/concepts/lbug-portability-libstdcxx-abi.md
+++ b/docs/concepts/lbug-portability-libstdcxx-abi.md
@@ -185,6 +185,29 @@ The [platform installer](./platform-installer.md) makes the guarantee concrete:
 The net result: a **working cognitive-memory store on both Ubuntu 25.10 and
 26.04** from the same install command.
 
+## Proven end-to-end on host `dev` (Ubuntu 26.04)
+
+The installer was run against the real target. The prebuilt binary's
+crash was reproduced (systemd journal: `status=11/SEGV` during startup), then a
+from-source rebuild produced a daemon whose cognitive memory **opens cleanly**
+(no `initBufferManager`/`std::vformat` SIGSEGV) and reaches **live OODA cycles**
+with a stable PID (`NRestarts=0`), side-by-side with the primary identity.
+
+Two *further* lbug 0.17.1 from-source defects surfaced during that run and are
+tracked in [amplihack-memory-lib#130](https://github.com/rysweet/amplihack-memory-lib/issues/130),
+each with a downstream workaround the installer now applies:
+
+1. **Duplicate-symbol link failure** — the from-source static build links its
+   bundled `utf8proc`/`antlr4` objects twice (inside `liblbug.a` and as separate
+   `--whole-archive` libs), so `LBUG_BUILD_FROM_SOURCE=1` alone does not link.
+   The installer adds `RUSTFLAGS=-Clink-arg=-Wl,--allow-multiple-definition`.
+2. **Post-verdict static-teardown SIGSEGV** — a clean from-source binary still
+   SIGSEGVs in C++ global-destructor teardown *after* returning success
+   (reproduces on prebuilt and from-source alike, so it is not the open-time ABI
+   bug). The read-only guardrail gate therefore keys on the explicit affirmative
+   verdict marker (fail-closed preserved) rather than the exit code alone, so a
+   post-verdict teardown crash cannot false-fail a proven-safe gate.
+
 ## Boundaries and ownership
 
 - **Engine/portability *contract* → `amplihack-memory-lib`.** The persistent

--- a/docs/concepts/platform-installer.md
+++ b/docs/concepts/platform-installer.md
@@ -1,0 +1,254 @@
+---
+title: The Simard platform installer — provision, install, prove, run
+description: Why and how a single idempotent, fail-closed installer stands up a Simard-family agent daemon (Simard, Crocutus, or a future identity) on a fresh host — detecting and preparing the OS toolchain and native deps, building a portable cognitive-memory store, materializing an isolated identity and systemd unit, proving guardrails, and verifying a live OODA cycle over local or azlin-remote targets.
+last_updated: 2026-07-08
+review_schedule: as-needed
+owner: simard
+doc_type: concept
+related:
+  - ./lbug-portability-libstdcxx-abi.md
+  - ./pluggable-identity.md
+  - ./reconcile-and-self-deploy.md
+  - ../howto/install-a-simard-family-agent.md
+  - ../howto/run-the-installer-preflight-doctor.md
+  - ../reference/platform-installer-cli.md
+  - ../tutorials/stand-up-a-read-only-observer.md
+---
+
+# The Simard platform installer — provision, install, prove, run
+
+## The problem
+
+Simard and its sibling identities (Crocutus today; more to come) are the *same*
+cognition — one OODA daemon, one cognitive-memory engine, one brain — run
+side-by-side as distinct identities. Building a second identity is deliberately
+"mostly configuration" (see [Pluggable identity](./pluggable-identity.md)). But
+*standing up* an identity's daemon on a **fresh host** was not mostly
+configuration. It was a sequence of manual, error-prone steps that a person had
+to get right in order, and one of them was a hard portability crash.
+
+The first real second-identity deployment — installing **Crocutus** (a
+read-only observer) on host `dev`, an Azure VM reached with `azlin connect dev`
+over Bastion — surfaced nine concrete points of friction. Every one of them is a
+requirement the installer now owns:
+
+1. **No Rust toolchain.** The fresh host had no `rustup`/`cargo`; they were
+   installed by hand.
+2. **Missing native build deps.** The build failed on missing `pkg-config` and
+   `libssl-dev` (and needs `build-essential`, `cmake`, `clang`); each was
+   `sudo apt install`-ed reactively as the build failed again.
+3. **No `amplihack` CLI.** Simard's OODA daemon runs an
+   [amplihack freshness gate](./amplihack-freshness-gate.md) and dispatches
+   amplihack recipes, so the `amplihack` CLI and its
+   `~/.amplihack/amplifier-bundle` must be present and synced.
+4. **A stale dependency check.** `simard ensure-deps` still probed for a Python
+   `kuzu` package. Simard's cognitive memory is **embedded lbug** (compiled and
+   linked into the binary via `amplihack-memory-lib`), not kuzu. The check was
+   misleading noise.
+5. **A hard portability crash.** On host `dev` (Ubuntu 26.04 LTS, libstdc++
+   `GLIBCXX_3.4.35`) the binary **segfaulted during cognitive-memory init** —
+   `LibraryCognitiveMemory::open` → `lbug::main::Database::initBufferManager` →
+   `std::vformat` SIGSEGV — while working fine on host `ia2` (Ubuntu 25.10,
+   libstdc++ 3.4.34). This is the centerpiece; see
+   [lbug portability](./lbug-portability-libstdcxx-abi.md).
+6. **Manual identity/isolation wiring.** `SIMARD_STATE_ROOT`, `SIMARD_IDENTITY`,
+   the prompt-asset dir, a distinct dashboard port, and a distinct systemd unit
+   name — all set by hand, with nothing stopping two identities from colliding.
+7. **Manual systemd wiring.** Installing the user unit, its fail-closed
+   `ExecStartPre` guardrail gate, `daemon-reload`/`enable`/`start`, and checking
+   for a stable PID rather than a crash-loop.
+8. **Manual credential wiring.** A read-only Azure DevOps token for a read-only
+   observer, with nothing enforcing least privilege or *failing closed* when a
+   required credential was absent.
+9. **Reaching the host.** This fleet uses [`azlin`](https://github.com/rysweet/azlin)
+   over Azure Bastion; the installer must work the same way remotely as it does
+   locally.
+
+The Crocutus exercise proved the framework works. It also proved that
+"provision → install → prove → run" was a tribal-knowledge ritual. The platform
+installer turns that ritual into **one reliable, idempotent, guardrailed
+operation**.
+
+## What the installer guarantees
+
+Given a **host**, an **identity config**, and **credentials**, the installer
+performs an install that is:
+
+- **Idempotent.** Re-running it converges to the same working state. It never
+  double-installs a toolchain, never clobbers an existing identity's state, and
+  is safe to run again after a partial failure.
+- **Fail-closed.** Every guardrail and every required credential is *proven*
+  before the daemon starts. Missing credential, unproven read-only floor, or a
+  cognitive-memory store that will not open cleanly are hard stops with a
+  precise, actionable error — never a silent fallback or a degraded run.
+- **Multi-identity safe.** It never collides with an existing identity's state
+  root, dashboard port, socket, or systemd unit name.
+- **Local or remote.** The same operation runs on the local host or against an
+  `azlin` target over Bastion.
+
+The install is not "done" when the unit is enabled. It is done when the
+installer has **verified a live OODA cycle**: cognitive memory opened without a
+SIGSEGV, the guardrail proof passed, and the daemon holds a **stable new PID**
+(not a crash-loop).
+
+## Where the installer lives, and why
+
+The installer's canonical home is the **Crocutus repository**, alongside the
+identity scaffold it already owns (`scripts/`, `config/`, `systemd/`,
+`identity/`). Crocutus is the natural multi-identity owner: it is a
+configuration-and-prompts identity built *on* Simard, and it already carries the
+working `install-on-dev.sh` shape (build → materialize env → prove guardrail →
+install unit).
+
+Simard core exposes a **thin `simard platform install` rail** (namespaced under
+`simard platform …` to avoid the pre-existing `simard install` binary-persist
+verb) that shells to the same logic. The rail is a convenience entry point, not a
+second source of truth — it keeps a fat installer out of the framework crate.
+Engine and portability work (the lbug fix) lives in **`amplihack-memory-lib`**,
+and Simard consumes it by bumping its dependency pin. This placement follows the
+project's standing rule:
+*prefer recipes, prompts, config, and thin rails over new code in the framework;
+memory/engine work belongs in the memory library.*
+
+```
+Crocutus repo (canonical)            Simard repo (thin)              amplihack-memory-lib (engine)
+─────────────────────────            ──────────────────              ─────────────────────────────
+scripts/install.sh    ◄────────────  `simard platform install` rail  lbug build-from-source mode
+scripts/doctor.sh     ◄────────────  `simard platform doctor` rail    (fixes the libstdc++ ABI crash)
+config/<identity>.env                (ensure-deps: kuzu check              ▲
+systemd/<identity>-ooda.service       removed)                            │ Simard bumps its pin
+identity/<identity>_system.md                                            │ to consume the fix
+```
+
+> **Verb note.** The rail is `simard platform install` / `simard platform
+> doctor`, *not* bare `simard install` — that verb already exists and persists
+> the current binary to `~/.simard/bin` (used by the `npx` wrapper). The platform
+> installer namespaces itself under `simard platform …` to avoid the collision.
+> See the [CLI reference](../reference/platform-installer-cli.md#entry-points).
+
+> **Scaffold status.** `scripts/install.sh` and `scripts/doctor.sh` are the
+> **target** shape. Today Crocutus ships `scripts/install-on-dev.sh`
+> (interactive, host-`dev`-specific, in-place overwrite, no idempotency /
+> `--upgrade` / `--uninstall`), plus `bootstrap-readonly.sh` and
+> `prove-guardrail.sh`. Reaching the target means generalizing the on-`dev`
+> script, extracting the preflight into `doctor.sh`, and adding idempotency,
+> remote/azlin support, upgrade/uninstall, and the atomic binary swap.
+
+## The install as a phase machine
+
+The installer is a small, ordered state machine. Each phase is independently
+idempotent and fails closed. The
+[CLI reference](../reference/platform-installer-cli.md) is the authoritative
+contract for each phase's inputs, outputs, and exit codes; the shape is:
+
+1. **Preflight (doctor).** Detect the host: OS and libstdc++ version, Rust
+   toolchain, native build deps, the `amplihack` CLI and bundle, free disk,
+   dashboard-port availability, systemd unit-name collisions, and the **lbug
+   source-build prerequisites**. Auto-remediate what is safe to remediate (install
+   the toolchain, `apt install` the native deps, install/sync `amplihack`) or stop
+   with an exact error. Preflight is also runnable on its own — see
+   [Run the preflight doctor](../howto/run-the-installer-preflight-doctor.md).
+2. **Build a portable binary.** Build the agent binary with a cognitive-memory
+   store compiled **from source** against the host toolchain — the installer's
+   build phase exports `LBUG_BUILD_FROM_SOURCE=1` (and `amplihack-memory-lib`'s
+   persistent-feature guard warns loudly if a prebuilt were ever linked without
+   it). There is no prebuilt lbug in the process to mismatch the host libstdc++,
+   which is why the SIGSEGV does not recur; see
+   [lbug portability](./lbug-portability-libstdcxx-abi.md).
+3. **Materialize the identity.** Create the **identity home** `~/.<identity>`
+   (holding `bin/<identity>` and `targets/`), the isolated state root
+   `~/.<identity>/state`, the materialized env file (with a distinct dashboard
+   port and identity name), the prompt-asset location, and the systemd **user**
+   unit under a distinct name — chosen so it cannot collide with any identity
+   already installed on the host.
+4. **Prove guardrails.** Run the identity's guardrail proof (for Crocutus, the
+   read-only floor at the capability layer *and* the absence of a write
+   credential at the credential layer). If the proof is uncertain, the install
+   stops here. The same proof is wired as the unit's `ExecStartPre` start-gate,
+   so the daemon also refuses to start later if the guardrail regresses.
+5. **Start the daemon.** `daemon-reload`, enable, and start the user unit.
+6. **Verify a live cycle.** Confirm a positive **store-opened / first-OODA-cycle
+   log marker**, no `initBufferManager`/`std::vformat` SIGSEGV, the guardrail gate
+   passed, and a **stable new PID** across at least one `RestartSec` window. A
+   crash-loop (PID flapping / unit sub-state `failed`) is a failed install, not a
+   warning.
+7. **Report.** Emit a durable, machine-readable summary of what was detected,
+   remediated, built, and verified.
+
+## Multi-identity isolation is structural, not advisory
+
+Two identities coexist on one host only if they never share mutable state. The
+installer enforces these independent isolation axes and refuses to proceed if any
+would collide with an already-installed identity:
+
+| Axis | Mechanism | Why it matters |
+|------|-----------|----------------|
+| **Identity home** | Distinct `~/.<identity>` (holds `bin/<identity>`, `targets/`, materialized env) | Binaries, target clones, and env for one identity never overlap another's. |
+| **State root** | Distinct `SIMARD_STATE_ROOT` (`~/.<identity>/state`) — a subtree of the identity home | The goal board and the cognitive-memory `flock` are per-identity; a shared root deadlocks or corrupts memory. |
+| **Dashboard port** | Distinct `SIMARD_DASHBOARD_PORT` | Two daemons cannot bind the same port. |
+| **Systemd unit** | Distinct `<identity>-ooda.service` user unit | `simard-ooda.service` and `crocutus-ooda.service` enable/start/stop independently. |
+| **Persona + creds** | Distinct `SIMARD_IDENTITY`, prompt root, and credential file | Personas and least-privilege credentials never cross. |
+
+Note the identity home (`~/.<identity>`) and the state root
+(`~/.<identity>/state`) are **distinct**: the binary lives at
+`~/.<identity>/bin/<identity>`, not under the state root. This is the same
+isolation Crocutus ships today, promoted from "set these environment variables by
+hand and hope" to "the installer allocates and verifies them, and refuses on
+collision."
+
+## Fail-closed, in depth
+
+The installer inherits Simard's defense-in-depth stance. It never runs a daemon
+it cannot prove is safe:
+
+- **A write-capable credential present → stop.** For a read-only identity, the
+  guardrail proof refuses to proceed if any write-capable token
+  (`AZURE_DEVOPS_EXT_PAT`, `SYSTEM_ACCESSTOKEN`, `ADO_WRITE_PAT`) is in the
+  environment. This is the real, enforced credential guardrail.
+- **A declared-required credential absent → stop.** If the identity config marks
+  a credential as required and it is absent, the install stops. (For a read-only
+  *observer* the read PAT is optional by default — absent, the observer degrades
+  to anonymous read or does nothing, fail-closed at runtime — so requiring it is
+  a per-identity choice, not an installer default.)
+- **Unproven guardrail → stop.** The guardrail proof must pass before start, and
+  it is *also* the unit's start-gate, so a later regression keeps the daemon
+  down rather than up-and-unsafe.
+- **Cognitive memory won't open cleanly → stop.** If the store cannot initialize
+  without a SIGSEGV on this host, the install fails at the build/verify phase
+  with the ABI diagnosis — it does not ship a daemon that crash-loops.
+
+There are no wall-clock timeouts on the agentic verification steps; the installer
+waits for a real live-cycle signal rather than guessing.
+
+## Upgrade and uninstall
+
+Upgrades reuse the [reconcile-and-self-deploy](./reconcile-and-self-deploy.md)
+discipline: stop the unit, swap the binary **atomically** (write-new-then-rename,
+which survives the held-inode problem of overwriting a running binary), restart,
+and re-verify a live cycle — rolling back on failure. Uninstall stops and
+disables the unit and removes the identity's state root and unit file, leaving
+other identities on the host untouched.
+
+## What this closes
+
+- The nine friction points above become one command.
+- The stale `kuzu` check is removed from `simard ensure-deps` (a small Simard
+  change) so dependency reporting tells the truth: memory is embedded lbug, not
+  kuzu. `ensure-deps` stays a minimal runtime check (`git`, `python3`, `gh`);
+  the heavier build/host preconditions belong to `simard platform doctor`. See
+  the [CLI reference](../reference/platform-installer-cli.md#simard-ensure-deps-and-the-removed-kuzu-check).
+- The lbug libstdc++ ABI crash is fixed *in the engine library*
+  (`amplihack-memory-lib`) and consumed by a pin bump, not forked into Simard.
+- Standing up the next identity is now genuinely "mostly configuration" — end to
+  end, including the host it runs on.
+
+## See also
+
+- [lbug portability across libstdc++ ABIs](./lbug-portability-libstdcxx-abi.md)
+  — the centerpiece root-cause and fix.
+- [Install a Simard-family agent](../howto/install-a-simard-family-agent.md) —
+  the operational how-to (local and azlin-remote).
+- [Run the preflight doctor](../howto/run-the-installer-preflight-doctor.md).
+- [Platform installer CLI reference](../reference/platform-installer-cli.md).
+- [Stand up a read-only observer](../tutorials/stand-up-a-read-only-observer.md)
+  — end-to-end tutorial on host `dev`.

--- a/docs/concepts/resource-aware-engineer-admission.md
+++ b/docs/concepts/resource-aware-engineer-admission.md
@@ -1,0 +1,188 @@
+---
+title: Resource-aware engineer admission — agentic admission under the count cap
+description: Why Simard weighs disk, build-cache size, and system load — not just engineer count — before spawning another engineer, and how a structured-reasoning brain step decides ADMIT / DEFER / RECLAIM-FIRST each cycle.
+last_updated: 2026-07-07
+owner: simard
+doc_type: concept
+related:
+  - ../reference/resource-aware-admission-api.md
+  - ../reference/ooda-resource-admission-recipe.md
+  - ../howto/configure-resource-aware-admission.md
+  - ./adaptive-scaling.md
+  - ./automated-disk-health.md
+  - ../reference/concurrent-engineer-dispatch.md
+---
+
+# Resource-aware engineer admission — agentic admission under the count cap
+
+## The incident: count-control is not resource-admission
+
+The [AIMD adaptive scaler](adaptive-scaling.md) bounds how many actions the OODA
+cycle dispatches concurrently, and the [concurrent-engineer
+dispatcher](../reference/concurrent-engineer-dispatch.md) holds a semaphore that
+caps how many engineers run at once. Both are **count controls**: they answer
+the question *"how many?"* — never *"can this host afford one more?"*
+
+On a busy self-improvement host, that gap bit hard. The scaler happily kept the
+engineer count under its ceiling while **40+ engineer worktrees** accumulated,
+each with its own `cargo` build cache. Parallel builds piled up, disk climbed to
+**91%**, and the next allocation tripped `ENOSPC` (No space left on device) —
+which kills recipes mid-flight and corrupts in-progress work.
+
+The AIMD scaler did nothing wrong. It was never told about disk. A count cap
+cannot see a full disk, a thrashing load average, or a build cache that has
+quietly grown to tens of gigabytes. **Bounding the count is necessary but not
+sufficient. Admission also has to weigh resources.**
+
+## The idea: agentic admission, not another threshold pile
+
+The naive fix is a wall of hardcoded `if disk > X && load > Y && cache > Z`
+heuristics in Rust. Simard deliberately does **not** do that. Thresholds rot,
+interact badly, and never capture the judgment call ("disk is high but the cache
+is reclaimable and load is low, so reclaim then retry").
+
+Instead, admission follows the same pattern already proven in the [engineer
+lifecycle brain](../reference/ooda-engineer-lifecycle-recipe.md): **the
+intelligence lives in a structured-reasoning prompt that the brain executes
+repeatedly**, and only a thin deterministic rail guards the one irreversible,
+safety-critical outcome.
+
+Before admitting a **fresh** engineer, the daemon:
+
+1. **Gathers a resource picture** — disk usage %, worktree/build-cache size,
+   1-minute load average, CPU count, and in-flight engineer count.
+2. **Asks the admission brain to reason** over that picture and choose one of
+   three outcomes.
+3. **Applies the decision**, subject to one hard rail.
+
+```
+                         fresh-engineer spawn request
+                                    │
+                     (already under the AIMD count cap)
+                                    │
+                    ┌───────────────▼────────────────┐
+                    │ gather_resource_admission_ctx() │  best-effort probes
+                    │  disk% · cache bytes · load ·   │  (any field → None on error)
+                    │  cpu count · in-flight count    │
+                    └───────────────┬────────────────┘
+                                    │
+                    ┌───────────────▼────────────────┐
+                    │  admission brain reasons        │  ← intelligence (prompt)
+                    │  ADMIT / DEFER / RECLAIM-FIRST  │
+                    └───────────────┬────────────────┘
+                                    │
+                    ┌───────────────▼────────────────┐
+                    │  HARD RAIL (thin, deterministic)│  ← safety (code)
+                    │  disk known AND ≥ ceiling →     │
+                    │  force DEFER regardless         │
+                    └───────────────┬────────────────┘
+                                    │
+              ┌─────────────────────┼─────────────────────┐
+              ▼                     ▼                     ▼
+           ADMIT                 DEFER              RECLAIM-FIRST
+     allocate worktree,     benign skip: no       run disk-health
+       spawn engineer       worktree, no          reclaim recipe,
+                            failure-count bump      then DEFER
+```
+
+## The three outcomes
+
+| Outcome | Meaning | Effect |
+|---|---|---|
+| **ADMIT** | Resources are healthy enough to add an engineer. | Continue to worktree allocation and spawn — the normal path. |
+| **DEFER** | Resources are tight; adding an engineer now is unwise. | **Benign skip**: no worktree allocated, the goal is retried next cycle, and the goal's failure counter is **not** incremented. |
+| **RECLAIM-FIRST** | Disk pressure is reclaimable (stale worktrees, build caches). | Invoke the existing [disk-health reclaim recipe](automated-disk-health.md), then DEFER this cycle and re-evaluate next cycle. |
+
+DEFER is the critical design point. A resource defer is **not a failure** — no
+progress was attempted and none was lost. It must never look like a stuck goal.
+See ["Why DEFER is a benign skip"](#why-defer-is-a-benign-skip) below.
+
+## Repeated structured thought
+
+Admission is not a one-time gate. The brain reasons **at every fresh-engineer
+admission**, so the decision tracks the live resource picture as it changes cycle
+to cycle. This is the same "repeated execution of structured thought" model the
+rest of the OODA brain uses: gather structured context → reason → apply → observe
+→ repeat. Nothing is memoized; each admission is judged on current conditions.
+
+## The one hard rail: an ENOSPC floor the brain cannot override
+
+Agentic reasoning is the right tool for the *judgment* ("is now a good time?"),
+but an irreversible `ENOSPC` crash is not a judgment call — it is a floor.
+
+So exactly one deterministic rail sits below the brain: a configurable **disk
+admission ceiling** (`SIMARD_DISK_ADMISSION_CEILING_PCT`, default **90%**). If
+the disk usage is successfully read **and** is at or above the ceiling, admission
+is refused (downgraded to DEFER) **regardless of what the brain decided**. An
+`ADMIT` from the model can only ever be made *more* conservative by the rail,
+never less. The model cannot talk the daemon into filling the disk.
+
+This is the *only* hardcoded threshold in the whole feature. Everything else is
+prompt-driven.
+
+### Fail-open on unknown
+
+The rail engages **only** on a *successful, over-ceiling* disk read. If the disk
+probe fails (transient `df` error, unusual platform), disk usage degrades to
+`None` — "unknown" — and the rail does **not** fire. The unknown is instead
+passed to the brain, which reasons about it. A spurious probe failure must never
+be able to deadlock all spawning; the layered protection (this rail plus the
+[≥95% emergency cleanup tier](automated-disk-health.md)) means unknown-disk is
+safe to let through to reasoning.
+
+The invariant, stated precisely:
+
+> **known-and-over-ceiling ⇒ DEFER. unknown ⇒ reasoner. Never known-over-ceiling ⇒ ADMIT. Never deadlock on unknown.**
+
+## Why DEFER is a benign skip
+
+The OODA cycle bumps a goal's failure counter whenever an action outcome reports
+`success = false`, and three strikes blocks the goal. A resource defer must sit
+entirely outside that machinery:
+
+- DEFER returns a **success outcome** (`success = true`) with
+  `detail = "deferred: resource pressure"`.
+- No worktree is allocated (so a deferred cycle cannot itself grow disk).
+- The goal's `goal_failure_counts` entry is untouched.
+- The goal is simply retried on the next cycle.
+
+Deferring is neither progress nor failure — it is a no-op skip driven by host
+conditions, not by anything wrong with the goal. Conflating it with failure
+would let a temporarily-full disk permanently block healthy goals, which is
+exactly the kind of silent degradation Simard forbids.
+
+## What this feature deliberately does **not** change
+
+- **The AIMD scaler is untouched.** Resource admission is *additive*: it runs
+  underneath the count cap, only for fresh-engineer spawns. If the count cap
+  already said no, admission never runs.
+- **No new reclaim logic.** RECLAIM-FIRST reuses the existing
+  [disk-health](automated-disk-health.md) reclaim recipe. There is one reclaim
+  implementation, not two.
+- **Live re-attach is exempt.** Admission gates only the *fresh spawn* path.
+  Re-attaching to an already-running engineer allocates no new resources, so it
+  is never gated.
+
+## Where it lives in the loop
+
+The gate sits inside `dispatch_spawn_engineer`
+(`src/ooda_actions/advance_goal/spawn.rs`), in the fresh-spawn path: after the
+live-engineer lifecycle branch, after the subordinate-depth recursion guard,
+under the AIMD count cap, and **before** the engineer worktree is allocated.
+Placing it before allocation is what guarantees a deferred cycle grows nothing.
+
+Both dispatch call sites — the concurrent dispatcher (under its AIMD permit) and
+the direct `advance_goal` path — inherit the gate automatically because it lives
+inside the shared dispatch function.
+
+## See also
+
+- [Resource-aware admission API reference](../reference/resource-aware-admission-api.md)
+  — the `OodaAdmissionBrain` trait, `ResourceAdmissionCtx`, `AdmissionDecision`,
+  the pure gate, and the hard rail.
+- [OODA resource-admission recipe & prompt schema](../reference/ooda-resource-admission-recipe.md)
+  — where the intelligence lives.
+- [Configure resource-aware admission (how-to)](../howto/configure-resource-aware-admission.md)
+  — tuning the ceiling, reading decisions, tutorial.
+- [Adaptive scaling](adaptive-scaling.md) — the count control this layers on top of.
+- [Automated disk-health management](automated-disk-health.md) — the reclaim path RECLAIM-FIRST invokes.

--- a/docs/howto/configure-resource-aware-admission.md
+++ b/docs/howto/configure-resource-aware-admission.md
@@ -1,0 +1,282 @@
+---
+title: Configure and monitor resource-aware engineer admission
+description: Operator guide for Simard's resource-aware admission gate — set the disk ceiling, read ADMIT/DEFER/RECLAIM-FIRST decisions, edit the reasoning prompt, and walk a worked example.
+last_updated: 2026-07-07
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../concepts/resource-aware-engineer-admission.md
+  - ../reference/resource-aware-admission-api.md
+  - ../reference/ooda-resource-admission-recipe.md
+  - ./configure-adaptive-scaling.md
+  - ./configure-disk-health-check.md
+  - ./reclaim-disk-space-and-run-low-space-rust-builds.md
+  - ./spawn-engineers-from-ooda-daemon.md
+---
+
+# Configure and monitor resource-aware engineer admission
+
+Resource-aware admission stops the daemon from spawning another engineer when
+the host cannot afford one — even if the [AIMD count
+cap](./configure-adaptive-scaling.md) still has headroom. Before each **fresh**
+engineer spawn, an admission brain reasons over disk, build-cache size, and load,
+and decides **ADMIT**, **DEFER**, or **RECLAIM-FIRST**. One deterministic disk
+ceiling backs it up so `ENOSPC` is unreachable.
+
+This guide is for operators: what to tune, how to read decisions, and how to
+change the reasoning. For the *why*, see the
+[concept](../concepts/resource-aware-engineer-admission.md); for the Rust
+contract, see the [API reference](../reference/resource-aware-admission-api.md).
+
+---
+
+## At a glance
+
+| What | Where |
+|---|---|
+| Tune the hard ceiling | `SIMARD_DISK_ADMISSION_CEILING_PCT` env (default `90`) |
+| Change the reasoning | `prompt_assets/simard/recipes/ooda-resource-admission.yaml` (hot-reload) |
+| Read decisions | `brain_admission_decision` metric, `resource_admission` judgment phase, `[simard] resource admission` tracing |
+| Reclaim path | reuses the [disk-health reclaim recipe](./configure-disk-health-check.md) |
+
+Nothing here changes the count cap — admission runs **underneath** it.
+
+---
+
+## 1. Set the disk admission ceiling
+
+The ceiling is the only hard threshold. When disk usage is read successfully and
+is **at or above** the ceiling, admission is refused regardless of what the brain
+decided.
+
+```bash
+# Default is 90%. Lower it on a small/busy partition for more headroom:
+SIMARD_DISK_ADMISSION_CEILING_PCT=85 simard ooda run
+
+# Raise it on a large partition where 90% still leaves plenty of room:
+SIMARD_DISK_ADMISSION_CEILING_PCT=93 simard ooda run
+```
+
+Rules:
+
+- Default **90** if unset or unparseable.
+- Clamped to **1–99**. `0` (would deadlock all spawns) and `≥100` (would disable
+  the rail) are impossible after clamping.
+- Read fresh each cycle — no rebuild or restart needed to change it.
+
+Choosing a value:
+
+| Partition size / pressure | Suggested ceiling |
+|---|---|
+| Small (< 200G) or many engineers | `80`–`85` |
+| Default host | `90` |
+| Large (> 1T), light engineer count | `92`–`93` |
+
+Keep the ceiling **below** the [≥95% emergency-cleanup
+tier](./configure-disk-health-check.md) so the admission gate throttles *before*
+the emergency tier ever has to fire.
+
+> **Fail-open, by design.** If the `df` probe fails, disk reads as *unknown* and
+> the ceiling does **not** engage — the decision falls through to the brain. A
+> transient probe error can never deadlock spawning. The layered
+> [disk-health](./configure-disk-health-check.md) protection covers the unknown
+> case.
+
+---
+
+## 2. Read admission decisions
+
+Every fresh-spawn admission emits these signals.
+
+### Tracing
+
+```
+INFO simard::ooda_brain::admission: resource admission decided
+    goal=improve-test-coverage
+    choice=defer
+    disk_pct=91 ceiling=90 cache_bytes=53687091200 load_1m=18.4 cpus=8 in_flight=12
+    rationale="disk over ceiling — hard rail engaged"
+```
+
+`choice` is one of `admit`, `defer`, `reclaim_first`. The context fields show
+exactly what the brain saw. `reason`/`rationale` is untrusted model text, emitted
+as a structured `tracing` field (target `simard::ooda_brain`) — never
+shell-interpreted — so it is safe to read directly. (The example above is
+illustrative; the live lines read like `resource-aware admission: DEFER …` with
+`goal` and `reason` fields.)
+
+### Metric — `brain_admission_decision`
+
+One event per admission, labeled **only** by `choice` (`admit` / `defer` /
+`reclaim_first`, bounded cardinality) — emitted by the recipe brain, so it
+records the brain's *intent* before the disk hard rail. Use it to watch how
+often the daemon is deferring:
+
+```bash
+# via the status/metrics surface (see the telemetry reference)
+simard status --metrics | grep brain_admission_decision
+```
+
+A rising `defer` / `reclaim_first` share is the early-warning signal that the
+host is under resource pressure — long before `ENOSPC`.
+
+### Parse health — surfaced as an explicit error, not a metric series
+
+Unlike the decide / orient / lifecycle brains, admission does **not** route
+through the shared verdict-parse chokepoint, so there is **no**
+`brain_verdict_parsed_total{phase="resource_admission"}` series. Admission uses a
+direct parse with **NO FALLBACK**: if the recipe output can't be parsed into a
+`{"choice":..,"rationale":..}` decision, `judge_admission` returns an error and
+the seam surfaces it as a visible cycle failure (`success=false`) — it never
+fabricates an admit. So "the recipe output can no longer be parsed" shows up as
+admission **failures** in the daemon log / cycle outcomes (grep for
+`resource-admission brain failure`), not as a parse-rate metric.
+
+### Judgment record — `resource_admission` phase
+
+Admission decisions appear in [brain
+introspection](../reference/brain-introspection-api.md) under the
+`resource_admission` phase, alongside `decide` / `act` / `orient`, each carrying
+the rationale and the prompt version that produced it.
+
+---
+
+## 3. Interpret each outcome
+
+| You see | It means | Operator action |
+|---|---|---|
+| `admit` (steady) | Host is healthy. | None — normal operation. |
+| `defer` (occasional) | Brief resource tightness; goals retry next cycle. | None — this is the gate working. |
+| `defer` (sustained) | Persistent pressure (full disk / high load). | Reclaim space, lower engineer count, or lower the ceiling if it is too tight. |
+| `reclaim_first` (repeating) | Disk is high but reclaimable each cycle. | Investigate what keeps growing (stale worktrees, caches); see [reclaim disk space](./reclaim-disk-space-and-run-low-space-rust-builds.md). |
+| Hard-rail `defer` at `disk_pct ≥ ceiling` | The deterministic floor engaged. | Free disk or raise the ceiling *only if* genuinely safe. |
+
+A `defer` is **not** a goal failure — it never bumps the goal's failure counter
+and never blocks the goal. If you see a goal "not progressing" purely because of
+`defer`, the fix is host resources, not the goal.
+
+---
+
+## 4. Edit the reasoning (prompt hot-reload)
+
+All the judgment lives in the recipe prompt — change it without a rebuild:
+
+```bash
+# In-tree (takes effect next cycle):
+$EDITOR prompt_assets/simard/recipes/ooda-resource-admission.yaml
+
+# Or hot-reload copy (wins over in-tree):
+$EDITOR ~/.simard/prompt_assets/simard/recipes/ooda-resource-admission.yaml
+```
+
+Typical edits:
+
+- Make the brain more conservative under load (tighten the `defer` guidance).
+- Prefer `reclaim_first` earlier when the cache is large.
+- Adjust the ROLE wording for a specific host profile.
+
+Bump the recipe `version:` field when you change decision-affecting wording so
+the change is traceable in the judgment record. See the
+[recipe & prompt schema](../reference/ooda-resource-admission-recipe.md) for the
+context variables and the required output envelope.
+
+> Do **not** try to encode thresholds in the prompt as the enforcement mechanism.
+> The prompt is judgment; the *only* hard threshold is
+> `SIMARD_DISK_ADMISSION_CEILING_PCT`.
+
+---
+
+## 5. Disable / floor behavior
+
+There is no "off" switch for admission — a gate that can be turned off cannot
+protect against `ENOSPC`. But you can control its aggressiveness:
+
+- **Effectively permissive:** raise `SIMARD_DISK_ADMISSION_CEILING_PCT` toward
+  `99` and relax the prompt's `defer` guidance. The gate still blocks a genuinely
+  full disk.
+- **No recipe available:** if `recipe-runner-rs` or the recipe YAML is missing,
+  admission falls back to the **deterministic floor** (`DeterministicAdmissionBrain`),
+  which always returns `Admit`. The hard ceiling still guards ENOSPC, so the
+  daemon stays safe even with no LLM.
+
+---
+
+## Worked example / tutorial
+
+Simulate the incident this feature was built for and watch it throttle.
+
+1. **Start the daemon with a tight ceiling** to make the gate observable:
+
+   ```bash
+   SIMARD_DISK_ADMISSION_CEILING_PCT=85 SIMARD_SCALING=auto simard ooda run
+   ```
+
+2. **Fill the partition toward the ceiling** (e.g., let several engineers build,
+   or drop a large scratch file). As disk approaches 85%, watch the admission
+   log:
+
+   ```
+   INFO … resource admission decided goal=… choice=reclaim_first
+        disk_pct=84 ceiling=85 cache_bytes=61055517081 … rationale="disk near ceiling; caches reclaimable"
+   ```
+
+   The brain chooses `reclaim_first`: it runs the disk-health reclaim recipe and
+   defers this cycle — no new worktree is created while disk is tight.
+
+3. **Push past the ceiling.** Now the deterministic rail takes over regardless of
+   the model:
+
+   ```
+   INFO … resource admission decided goal=… choice=defer
+        disk_pct=86 ceiling=85 … rationale="disk over ceiling — hard rail engaged"
+   ```
+
+   Even if the model had said `admit`, the gate downgrades to `defer`. The
+   partition never reaches `ENOSPC`.
+
+4. **Confirm goals are not penalized.** The deferred goals show `success=true`
+   skip outcomes (`deferred: resource pressure`) and their failure counters are
+   unchanged:
+
+   ```bash
+   simard status | grep -i defer
+   ```
+
+5. **Reclaim and recover.** After the reclaim recipe frees space (or you clean up
+   manually — see
+   [reclaim disk space](./reclaim-disk-space-and-run-low-space-rust-builds.md)),
+   disk drops back under the ceiling and admissions return to `admit`:
+
+   ```
+   INFO … resource admission decided goal=… choice=admit
+        disk_pct=63 ceiling=85 … rationale="disk 63% under ceiling; room to spawn"
+   ```
+
+You have now seen the full cycle: reason → reclaim → hard-rail floor →
+benign-skip → recover, all without an `ENOSPC` crash and without any goal being
+marked failed.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Spawns blocked, disk looks fine | Ceiling set too low, or high load driving `defer` | Raise `SIMARD_DISK_ADMISSION_CEILING_PCT`; check `load_1m` vs `cpus` in the log |
+| Constant `reclaim_first` | Something regrows disk each cycle | Inspect worktrees/caches; [inspect & clean engineer worktrees](./inspect-and-clean-engineer-worktrees.md) |
+| Never any `defer` even when full | Recipe missing → deterministic floor; **or** `df` probe failing (unknown disk) | Confirm recipe path resolves; check for `df` errors; the ceiling only fires on a *successful* read |
+| Prompt edit not taking effect | Editing in-tree while a hot-reload copy exists | The `~/.simard/…` copy wins — edit that, or remove it |
+| Goal seems stuck but only `defer` outcomes | Host resource pressure, not a goal problem | Free resources; `defer` never blocks a goal |
+
+---
+
+## See also
+
+- [Resource-aware engineer admission (concept)](../concepts/resource-aware-engineer-admission.md)
+- [Resource-aware admission API reference](../reference/resource-aware-admission-api.md)
+- [OODA resource-admission recipe & prompt schema](../reference/ooda-resource-admission-recipe.md)
+- [Configure adaptive scaling](./configure-adaptive-scaling.md) — the count cap this layers under
+- [Configure and monitor the disk health check](./configure-disk-health-check.md) — the reclaim path and emergency tier
+- [Reclaim disk space and run low-space Rust builds](./reclaim-disk-space-and-run-low-space-rust-builds.md)
+- [Spawn engineers from the OODA daemon](./spawn-engineers-from-ooda-daemon.md)

--- a/docs/howto/install-a-simard-family-agent.md
+++ b/docs/howto/install-a-simard-family-agent.md
@@ -1,0 +1,222 @@
+---
+title: How to install a Simard-family agent
+description: Stand up a Simard-family agent daemon (Simard, Crocutus, or a future identity) on a host with one idempotent, fail-closed command — locally or over an azlin-remote target. Covers identity config, credential wiring, preflight, verification of a live OODA cycle, and upgrade/uninstall.
+last_updated: 2026-07-08
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../concepts/platform-installer.md
+  - ../concepts/lbug-portability-libstdcxx-abi.md
+  - ./run-the-installer-preflight-doctor.md
+  - ./configure-pluggable-identity.md
+  - ../reference/platform-installer-cli.md
+  - ../tutorials/stand-up-a-read-only-observer.md
+---
+
+# How to install a Simard-family agent
+
+The platform installer stands up a Simard-family identity's daemon on a host in
+one idempotent, fail-closed operation: it prepares the host, builds a binary with
+a portable cognitive-memory store, materializes an isolated identity and systemd
+unit, proves the identity's guardrails, starts the daemon, and verifies it
+reaches a live OODA cycle. See
+[The Simard platform installer](../concepts/platform-installer.md) for the
+design; this guide is the operational recipe.
+
+## Prerequisites
+
+- **A target host.** Either the local machine, or an
+  [`azlin`](https://github.com/rysweet/azlin)-reachable VM (requires the
+  `az ssh` extension and Bastion access, e.g. `azlin connect dev`).
+- **An identity config** (see [Identity config](#choose-or-write-an-identity-config)).
+- **Credentials** the identity requires, supplied out-of-band (never committed).
+  For a read-only observer like Crocutus, this is a **read-only** Azure DevOps
+  PAT (`Code: Read`) — never a write token.
+- On the *operator* machine: `git`, and for remote installs, `azlin`.
+
+The installer provisions everything else on the target itself — the Rust
+toolchain, native build deps (`build-essential`, `cmake`, `clang`,
+`pkg-config`, `libssl-dev`), and the `amplihack` CLI and bundle. You do not
+pre-install those by hand.
+
+## Choose or write an identity config
+
+An identity config declares the four isolation axes and the identity's
+credentials and guardrails. The canonical scaffolds live in the Crocutus repo
+(`config/<identity>.env`, `systemd/<identity>-ooda.service`,
+`identity/<identity>_system.md`). A minimal read-only observer config:
+
+```ini
+# config/crocutus.env  (systemd EnvironmentFile format)
+# %h is an installer-materialized placeholder: the installer runs
+# `sed "s#%h#$HOME#g"` at deploy time to produce a materialized env file.
+# systemd does NOT expand %h inside an EnvironmentFile's contents.
+SIMARD_OBSERVE_ONLY=1                      # the read-only floor (guardrail)
+SIMARD_STATE_ROOT=%h/.crocutus/state       # isolated goal board + memory flock
+SIMARD_IDENTITY=crocutus                   # persona
+SIMARD_IDENTITY_PATH=%h/crocutus/identity
+SIMARD_PROMPT_ROOT=%h/crocutus
+SIMARD_DASHBOARD_PORT=8090                 # distinct port (no collision)
+SIMARD_ADO_PAT_FILE=%h/.crocutus/ado_readonly.pat   # READ-scoped PAT the daemon reads
+```
+
+The installer allocates and **verifies** these against identities already on the
+host and refuses to proceed on any collision (identity home, state root, port,
+socket, or unit name). Note the **identity home** `~/.crocutus` (which holds the
+binary and target clones) is distinct from the **state root** `~/.crocutus/state`
+(goal board + memory `flock`). See
+[Pluggable identity](../concepts/pluggable-identity.md) and
+[How to configure pluggable identities](./configure-pluggable-identity.md).
+
+## Run the installer
+
+### Local install
+
+```bash
+# From the identity repo (e.g. a Crocutus checkout) on the target host:
+export ADO_READONLY_PAT=…        # read-only PAT for the deploy-time target clone
+simard platform install \
+  --identity ./config/crocutus.env \
+  --local
+```
+
+Equivalently, the canonical Crocutus scaffold script:
+
+```bash
+./scripts/install.sh --identity ./config/crocutus.env
+```
+
+`simard platform install` is a thin rail that shells to the same scaffold logic
+(it is namespaced under `simard platform …` because the bare `simard install`
+verb already persists the binary to `~/.simard/bin`). Use whichever entry point
+you prefer. See the [CLI reference](../reference/platform-installer-cli.md) for
+every flag.
+
+### Remote install over azlin
+
+Run the *same* operation against a Bastion-reachable VM. Confirm the target first
+with `azlin list` (and reach it with `azlin connect dev -- hostname`), then:
+
+```bash
+simard platform install \
+  --identity ./config/crocutus.env \
+  --remote azlin:dev
+```
+
+Under the hood the rail reaches the host with `azlin connect dev -- …`. For a
+remote install the installer must transport two things to the target — **without
+committing either**:
+
+- **The identity repo/config** — cloned on the target (or copied over the azlin
+  channel), so the scaffold runs there.
+- **The credential** — a local `export ADO_READONLY_PAT=…` on your operator shell
+  does **not** reach the remote daemon. The read PAT must be delivered to the
+  target out-of-band (e.g. written to `SIMARD_ADO_PAT_FILE` on the host over the
+  azlin channel) and never placed in the repo or the unit file.
+
+### What happens, in order
+
+The installer runs the [phase machine](../concepts/platform-installer.md#the-install-as-a-phase-machine):
+**preflight → build (from-source lbug) → materialize identity → prove guardrails →
+start daemon → verify live cycle → report.** Each phase is idempotent; re-running
+after a partial failure converges rather than duplicating work.
+
+## Supply credentials (fail closed)
+
+There are **two** credential rules; keep them separate:
+
+1. **A write-capable token present → hard stop.** For a read-only observer the
+   guardrail proof refuses to install if any write-capable token
+   (`AZURE_DEVOPS_EXT_PAT`, `SYSTEM_ACCESSTOKEN`, `ADO_WRITE_PAT`) is in the
+   environment. This is the real, enforced credential guardrail — the installer
+   cannot introspect a PAT's scope offline, so it enforces the *absence* of write
+   tokens.
+2. **A declared-required credential absent → stop.** If the identity config marks
+   a credential as required and it is absent, the install stops.
+
+For a read-only observer the **read PAT is optional by default**: without it, the
+observer degrades to anonymous read or does nothing (fail-closed at runtime), and
+the install still completes. Two different PAT mechanisms are involved — don't
+conflate them:
+
+- `ADO_READONLY_PAT` (operator env) is consumed **at deploy time** by
+  `bootstrap-readonly.sh` to fetch the read-only target clone.
+- `SIMARD_ADO_PAT_FILE` (a path) is what the **daemon reads at runtime** to
+  observe Azure DevOps. Store the token there (e.g. `~/.crocutus/ado_readonly.pat`),
+  readable only by the daemon user.
+
+## Verify the install
+
+The installer verifies the install for you and reports it. To confirm by hand:
+
+```bash
+# The unit is active and has a stable (non-flapping) PID:
+systemctl --user status crocutus-ooda.service
+
+# Cognitive memory opened with no SIGSEGV and the OODA loop is live:
+journalctl --user -u crocutus-ooda.service -f
+#   → expect a live OODA cycle; NO 'SIGSEGV' / 'initBufferManager' backtrace.
+
+# Side-by-side isolation from any other identity on the host:
+ls ~/.simard/state ~/.crocutus/state    # distinct state roots
+```
+
+A crash-loop (PID changing every `RestartSec`) is a **failed** install, not a
+warning. If cognitive memory segfaults on start, this is the libstdc++ ABI class
+of failure — see
+[lbug portability](../concepts/lbug-portability-libstdcxx-abi.md) — and the
+installer should have failed closed at the build/verify phase; re-run the
+[preflight doctor](./run-the-installer-preflight-doctor.md) to confirm the host's
+libstdc++/toolchain and the from-source lbug build.
+
+## Run side-by-side with another identity
+
+Nothing extra is required: the installer guarantees a distinct state root,
+dashboard port, socket, and unit name. Both units enable and run independently:
+
+```bash
+systemctl --user status simard-ooda.service crocutus-ooda.service
+```
+
+If you deliberately reuse a value that collides (same port, same state root, same
+unit name) the installer refuses rather than overwriting the existing identity.
+
+## Upgrade
+
+Upgrades stop the unit, swap the binary **atomically** (survives the held-inode
+problem), restart, and re-verify a live cycle — rolling back on failure:
+
+```bash
+simard platform install --identity ./config/crocutus.env --upgrade
+```
+
+This reuses the [reconcile-and-self-deploy](../concepts/reconcile-and-self-deploy.md)
+discipline.
+
+## Uninstall
+
+```bash
+simard platform install --identity ./config/crocutus.env --uninstall
+```
+
+Stops and disables the unit and removes the identity's state root and unit file,
+leaving other identities on the host untouched.
+
+## Troubleshooting
+
+| Symptom | Cause | Action |
+|---------|-------|--------|
+| Install stops in preflight on a missing dep | Toolchain / native dep / `amplihack` absent and not auto-remediable | Read the doctor's exact line; see [Run the preflight doctor](./run-the-installer-preflight-doctor.md). |
+| Install stops: "missing required credential" | Fail-closed on absent credential | Provide the read-only token at the configured path. |
+| Install stops: "write-capable credential present" | A write token is in the environment | Remove it; a read-only observer must have no write token. |
+| Verify fails: SIGSEGV in `initBufferManager` | libstdc++ ABI mismatch from a prebuilt lbug | Confirm the from-source lbug build; see [lbug portability](../concepts/lbug-portability-libstdcxx-abi.md). |
+| Install refuses: unit/port/state-root collision | Another identity already uses that value | Choose distinct values in the identity config. |
+
+## See also
+
+- [The Simard platform installer](../concepts/platform-installer.md)
+- [lbug portability across libstdc++ ABIs](../concepts/lbug-portability-libstdcxx-abi.md)
+- [Run the preflight doctor](./run-the-installer-preflight-doctor.md)
+- [Platform installer CLI reference](../reference/platform-installer-cli.md)
+- [Stand up a read-only observer](../tutorials/stand-up-a-read-only-observer.md)

--- a/docs/howto/run-the-installer-preflight-doctor.md
+++ b/docs/howto/run-the-installer-preflight-doctor.md
@@ -1,0 +1,125 @@
+---
+title: How to run the installer preflight doctor
+description: Run the platform installer's preflight doctor to check a host before (or independently of) an install — OS and libstdc++ version, Rust toolchain, native build deps, the amplihack CLI and bundle, free disk, dashboard-port availability, systemd unit-name collisions, and lbug ABI compatibility — and either auto-remediate or fail with a precise, actionable error.
+last_updated: 2026-07-08
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../concepts/platform-installer.md
+  - ../concepts/lbug-portability-libstdcxx-abi.md
+  - ./install-a-simard-family-agent.md
+  - ../reference/platform-installer-cli.md
+---
+
+# How to run the installer preflight doctor
+
+The **preflight doctor** is the installer's first phase, exposed as a standalone
+command so you can check a host without committing to an install. It detects
+everything the install depends on and either **auto-remediates** what is safe to
+fix or **fails closed** with an exact, actionable error. There is no silent
+fallback: a check either passes, is remediated, or stops the run.
+
+## When to run it
+
+- **Before a first install** on an unfamiliar host, to see what will be
+  provisioned.
+- **After a failed install**, to isolate which precondition regressed.
+- **As a fleet audit**, to confirm a host can host another identity (ports, unit
+  names, disk).
+
+## Run it
+
+```bash
+# Local host:
+simard platform doctor --identity ./config/crocutus.env
+
+# Remote host over azlin:
+simard platform doctor --identity ./config/crocutus.env --remote azlin:dev
+```
+
+The canonical Crocutus scaffold equivalent is `./scripts/doctor.sh`. By default
+the doctor **reports and auto-remediates**; pass `--check-only` to report without
+changing the host (useful for audits). See the
+[CLI reference](../reference/platform-installer-cli.md) for all flags and exit
+codes.
+
+> `simard platform doctor` is namespaced under `simard platform …` to avoid the
+> pre-existing `simard install` verb. It is a superset host check; the separate
+> `simard ensure-deps` command remains a minimal *runtime* check (`git`,
+> `python3`, `gh`) and no longer probes for the (stale) Python `kuzu` package —
+> memory is embedded lbug.
+
+## What it checks
+
+Each check maps to a friction point the first real install hit
+(see [the concept](../concepts/platform-installer.md#the-problem)):
+
+| Check | Passes when | Auto-remediation | Fails closed when |
+|-------|-------------|------------------|-------------------|
+| **OS + libstdc++** | Reads distro and `GLIBCXX_3.4.NN` | — (informational input to the lbug check) | Cannot determine libstdc++ |
+| **Rust toolchain** | `cargo`/`rustc` present | Installs `rustup`/`cargo` | Install not permitted / fails |
+| **Native build deps** | `build-essential`, `cmake`, `clang`, `pkg-config`, `libssl-dev` present | `apt install` the missing set | `sudo`/apt unavailable |
+| **amplihack CLI + bundle** | `amplihack` on PATH and `~/.amplihack/amplifier-bundle` synced | Installs/syncs it | Install/sync fails |
+| **Disk** | Enough free space for a from-source build + store | — | Below the build threshold |
+| **Dashboard port** | The identity's `SIMARD_DASHBOARD_PORT` is free | — | Port already bound (collision) |
+| **Unit-name collision** | No existing user unit with the identity's name | — | `<identity>-ooda.service` already exists for a *different* identity |
+| **State-root collision** | The identity's `SIMARD_STATE_ROOT` is unused by another identity | — | Another identity owns that root |
+| **lbug source-build prerequisites** | The C++ toolchain needed to build lbug from source is present | Installs the missing toolchain (via Rust/native-deps rows) | The source-build toolchain cannot be provisioned |
+
+The **lbug source-build** check is the one that prevents the newer-OS SIGSEGV.
+Building lbug from source is the *unconditional* choice at deploy time (the
+installer's build phase exports `LBUG_BUILD_FROM_SOURCE=1`, and
+`amplihack-memory-lib`'s persistent-feature guard warns loudly if a prebuilt were
+ever linked without it), so this check does **not** choose prebuilt-vs-source —
+it verifies the source-build toolchain is present and reports the host's
+libstdc++ for the record. There is no prebuilt in the process to mismatch the
+host ABI. See
+[lbug portability](../concepts/lbug-portability-libstdcxx-abi.md).
+
+## Read the report
+
+The doctor prints one line per check with a status icon and, on failure, the
+exact remediation. It ends with a machine-readable summary and a non-zero exit if
+any check failed and could not be remediated. Example (abridged):
+
+```
+simard platform doctor: preflight for identity 'crocutus' on host 'dev'
+
+  ✓ os              Ubuntu 26.04 LTS
+  ✓ libstdc++       GLIBCXX_3.4.35
+  ✓ rust            cargo 1.90 (installed via rustup)
+  ✓ native-deps     build-essential, cmake, clang, pkg-config, libssl-dev
+  ✓ amplihack       amplihack 0.x + amplifier-bundle synced
+  ✓ disk            18 GiB free (need ≥ 6 GiB)
+  ✓ port            8090 free
+  ✓ unit-name       crocutus-ooda.service available
+  ✓ state-root      ~/.crocutus/state unused
+  ✓ lbug-source     toolchain present → lbug builds from source (LBUG_BUILD_FROM_SOURCE=1)
+
+preflight PASSED — host 'dev' is ready to install identity 'crocutus'.
+```
+
+A failing run stops at the first unremediable check and tells you exactly what to
+do, for example:
+
+```
+  ✗ native-deps     missing: cmake, libssl-dev
+                    remediation requires sudo apt; run:
+                    sudo apt-get install -y cmake libssl-dev
+preflight FAILED (fail-closed): host is not ready. Fix the above and re-run.
+```
+
+## Exit codes
+
+- `0` — all checks pass (after any auto-remediation).
+- non-zero — at least one check failed and could not be remediated; the report
+  names it. The installer treats a non-zero doctor as a hard stop and does not
+  proceed to build or start anything.
+
+## See also
+
+- [The Simard platform installer](../concepts/platform-installer.md)
+- [lbug portability across libstdc++ ABIs](../concepts/lbug-portability-libstdcxx-abi.md)
+- [Install a Simard-family agent](./install-a-simard-family-agent.md)
+- [Platform installer CLI reference](../reference/platform-installer-cli.md)

--- a/docs/reference/ooda-resource-admission-recipe.md
+++ b/docs/reference/ooda-resource-admission-recipe.md
@@ -1,0 +1,274 @@
+---
+title: OODA resource-admission recipe and prompt schema
+description: Reference for the ooda-resource-admission recipe and prompt — the structured-reasoning asset that decides ADMIT / DEFER / RECLAIM-FIRST, its context variables, the decision envelope, and runtime hot-reload.
+last_updated: 2026-07-07
+owner: simard
+doc_type: reference
+related:
+  - ../concepts/resource-aware-engineer-admission.md
+  - ./resource-aware-admission-api.md
+  - ../howto/configure-resource-aware-admission.md
+  - ./ooda-engineer-lifecycle-recipe.md
+  - ./ooda-decide-prompt.md
+  - ./recipe-context-var-sanitization.md
+---
+
+# OODA resource-admission recipe and prompt schema
+
+**Recipe:** `prompt_assets/simard/recipes/ooda-resource-admission.yaml`
+**Prompt asset:** `prompt_assets/simard/prompts/ooda-resource-admission.md`
+**Shim:** `impl OodaAdmissionBrain for RecipeBrain` (`src/ooda_brain/recipe_brain.rs`)
+
+This recipe is the **single source of truth for the resource-admission
+decision**. It is where the intelligence of the feature lives — the Rust seam
+only gathers structured context, calls this recipe, and applies the result under
+one hard rail (see the [API reference](./resource-aware-admission-api.md)).
+
+It follows the same recipe-brain pattern as
+[`ooda-decide.yaml`](./ooda-decide-prompt.md) and
+[`ooda-engineer-lifecycle.yaml`](./ooda-engineer-lifecycle-recipe.md): a single
+terminal `agent` step run via `recipe-runner-rs`, whose stdout is a JSON
+envelope from which `RecipeBrain` extracts the final step's output and parses the
+decision.
+
+---
+
+## Recipe layout
+
+```yaml
+name: "ooda-resource-admission"
+description: "OODA engineer-admission brain — resource-aware ADMIT/DEFER/RECLAIM-FIRST"
+version: "1.0.0"
+author: "Simard"
+tags: ["simard", "ooda", "admission", "resource"]
+
+context: {}
+
+steps:
+  - id: "decide-admission"
+    type: "agent"
+    agent: "default"
+    prompt: |
+      {{escalation_note}}
+
+      # OODA Brain — Engineer-Admission Decision (resource-aware)
+
+      ## ROLE
+      You are the admission brain for Simard's engineer dispatcher. The count
+      cap already said there is room for one more engineer by COUNT. Your job is
+      the resource question the count cap cannot answer: given the current disk,
+      build-cache, and load picture on THIS host, is now a good moment to spawn
+      one more engineer — each of which starts its own parallel `cargo` build?
+
+      A full disk is fatal (ENOSPC kills recipes). Be conservative when disk is
+      high or load is thrashing. Prefer reclaiming reclaimable space over
+      blocking progress outright.
+
+      ## CONTEXT
+      - disk_usage_pct:        {{disk_usage_pct}}
+      - disk_ceiling_pct:      {{ceiling_pct}}
+      - worktree_cache_bytes:  {{worktree_cache_bytes}}
+      - load_avg_1m:           {{load_avg_1m}}
+      - cpu_count:             {{cpu_count}}
+      - in_flight_engineers:   {{in_flight_engineers}}
+
+      ## OPTIONS
+      Choose exactly one:
+      - admit         — resources are healthy; add the engineer.
+      - defer         — resources are tight; skip this cycle, retry next.
+      - reclaim_first — disk is high but reclaimable (stale worktrees / caches);
+                        reclaim now, then defer this cycle.
+
+      ## OUTPUT
+      Emit ONE JSON object and nothing else:
+      {"choice": "<admit|defer|reclaim_first>", "rationale": "<one sentence>"}
+
+      ## EXAMPLES
+      … (see Examples below) …
+```
+
+The recipe is a single terminal `agent` step. `recipe-runner-rs` handles
+Handlebars rendering, agent invocation, and stdout capture; `RecipeBrain` parses
+the decision from the JSON envelope.
+
+---
+
+## Context variables
+
+`recipe-runner-rs` performs Handlebars `{{name}}` substitution from the context
+vars the shim passes (via `-c name=value`), sourced from
+[`ResourceAdmissionCtx`](./resource-aware-admission-api.md#resourceadmissionctx).
+`Option` fields render as the literal string `unknown` when `None`.
+
+| Variable | Source field | `None` renders as |
+|---|---|---|
+| `{{disk_usage_pct}}` | `disk_usage_pct` | `unknown` |
+| `{{ceiling_pct}}` | `ceiling_pct` | (never `None`) |
+| `{{worktree_cache_bytes}}` | `worktree_cache_bytes` | `unknown` |
+| `{{load_avg_1m}}` | `load_avg_1m` | `unknown` |
+| `{{cpu_count}}` | `cpu_count` | `unknown` |
+| `{{in_flight_engineers}}` | `in_flight_engineers` | (never `None`; `0` on error) |
+
+Every context var is a **daemon-computed number** (or the literal `unknown` for a
+failed probe) — no goal- or LLM-supplied string ever reaches this recipe, so the
+prompt-injection surface is minimal. (Unlike the decide/orient/lifecycle recipes,
+admission takes no free-text context var and therefore no `escalation_note`.)
+
+---
+
+## Decision envelope (wire format)
+
+The agent's final step output is the JSON decision object. `RecipeBrain`:
+
+1. Runs `recipe-runner-rs … --output-format json`.
+2. Deserializes the envelope and extracts the **final** step's `output`
+   (`extract_recipe_decision_output` — the shared parse chokepoint; a
+   `success=false` recipe or empty step surfaces
+   `SimardError::AdapterInvocationFailed`, never a silent empty).
+3. Parses that output into
+   [`AdmissionDecision`](./resource-aware-admission-api.md#admissiondecision) —
+   `parse_admission_decision` runs the output through the shared
+   `recipe_output::extract_json_payload` sanitizer (strips banner / ANSI / log
+   noise) and then `serde_json::from_str` on the
+   `#[serde(tag = "choice", rename_all = "snake_case")]` enum.
+
+```json
+{"choice": "admit",         "rationale": "disk 61%, load 2.1 on 16 cpus — healthy"}
+{"choice": "defer",         "rationale": "load 22 on 8 cpus; builds thrashing"}
+{"choice": "reclaim_first", "rationale": "disk 88% but 30 stale worktrees reclaimable"}
+```
+
+| `choice` | Parses to |
+|---|---|
+| `admit` | `AdmissionDecision::Admit { rationale }` |
+| `defer` | `AdmissionDecision::Defer { rationale }` |
+| `reclaim_first` | `AdmissionDecision::ReclaimFirst { rationale }` |
+
+### Parse failure — NO FALLBACK
+
+Admission uses a **direct parse**, not the confidence-gated escalation ladder the
+other recipe brains use. On a parse-miss (non-JSON output, unknown `choice`,
+missing `rationale`), `judge_admission` returns
+`SimardError::AdapterInvocationFailed` immediately — **no ladder retry, no
+`escalation_note`, and NO FALLBACK**. The seam surfaces that `Err` as a visible
+cycle failure (`success=false`); it never fabricates an `Admit` from a malformed
+response. (An accidental admit could fill the disk, so a broken brain must fail
+loud.) The deterministic disk ceiling in `resolve_admission` is the separate,
+always-on ENOSPC guard.
+
+The admission path emits a **single** metric, `brain_admission_decision` (which
+`choice` the brain made, plus the numeric picture). It deliberately does **not**
+flow through the shared verdict-parse chokepoint, so there is no
+`brain_verdict_parsed_total{phase="resource_admission"}` series; see the
+[API reference observability section](./resource-aware-admission-api.md#observability).
+
+---
+
+## Runtime loading (hot-reload, not compile-time)
+
+The recipe is loaded at runtime by `recipe-runner-rs`. `RecipeBrain` resolves the
+recipe path in this order (same as the other recipes):
+
+1. **Hot-reload:** `~/.simard/prompt_assets/simard/recipes/ooda-resource-admission.yaml`
+2. **In-tree:** `<repo_root>/prompt_assets/simard/recipes/ooda-resource-admission.yaml`
+
+Prompt edits take effect on the **next admission cycle without a rebuild**. Bump
+the `version:` field when you change decision-affecting wording so the change is
+traceable in the judgment record's prompt-version field.
+
+---
+
+## Examples
+
+### `admit` — healthy host
+
+Context: `disk_usage_pct=58 ceiling_pct=90 worktree_cache_bytes=8589934592 load_avg_1m=3.2 cpu_count=16 in_flight_engineers=4`
+
+Agent output:
+
+```json
+{"choice": "admit", "rationale": "disk 58% well under the 90% ceiling; load 3.2 on 16 cpus is comfortable — room for another engineer"}
+```
+
+Parsed:
+
+```rust
+AdmissionDecision::Admit {
+    rationale: "disk 58% well under the 90% ceiling; load 3.2 on 16 cpus is comfortable — room for another engineer".into(),
+}
+```
+
+Gate outcome: **Admit** → proceed to spawn.
+
+### `defer` — load thrashing
+
+Context: `disk_usage_pct=70 ceiling_pct=90 worktree_cache_bytes=12884901888 load_avg_1m=26.5 cpu_count=8 in_flight_engineers=9`
+
+Agent output:
+
+```json
+{"choice": "defer", "rationale": "load 26.5 on only 8 cpus with 9 engineers already building; another parallel cargo build would thrash — wait a cycle"}
+```
+
+Gate outcome: **Defer** → benign skip, retry next cycle.
+
+### `reclaim_first` — high but reclaimable disk
+
+Context: `disk_usage_pct=87 ceiling_pct=90 worktree_cache_bytes=64424509440 load_avg_1m=5.1 cpu_count=16 in_flight_engineers=6`
+
+Agent output:
+
+```json
+{"choice": "reclaim_first", "rationale": "disk 87% approaching the 90% ceiling, but 60G sits in worktree build caches — reclaim before admitting"}
+```
+
+Gate outcome: reclaim recipe runs, then **Defer** this cycle.
+
+### Hard rail overrides `admit` above ceiling
+
+Context: `disk_usage_pct=93 ceiling_pct=90 …`
+
+Even if the agent emits:
+
+```json
+{"choice": "admit", "rationale": "load looks fine"}
+```
+
+`resolve_admission` **downgrades to `Defer`** because `disk_usage_pct=93 ≥ ceiling=90`.
+The model can only be overridden toward caution, never toward filling the disk.
+
+### Unknown disk fails open
+
+Context: `disk_usage_pct=unknown ceiling_pct=90 …` (a `df` probe failure)
+
+Agent output `{"choice":"admit", …}` → gate outcome **`Proceed`**. The hard rail
+does not fire on unknown disk; the reasoner's judgment stands.
+
+---
+
+## Versioning & compatibility
+
+Cosmetic edits (ROLE phrasing, examples, rationale guidance) are safe to ship
+alone and take effect on the next cycle without a rebuild.
+
+Adding a new admission outcome requires a coordinated change:
+
+1. Add the variant to `AdmissionDecision` in `src/ooda_brain/admission.rs`.
+2. Extend the `label` / `rationale` accessors.
+3. Handle it in `resolve_admission` (map to the appropriate `AdmissionGate`).
+4. Add it to the `OPTIONS` and `OUTPUT` sections of this recipe.
+5. Add an example here and to the [wire-formats reference](./text-parsing-wire-formats.md).
+6. Add a hermetic gate test to `admission_tests.rs`.
+7. Bump the recipe `version:`.
+
+---
+
+## See also
+
+- [Resource-aware engineer admission (concept)](../concepts/resource-aware-engineer-admission.md)
+- [Resource-aware admission API reference](./resource-aware-admission-api.md)
+- [Configure resource-aware admission (how-to)](../howto/configure-resource-aware-admission.md)
+- [OODA Engineer-Lifecycle Recipe](./ooda-engineer-lifecycle-recipe.md) — the sibling recipe this mirrors
+- [OODA Decide Prompt Schema](./ooda-decide-prompt.md) — the tagged-envelope sibling
+- [Recipe context-var sanitization](./recipe-context-var-sanitization.md) — how string context is cleaned
+- [Recipe-Brain API](./recipe-brain-api.md) — the envelope-parse chokepoint and escalation ladder

--- a/docs/reference/platform-installer-cli.md
+++ b/docs/reference/platform-installer-cli.md
@@ -1,0 +1,241 @@
+---
+title: Platform installer CLI reference
+description: Authoritative contract for the Simard-family platform installer — the `simard platform install` and `simard platform doctor` rails and their canonical Crocutus scaffold, every flag, the identity-config schema and env-var contract, the install phase state machine, the fail-closed rules, exit codes, and the upgrade/uninstall contracts.
+last_updated: 2026-07-08
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+related:
+  - ../concepts/platform-installer.md
+  - ../concepts/lbug-portability-libstdcxx-abi.md
+  - ../howto/install-a-simard-family-agent.md
+  - ../howto/run-the-installer-preflight-doctor.md
+  - ./simard-cli.md
+---
+
+# Platform installer CLI reference
+
+This is the authoritative contract for the platform installer. Prose and
+walkthroughs live in
+[The Simard platform installer](../concepts/platform-installer.md) and
+[Install a Simard-family agent](../howto/install-a-simard-family-agent.md); this
+page is the reference.
+
+## Entry points
+
+The installer has one implementation with two equivalent front doors:
+
+| Front door | Location | Notes |
+|------------|----------|-------|
+| `simard platform install` / `simard platform doctor` | Simard binary (thin rail) | Convenience wrapper; shells to the canonical scaffold. |
+| `scripts/install.sh` / `scripts/doctor.sh` | **Crocutus repo (canonical)** | Source of truth. The rail delegates here. |
+
+The rail is *not* a second implementation; it forwards flags to the scaffold so
+there is a single code path to test and maintain.
+
+> **Verb deconfliction.** The bare `simard install` verb is **already taken**: it
+> persists the current binary to `~/.simard/bin` (used by the `npx` wrapper — see
+> [`simard install` in the CLI reference](./simard-cli.md#simard-install)) and it
+> rejects extra arguments. The platform installer therefore lives under a new
+> `simard platform …` subcommand group so it never collides with the existing
+> command. `simard platform doctor` is a new subcommand. The canonical scaffold
+> scripts remain the source of truth; the rail only forwards to them.
+
+### Target-artifact note
+
+The canonical `scripts/install.sh` and `scripts/doctor.sh` are the **target**
+shape. Today the Crocutus repo ships `scripts/install-on-dev.sh` (interactive,
+host-`dev`-specific, unconditional rebuild, in-place `install -m 0755` overwrite,
+with no idempotency/`--upgrade`/`--uninstall`/`--check-only`),
+`scripts/bootstrap-readonly.sh`, and `scripts/prove-guardrail.sh`. Reaching this
+reference means generalizing `install-on-dev.sh` → `install.sh`, extracting the
+preflight phase into `doctor.sh`, and adding idempotency, `--local/--remote`,
+`--upgrade/--uninstall`, `--yes`, non-interactive host confirmation, and the
+atomic binary swap. Those are new work, not shipped behavior.
+
+## `simard platform install`
+
+Stand up (or upgrade/uninstall) an identity's daemon on a host.
+
+```
+simard platform install --identity <path> [--local | --remote azlin:<vm>]
+                        [--upgrade | --uninstall]
+                        [--check-only] [--yes] [--dashboard-port <n>]
+                        [--state-root <path>] [--unit-name <name>]
+```
+
+### Flags
+
+| Flag | Required | Default | Meaning |
+|------|----------|---------|---------|
+| `--identity <path>` | yes | — | Path to the identity config (EnvironmentFile format). Declares the isolation axes, guardrails, and required credentials. |
+| `--local` | one of `--local`/`--remote` | `--local` | Install on the current host. |
+| `--remote azlin:<vm>` | " | — | Install on an azlin-reachable VM over Bastion (`azlin connect <vm> -- …`). |
+| `--upgrade` | no | — | Stop unit, atomically swap the binary, restart, re-verify; roll back on failure. |
+| `--uninstall` | no | — | Stop and disable the unit; remove the identity's state root and unit file. Leaves other identities intact. |
+| `--check-only` | no | off | Run preflight only (equivalent to `simard platform doctor`); make no changes. |
+| `--yes` | no | off | Non-interactive; assume "yes" to safe prompts (e.g. host confirmation). Required for unattended/recipe runs. |
+| `--dashboard-port <n>` | no | from config | Override the identity's dashboard port; must not collide. |
+| `--state-root <path>` | no | from config | Override the identity's state root; must not collide. |
+| `--unit-name <name>` | no | `<identity>-ooda.service` | Override the systemd user unit name; must not collide. |
+
+### Required environment / credentials
+
+Credentials are supplied out-of-band and are **never** committed. There are two
+distinct credential mechanisms and two distinct fail-closed rules; do not conflate
+them:
+
+| Variable | Kind | Consumed by | Role |
+|----------|------|-------------|------|
+| `ADO_READONLY_PAT` | operator env var | `bootstrap-readonly.sh` at **deploy time** | Fetches the read-only clone of the observed target. Read-scoped only. |
+| `SIMARD_ADO_PAT_FILE` | path to a PAT file | the **daemon at runtime** | The read-scoped PAT the running daemon reads to observe Azure DevOps. |
+| `AZURE_DEVOPS_EXT_PAT`, `SYSTEM_ACCESSTOKEN`, `ADO_WRITE_PAT` | write-capable tokens | — | Presence of any for a read-only identity is a **guardrail failure**. |
+
+**Fail-closed rules (two separate things):**
+
+1. **A write-capable token present → hard stop.** For a read-only identity, the
+   guardrail proof (`prove-guardrail.sh` layer a) refuses to proceed if any
+   write-capable token is in the environment. This is the *real* credential
+   guardrail and it is enforced.
+2. **A declared-required credential absent → stop.** If the identity config marks
+   a credential as required and it is absent, the install stops. **Note:** for a
+   read-only *observer* the read PAT is **optional** by default — absent, the
+   observer degrades to anonymous read or does nothing (fail-closed at runtime),
+   and the current scaffold *continues* installing without it. Only mark the read
+   PAT required if the identity genuinely cannot observe anonymously; that is an
+   identity-config choice, not an installer default.
+
+The installer cannot introspect a PAT's scope offline; it enforces the *absence
+of write tokens* for read-only identities and relies on the operator to supply a
+correctly-scoped read token.
+
+## `simard platform doctor`
+
+Run the preflight phase standalone. See
+[Run the preflight doctor](../howto/run-the-installer-preflight-doctor.md).
+
+```
+simard platform doctor --identity <path> [--local | --remote azlin:<vm>] [--check-only]
+```
+
+`--check-only` reports without auto-remediating (audit mode). Without it, the
+doctor auto-remediates safe items (toolchain, native deps, amplihack) and only
+fails on the unremediable.
+
+## Identity config schema
+
+The identity config is a systemd `EnvironmentFile` (KEY=VALUE, no shell
+expansion). It uses `%h` as an **installer-materialized placeholder** for the
+deploying user's `$HOME`: systemd does **not** expand `%h` inside the *contents*
+of an `EnvironmentFile`, so the installer runs `sed "s#%h#$HOME#g"` at deploy time
+to produce a materialized env file (e.g. `~/.crocutus/crocutus.env.materialized`)
+and rewrites the unit's `EnvironmentFile=` to point at it. A literal `%h` must
+never reach the running daemon. Recognized keys:
+
+| Key | Required | Purpose |
+|-----|----------|---------|
+| `SIMARD_IDENTITY` | yes | Persona name; also the default unit-name prefix and the default identity-home name (`~/.<identity>`). |
+| `SIMARD_STATE_ROOT` | yes | Isolated state root (goal board + cognitive-memory `flock`), typically `%h/.<identity>/state`. Must be unique per host. |
+| `SIMARD_DASHBOARD_PORT` | yes | Dashboard port. Must be unique per host. |
+| `SIMARD_IDENTITY_PATH` | yes | Identity manifest directory (`identity.toml`, persona prompt). |
+| `SIMARD_PROMPT_ROOT` | yes | Prompt-asset root. |
+| `SIMARD_OBSERVE_ONLY` | for observers | `1` activates the read-only floor (`read_only_guard`). |
+| `SIMARD_GIT_GUARDRAILS` | no | `enabled` keeps the destructive-git guardrail on. |
+| `SIMARD_ADO_PAT_FILE` | when observing ADO | Path to a **read-scoped** PAT file the daemon reads at runtime. |
+| `SIMARD_TARGET_ADO_ORG` / `SIMARD_TARGET_ADO_PROJECT` / `SIMARD_TARGET_REPO_URL` | for observers | The observed target (read-only). |
+
+The **identity home** `~/.<identity>` (which holds `bin/<identity>`, `targets/`,
+and the materialized env) is distinct from the **state root**
+`~/.<identity>/state` (goal board + memory `flock`). See
+[Pluggable identity](../concepts/pluggable-identity.md) for how these map to
+Simard's runtime identity.
+
+## Install phase state machine
+
+The installer runs these phases in order. Each is idempotent and fails closed;
+re-running converges rather than duplicating.
+
+| # | Phase | Succeeds when | Fails closed when |
+|---|-------|---------------|-------------------|
+| 1 | **preflight** | All doctor checks pass (after safe auto-remediation) | Any unremediable check (see doctor table) |
+| 2 | **build** | Agent binary built with lbug compiled **from source** (the installer's build phase exports `LBUG_BUILD_FROM_SOURCE=1`; `amplihack-memory-lib`'s guard warns if it were missing) against the host toolchain | Source-build toolchain missing / build fails |
+| 3 | **materialize** | Identity home, isolated state root, materialized env, prompt root, and distinct user unit created | Any isolation-axis collision (port, state root, socket, unit name) |
+| 4 | **prove-guardrails** | The identity's guardrail proof passes (e.g. read-only floor + no write credential) | Proof uncertain or a required credential absent |
+| 5 | **start** | `daemon-reload` + enable + start succeed | systemd cannot start the unit |
+| 6 | **verify** | A positive store-opened / first-OODA-cycle log marker is observed **and** the daemon holds a **stable new PID** across ≥ 1 `RestartSec` window | Crash-loop (PID flapping / unit sub-state `failed`), or a journal frame matching `initBufferManager` / `std::vformat` (the lbug SIGSEGV class) |
+| 7 | **report** | Durable machine-readable summary emitted | — |
+
+There are **no wall-clock timeouts** on the agentic verify step; it waits for a
+real live-cycle signal (the positive marker above), not a fixed delay.
+
+## systemd unit contract
+
+The installed unit is a **user** unit at
+`~/.config/systemd/user/<identity>-ooda.service`. It references **two** distinct
+directories — do not conflate them:
+
+- the **repo checkout / prompt root** `~/<identity>` (e.g. `~/crocutus`, no dot),
+  which holds `scripts/` and the *source* `config/<identity>.env`; and
+- the **identity home** `~/.<identity>` (e.g. `~/.crocutus`, with dot), which
+  holds `bin/<identity>`, `targets/`, and the *materialized* env — and is itself
+  distinct from the state root `~/.<identity>/state`.
+
+The load-bearing directives are:
+
+- `ExecStartPre=<prompt-root>/scripts/prove-guardrail.sh` (e.g.
+  `~/crocutus/scripts/prove-guardrail.sh`) — the fail-closed **start-gate**; a
+  non-zero exit aborts the unit, so a later guardrail regression keeps the daemon
+  down rather than up-and-unsafe.
+- `ExecStart=<identity-home>/bin/<identity>` — the installed binary (e.g.
+  `~/.crocutus/bin/crocutus`).
+- `EnvironmentFile=<identity-home>/<identity>.env.materialized` — the
+  sed-materialized env (e.g. `~/.crocutus/crocutus.env.materialized`), never the
+  `%h` source file `<prompt-root>/config/<identity>.env`.
+- `WorkingDirectory=<identity-home>/targets/<primary-repo>` — a read-only clone
+  of the observed target (e.g. `~/.crocutus/targets/hyenas`); the OODA loop reads
+  `current_dir()`.
+- `Type=simple`, `Restart=on-failure`, `RestartSec=10`.
+- Hardening: `NoNewPrivileges=true`, `ProtectSystem=strict`,
+  `ReadWritePaths=<identity-home>`, `ReadOnlyPaths=<identity-home>/targets`,
+  `ProtectHome=false`, `MemoryMax=2G`, `LimitNOFILE=65536`.
+- `[Install] WantedBy=default.target`.
+
+## `simard ensure-deps` and the removed kuzu check
+
+`simard ensure-deps` reports runtime dependencies. Historically it probed for a
+Python `kuzu` package — **stale and misleading**, because Simard's cognitive
+memory is embedded **lbug** compiled into the binary via `amplihack-memory-lib`,
+not kuzu. The target state:
+
+- The `kuzu` Python-package probe is **removed** from `src/cmd_ensure_deps.rs`.
+- Nothing installs kuzu; the installer never references it.
+- `ensure-deps` remains a lightweight runtime check (`git`, `python3`, `gh`); the
+  heavier build/host preconditions (Rust, `build-essential`, `cmake`, `clang`,
+  `pkg-config`, `libssl-dev`, `amplihack` CLI + bundle) are the **doctor's**
+  responsibility. Treat `simard platform doctor` as the superset host check and
+  `ensure-deps` as the minimal runtime check.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success. For `install`: the daemon reached a verified live OODA cycle. For `doctor`: all checks pass. |
+| non-zero | A phase failed closed. The report names the phase and the exact remediation. No partial daemon is left running. |
+
+## Idempotency and re-runs
+
+- Re-running `install` on an already-installed identity re-verifies and converges
+  (no double toolchain install, no clobbered state).
+- `--upgrade` swaps the binary atomically (write-new-then-rename) to survive the
+  held-inode problem of overwriting a running binary; on failed verify it rolls
+  back to the prior binary. (Today's `install-on-dev.sh` overwrites in place with
+  `install -m 0755`; the atomic swap is target work.)
+- `--uninstall` is safe to run repeatedly.
+
+## See also
+
+- [The Simard platform installer](../concepts/platform-installer.md)
+- [lbug portability across libstdc++ ABIs](../concepts/lbug-portability-libstdcxx-abi.md)
+- [Install a Simard-family agent](../howto/install-a-simard-family-agent.md)
+- [Run the preflight doctor](../howto/run-the-installer-preflight-doctor.md)
+- [simard CLI reference](./simard-cli.md)

--- a/docs/reference/resource-aware-admission-api.md
+++ b/docs/reference/resource-aware-admission-api.md
@@ -1,0 +1,599 @@
+---
+title: Resource-aware admission API reference
+description: Rust API reference for the OodaAdmissionBrain trait, ResourceAdmissionCtx, the AdmissionDecision tagged enum, the pure resolve_admission hard rail and judge_and_resolve seam, context gathering, observability, and daemon wiring.
+last_updated: 2026-07-07
+owner: simard
+doc_type: reference
+related:
+  - ../concepts/resource-aware-engineer-admission.md
+  - ./ooda-resource-admission-recipe.md
+  - ../howto/configure-resource-aware-admission.md
+  - ./ooda-brain-api.md
+  - ./recipe-brain-api.md
+  - ./disk-health-api.md
+  - ./adaptive-scaling-api.md
+---
+
+# Resource-aware admission API reference
+
+**Module:** `src/ooda_brain/admission.rs`
+**Seam:** `src/ooda_actions/advance_goal/spawn.rs` (`dispatch_spawn_engineer`)
+
+Resource-aware admission adds an agentic gate on top of the
+[AIMD count cap](./adaptive-scaling-api.md). Before a **fresh** engineer is
+spawned, the daemon gathers a resource picture, asks the admission brain to
+reason over it, and applies the resulting `AdmissionDecision` — subject to one
+deterministic disk ceiling that the brain cannot override.
+
+The module mirrors the Decide-phase template
+(`OodaDecideBrain` + `DecideJudgment` + `DeterministicDecideBrain`, see
+[`decide.rs`](./ooda-brain-api.md)): a single-decision-site trait, a tagged
+judgment enum the LLM emits as a JSON envelope, and a deterministic floor brain
+that needs no LLM.
+
+---
+
+## `ResourceAdmissionCtx`
+
+The read-only resource snapshot fed to the brain. Every probed field is
+`Option` — any probe that fails degrades to `None` (rendered as `"unknown"` in
+the prompt) rather than panicking or blocking.
+
+```rust
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ResourceAdmissionCtx {
+    /// Disk usage of the state/repo partition, 0–100. `None` if `df` failed.
+    pub disk_usage_pct: Option<u8>,
+    /// Total bytes under the engineer-worktree root
+    /// (`<state_root>/<WORKTREES_SUBDIR>`, i.e. `engineer-worktrees/`).
+    /// `None` if `du` failed.
+    pub worktree_cache_bytes: Option<u64>,
+    /// 1-minute load average from `/proc/loadavg`. `None` off Linux / on error.
+    pub load_avg_1m: Option<f64>,
+    /// Logical CPU count, from `std::thread::available_parallelism()`.
+    /// Lets the prompt normalize load. `None` if unavailable.
+    pub cpu_count: Option<usize>,
+    /// Live engineer worktrees with a heartbeat claim (never `None`; 0 on error).
+    pub in_flight_engineers: u32,
+    /// The configured disk admission ceiling in effect this cycle (1–99).
+    pub ceiling_pct: u8,
+}
+```
+
+| Field | Type | Source | Degrades to |
+|---|---|---|---|
+| `disk_usage_pct` | `Option<u8>` | `df --output=pcent <path>` | `None` |
+| `worktree_cache_bytes` | `Option<u64>` | `du -sb <state_root>/<WORKTREES_SUBDIR>` | `None` |
+| `load_avg_1m` | `Option<f64>` | first field of `/proc/loadavg` | `None` |
+| `cpu_count` | `Option<usize>` | `std::thread::available_parallelism()` | `None` |
+| `in_flight_engineers` | `u32` | `count_live_engineer_claims` (`src/ooda_brain/context.rs`) | `0` |
+| `ceiling_pct` | `u8` | `SIMARD_DISK_ADMISSION_CEILING_PCT` env (default 90, clamped 1–99) | default `90` |
+
+`disk_usage_pct`, `worktree_cache_bytes`, and `in_flight_engineers` are the same
+primitives already used by the [disk-health](./disk-health-api.md) and
+engineer-lifecycle paths.
+
+---
+
+## `AdmissionDecision`
+
+The tagged judgment the brain emits. Mirrors `DecideJudgment`: a closed enum
+tagged on `choice`, each variant carrying human-readable `rationale`.
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "choice", rename_all = "snake_case")]
+pub enum AdmissionDecision {
+    Admit { rationale: String },
+    Defer { rationale: String },
+    ReclaimFirst { rationale: String },
+}
+```
+
+Wire form (the JSON envelope the recipe agent produces):
+
+```json
+{"choice": "admit",         "rationale": "disk 61%, cache 8G, load 2.1 on 16 cpus — healthy"}
+{"choice": "defer",         "rationale": "load 22 on 8 cpus; builds are thrashing, wait a cycle"}
+{"choice": "reclaim_first", "rationale": "disk 88% but 30 stale worktrees are reclaimable"}
+```
+
+| Variant | `choice` tag | Meaning |
+|---|---|---|
+| `Admit` | `admit` | Proceed to worktree allocation and spawn. |
+| `Defer` | `defer` | Benign skip — no worktree, no failure-count bump, retry next cycle. |
+| `ReclaimFirst` | `reclaim_first` | Run the disk-health reclaim recipe, then defer this cycle. |
+
+The enum is **closed**. An unknown `choice` tag or a missing `rationale` field is
+a parse **error** (`SimardError::AdapterInvocationFailed`) — the parser never
+silently defaults to `Admit`. Fail-loud on malformed model output; the seam then
+falls back to the deterministic floor (below), where the hard rail still applies.
+
+```rust
+impl AdmissionDecision {
+    /// The `choice` label, for metrics and logs (bounded cardinality).
+    pub fn label(&self) -> &'static str { /* "admit" | "defer" | "reclaim_first" */ }
+
+    pub fn rationale(&self) -> &str { /* the variant's rationale */ }
+}
+```
+
+---
+
+## `OodaAdmissionBrain` trait
+
+Single-decision-site trait, synchronous to match the other OODA brain traits
+(the LLM-backed impl bridges to async internally).
+
+```rust
+pub trait OodaAdmissionBrain: Send + Sync {
+    /// Reason over the current resource picture and choose an admission outcome.
+    fn judge_admission(&self, ctx: &ResourceAdmissionCtx) -> SimardResult<AdmissionDecision>;
+}
+```
+
+### Implementations
+
+| Impl | Where | Behavior |
+|---|---|---|
+| `RecipeBrain` | `src/ooda_brain/recipe_brain.rs` | Constructed via `RecipeBrain::new(repo_root, ADMISSION_RECIPE_NAME, "recipe-resource-admission-brain")` (see [Construction](#construction)), where `ADMISSION_RECIPE_NAME = "ooda-resource-admission.yaml"` (re-exported from `admission.rs`) and the adapter-tag literal `"recipe-resource-admission-brain"` mirrors the existing `DECIDE_ADAPTER_TAG` / `ORIENT_ADAPTER_TAG` / `LIFECYCLE_ADAPTER_TAG` naming. `judge_admission` invokes the recipe via `recipe-runner-rs`, reuses the shared decision-output chokepoint (`extract_recipe_decision_output` → `recipe_output::extract_json_payload`), deserializes the `{"choice":..,"rationale":..}` object directly into `AdmissionDecision`, and emits the `brain_admission_decision` metric. A parse miss (or any recipe-runner failure) surfaces as an explicit `Err` — **NO FALLBACK**. Production path. |
+| `DeterministicAdmissionBrain` | `src/ooda_brain/admission.rs` | LLM-free floor. Always returns `Admit`. Used in tests and whenever no recipe brain can be constructed. Safe because the hard rail still guards ENOSPC. |
+
+```rust
+/// LLM-free floor. NOT a fallback hack — the explicit deterministic impl.
+/// Always admits; the deterministic disk ceiling in `resolve_admission` is the
+/// ENOSPC safety net, so a None/deterministic brain can never fill the disk.
+#[derive(Debug, Default)]
+pub struct DeterministicAdmissionBrain;
+
+impl OodaAdmissionBrain for DeterministicAdmissionBrain {
+    fn judge_admission(&self, _ctx: &ResourceAdmissionCtx) -> SimardResult<AdmissionDecision> {
+        Ok(AdmissionDecision::Admit {
+            rationale: "deterministic-brain: admit (hard rail guards disk)".into(),
+        })
+    }
+}
+```
+
+---
+
+## `AdmissionGate`, `resolve_admission`, `judge_and_resolve` — the pure gate + hard rail
+
+The gate is split into a **pure, brain-free** rail (`resolve_admission`) and a
+thin **reason→apply** wrapper (`judge_and_resolve`). Both are **zero-I/O**: the
+reclaim side effect (invoking the disk-health recipe) is performed by the
+**seam**, not by the gate, so the gate is fully hermetic in tests. The resolved
+gate is a 3-variant enum — `Reclaim` is a distinct outcome the seam acts on,
+not a closure folded into the gate.
+
+```rust
+/// The resolved admission outcome after the deterministic hard rail has had the
+/// final say over the brain's `AdmissionDecision`. This is what the spawn seam
+/// applies.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AdmissionGate {
+    /// Admit: proceed with the fresh spawn (allocate worktree, spawn engineer).
+    Proceed,
+    /// Skip this cycle without allocating resources. Benign — no failure bump.
+    Defer { reason: String },
+    /// Run disk reclamation now (disk-health recipe), then defer this cycle.
+    Reclaim { reason: String },
+}
+
+impl AdmissionGate {
+    /// `true` only for `AdmissionGate::Proceed` — i.e. an actual admission.
+    pub fn is_proceed(&self) -> bool { matches!(self, Self::Proceed) }
+}
+
+/// Apply the THIN deterministic hard rail over the brain's decision, then map it
+/// to an `AdmissionGate`. Pure — takes the decision, never calls the brain.
+///
+/// Rail: if `ctx.disk_usage_pct` is `Some(p)` AND `p >= ctx.ceiling_pct`, an
+/// `Admit` is forced to `Defer` regardless of the brain. Fail-open: a `None`
+/// disk reading never triggers the rail. `Defer` / `ReclaimFirst` are already
+/// non-admitting and pass through unchanged.
+pub fn resolve_admission(ctx: &ResourceAdmissionCtx, decision: AdmissionDecision) -> AdmissionGate;
+
+/// Seam core: reason → apply. Calls the brain for an `AdmissionDecision` and
+/// resolves it through the hard rail into an `AdmissionGate`.
+///
+/// NO FALLBACK: a brain error propagates unchanged so the seam surfaces it as a
+/// visible cycle failure (a broken brain must never look like a silent admit).
+pub fn judge_and_resolve(
+    brain: &dyn OodaAdmissionBrain,
+    ctx: &ResourceAdmissionCtx,
+) -> SimardResult<AdmissionGate>;
+```
+
+### Decision table
+
+Let `over_ceiling = matches!(ctx.disk_usage_pct, Some(p) if p >= ctx.ceiling_pct)`.
+
+| Brain result | `over_ceiling` | `resolve_admission` gate | Seam action |
+|---|---|---|---|
+| `Admit` | `false` | **Proceed** | allocate + spawn |
+| `Admit` | `true` | **Defer** (hard-rail downgrade) | benign skip |
+| `Defer` | any | **Defer** | benign skip |
+| `ReclaimFirst` | any | **Reclaim** | run disk-health recipe, then benign skip (defer) |
+| `Err(..)` (brain/parse failed) | — | — | **NO FALLBACK**: `judge_and_resolve` returns `Err`; the seam returns `success=false` (visible cycle failure), never a phantom admit |
+
+Key invariants:
+
+- A brain `Admit` can only be made **more** conservative by the rail, never less.
+- The rail fires **only** on a *successful, over-ceiling* disk read
+  (`Some(p) if p >= ceiling`). Unknown disk (`None`) never blocks.
+- `ReclaimFirst` always defers *after* invoking reclaim — it never races a spawn
+  against an in-flight cleanup.
+
+---
+
+## `gather_resource_admission_ctx` — best-effort probes
+
+```rust
+/// Build a `ResourceAdmissionCtx` with best-effort, never-panic probes.
+/// Every probe that fails degrades its field to `None` (or `0` for the count).
+pub fn gather_resource_admission_ctx(
+    state_root: &Path,
+    ceiling_pct: u8,
+) -> ResourceAdmissionCtx;
+```
+
+| Probe | Command / call | Failure handling |
+|---|---|---|
+| disk % | `df --output=pcent <state_root>` (argv form) | parse fail → `None` |
+| cache bytes | `du -sb <state_root>/<WORKTREES_SUBDIR>` (`WORKTREES_SUBDIR = "engineer-worktrees"`, `src/engineer_worktree/mod.rs`) | parse fail → `None` |
+| load 1m | read `/proc/loadavg`, take field 0 | non-Linux / read fail → `None` |
+| cpu count | `std::thread::available_parallelism()` | `Err` → `None` |
+| in-flight | `count_live_engineer_claims(state_root)` (`src/ooda_brain/context.rs`) | already returns `0` on error |
+
+> **Which root is measured.** The `du` probe sizes the daemon's *engineer*
+> worktrees under `<state_root>/engineer-worktrees/` (the
+> [`WORKTREES_SUBDIR`](https://github.com/rysweet/Simard/blob/main/src/engineer_worktree/mod.rs)
+> constant). This is a **different** directory from the one
+> [`disk_health::emergency_cleanup`](./disk-health-api.md) reclaims
+> (`<repo_root>/worktrees/*/target/`, `disk_health.rs`). The admission probe
+> reports occupancy of the engineer-worktree area it is gating; RECLAIM-FIRST
+> then delegates to the disk-health recipe, which cleans build-cache targets
+> across both roots.
+
+All subprocess probes are **argv-form** (`Command::new("df").arg(..)`), never
+`sh -c`, so shell injection is structurally impossible. Probe paths are always
+daemon-derived (state/repo root) — never goal- or LLM-supplied.
+
+---
+
+## `SIMARD_DISK_ADMISSION_CEILING_PCT` — the ceiling config
+
+The only tunable, and the only hardcoded threshold in the feature.
+
+```rust
+/// Read the disk admission ceiling from the environment.
+/// Default 90. Clamped to 1–99 (0 would deadlock; ≥100 would disable the rail).
+pub fn configured_ceiling_pct() -> u8 {
+    // parse_ceiling(std::env::var("SIMARD_DISK_ADMISSION_CEILING_PCT").ok().as_deref())
+    // → best-effort parse; unparseable/absent → DEFAULT_CEILING_PCT (90);
+    //   in-range values clamped to CEILING_MIN..=CEILING_MAX (1..=99).
+}
+```
+
+| Env var | Default | Range | Notes |
+|---|---|---|---|
+| `SIMARD_DISK_ADMISSION_CEILING_PCT` | `90` | clamped to `1..=99` | Best-effort parse; unparseable → default. `0` and `≥100` are impossible after clamping. |
+
+Read at the seam each cycle (mirroring the `SIMARD_SUBORDINATE_DEPTH` env read in
+`spawn.rs`), so it takes effect without a rebuild or restart.
+
+---
+
+## Integration seam (`dispatch_spawn_engineer`)
+
+The gate is inserted in the **fresh-spawn path** of `dispatch_spawn_engineer`:
+
+- **after** the live-engineer lifecycle branch (re-attach is exempt),
+- **after** the subordinate-depth recursion guard,
+- **under** the AIMD count cap (the caller already holds its permit),
+- **before** `EngineerWorktree::allocate` (so a defer grows nothing).
+
+```rust
+// … live-engineer branch returned above; depth guard passed …
+
+let state_root = engineer_worktree_state_root();
+let ceiling = configured_ceiling_pct();
+let ctx = gather_resource_admission_ctx(&state_root, ceiling);
+
+// `admission: &dyn OodaAdmissionBrain` is threaded in from the caller
+// (`bridges.admission_brain`, falling back to `&DeterministicAdmissionBrain`
+// when `None`). `repo_root: &Path` is threaded in for the reclaim recipe.
+match judge_and_resolve(admission, &ctx) {
+    Ok(AdmissionGate::Proceed) => {
+        // Observability: record the admission at the seam.
+        push_brain_judgment(BrainJudgmentRecord::from_admission(
+            goal_id, "admit", "resources healthy; admitting fresh engineer", "",
+        ));
+        // fall through to allocate + spawn
+    }
+    Ok(AdmissionGate::Defer { reason }) => {
+        // Benign skip: success=true, no worktree, no failure-count bump.
+        push_brain_judgment(BrainJudgmentRecord::from_admission(goal_id, "defer", &reason, ""));
+        return make_outcome(action, true, format!("deferred: resource pressure: {reason}"));
+    }
+    Ok(AdmissionGate::Reclaim { reason }) => {
+        // Reclaim first (reuse the disk-health recipe), then defer this cycle.
+        push_brain_judgment(BrainJudgmentRecord::from_admission(goal_id, "reclaim", &reason, ""));
+        if let Err(e) = crate::disk_health::run_disk_health_check(repo_root, &state_root, None) {
+            warn!(error = %e, "resource-admission reclaim failed (still deferring this cycle)");
+        }
+        return make_outcome(action, true, format!("deferred: reclaim-first: {reason}"));
+    }
+    Err(e) => {
+        // NO FALLBACK: a broken admission brain surfaces as a visible cycle
+        // failure (success=false → cycle.rs bumps the failure count), never a
+        // silent phantom admit that could fill the disk.
+        return make_outcome(action, false, format!("resource-admission brain failure: {e}"));
+    }
+}
+
+// … EngineerWorktree::allocate(..) …
+```
+
+Both dispatch call sites — the concurrent dispatcher and the direct
+`advance_goal` path — inherit the gate because it lives inside the shared
+function.
+
+### Why `Option<Arc<dyn OodaAdmissionBrain>>` on `OodaBridges`
+
+The admission brain is added as `admission_brain`, matching the existing
+`decide_brain` / `orient_brain` sibling fields:
+
+```rust
+pub struct OodaBridges {
+    // … existing brains/bridges …
+    pub decide_brain: Option<Arc<dyn OodaDecideBrain>>,
+    pub orient_brain: Option<Arc<dyn OodaOrientBrain>>,
+    pub admission_brain: Option<Arc<dyn OodaAdmissionBrain>>, // new
+}
+```
+
+`Option` keeps construction churn minimal (defaults to `None`) and the seam
+falls back to `DeterministicAdmissionBrain` when it is `None` — which remains
+ENOSPC-safe because the hard rail is in `resolve_admission`, not in the brain.
+
+### Construction
+
+`src/operator_commands_ooda/daemon/brains.rs` gains `build_admission_brain`,
+mirroring `build_act_brain`. Unlike `build_decide_brain` / `build_orient_brain`
+(which return `Option`), admission **always** yields a concrete brain — the seam
+must always have a reasoner to consult, and the deterministic floor + hard rail
+keep behaviour safe even with no LLM. `RecipeBrain::new` takes **three** args —
+`(repo_root, recipe_filename, adapter_tag)` — exactly like the decide/orient
+builders:
+
+```rust
+pub(super) fn build_admission_brain(
+    state_root: &Path,
+    repo_root: &Path,
+) -> Arc<dyn OodaAdmissionBrain> {
+    if let Some(b) = RecipeBrain::new(
+        repo_root,
+        crate::ooda_brain::ADMISSION_RECIPE_NAME, // "ooda-resource-admission.yaml"
+        "recipe-resource-admission-brain",
+    ) {
+        daemon_log(state_root, "[simard] OODA daemon: admission_brain = RecipeBrain …");
+        return Arc::new(b);
+    }
+    // No recipe-runner-rs / recipe YAML: fall back — loudly, via record_fallback —
+    // to the deterministic floor. The hard rail still guards ENOSPC.
+    record_fallback(state_root, "admission", "recipe-runner-rs or recipe not available");
+    Arc::new(DeterministicAdmissionBrain)
+}
+```
+
+The production `OodaBridges` literal wires `admission_brain: Some(build_admission_brain(&state_root, &repo_root))`; tests and non-daemon callers leave it `None` (→ the seam's `DeterministicAdmissionBrain` floor).
+
+---
+
+## Observability
+
+Every admission emits these signals, mirroring the lifecycle brain's telemetry
+(two of them are metrics — see the reconciliation table below):
+
+### 1. Judgment record — `BrainPhase::ResourceAdmission`
+
+A new `BrainPhase` variant (`src/ooda_brain/judgment_record.rs`) with
+byte-stable serde (`"resource_admission"`), plus a
+`BrainJudgmentRecord::from_admission(goal_id, label, reason, prompt_version)`
+constructor. `label` is the resolved gate label (`admit` / `defer` /
+`reclaim`); `reason` is the brain's (or hard-rail's) rationale; the 4th arg —
+`prompt_version: impl Into<String>` — mirrors `from_engineer_lifecycle` (the
+seam passes `""` since the admission recipe is not registered in the prompt
+store). Pushed via `push_brain_judgment` at each of the three seam arms
+(Proceed / Defer / Reclaim), so cycle reports and
+[brain introspection](./brain-introspection-api.md) show the final gate action.
+
+```rust
+pub enum BrainPhase {
+    Act,
+    Decide,
+    Orient,
+    MergeJudge,
+    ResourceAdmission, // new
+}
+// BrainPhase::as_str(self): BrainPhase::ResourceAdmission => "resource_admission"
+```
+
+> **Adding this variant touches the exhaustive `match` on `BrainPhase`** — the
+> enum's own `as_str` (`judgment_record.rs`). `parse_failure::phase_to_string`
+> delegates to `as_str`, so there is effectively **one** phase-string site plus
+> the byte-stability test (`mod.rs`), all agreeing on `"resource_admission"`.
+> See [Add a New Recipe-Brain Phase](../howto/add-a-new-recipe-brain-phase.md).
+
+### 2. Metric — `brain_admission_decision` (emitted by the recipe brain)
+
+The recipe-backed admission path emits one `brain_admission_decision` event per
+brain invocation, mirroring `brain_lifecycle_decision`
+(`record_lifecycle_decision_metric`). `record_metric`'s signature is
+`record_metric(name: &str, value: f64, context: &str)` — the third argument is a
+**JSON `context` string**, not a struct — so the call passes a serialized
+payload carrying the bounded-cardinality `choice` label (the brain's raw 3-way
+`AdmissionDecision::label()`: `admit` / `defer` / `reclaim_first`) plus the
+numeric resource picture. It is labeled by the enum + numbers only, never by
+rationale or paths, and is a no-op under `cfg!(test)`:
+
+```rust
+// inside judge_admission, mirroring build_lifecycle_metric_context:
+let context = serde_json::json!({
+    "choice": decision.label(), // "admit" | "defer" | "reclaim_first"
+    "disk_usage_pct": ctx.disk_usage_pct,
+    "worktree_cache_bytes": ctx.worktree_cache_bytes,
+    "load_avg_1m": ctx.load_avg_1m,
+    "cpu_count": ctx.cpu_count,
+    "in_flight_engineers": ctx.in_flight_engineers,
+    "ceiling_pct": ctx.ceiling_pct,
+})
+.to_string();
+let _ = record_metric("brain_admission_decision", 1.0, &context);
+```
+
+Because it fires in the brain (**before** the hard rail), it records the brain's
+*intent* — so a `reclaim_first` is visible even though the seam's final gate
+collapses to `Reclaim`→defer. The seam's judgment record (above) records the
+*final* gate action after the rail.
+
+> **Note.** Unlike the decide / orient / lifecycle brains, the admission brain
+> does **not** route through the confidence-gated escalation ladder or the
+> shared `brain_verdict_parsed_total` verdict-parse chokepoint. `judge_admission`
+> parses the `{"choice":..,"rationale":..}` object directly (via
+> `extract_json_payload` → `serde_json::from_str`); a parse miss is an explicit
+> `Err` (NO FALLBACK), not a ladder retry. So there is **no**
+> `brain_verdict_parsed_total{phase="resource_admission"}` series — the single
+> admission metric is `brain_admission_decision`.
+
+### 3. Tracing
+
+A single structured line per admission (emitted at the seam — `info!` for
+Proceed/Defer, `warn!` for Reclaim and brain-error), for example:
+
+```
+INFO simard::ooda_brain::admission: resource admission decided
+    goal=improve-test-coverage
+    choice=defer
+    disk_pct=91 ceiling=90 cache_bytes=53687091200 load_1m=18.4 cpus=8 in_flight=12
+    rationale="disk over ceiling — hard rail engaged"
+```
+
+The `rationale`/`reason` is untrusted model text. It is stored in the cycle
+report only through serde (JSON-escaped, never shell-interpreted) and emitted as
+a **structured** `tracing` field (not string-interpolated into a format that
+could break log parsing). The bounded-cardinality metric
+(`brain_admission_decision`) deliberately **excludes** it — it carries only the
+`choice` label plus numeric fields — so untrusted text can never inflate metric
+cardinality.
+
+---
+
+## Test inventory (hermetic)
+
+All tests stub the brain — **no `recipe-runner-rs`, no LLM, no real `df`/`du`**
+in the test path (the resource *reasoning quality* lives in the prompt, not the
+tests). The pure gate + hard rail are the contract these pin.
+
+**`src/ooda_brain/admission_tests.rs`** (27 hermetic tests via a stub brain):
+
+| Test | Proves |
+|---|---|
+| `rail_allows_admit_below_ceiling` | `Admit` + disk < ceiling → `Proceed` |
+| `rail_blocks_admit_at_ceiling_boundary` | `Admit` + disk == ceiling → `Defer` (`>=`, not `>`) |
+| `rail_blocks_admit_above_ceiling` | `Admit` + disk > ceiling → `Defer` (reason cites disk + ceiling) |
+| `rail_fails_open_when_disk_unknown` | `Admit` + `disk = None` → `Proceed` (rail does not fire) |
+| `rail_never_proceeds_when_over_ceiling_for_any_decision` | over-ceiling ⇒ never `Proceed`, for EVERY decision |
+| `defer_maps_to_defer_and_preserves_reason` / `reclaim_first_maps_to_reclaim_and_preserves_reason` | decision → gate mapping (FR-4) |
+| `reclaim_first_honored_even_over_ceiling` | `ReclaimFirst` over ceiling → `Reclaim` (still non-admitting) |
+| `seam_admit_decision_proceeds_when_healthy` / `seam_defer_decision_defers` / `seam_reclaim_decision_reclaims` | `judge_and_resolve` reason→apply seam |
+| `seam_rail_overrides_brain_admit_when_over_ceiling` | rail overrides a stub `Admit` when over ceiling |
+| `seam_surfaces_brain_error_no_fallback` | brain `Err` → `Err` (**NO FALLBACK**, never a phantom admit) |
+| `parse_ceiling_*` / `configured_ceiling_is_in_range` | unparseable → 90; `0` → 1; `250` → 99; env read always in range |
+| `decision_*_roundtrips` / `decision_ignores_extra_fields` | envelope `{"choice":..,"rationale":..}` ↔ enum, forward-compat |
+| `decision_unknown_choice_fails_to_parse` | `{"choice":"boom"}` → parse `Err`, not `Admit` |
+| `deterministic_brain_*` | floor always `Admit`, still beaten by the rail over ceiling |
+| `ctx_roundtrips_including_unknown_probes` | `ResourceAdmissionCtx` serde incl. `None` probes |
+
+**`src/ooda_brain/recipe_brain.rs`** (inline `#[cfg(test)]`):
+
+| Test | Proves |
+|---|---|
+| `parse_admission_decision_reads_all_three_choices` | direct `{"choice":..}` → `AdmissionDecision` for admit/defer/reclaim |
+| `parse_admission_decision_recovers_from_banner_and_fence` | banner + ```json fence still parses (shared chokepoint) |
+| `parse_admission_decision_none_for_unparseable` | empty / garbage / unknown tag → `None` (→ seam `Err`) |
+| `judge_admission_surfaces_error_no_fallback` | recipe-runner failure → `Err` naming the adapter tag (NO FALLBACK) |
+| `admission_metric_context_carries_choice_and_numbers` | `brain_admission_decision` payload carries `choice` + numeric picture |
+
+**`src/ooda_brain/mod.rs`** / **`context.rs`** / **`daemon/brains.rs`**:
+
+| Test | Proves |
+|---|---|
+| `brain_phase_serializes_as_lowercase` (mod.rs) | `BrainPhase::ResourceAdmission` ↔ `"resource_admission"` + `as_str` |
+| `admission_judgment_record_captures_gate` (mod.rs) | `from_admission` record shape + JSON round-trip |
+| `gather_resource_admission_ctx_is_hermetic_and_preserves_ceiling` (context.rs) | missing root → no panic, ceiling preserved, cache `None` |
+| `build_admission_brain_falls_back_to_deterministic_floor` (brains.rs) | unresolvable repo → loud fallback to the floor, which admits |
+
+---
+
+## Security
+
+| Concern | Handling |
+|---|---|
+| Shell injection | All probes argv-form; no `sh -c`. Probe paths daemon-derived only. |
+| Prompt injection | Context is numeric where possible (disk %, bytes, load, cpu, counts); any string context var passes `sanitize_context_var`. |
+| Fail-loud parsing | `AdmissionDecision` is a closed `#[serde(tag="choice")]` enum; unknown tag / missing field → parse `Err`, never default-to-`Admit`. |
+| Untrusted rationale | Stored only via serde (JSON-escaped) + emitted as a structured `tracing` field; never shell-interpreted or re-executed. Excluded from the metric so it cannot inflate cardinality. |
+| Ceiling misconfig | `parse().ok().unwrap_or(90).clamp(1,99)` — never `unwrap`, never 0, never ≥100. |
+| Availability invariant | known-over-ceiling ⇒ Defer; unknown ⇒ reasoner; never known-over-ceiling ⇒ Admit; never deadlock on unknown. |
+| Metric cardinality | `brain_admission_decision` labeled by enum only, never rationale/paths. |
+
+No authN/authZ: single-tenant, single-process, local daemon — no network
+boundary is crossed, so none is invented. No data-at-rest, no secrets, no PII.
+
+---
+
+## Module layout
+
+```
+src/ooda_brain/
+├── admission.rs          # OodaAdmissionBrain, ResourceAdmissionCtx, AdmissionDecision,
+│                         #   AdmissionGate, DeterministicAdmissionBrain,
+│                         #   resolve_admission (pure rail), judge_and_resolve (seam core),
+│                         #   parse_ceiling / configured_ceiling_pct,
+│                         #   RECIPE_NAME ("ooda-resource-admission.yaml")
+├── admission_tests.rs    # 27 hermetic tests (stub brain): seam + hard rail
+├── context.rs            # gather_resource_admission_ctx (best-effort probes)
+├── recipe_brain.rs       # impl OodaAdmissionBrain for RecipeBrain; parse_admission_decision;
+│                         #   brain_admission_decision metric (adapter tag literal)
+├── judgment_record.rs    # BrainPhase::ResourceAdmission + BrainJudgmentRecord::from_admission
+└── mod.rs                # mod admission; re-exports (ADMISSION_RECIPE_NAME = RECIPE_NAME)
+
+src/ooda_actions/advance_goal/
+└── spawn.rs              # gate seam in dispatch_spawn_engineer (Proceed/Defer/Reclaim/Err)
+
+src/ooda_loop/
+└── types.rs              # OodaBridges.admission_brain: Option<Arc<dyn OodaAdmissionBrain>>
+
+src/operator_commands_ooda/daemon/
+└── brains.rs             # build_admission_brain(..) -> Arc<dyn OodaAdmissionBrain>
+
+src/disk_health.rs        # get_disk_usage_pct (pub(crate), reused); run_disk_health_check (reclaim)
+
+prompt_assets/simard/recipes/
+└── ooda-resource-admission.yaml   # the intelligence (see recipe reference)
+```
+
+---
+
+## See also
+
+- [Resource-aware engineer admission (concept)](../concepts/resource-aware-engineer-admission.md)
+- [OODA resource-admission recipe & prompt schema](./ooda-resource-admission-recipe.md)
+- [Configure resource-aware admission (how-to)](../howto/configure-resource-aware-admission.md)
+- [`OodaBrain` API](./ooda-brain-api.md) — the sibling Decide/Act/Orient traits and the deterministic-floor pattern
+- [Recipe-Brain API](./recipe-brain-api.md) — the `RecipeBrain` envelope-parse chokepoint and escalation ladder
+- [Disk-Health API](./disk-health-api.md) — `run_disk_health_check` (RECLAIM-FIRST) and `emergency_cleanup` (≥95% tier)
+- [Adaptive Scaling API](./adaptive-scaling-api.md) — the count cap this layers under

--- a/docs/tutorials/stand-up-a-read-only-observer.md
+++ b/docs/tutorials/stand-up-a-read-only-observer.md
@@ -1,0 +1,171 @@
+---
+title: Stand up a read-only observer on a fresh host
+description: A guided, end-to-end walkthrough that uses the platform installer to stand up the Crocutus read-only observer daemon on host "dev" (Ubuntu 26.04) — from an unprepared host to a verified live OODA cycle with cognitive memory initializing cleanly and the read-only guardrail proven, running side-by-side with the primary Simard daemon.
+last_updated: 2026-07-08
+review_schedule: as-needed
+owner: simard
+doc_type: tutorial
+related:
+  - ../concepts/platform-installer.md
+  - ../concepts/lbug-portability-libstdcxx-abi.md
+  - ../howto/install-a-simard-family-agent.md
+  - ../howto/run-the-installer-preflight-doctor.md
+  - ../reference/platform-installer-cli.md
+---
+
+# Stand up a read-only observer on a fresh host
+
+In this tutorial you will use the platform installer to stand up **Crocutus** — a
+read-only observer built on the Simard framework — on host `dev`, an Azure VM
+reached over Bastion with [`azlin`](https://github.com/rysweet/azlin). You will
+go from an *unprepared* host all the way to a **verified live OODA cycle**:
+cognitive memory opens with no SIGSEGV, the read-only guardrail is proven, and
+the daemon runs side-by-side with the primary Simard daemon.
+
+By the end you will have seen every phase the installer runs and why each one
+exists. For the design behind it, read
+[The Simard platform installer](../concepts/platform-installer.md).
+
+## What you need
+
+- Operator access to run `azlin` (the `az ssh` extension and Bastion access).
+- A Crocutus checkout on your operator machine (it declares Simard as a Cargo
+  git dependency — you do **not** fork Simard).
+- A **read-only** Azure DevOps PAT (`Code: Read`) for the observed project.
+  Never a write token.
+
+You do **not** need to pre-install Rust, cmake, or `amplihack` on `dev` — the
+installer provisions those.
+
+## Step 1 — Confirm the target host
+
+```bash
+azlin list
+azlin connect dev -- hostname
+```
+
+Confirm `dev` is the host you intend and that you can reach it. The installer
+also asks for confirmation before it changes anything (skip with `--yes` for
+unattended runs).
+
+## Step 2 — Run the preflight doctor
+
+Before installing, see exactly what the host needs. Run the doctor remotely:
+
+```bash
+simard platform doctor --identity ./config/crocutus.env --remote azlin:dev
+```
+
+On a fresh 26.04 host you will see the doctor detect gaps and plan
+remediations — and confirm that lbug will build from source against the host
+toolchain (which is what avoids the SIGSEGV):
+
+```
+  ✓ os              Ubuntu 26.04 LTS
+  ✓ libstdc++       GLIBCXX_3.4.35
+  ⧗ rust            missing → will install via rustup
+  ⧗ native-deps     missing: cmake, libssl-dev → will apt-install
+  ⧗ amplihack       missing → will install + sync amplifier-bundle
+  ✓ disk            18 GiB free
+  ✓ port            8090 free
+  ✓ unit-name       crocutus-ooda.service available
+  ✓ state-root      ~/.crocutus/state unused
+  ✓ lbug-source     toolchain present → lbug builds from source (LBUG_BUILD_FROM_SOURCE=1)
+```
+
+That last line is the key to this whole exercise: on 26.04 a *prebuilt* lbug would
+mismatch the host's libstdc++ `std::format` ABI and segfault. Because the store is
+built **from source** against the host toolchain (unconditionally), there is no
+prebuilt in the process to mismatch. See
+[lbug portability](../concepts/lbug-portability-libstdcxx-abi.md).
+
+## Step 3 — Supply the read-only credential
+
+Provide the read-only PAT used to fetch the target's read-only clone (never a
+write token):
+
+```bash
+export ADO_READONLY_PAT=…     # READ-scoped PAT; never a write token
+```
+
+If a *write-capable* token is present in your environment, the installer treats
+that as a guardrail failure and refuses — a read-only observer must have no write
+token. (For a read-only observer the read PAT itself is optional: without it the
+observer degrades to anonymous read or does nothing, fail-closed at runtime.)
+
+## Step 4 — Install
+
+Run the one command. The installer executes every phase on `dev`:
+
+```bash
+simard platform install --identity ./config/crocutus.env --remote azlin:dev --yes
+```
+
+Watch it work through the
+[phase machine](../concepts/platform-installer.md#the-install-as-a-phase-machine):
+
+1. **preflight** — installs Rust, the native deps, and `amplihack`.
+2. **build** — builds the Crocutus binary with a **from-source lbug** matched to
+   `dev`'s libstdc++ (this is what prevents the SIGSEGV).
+3. **materialize** — creates `~/.crocutus/state`, the env file, the prompt root,
+   and the `crocutus-ooda.service` **user** unit with its guardrail start-gate.
+4. **prove-guardrails** — proves the read-only floor holds (target writes
+   refused, reads allowed) *and* that no write credential is present.
+5. **start** — `daemon-reload`, enable, start.
+6. **verify** — confirms cognitive memory opened (no SIGSEGV) and the daemon
+   reached a live OODA cycle with a stable new PID.
+7. **report** — prints a durable summary.
+
+## Step 5 — See the live cycle
+
+```bash
+azlin connect dev -- journalctl --user -u crocutus-ooda.service -f
+```
+
+You should see the read-only identity assumed, the guardrail proven, cognitive
+memory open **without** any `initBufferManager` / `std::vformat` SIGSEGV, and the
+OODA loop begin observing. That is the outcome the whole installer exists to
+guarantee.
+
+## Step 6 — Confirm side-by-side isolation
+
+Crocutus runs next to the primary Simard daemon without interfering:
+
+```bash
+azlin connect dev -- systemctl --user status simard-ooda.service crocutus-ooda.service
+azlin connect dev -- ls '~/.simard/state' '~/.crocutus/state'   # distinct roots
+```
+
+Distinct state roots, distinct ports, distinct units — two identities, one host,
+no collision.
+
+## Step 7 — Prove it changed nothing
+
+Crocutus is read-only in depth. Prove the guardrail any time:
+
+```bash
+azlin connect dev -- '~/crocutus/scripts/prove-guardrail.sh'
+```
+
+It exits non-zero if *any* layer (capability or credential) is uncertain. A green
+proof means Crocutus cannot write to the target — by construction.
+
+## What you learned
+
+- The installer turns "provision → install → prove → run" into one idempotent,
+  fail-closed command — locally or over azlin.
+- The preflight doctor detects the host's libstdc++ and verifies the from-source
+  lbug toolchain. The store is *always* built from source (never a prebuilt), so
+  there is no mismatched ABI in the process — which is what stops the 26.04
+  SIGSEGV.
+- "Done" means a **verified live OODA cycle** with cognitive memory open, not
+  merely an enabled unit.
+- Multi-identity isolation (state root, port, unit) is enforced, so a new
+  identity is safe to add to a host that already runs one.
+
+## Next steps
+
+- [Install a Simard-family agent](../howto/install-a-simard-family-agent.md) —
+  the operational reference for upgrades, uninstall, and local installs.
+- [Run the preflight doctor](../howto/run-the-installer-preflight-doctor.md).
+- [lbug portability across libstdc++ ABIs](../concepts/lbug-portability-libstdcxx-abi.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,9 +119,12 @@ nav:
     - Resource-Aware Engineer Admission: concepts/resource-aware-engineer-admission.md
     - Update-Check Design: concepts/update-check-design.md
     - The amplihack Freshness Gate: concepts/amplihack-freshness-gate.md
+    - The Simard Platform Installer: concepts/platform-installer.md
+    - lbug Portability across libstdc++ ABIs: concepts/lbug-portability-libstdcxx-abi.md
   - Tutorials:
     - First Local Session: tutorials/run-your-first-local-session.md
     - First Benchmark Suite: tutorials/run-your-first-benchmark-gym.md
+    - Stand Up a Read-Only Observer: tutorials/stand-up-a-read-only-observer.md
   - How-To Guides:
     - Terminal to Engineer: howto/move-from-terminal-recipes-into-engineer-runs.md
     - Use the Agent-Orchestration Engineer Loop: howto/use-agent-orchestration-engineer-loop.md
@@ -162,6 +165,8 @@ nav:
     - Run Self-Deploy from Any Directory: howto/run-self-deploy-from-any-directory.md
     - Check for Updates: howto/check-for-updates.md
     - Configure the amplihack Freshness Gate: howto/configure-amplihack-freshness-gate.md
+    - Install a Simard-Family Agent: howto/install-a-simard-family-agent.md
+    - Run the Installer Preflight Doctor: howto/run-the-installer-preflight-doctor.md
     - Self-Maintain Dependency Pins: howto/self-maintain-dependency-pins.md
     - Configure Adaptive Scaling: howto/configure-adaptive-scaling.md
     - Configure Pluggable Identity: howto/configure-pluggable-identity.md
@@ -198,6 +203,7 @@ nav:
     - amplihack Freshness Gate: reference/amplihack-freshness-gate.md
     - Multi-Binary Self-Update: reference/multi-binary-self-update.md
     - Self-Deploy API: reference/self-deploy-api.md
+    - Platform Installer CLI: reference/platform-installer-cli.md
     - Self-Deploy Source Prep & Warm Target Dir: reference/self-deploy-source-prep.md
     - State-Root Resolution: reference/state-root-resolution.md
     - Operator Read State-Root Contract: reference/operator-read-state-root-contract.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
     - Goal Stewardship Mode: concepts/stewardship-mode.md
     - The Simard Whisperer: concepts/simard-whisperer.md
     - Automated Disk-Health Management: concepts/automated-disk-health.md
+    - Resource-Aware Engineer Admission: concepts/resource-aware-engineer-admission.md
     - Update-Check Design: concepts/update-check-design.md
     - The amplihack Freshness Gate: concepts/amplihack-freshness-gate.md
   - Tutorials:
@@ -172,6 +173,7 @@ nav:
     - Configure the Monthly Self-Quality-Audit: howto/configure-self-quality-audit.md
     - Configure the Disk-Health Check: howto/configure-disk-health-check.md
     - Reclaim Disk Space (Low-Space Rust Builds): howto/reclaim-disk-space-and-run-low-space-rust-builds.md
+    - Configure Resource-Aware Admission: howto/configure-resource-aware-admission.md
     - Fix CI Linker OOM: howto/fix-ci-linker-oom.md
     - Triage Stale Pull Requests: howto/triage-stale-pull-requests.md
     - Diagnose merge-pr Verdict-Parse Failures: howto/diagnose-merge-pr-verdict-parse-failures.md
@@ -215,6 +217,7 @@ nav:
     - OODA Orient Prompt Schema: reference/ooda-orient-prompt.md
     - OODA Orient Recipe: reference/ooda-orient-recipe.md
     - OODA Engineer-Lifecycle Recipe: reference/ooda-engineer-lifecycle-recipe.md
+    - OODA Resource-Admission Recipe: reference/ooda-resource-admission-recipe.md
     - OODA Procedural Memory: reference/ooda-procedural-memory.md
     - Recipe-Brain Verdict/Decision Parsing: reference/recipe-brain-verdict-parsing.md
     - OODA Binary-Identity Reload Gate: reference/ooda-binary-identity-reload-gate.md
@@ -277,6 +280,7 @@ nav:
     - Brain Introspection API: reference/brain-introspection-api.md
     - Self-Quality-Audit API: reference/self-quality-audit-api.md
     - Disk-Health API: reference/disk-health-api.md
+    - Resource-Aware Admission API: reference/resource-aware-admission-api.md
     - Dashboard E2E Tests: reference/dashboard-e2e-tests.md
     - Dashboard Action-Detail Humanization: reference/dashboard-action-detail-humanization.md
     - Azlin Hosts Self-Membership: reference/azlin-hosts-self-membership.md

--- a/prompt_assets/simard/recipes/ooda-resource-admission.yaml
+++ b/prompt_assets/simard/recipes/ooda-resource-admission.yaml
@@ -1,0 +1,158 @@
+# ooda-resource-admission.yaml — Recipe-runner recipe for the OODA
+# RESOURCE-AWARE engineer admission brain (fresh-spawn gate).
+#
+# WHY THIS EXISTS
+# The AIMD adaptive scaler bounds how MANY engineers run concurrently, but a
+# count cap cannot see a full disk, a thrashing load average, or a cargo build
+# cache that has quietly grown to tens of gigabytes. On a busy self-improvement
+# host that gap bit hard: 40+ engineer worktrees accumulated, parallel `cargo`
+# builds piled up, disk climbed to 91%, and the next allocation tripped ENOSPC
+# (No space left on device) — which kills recipes mid-flight. Count-control is
+# necessary but NOT sufficient; admission must also weigh RESOURCES.
+#
+# This recipe is the intelligence for that admission decision. It runs at EVERY
+# fresh-engineer spawn (repeated structured thought), reasons over the current
+# resource picture, and emits exactly one of ADMIT / DEFER / RECLAIM-FIRST.
+#
+# The Rust shim (src/ooda_brain/recipe_brain.rs :: judge_admission) parses the
+# structured JSON decision below into an `AdmissionDecision`. A THIN
+# deterministic hard-rail in Rust (src/ooda_brain/admission.rs ::
+# resolve_admission) sits BELOW this reasoning: if disk% is known to be at/above
+# `ceiling_pct`, admission is refused regardless of what you decide here. You
+# can only ever be made MORE conservative by the rail, never less — so you never
+# have to hedge toward safety on disk; state your honest judgment.
+#
+# Context vars (passed via -c). Any probe that failed on the host renders as the
+# literal string `unknown`; weigh an `unknown` explicitly rather than assuming
+# the best case:
+#   disk_usage_pct        — % full of the state/worktree filesystem (0-100)
+#   worktree_cache_bytes  — total bytes under the engineer-worktrees/build-cache
+#   load_avg_1m           — 1-minute system load average
+#   cpu_count             — logical CPU count (normalize load per core)
+#   in_flight_engineers   — engineers already running this cycle
+#   ceiling_pct           — the deterministic disk hard-rail ceiling in effect
+#
+# Output: a single JSON object (see OUTPUT FORMAT) as the agent step output.
+
+name: "ooda-resource-admission"
+description: "OODA resource-aware engineer admission — ADMIT / DEFER / RECLAIM-FIRST"
+version: "1.0.0"
+author: "Simard"
+tags: ["simard", "ooda", "admission", "resource-aware"]
+
+context: {}
+
+steps:
+  - id: "resource-admission-decision"
+    type: "agent"
+    agent: "default"
+    prompt: |
+      # OODA Brain — Resource-Aware Engineer Admission
+
+      ## ROLE
+
+      You are the brain of Simard's OODA daemon. A goal has already passed the
+      AIMD engineer-COUNT cap and is about to spawn a FRESH engineer, which will
+      allocate a new git worktree and (very likely) kick off a parallel `cargo`
+      build with its own multi-gigabyte target cache. Before that allocation
+      happens, decide whether this host can currently AFFORD one more engineer.
+
+      Your job is resource ADMISSION, not count control. The count question was
+      already answered "yes" upstream. You answer the different question: **"can
+      this host afford one more engineer RIGHT NOW, given disk / build-cache /
+      load?"** Judge on the live numbers below, not on habit.
+
+      ## CONTEXT (current resource picture)
+
+      - disk_usage_pct: {{disk_usage_pct}}      # % full; `unknown` if the probe failed
+      - worktree_cache_bytes: {{worktree_cache_bytes}}  # bytes under engineer-worktrees / build caches
+      - load_avg_1m: {{load_avg_1m}}            # 1-minute load average
+      - cpu_count: {{cpu_count}}                # logical CPUs (load_avg_1m / cpu_count = load-per-core)
+      - in_flight_engineers: {{in_flight_engineers}}   # engineers already running this cycle
+      - ceiling_pct: {{ceiling_pct}}            # deterministic disk hard-rail ceiling
+
+      ## HOW TO REASON
+
+      Weigh three signals together — no single hardcoded threshold, that is the
+      whole point of doing this agentically:
+
+      1. **Disk headroom.** The dominant, irreversible risk is ENOSPC. The closer
+         `disk_usage_pct` is to `ceiling_pct`, the less headroom another build
+         cache leaves. Well below the ceiling with room to spare → disk is not a
+         reason to hold back. Approaching the ceiling → be cautious. At/above the
+         ceiling the deterministic rail will block you anyway, but if the disk is
+         high AND the growth is clearly reclaimable (a large `worktree_cache_bytes`
+         from stale worktrees / build caches), prefer RECLAIM-FIRST so the next
+         cycle has room, rather than a bare DEFER that just spins.
+      2. **Build-cache size.** A large `worktree_cache_bytes` relative to the
+         disk means much of the disk pressure is *reclaimable* (stale worktrees,
+         `target/` dirs) rather than load-bearing. That favors RECLAIM-FIRST over
+         DEFER when disk is tight, and is reassuring (reclaim is available) when
+         disk is moderate.
+      3. **System load.** Compare `load_avg_1m` to `cpu_count`. Load per core well
+         under ~1.0 means CPU headroom for another parallel build; load per core
+         well above ~1.5-2.0 means the host is already saturated and another
+         build would thrash without finishing faster. Many `in_flight_engineers`
+         plus high load is a strong DEFER signal even when disk is fine.
+
+      Treat any `unknown` field as a genuine unknown: do not assume it is
+      healthy. If disk is `unknown` you have lost your primary safety signal, so
+      lean conservative (DEFER) unless load and in-flight counts are clearly low.
+
+      ## OPTIONS — pick exactly one `choice`
+
+      - `admit` — Resources are healthy enough to add an engineer now. Disk has
+        clear headroom below the ceiling AND load-per-core leaves room for another
+        build. This is the normal, healthy answer; use it whenever the numbers
+        genuinely support it. Do NOT reflexively hold back — throttling a healthy
+        host wastes throughput.
+      - `defer` — Resources are tight and adding an engineer now is unwise (high
+        load-per-core, many in-flight engineers, or disk near the ceiling with
+        little reclaimable cache). A benign skip: no worktree is allocated, the
+        goal is simply retried next cycle, and this is NOT counted as a failure.
+      - `reclaim_first` — Disk pressure is high but clearly RECLAIMABLE (a large
+        build-cache / worktree footprint). Run disk reclamation first, then defer
+        this cycle and re-evaluate next cycle once space is freed.
+
+      ## OUTPUT FORMAT
+
+      Respond with a SINGLE JSON object of this exact shape (a fenced ```json
+      block is fine; the daemon strips any surrounding banner/prose before
+      parsing):
+
+      ```json
+      {"choice": "<admit|defer|reclaim_first>", "rationale": "<one concise sentence citing the numbers you weighed>"}
+      ```
+
+      `choice` MUST be exactly one of `admit`, `defer`, `reclaim_first`. There is
+      NO default: if your output is unparseable the daemon surfaces an explicit
+      error (and does NOT silently admit — an accidental admit could fill the
+      disk). Always cite the concrete numbers you weighed in the rationale so the
+      decision is auditable.
+
+      ## EXAMPLES
+
+      Healthy host — admit:
+
+      ```json
+      {"choice": "admit", "rationale": "disk 42% (ceiling 90), load 3.1 over 16 cpus = 0.19/core, 2 engineers in flight — ample headroom"}
+      ```
+
+      Saturated host — defer:
+
+      ```json
+      {"choice": "defer", "rationale": "disk 61% is fine but load 34 over 16 cpus = 2.1/core with 8 engineers in flight; another build would thrash, retry next cycle"}
+      ```
+
+      Tight but reclaimable disk — reclaim_first:
+
+      ```json
+      {"choice": "reclaim_first", "rationale": "disk 88% near ceiling 90, but worktree_cache_bytes is 210GB of stale caches — reclaim then re-evaluate rather than block"}
+      ```
+
+      Lost disk signal — conservative defer:
+
+      ```json
+      {"choice": "defer", "rationale": "disk_usage_pct unknown so primary safety signal is gone; with 6 engineers in flight, defer one cycle rather than risk ENOSPC"}
+      ```
+    output: "admission_result"

--- a/src/cmd_ensure_deps.rs
+++ b/src/cmd_ensure_deps.rs
@@ -1,9 +1,19 @@
 //! Dependency checker: verifies that Simard runtime dependencies are present.
 //!
-//! Checks for required tools (python3, gh, git) and Python packages (kuzu).
-//! Reports missing dependencies with actionable guidance rather than
-//! auto-installing them — Simard's native Rust modules now cover capabilities
-//! that previously required the Python amplihack installation.
+//! Checks for the minimal runtime tools (`git`, `python3`, `gh`) and reports
+//! missing ones with actionable guidance rather than auto-installing them —
+//! Simard's native Rust modules now cover capabilities that previously required
+//! the Python amplihack installation.
+//!
+//! Cognitive memory is embedded **lbug** (LadybugDB), compiled and linked into
+//! the binary via `amplihack-memory-lib`'s `persistent` feature — it is *not*
+//! the Python `kuzu` package. There is therefore no `kuzu` probe here; a stale
+//! kuzu check was removed (issue #3119) because it was misleading noise. The
+//! heavier build/host preconditions (Rust toolchain, `build-essential`, `cmake`,
+//! `clang`, `pkg-config`, `libssl-dev`, the `amplihack` CLI + bundle, and the
+//! lbug from-source build prerequisites) are the platform installer's preflight
+//! doctor's responsibility (`simard platform doctor`), not this minimal runtime
+//! check.
 
 use std::process::Command;
 
@@ -16,7 +26,6 @@ struct DepCheck {
 enum DepStatus {
     Ok(String),
     Missing(String),
-    Warning(String),
 }
 
 /// Run all dependency checks and report results.
@@ -27,19 +36,13 @@ pub fn handle_ensure_deps() -> Result<(), Box<dyn std::error::Error>> {
         check_binary("git", &["--version"]),
         check_binary("python3", &["--version"]),
         check_binary("gh", &["--version"]),
-        check_python_package("kuzu"),
     ];
 
     println!();
     let mut failed = 0;
-    let mut warnings = 0;
     for dep in &results {
         let (icon, detail) = match &dep.status {
             DepStatus::Ok(msg) => ("✓", msg.as_str()),
-            DepStatus::Warning(msg) => {
-                warnings += 1;
-                ("⚠", msg.as_str())
-            }
             DepStatus::Missing(msg) => {
                 failed += 1;
                 ("✗", msg.as_str())
@@ -52,11 +55,7 @@ pub fn handle_ensure_deps() -> Result<(), Box<dyn std::error::Error>> {
     if failed > 0 {
         Err(format!("{failed} dependency check(s) failed").into())
     } else {
-        if warnings > 0 {
-            println!("All required dependencies satisfied ({warnings} optional warning(s)).");
-        } else {
-            println!("All dependencies satisfied.");
-        }
+        println!("All dependencies satisfied.");
         Ok(())
     }
 }
@@ -86,28 +85,6 @@ fn check_binary(name: &'static str, version_args: &[&str]) -> DepCheck {
     }
 }
 
-fn check_python_package(package: &'static str) -> DepCheck {
-    let check = Command::new("python3")
-        .args(["-c", &format!("import {package}")])
-        .output();
-
-    if let Ok(output) = &check
-        && output.status.success()
-    {
-        return DepCheck {
-            name: package,
-            status: DepStatus::Ok("importable".into()),
-        };
-    }
-
-    DepCheck {
-        name: package,
-        status: DepStatus::Warning(format!(
-            "not importable; install with: pip install {package}"
-        )),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -122,12 +99,5 @@ mod tests {
     fn check_binary_missing_returns_missing() {
         let result = check_binary("nonexistent-binary-xyz", &["--version"]);
         assert!(matches!(result.status, DepStatus::Missing(_)));
-    }
-
-    #[test]
-    fn check_python_package_reports_status() {
-        // A package that definitely doesn't exist should warn
-        let result = check_python_package("nonexistent_pkg_xyz_12345");
-        assert!(matches!(result.status, DepStatus::Warning(_)));
     }
 }

--- a/src/disk_health.rs
+++ b/src/disk_health.rs
@@ -223,7 +223,7 @@ pub fn emergency_cleanup(repo_root: &Path, state_root: &Path) -> Option<DiskHeal
 }
 
 /// Get disk usage percentage for the filesystem containing `path`.
-fn get_disk_usage_pct(path: &Path) -> Option<u8> {
+pub(crate) fn get_disk_usage_pct(path: &Path) -> Option<u8> {
     let output = Command::new("df")
         .arg("--output=pcent")
         .arg(path)

--- a/src/meeting_backend/agent_proxy.rs
+++ b/src/meeting_backend/agent_proxy.rs
@@ -1,8 +1,20 @@
 //! Direct-invoke agent proxy for meeting conversations.
 //!
-//! Spawns the coding agent per-turn via `copilot -p "MESSAGE"` with piped
-//! stdout — no PTY, no script(1), no bash wrapper. This is the "thin proxy"
-//! replacing the 30-90s PTY overhead (issue #2179).
+//! Spawns the coding agent per-turn via `copilot -p "MESSAGE"`. Each turn runs
+//! under a lightweight one-shot `script(1)` pseudo-terminal by default so the
+//! Node-based CLI detects an interactive TTY and flushes its reply
+//! incrementally — letting the streaming reader tee each line to the client as
+//! it arrives (issue #2581) instead of the reply appearing only once the whole
+//! turn completes. Over a plain pipe those CLIs detect a non-tty and
+//! block-buffer the entire turn into a single final write, which is exactly the
+//! "wait for the whole thread" latency this wrapper removes.
+//!
+//! This is distinct from the persistent, prompt-driven PTY session that added
+//! 30-90s of handshake overhead (issue #2179): the wrapper here is a single
+//! non-interactive invocation that self-terminates, so its startup cost is
+//! negligible and per-turn latency stays in the ~4-15s range. Set
+//! `SIMARD_AGENT_PTY_STREAM=0` to fall back to a direct piped invocation
+//! (marginally faster to start, but the reply only appears once the turn ends).
 //!
 //! Copilot CLI does not support persistent interactive stdin when piped, so
 //! each turn is a separate subprocess. The conversation context is maintained
@@ -24,6 +36,141 @@ use crate::base_types::{
 use crate::error::{SimardError, SimardResult};
 use crate::metadata::{BackendDescriptor, Freshness};
 use crate::runtime::RuntimeTopology;
+
+/// External PTY launcher used to give a one-shot agent turn an interactive
+/// terminal so the CLI streams its output incrementally (issue #2581). Matches
+/// the `terminal_session` launcher; `script(1)` is present on Linux
+/// (util-linux) and macOS (BSD).
+const PTY_LAUNCHER: &str = "script";
+
+/// Whether agent turns run under a `script(1)` PTY (default) so the CLI streams
+/// its reply incrementally, versus a direct piped invocation where the reply
+/// only lands once the turn ends. Pure over the raw env value so the parsing is
+/// unit-testable without mutating process env (mirrors `parse_turn_timeout`).
+///
+/// Any of `0`, `false`, `no`, `off` (case-insensitive) disables the PTY; every
+/// other value — including an unset var — keeps it on.
+fn pty_streaming_from_env(raw: Option<String>) -> bool {
+    match raw {
+        Some(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        ),
+        None => true,
+    }
+}
+
+/// Live check of [`pty_streaming_from_env`] against the process environment.
+fn pty_streaming_enabled() -> bool {
+    pty_streaming_from_env(std::env::var("SIMARD_AGENT_PTY_STREAM").ok())
+}
+
+/// POSIX single-quote escaping so an arbitrary string — including the untrusted
+/// user prompt — can be embedded in the `sh -c` command line that `script`
+/// evaluates without any risk of shell injection. Wraps the value in single
+/// quotes and rewrites each embedded quote as the canonical `'\''` sequence.
+fn shell_single_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for c in s.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+/// Reconstruct the full agent invocation (`<cmd> <base_args…> -p <prompt>`) as a
+/// single shell-escaped command line suitable for `sh -c` / `script -c`. Every
+/// token is quoted independently so neither the args nor the prompt can alter
+/// the command structure.
+fn agent_shell_line(agent_cmd: &str, base_args: &[String], prompt: &str) -> String {
+    let mut tokens: Vec<String> = Vec::with_capacity(base_args.len() + 3);
+    tokens.push(shell_single_quote(agent_cmd));
+    for a in base_args {
+        tokens.push(shell_single_quote(a));
+    }
+    tokens.push(shell_single_quote("-p"));
+    tokens.push(shell_single_quote(prompt));
+    tokens.join(" ")
+}
+
+/// Strip a trailing carriage return and any ANSI/VT escape sequences from one
+/// line of agent output. PTY-relayed output carries CRLF line endings and may
+/// embed colour/cursor control sequences the CLI emits once it detects a TTY;
+/// neither belongs in the substantive chat text (issue #2581). A line with no
+/// escapes is returned unchanged apart from a trailing `\r`, so this is safe to
+/// apply to plain piped (non-PTY) output too. Char-based so multi-byte UTF-8 is
+/// preserved intact.
+///
+/// Takes the line by value so the common escape-free case reuses the caller's
+/// existing buffer — the trailing `\r` is popped in place and the same `String`
+/// handed straight back with zero extra allocation. Only a line that actually
+/// carries an ESC pays for a stripped copy. This matters because the streaming
+/// reader calls this once per output line (issue #2581).
+fn sanitize_terminal_line(mut line: String) -> String {
+    // Drop a trailing CR from CRLF terminal endings in place — no reallocation.
+    if line.ends_with('\r') {
+        line.pop();
+    }
+    // Fast path: no escape sequences, so the buffer is already the clean line —
+    // return it as-is without copying.
+    if !line.contains('\u{1b}') {
+        return line;
+    }
+    let mut out = String::with_capacity(line.len());
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        match chars.peek() {
+            // CSI: ESC '[' … terminated by a final byte in 0x40..=0x7e.
+            Some('[') => {
+                chars.next();
+                while let Some(&nc) = chars.peek() {
+                    chars.next();
+                    if ('\u{40}'..='\u{7e}').contains(&nc) {
+                        break;
+                    }
+                }
+            }
+            // String-payload control sequences: an ESC introducer followed by
+            // an opaque data string terminated by ST (ESC '\') or, defensively,
+            // BEL (0x07). All carry data — never visible text — so the whole
+            // sequence including its payload is dropped:
+            //   OSC  ESC ']'   operating system command (e.g. window title)
+            //   DCS  ESC 'P'   device control string
+            //   SOS  ESC 'X'   start of string
+            //   PM   ESC '^'   privacy message
+            //   APC  ESC '_'   application program command
+            Some(']') | Some('P') | Some('X') | Some('^') | Some('_') => {
+                chars.next();
+                while let Some(nc) = chars.next() {
+                    if nc == '\u{07}' {
+                        break;
+                    }
+                    if nc == '\u{1b}' {
+                        if let Some('\\') = chars.peek() {
+                            chars.next();
+                        }
+                        break;
+                    }
+                }
+            }
+            // Two-character escape (e.g. ESC M): drop the following byte.
+            Some(_) => {
+                chars.next();
+            }
+            None => {}
+        }
+    }
+    out
+}
 
 /// True when a single agent output line is copilot CLI noise (usage stats,
 /// bootstrap banners, progress indicators) that should never be surfaced as
@@ -229,13 +376,15 @@ fn resolve_agent_command() -> SimardResult<(String, Vec<String>)> {
 }
 
 /// A direct-invoke agent proxy that spawns the coding agent per-turn via
-/// `copilot -p "MESSAGE"` with piped stdout.
+/// `copilot -p "MESSAGE"`.
 ///
-/// Unlike `CopilotSdkAdapter` (which uses PTY/script per turn), this proxy
-/// invokes the agent directly with `-p` flag and captures stdout — no PTY
-/// allocation, no script(1) wrapper, no bash intermediary.
-///
-/// Response time: ~4-15s per turn vs 30-90s with the old PTY path.
+/// Each turn is wrapped in a one-shot `script(1)` PTY by default so the CLI
+/// streams its reply incrementally (issue #2581). This is a single
+/// non-interactive invocation — not the persistent, prompt-driven PTY session
+/// `CopilotSdkAdapter` uses — so it keeps the ~4-15s/turn latency rather than
+/// the 30-90s of the old interactive PTY path (issue #2179).
+/// `SIMARD_AGENT_PTY_STREAM=0` opts back into a direct piped invocation (no PTY,
+/// but the reply then only appears once the turn ends).
 pub struct PersistentAgentProxy {
     descriptor: BaseTypeDescriptor,
     is_open: bool,
@@ -312,6 +461,58 @@ impl PersistentAgentProxy {
         Ok(())
     }
 
+    /// Build the per-turn agent spawn command (program + argv only; stdio,
+    /// process group, and working directory are applied by the caller so both
+    /// modes share them).
+    ///
+    /// When `pty` is true (the default; see [`pty_streaming_enabled`]) the agent
+    /// runs under a one-shot `script(1)` PTY so the Node-based CLI
+    /// (`copilot`/`claude`) sees an interactive terminal and flushes its reply
+    /// incrementally, letting [`Self::invoke_agent_streaming`] tee each line to
+    /// the client as it is produced (issue #2581). Over a plain pipe those CLIs
+    /// detect a non-tty and block-buffer the whole turn into a single final
+    /// write, so nothing streams until the turn completes. The untrusted prompt
+    /// is shell-escaped via [`agent_shell_line`] before it reaches `sh -c`.
+    ///
+    /// When `pty` is false the agent is spawned directly with its argv, giving
+    /// the piped, non-tty stdio of the original thin proxy (issue #2179).
+    fn build_agent_command(&self, prompt: &str, pty: bool) -> Command {
+        if !pty {
+            let mut cmd = Command::new(&self.agent_cmd);
+            cmd.args(&self.agent_base_args).arg("-p").arg(prompt);
+            return cmd;
+        }
+
+        let agent_line = agent_shell_line(&self.agent_cmd, &self.agent_base_args, prompt);
+        let mut cmd = Command::new(PTY_LAUNCHER);
+        if cfg!(target_os = "macos") {
+            // BSD `script` (macOS): `-F` flushes each write; the typescript file
+            // is positional and precedes the command, which we run via an
+            // explicit shell so the escaped argv is honored identically.
+            cmd.arg("-qFe")
+                .arg("/dev/null")
+                .arg("/bin/sh")
+                .arg("-c")
+                .arg(agent_line);
+        } else {
+            // util-linux `script` (Linux): `-f` flushes each write, `-e`
+            // propagates the child exit code, and `-c` takes the command
+            // string; the typescript is discarded to /dev/null.
+            //
+            // util-linux `script -c` runs the command via `$SHELL`, falling
+            // back to `/bin/sh` only when it is unset. Pin `SHELL=/bin/sh` so
+            // an operator's non-POSIX login shell (fish, csh, …) can never
+            // reinterpret the POSIX single-quote-escaped command line — the
+            // macOS branch above already names `/bin/sh` explicitly. This
+            // hardens the one shell-boundary crossing (security review #2581).
+            cmd.env("SHELL", "/bin/sh")
+                .arg("-qefc")
+                .arg(agent_line)
+                .arg("/dev/null");
+        }
+        cmd
+    }
+
     /// Invoke the agent with a prompt and return the full (noise-stripped)
     /// response. Thin wrapper over [`Self::invoke_agent_streaming`] with a
     /// no-op chunk sink, for callers that don't need incremental output.
@@ -341,11 +542,12 @@ impl PersistentAgentProxy {
             "Invoking agent (streaming)"
         );
 
-        let mut cmd = Command::new(&self.agent_cmd);
-        cmd.args(&self.agent_base_args)
-            .arg("-p")
-            .arg(prompt)
-            .stdin(std::process::Stdio::null())
+        // Build the turn command — under a one-shot `script(1)` PTY by default
+        // so the agent CLI streams its reply incrementally instead of
+        // block-buffering the whole turn behind a non-tty pipe (issue #2581).
+        // `SIMARD_AGENT_PTY_STREAM=0` opts back into the direct piped path.
+        let mut cmd = self.build_agent_command(prompt, pty_streaming_enabled());
+        cmd.stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
 
@@ -467,6 +669,11 @@ impl PersistentAgentProxy {
                     // Fresh output — reset the idle-liveness clock so a
                     // productive turn is never reaped regardless of total length.
                     last_activity = Instant::now();
+                    // PTY-relayed output carries CRLF endings and may embed ANSI
+                    // control sequences the CLI emits once it sees a TTY; strip
+                    // both so the streamed preview and the final joined response
+                    // are clean text (a no-op for plain piped output).
+                    let line = sanitize_terminal_line(line);
                     if !line_is_noise(line.trim()) {
                         on_chunk(&line);
                     }
@@ -692,6 +899,93 @@ mod tests {
         let input = "Normal response.\nWith multiple lines.";
         let result = strip_copilot_noise(input);
         assert_eq!(result, "Normal response.\nWith multiple lines.");
+    }
+
+    // ── issue #2581: PTY streaming helpers ──
+
+    #[test]
+    fn pty_streaming_defaults_on_when_unset() {
+        assert!(
+            pty_streaming_from_env(None),
+            "unset env must keep incremental PTY streaming enabled by default"
+        );
+    }
+
+    #[test]
+    fn pty_streaming_disabled_by_falsey_values() {
+        for v in ["0", "false", "FALSE", "no", "Off", " off "] {
+            assert!(
+                !pty_streaming_from_env(Some(v.to_string())),
+                "{v:?} must disable PTY streaming"
+            );
+        }
+    }
+
+    #[test]
+    fn pty_streaming_enabled_by_other_values() {
+        for v in ["1", "true", "yes", "on", ""] {
+            assert!(
+                pty_streaming_from_env(Some(v.to_string())),
+                "{v:?} must keep PTY streaming enabled"
+            );
+        }
+    }
+
+    #[test]
+    fn shell_single_quote_escapes_embedded_quote() {
+        // A prompt attempting to break out of the sh -c string stays inert.
+        assert_eq!(shell_single_quote("a'b"), "'a'\\''b'");
+        assert_eq!(shell_single_quote("plain"), "'plain'");
+    }
+
+    #[test]
+    fn agent_shell_line_quotes_every_token() {
+        let base = vec!["--allow-all-tools".to_string()];
+        let line = agent_shell_line("copilot", &base, "hi; rm -rf /");
+        // Structure: '<cmd>' '<arg>' '-p' '<prompt>' — all single-quoted so the
+        // injected ';' and spaces are literal prompt text, not shell syntax.
+        assert_eq!(line, "'copilot' '--allow-all-tools' '-p' 'hi; rm -rf /'");
+    }
+
+    #[test]
+    fn sanitize_terminal_line_strips_cr_and_ansi() {
+        // Trailing CR from CRLF terminal endings.
+        assert_eq!(sanitize_terminal_line("hello\r".to_string()), "hello");
+        // CSI colour codes around real text.
+        assert_eq!(
+            sanitize_terminal_line("\u{1b}[32mgreen\u{1b}[0m text\r".to_string()),
+            "green text"
+        );
+        // OSC sequence (window title) terminated by BEL.
+        assert_eq!(
+            sanitize_terminal_line("\u{1b}]0;title\u{07}visible".to_string()),
+            "visible"
+        );
+        // DCS/SOS/PM/APC string sequences carry an opaque payload terminated by
+        // ST (ESC '\') — the whole sequence, payload included, must be dropped.
+        assert_eq!(
+            sanitize_terminal_line("\u{1b}Pq#0;2;0;0;0\u{1b}\\shown".to_string()),
+            "shown"
+        );
+        assert_eq!(
+            sanitize_terminal_line("\u{1b}_private data\u{1b}\\kept".to_string()),
+            "kept"
+        );
+        assert_eq!(
+            sanitize_terminal_line("\u{1b}^pm payload\u{1b}\\end".to_string()),
+            "end"
+        );
+    }
+
+    #[test]
+    fn sanitize_terminal_line_preserves_plain_and_utf8() {
+        assert_eq!(sanitize_terminal_line("just text".to_string()), "just text");
+        // Multi-byte UTF-8 must survive intact (char-based scan).
+        assert_eq!(sanitize_terminal_line("café ☕\r".to_string()), "café ☕");
+        assert_eq!(
+            sanitize_terminal_line("\u{1b}[1mbold café ☕\u{1b}[0m".to_string()),
+            "bold café ☕"
+        );
     }
 
     // ── issues #2549/#2581: default idle-liveness window ──
@@ -965,15 +1259,16 @@ mod tests {
         );
     }
 
-    // ── thin-proxy invariant (issue #2179): no PTY, piped stdio ──
+    // ── streaming vs thin-proxy stdio (issues #2179 / #2581) ──
 
     #[test]
-    fn invoke_agent_uses_piped_stdio_not_a_pty() {
-        // The thin proxy spawns the agent with a null stdin and a piped stdout —
-        // never a PTY/script(1)/bash wrapper (issue #2179, replacing the 30-90s
-        // PTY overhead). A child that inspects its own descriptors must therefore
-        // observe NON-tty stdin and stdout; if a PTY leaked back in, `[ -t 0 ]` /
-        // `[ -t 1 ]` would report a terminal and this assertion would fail.
+    fn invoke_agent_streams_under_a_pty_by_default() {
+        // Streaming (issue #2581) requires the agent to see an interactive
+        // terminal so it flushes incrementally instead of block-buffering the
+        // whole turn behind a non-tty pipe. By default the turn therefore runs
+        // under a one-shot `script(1)` PTY: a child that inspects its own
+        // descriptors observes tty stdin AND stdout. (`SIMARD_AGENT_PTY_STREAM`
+        // is unset in the test process, so the default PTY path is exercised.)
         let mut proxy = PersistentAgentProxy::new().unwrap();
         proxy.agent_cmd = "sh".to_string();
         proxy.agent_base_args = vec![
@@ -986,12 +1281,74 @@ mod tests {
 
         let response = proxy
             .invoke_agent("hello")
-            .expect("no-PTY probe child must return Ok");
+            .expect("PTY probe child must return Ok");
         assert_eq!(
-            response, "stdin=notty stdout=notty",
-            "proxy must invoke the agent over piped (non-PTY) stdio — no \
-             script(1)/PTY/bash wrapper (issue #2179)"
+            response, "stdin=tty stdout=tty",
+            "streaming turns must run the agent under a PTY so it flushes \
+             incrementally (issue #2581)"
         );
+    }
+
+    #[test]
+    fn build_agent_command_direct_mode_is_a_plain_pipe() {
+        // With the PTY disabled the agent is spawned directly with its own argv
+        // — no `script(1)`/PTY/bash wrapper — preserving the thin-proxy path
+        // (issue #2179) as an opt-out.
+        let mut proxy = PersistentAgentProxy::new().unwrap();
+        proxy.agent_cmd = "copilot".to_string();
+        proxy.agent_base_args = vec!["--allow-all-tools".to_string()];
+
+        let cmd = proxy.build_agent_command("hi there", false);
+        assert_eq!(cmd.get_program(), "copilot");
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args, vec!["--allow-all-tools", "-p", "hi there"]);
+    }
+
+    #[test]
+    fn build_agent_command_pty_mode_wraps_script_with_escaped_prompt() {
+        // With the PTY enabled the agent runs under `script(1)`; the full
+        // invocation is passed as a single shell-escaped command string so an
+        // adversarial prompt cannot break out of `sh -c`.
+        let mut proxy = PersistentAgentProxy::new().unwrap();
+        proxy.agent_cmd = "copilot".to_string();
+        proxy.agent_base_args = vec!["--allow-all-tools".to_string()];
+
+        let cmd = proxy.build_agent_command("hi; rm -rf /", true);
+        assert_eq!(cmd.get_program(), PTY_LAUNCHER);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        // The escaped agent line must appear verbatim as one argument, with the
+        // injected `;` quoted inside the prompt rather than as shell syntax.
+        let expected_line = "'copilot' '--allow-all-tools' '-p' 'hi; rm -rf /'";
+        assert!(
+            args.iter().any(|a| a == expected_line),
+            "escaped agent line must be passed as a single argument: {args:?}"
+        );
+        assert!(
+            args.iter().any(|a| a == "/dev/null"),
+            "typescript output must be discarded to /dev/null: {args:?}"
+        );
+        // Security hardening: the util-linux `script -c` path must pin
+        // `SHELL=/bin/sh` so a non-POSIX operator login shell cannot reinterpret
+        // the single-quote-escaped command line (macOS names /bin/sh directly).
+        #[cfg(not(target_os = "macos"))]
+        {
+            let shell = cmd
+                .get_envs()
+                .find(|(k, _)| *k == std::ffi::OsStr::new("SHELL"))
+                .and_then(|(_, v)| v)
+                .map(|v| v.to_string_lossy().into_owned());
+            assert_eq!(
+                shell.as_deref(),
+                Some("/bin/sh"),
+                "script -c must run the command under /bin/sh, not $SHELL"
+            );
+        }
     }
 
     #[test]

--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -814,7 +814,15 @@ pub fn classify_distill_error(err: &SimardError) -> DistillFailureClass {
         DistillFailureClass::RecipeReportedFailure
     } else if msg.starts_with("distill: `distill` step output did not contain a parseable")
         || msg.starts_with("distill: recipe run did not yield a parseable")
+        || msg.starts_with("distill: distill step produced no parseable facts file")
     {
+        // The structured file-channel manifestations (issues #2622, #2619): the
+        // recipe process exited 0 but the distill agent's dedicated facts-output
+        // file was missing / empty / not parseable JSON. This is the *same*
+        // failure mode as the legacy stdout parse miss — the run reached output
+        // parsing but yielded no facts — so it maps to `ParseFailure` (transient,
+        // in-cycle retried, counted in `distill_parse_success_rate`), never a
+        // silent success.
         DistillFailureClass::ParseFailure
     } else {
         DistillFailureClass::Other
@@ -1252,6 +1260,121 @@ pub(crate) fn parse_recipe_output_full(raw: &str) -> SimardResult<DistillOutput>
         "distill: recipe run did not yield a parseable {{ \"facts\": [...] }} object: {}",
         truncate(raw, 200)
     )))
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Structured file-channel parsing (issues #2622, #2619)
+// ───────────────────────────────────────────────────────────────────────────
+//
+// The stdout-scraping tiers above are the brittle G3 antipattern the operator
+// flagged: the copilot launcher BANNER / INFO log lines are captured as the
+// distill step "output", and a balanced-brace grep for `{ "facts": [...] }`
+// then fails, so distillation cannot parse its own output (parse-failure 67% /
+// 100%). The fix gives the distill agent a DEDICATED output channel: the recipe
+// passes `-c facts_output_path=<temp>` and instructs the agent to WRITE its
+// `{ "facts": [...], "procedures": [...] }` envelope to that file. Simard reads
+// the file after the subprocess exits and deserializes it — launcher banners
+// and log noise on stdout can never contaminate the parse.
+//
+// STATUS: the two functions below are the real, test-driven implementations of
+// the structured file channel; the suite in `distillation_file_channel_tests.rs`
+// pins their full contract. They deserialize the agent-written facts file
+// directly through the shared [`RecipeEnvelope`] serde boundary — the same
+// field-lenient / concept-canonicalizing contract the stdout path uses — with
+// the ONLY tolerated noise being surrounding whitespace and an optional ```json
+// markdown fence. They are referenced from the test suite today; wiring them into
+// `RecipeRunnerSubprocess::invoke_recipe` (pass `-c facts_output_path=<temp>`,
+// have the recipe write its envelope there, then read the file after the
+// subprocess exits) is the remaining production integration and is why they still
+// carry `#[allow(dead_code)]` for non-test builds — drop the allow once the
+// subprocess is wired to the file channel.
+
+/// Stable error prefix for every file-channel extraction miss. It is
+/// deliberately one of the prefixes [`classify_distill_error`] maps to
+/// [`DistillFailureClass::ParseFailure`], so a missing / empty / non-JSON facts
+/// file is a transient, in-cycle-retried parse miss counted in
+/// `distill_parse_success_rate` — never a silent success.
+const FILE_CHANNEL_PARSE_FAILURE_PREFIX: &str =
+    "distill: distill step produced no parseable facts file";
+
+/// Strip an optional surrounding ```json … ``` markdown fence (and any
+/// surrounding whitespace) the distill agent occasionally wraps its envelope in.
+///
+/// This is a single, well-defined unwrap of ONE fence — deliberately NOT the
+/// balanced-brace / banner-stripping stdout scanning that is the G3 antipattern
+/// the file channel exists to retire. Non-fenced input is returned trimmed and
+/// otherwise untouched.
+fn strip_optional_json_fence(contents: &str) -> &str {
+    let trimmed = contents.trim();
+    let Some(after_open) = trimmed.strip_prefix("```") else {
+        return trimmed;
+    };
+    // Drop the remainder of the fence-open line (e.g. the `json` language tag).
+    let body = match after_open.find('\n') {
+        Some(nl) => &after_open[nl + 1..],
+        None => after_open,
+    };
+    // Drop a trailing ``` fence if present, then re-trim.
+    let body = body.trim();
+    body.strip_suffix("```").unwrap_or(body).trim()
+}
+
+/// Parse the JSON envelope the distill agent writes to its dedicated
+/// facts-output file into a [`DistillOutput`].
+///
+/// STRICT structured channel — NOT stdout scraping. The agent's file-write tool
+/// owns this channel and writes ONLY the `{ "facts": [...], "procedures": [...] }`
+/// envelope, so this deserializes it directly via the shared [`RecipeEnvelope`]
+/// serde boundary (the same field-lenient / concept-canonicalizing contract the
+/// stdout path used, so one malformed sibling does not sink a batch). The only
+/// tolerated noise is surrounding whitespace and an optional ```json markdown
+/// fence — never balanced-brace scanning or ANSI/banner stripping.
+///
+/// Contract (see `distillation_file_channel_tests.rs`):
+/// - valid envelope → `Ok(DistillOutput { facts, procedures })`
+/// - `{"facts":[],"procedures":[]}` → `Ok(DistillOutput::default())` (SUCCESS,
+///   zero yield — NEVER `parse-failure`)
+/// - empty / non-JSON / launcher-banner contents → `Err` classified
+///   [`DistillFailureClass::ParseFailure`] (no silent fallback, no hollow `Ok`)
+// `#[allow(dead_code)]`: referenced from the TDD suite today; the production
+// caller (`invoke_recipe`) is wired to the file channel in the follow-on
+// integration — remove the allow then.
+#[allow(dead_code)]
+pub(crate) fn parse_distill_facts_file(contents: &str) -> SimardResult<DistillOutput> {
+    let cleaned = strip_optional_json_fence(contents);
+    serde_json::from_str::<RecipeEnvelope>(cleaned)
+        .map(RecipeEnvelope::into_output)
+        .map_err(|e| {
+            SimardError::BridgeError(format!(
+                "{FILE_CHANNEL_PARSE_FAILURE_PREFIX}: {e}: {}",
+                truncate(contents, 200)
+            ))
+        })
+}
+
+/// Read the distill agent's dedicated facts-output file at `path` and parse it
+/// via [`parse_distill_facts_file`].
+///
+/// A missing / unreadable / empty / unparseable file is an EXPLICIT
+/// [`DistillFailureClass::ParseFailure`] — never a silent success. This is the
+/// no-silent-fallback invariant: on a genuine extraction failure the caller
+/// surfaces telemetry and leaves the batch unmarked for a retry, but the healthy
+/// path reliably yields facts from the uncontaminated file.
+// `#[allow(dead_code)]`: referenced from the TDD suite today; the production
+// caller (`invoke_recipe`) is wired to the file channel in the follow-on
+// integration — remove the allow then.
+#[allow(dead_code)]
+pub(crate) fn read_distill_facts_file(path: &Path) -> SimardResult<DistillOutput> {
+    // A missing / unreadable file is itself a parse-failure-classified miss (the
+    // run reached output collection but yielded no facts file), so map the read
+    // error onto the shared prefix before delegating to the strict parse.
+    let contents = std::fs::read_to_string(path).map_err(|e| {
+        SimardError::BridgeError(format!(
+            "{FILE_CHANNEL_PARSE_FAILURE_PREFIX} at {}: {e}",
+            path.display()
+        ))
+    })?;
+    parse_distill_facts_file(&contents)
 }
 
 /// Recover a [`DistillOutput`] from recipe-runner stdout whose JSON envelope is

--- a/src/memory_consolidation/distillation_file_channel_tests.rs
+++ b/src/memory_consolidation/distillation_file_channel_tests.rs
@@ -1,0 +1,305 @@
+//! TDD (RED) tests for the DISTILLATION structured file channel
+//! (issues #2622 = 67% parse-failure, #2619 = 100% parse-failure).
+//!
+//! ## The defect these tests pin
+//!
+//! Distillation's memory fact-yield collapsed to ~zero because the recipe
+//! runner could not parse its OWN output. Two defects compounded (confirmed
+//! live in the daemon logs 02:45–02:47):
+//!
+//!   1. the copilot LAUNCHER BANNER / `INFO` log lines were captured *as* the
+//!      distill step output, and
+//!   2. the code BRITTLE-GREPPED that stdout for a `{ "facts": [...] }` object
+//!      (the G3 antipattern the operator flagged).
+//!
+//! So the captured "output" was literally the launcher banner
+//! (`… launching copilot binary=… version="GitHub Copilot CLI 1.0.69-1."`),
+//! the balanced-brace scan found no facts object, and the pass failed with
+//! `class="parse-failure"`.
+//!
+//! ## The fix these tests drive
+//!
+//! Give the distill agent a DEDICATED output channel: the recipe passes
+//! `-c facts_output_path=<temp>` and instructs the agent to WRITE its
+//! `{ "facts": [...], "procedures": [...] }` envelope to that file. Simard reads
+//! the file after the subprocess exits and deserializes it. Because the parse
+//! reads a FILE (by path), launcher banners / log noise on STDOUT can never
+//! contaminate it — structurally, not heuristically.
+//!
+//! ## TDD status
+//!
+//! These tests were written FIRST (Step 7) and drove the implementation. They
+//! target two `pub(crate)` functions in `distillation`:
+//!   * `parse_distill_facts_file(contents: &str) -> SimardResult<DistillOutput>`
+//!   * `read_distill_facts_file(path: &Path) -> SimardResult<DistillOutput>`
+//!
+//! These are now implemented: they deserialize the agent-written envelope
+//! through the shared `RecipeEnvelope` serde boundary (strict — no stdout
+//! scraping), with bounded tolerance for an optional ```json fence. The full
+//! suite below — positive path, the launcher-banner-can't-contaminate
+//! regression, and the negative / no-silent-fallback / classification cases — is
+//! GREEN. The remaining production integration is wiring
+//! `RecipeRunnerSubprocess::invoke_recipe` to the file channel (pass
+//! `-c facts_output_path`, have the recipe write the envelope there, read it
+//! after the subprocess exits); these functions are the tested seam it will call.
+
+use crate::memory_consolidation::distillation::{
+    DistillFailureClass, classify_distill_error, parse_distill_facts_file, read_distill_facts_file,
+};
+
+// ───────────────────────────────────────────────────────────────────────────
+// Fixtures: the exact live-incident stdout noise, and clean file envelopes.
+// ───────────────────────────────────────────────────────────────────────────
+
+/// The exact launcher-banner / log noise that (defect a) was being captured as
+/// the distill step output and (defect b) brittle-grepped for facts. Reproduced
+/// from the daemon logs 02:45–02:47 (Copilot CLI 1.0.69-1). The point of the
+/// file channel is that THIS never reaches the parser: it lives on stdout, the
+/// facts live in a separate file.
+const LIVE_LAUNCHER_BANNER: &str = "\u{2139} NODE_OPTIONS=--max-old-space-size=32768 (saved preference)\n\
+     2026-07-06T02:45:12.001Z INFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot version=\"GitHub Copilot CLI 1.0.69-1.\"\n\
+     Run 'copilot update' to update to the latest version.\n";
+
+/// A clean facts+procedures envelope exactly as the distill agent is asked to
+/// WRITE it to `facts_output_path`.
+fn clean_envelope() -> String {
+    r#"{
+      "facts": [
+        { "concept": "bug-pattern",
+          "content": "launcher banner on stdout was captured as distill output",
+          "source_episode_id": "epi_2622" },
+        { "concept": "lesson-learned",
+          "content": "read distilled facts from a dedicated file, never scrape stdout",
+          "source_episode_id": "epi_2619" }
+      ],
+      "procedures": [
+        { "name": "distill:file-channel",
+          "steps": ["pass -c facts_output_path", "agent writes envelope to file", "runner reads file after exit"],
+          "source_episode_ids": ["epi_2622", "epi_2619"] }
+      ]
+    }"#
+    .to_string()
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 1. Healthy path: the file channel yields structured facts AND procedures.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn file_channel_extracts_facts_and_procedures() {
+    let out = parse_distill_facts_file(&clean_envelope())
+        .expect("a clean facts+procedures envelope written to the file must parse");
+    assert_eq!(out.facts.len(), 2, "both facts must be extracted");
+    assert_eq!(out.facts[0].concept, "bug-pattern");
+    assert_eq!(
+        out.facts[0].content,
+        "launcher banner on stdout was captured as distill output"
+    );
+    assert_eq!(out.facts[0].source_episode_id, "epi_2622");
+    assert_eq!(out.facts[1].concept, "lesson-learned");
+    assert_eq!(out.procedures.len(), 1, "the procedure must be extracted");
+    assert_eq!(out.procedures[0].name, "distill:file-channel");
+    assert_eq!(out.procedures[0].steps.len(), 3);
+    assert_eq!(
+        out.procedures[0].source_episode_ids,
+        vec!["epi_2622", "epi_2619"]
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 2. THE core regression: a launcher banner on stdout is IRRELEVANT because the
+//    facts are read from a dedicated file by path. This is the hermetic proof
+//    that stdout noise can never cause a parse-failure (task VALIDATION).
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn launcher_banner_on_stdout_cannot_contaminate_the_file_channel() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let facts_path = dir.path().join("distill-facts.json");
+    std::fs::write(&facts_path, clean_envelope()).expect("write facts file");
+
+    // The launcher banner is what the OLD stdout-scraping path captured and
+    // choked on. Here it is *separate* from the facts channel — the runner would
+    // print it to stdout while the agent writes the envelope to `facts_path`. The
+    // file read never consults stdout, so the banner is structurally inert.
+    let _stdout_noise = LIVE_LAUNCHER_BANNER; // present in production; must not matter
+
+    let out = read_distill_facts_file(&facts_path)
+        .expect("facts must be read from the file regardless of any stdout banner");
+    assert_eq!(
+        out.facts.len(),
+        2,
+        "structured facts must be extracted from the file even though the live \
+         launcher banner is on stdout"
+    );
+    assert_eq!(out.procedures.len(), 1);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 3. No silent fallback: if the banner/noise somehow lands as the FILE contents
+//    (agent wrote noise instead of JSON), that is an EXPLICIT parse-failure —
+//    never a silent `Ok` and never a hollow success.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn banner_as_file_contents_is_explicit_parse_failure_not_silent_ok() {
+    let err = parse_distill_facts_file(LIVE_LAUNCHER_BANNER)
+        .expect_err("a launcher banner is not a facts envelope — must be an explicit error");
+    assert_eq!(
+        classify_distill_error(&err),
+        DistillFailureClass::ParseFailure,
+        "banner-as-file-contents must classify as parse-failure (transient, retried, counted), \
+         never a silent success"
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 4. A genuinely empty batch is SUCCESS (zero yield), NOT a parse-failure (A4).
+//    This is the metric-correctness invariant: parse-failure is reserved for
+//    missing/empty/non-JSON files, not for a legitimately-empty distill.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn empty_facts_envelope_is_success_not_parse_failure() {
+    let out = parse_distill_facts_file(r#"{"facts":[],"procedures":[]}"#)
+        .expect("an empty-but-valid envelope is 'nothing worth distilling', a SUCCESS");
+    assert!(out.facts.is_empty());
+    assert!(out.procedures.is_empty());
+}
+
+#[test]
+fn facts_only_envelope_without_procedures_key_parses() {
+    // `procedures` is optional in the contract; a facts-only file must parse
+    // with an empty procedures vec (not a parse-failure).
+    let out = parse_distill_facts_file(
+        r#"{"facts":[{"concept":"pr-pattern","content":"c","source_episode_id":"e1"}]}"#,
+    )
+    .expect("facts-only envelope (no procedures key) must parse");
+    assert_eq!(out.facts.len(), 1);
+    assert!(out.procedures.is_empty());
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 5. Missing / empty file → explicit ParseFailure (no silent fallback, A5).
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn missing_facts_file_is_explicit_parse_failure() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir.path().join("does-not-exist.json");
+    assert!(!missing.exists());
+
+    let err = read_distill_facts_file(&missing)
+        .expect_err("a missing facts file must surface an explicit error, never a silent Ok");
+    assert_eq!(
+        classify_distill_error(&err),
+        DistillFailureClass::ParseFailure,
+        "a missing facts file is a parse-failure (the run reached parsing but yielded no facts)"
+    );
+}
+
+#[test]
+fn empty_facts_file_is_explicit_parse_failure() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let empty = dir.path().join("empty.json");
+    std::fs::write(&empty, "").expect("write empty file");
+
+    let err = read_distill_facts_file(&empty)
+        .expect_err("an empty facts file must surface an explicit error, never a silent Ok");
+    assert_eq!(
+        classify_distill_error(&err),
+        DistillFailureClass::ParseFailure
+    );
+}
+
+#[test]
+fn non_json_file_contents_is_explicit_parse_failure() {
+    let err = parse_distill_facts_file("this is not json at all")
+        .expect_err("non-JSON file contents must be an explicit parse-failure");
+    assert_eq!(
+        classify_distill_error(&err),
+        DistillFailureClass::ParseFailure
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 6. Bounded, non-brittle tolerance: strip a surrounding ```json markdown fence
+//    the agent sometimes wraps the envelope in. This is a single well-defined
+//    unwrap — NOT balanced-brace stdout scanning — so it does not reintroduce
+//    the G3 antipattern while keeping the healthy path yielding facts.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn markdown_fenced_envelope_is_tolerated() {
+    let fenced = format!("```json\n{}\n```", clean_envelope());
+    let out = parse_distill_facts_file(&fenced)
+        .expect("a ```json-fenced envelope must still parse (bounded tolerance, not scraping)");
+    assert_eq!(out.facts.len(), 2);
+    assert_eq!(out.procedures.len(), 1);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 7. The file channel reuses the SAME contract as the stdout path: off-spec
+//    concepts are dropped, surface-form variants are canonicalized, and
+//    field-level noise on one fact does not sink the whole envelope.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn file_channel_canonicalizes_surface_variant_and_drops_offspec_concepts() {
+    let contents = r#"{
+      "facts": [
+        { "concept": "PR-Pattern", "content": "surface variant is canonicalized", "source_episode_id": "e1" },
+        { "concept": "made-up-label", "content": "off-spec is dropped", "source_episode_id": "e2" }
+      ],
+      "procedures": []
+    }"#;
+    let out = parse_distill_facts_file(contents).expect("must parse");
+    assert_eq!(out.facts.len(), 1, "off-spec concept must be dropped");
+    assert_eq!(
+        out.facts[0].concept, "pr-pattern",
+        "surface-form variant must be canonicalized to the closed label set"
+    );
+}
+
+#[test]
+fn file_channel_tolerates_field_level_noise_on_one_fact() {
+    // Issue #2506 shape: one fact carries a null `source_episode_id`. Field-level
+    // leniency must recover the well-formed sibling instead of serde rejecting
+    // the whole envelope (which is what silently dropped batches before).
+    let contents = r#"{
+      "facts": [
+        { "concept": "lesson-learned", "content": "well-formed survivor", "source_episode_id": "e1" },
+        { "concept": "bug-pattern", "content": "noisy sibling", "source_episode_id": null }
+      ],
+      "procedures": []
+    }"#;
+    let out = parse_distill_facts_file(contents)
+        .expect("field-level noise on one fact must not sink the whole envelope");
+    assert!(
+        out.facts
+            .iter()
+            .any(|f| f.content == "well-formed survivor"),
+        "the well-formed fact must survive a noisy sibling"
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 8. Guard: the file-channel error must NOT be misclassified as a structural
+//    class (spawn/terminal/serialize) — it reached parsing and yielded nothing.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn file_channel_parse_failure_reached_parsing() {
+    let err = parse_distill_facts_file("").expect_err("empty contents must be a parse-failure");
+    let class = classify_distill_error(&err);
+    assert!(
+        class.reached_parsing(),
+        "a file-channel parse miss reached output parsing (denominator of \
+         distill_parse_success_rate); got {:?}",
+        class
+    );
+    assert!(
+        class.recipe_exited_ok(),
+        "the recipe process exited 0 — only the facts file was unparseable"
+    );
+}

--- a/src/memory_consolidation/mod.rs
+++ b/src/memory_consolidation/mod.rs
@@ -981,6 +981,15 @@ pub mod scheduler;
 #[cfg(test)]
 mod distillation_tests;
 
+// Issues #2622 / #2619: hermetic TDD tests for the structured file-channel that
+// replaces stdout-scraping of the distill agent's `{ "facts": [...] }` output.
+// Pins that a launcher banner / log noise on stdout can NEVER cause a
+// parse-failure (the facts are read from a dedicated file), that a genuinely
+// empty batch is a SUCCESS not a parse-failure, and that a missing/empty/
+// unparseable file surfaces an explicit ParseFailure (no silent fallback).
+#[cfg(test)]
+mod distillation_file_channel_tests;
+
 // Perpetual-cognition sub-goal: raise distillation fact-yield. A deterministic,
 // DB-free benchmark that records a baseline facts-per-consolidation-input number
 // over a fixed sample corpus and proves the concept-canonicalization change

--- a/src/ooda_actions/advance_goal/mod.rs
+++ b/src/ooda_actions/advance_goal/mod.rs
@@ -143,6 +143,12 @@ pub(super) fn dispatch_advance_goal(
     // when we mutably borrow `bridges.session` below (issue #1266).
     let brain = std::sync::Arc::clone(&bridges.brain);
 
+    // Resource-aware admission brain (fresh-spawn gate) + repo_root for the
+    // RECLAIM-FIRST disk-health recipe. Cloned up-front for the same
+    // borrow-checker reason. `None` → the deterministic admission floor.
+    let admission = bridges.admission_brain.clone();
+    let admission_repo_root = bridges.repo_root.clone();
+
     // Same pattern for the progress-evidence checker (issue #1967): clone
     // the Arc up-front so it lives across the inner mutable session
     // borrow without colliding with the bridges field-borrow check.
@@ -181,7 +187,21 @@ pub(super) fn dispatch_advance_goal(
         }) = result.action
         {
             let state_mx = std::sync::Mutex::new(&mut *state);
-            return dispatch_spawn_engineer(action, &state_mx, &goal_id, &task, brain.as_ref());
+            let default_admission = crate::ooda_brain::DeterministicAdmissionBrain;
+            let admission_ref: &dyn crate::ooda_brain::OodaAdmissionBrain =
+                match admission.as_deref() {
+                    Some(b) => b,
+                    None => &default_admission,
+                };
+            return dispatch_spawn_engineer(
+                action,
+                &state_mx,
+                &goal_id,
+                &task,
+                brain.as_ref(),
+                admission_ref,
+                &admission_repo_root,
+            );
         }
 
         return result.outcome;

--- a/src/ooda_actions/advance_goal/spawn.rs
+++ b/src/ooda_actions/advance_goal/spawn.rs
@@ -7,10 +7,12 @@ use crate::agent_roles::AgentRole;
 use crate::agent_supervisor::{SubordinateConfig, spawn_subordinate};
 use crate::identity_composition::max_subordinate_depth;
 use crate::ooda_brain::{
-    BrainJudgmentRecord, EngineerLifecycleDecision, OodaBrain, apply_decision_to_state,
-    gather_engineer_lifecycle_ctx, push_brain_judgment,
+    AdmissionGate, BrainJudgmentRecord, EngineerLifecycleDecision, OodaAdmissionBrain, OodaBrain,
+    apply_decision_to_state, configured_ceiling_pct, gather_engineer_lifecycle_ctx,
+    gather_resource_admission_ctx, judge_and_resolve, push_brain_judgment,
 };
 use crate::ooda_loop::{ActionOutcome, OodaState, PlannedAction};
+use std::path::Path;
 
 use crate::ooda_actions::make_outcome;
 
@@ -84,12 +86,20 @@ pub(crate) fn lock_state<'g, 'a>(
 ///
 /// Honours `SIMARD_SUBORDINATE_DEPTH` vs. `SIMARD_MAX_SUBORDINATE_DEPTH`
 /// so a recursing supervisor does not spawn forever.
+///
+/// `admission` is the RESOURCE-AWARE admission reasoner consulted on the
+/// fresh-spawn path (after the count cap, before worktree allocation): it
+/// weighs disk / build-cache / load and decides ADMIT / DEFER / RECLAIM-FIRST,
+/// guarded by a deterministic disk hard-rail. `repo_root` locates the
+/// disk-health reclaim recipe invoked on RECLAIM-FIRST.
 pub fn dispatch_spawn_engineer(
     action: &PlannedAction,
     state: &Mutex<&mut OodaState>,
     goal_id: &str,
     task: &str,
     brain: &dyn OodaBrain,
+    admission: &dyn OodaAdmissionBrain,
+    repo_root: &Path,
 ) -> ActionOutcome {
     // Re-check assignment under a short exclusive state lock to prevent a
     // double-spawn race (two cycles/threads parsing spawn_engineer for the
@@ -122,11 +132,16 @@ pub fn dispatch_spawn_engineer(
     // clears the failure counter and makes FAILURE_PENALTY useless), consult
     // the prompt-driven brain. The brain reasons about whether to keep
     // skipping, reclaim, deprioritize, file an issue, or block the goal.
-    let state_root_inflight = engineer_worktree_state_root();
-    if let Some(live) = find_live_engineer_for_goal(&state_root_inflight, goal_id) {
+    // Resolve the engineer-worktree state root ONCE and reuse it for both the
+    // in-flight re-attach check below and the resource-admission gate further
+    // down. `engineer_worktree_state_root()` is a pure env-read + path-join, so
+    // this is a clarity win rather than a hot-path saving, but it removes a
+    // duplicate computation and keeps a single source of truth for the root.
+    let engineer_state_root = engineer_worktree_state_root();
+    if let Some(live) = find_live_engineer_for_goal(&engineer_state_root, goal_id) {
         let ctx = {
             let guard = lock_state(state);
-            gather_engineer_lifecycle_ctx(&guard, &state_root_inflight, goal_id, &live)
+            gather_engineer_lifecycle_ctx(&guard, &engineer_state_root, goal_id, &live)
         };
         // NO FALLBACK: brain.decide_engineer_lifecycle Err must surface as a
         // visible cycle failure (operator constraint, issue #1711, #1748).
@@ -290,6 +305,117 @@ pub fn dispatch_spawn_engineer(
                 "spawn_engineer denied for goal '{goal_id}': subordinate depth {current_depth} >= configured limit {depth_limit}"
             ),
         );
+    }
+
+    // ── RESOURCE-AWARE admission gate (fresh-spawn only) ─────────────────
+    //
+    // The AIMD scaler bounds engineer COUNT; nothing above this point weighs
+    // DISK / build-cache / system load. On a busy host that gap let 40+ cargo
+    // build caches pile up and drove disk to 91% → ENOSPC killed recipes.
+    // Before allocating another worktree, gather the resource picture and ask
+    // the admission brain to reason ADMIT / DEFER / RECLAIM-FIRST — repeated
+    // structured thought at every admission, following the same
+    // gather→reason→apply pattern as the engineer-lifecycle brain above. The
+    // *intelligence* lives in the recipe/prompt; the only deterministic code
+    // here is a THIN disk hard-rail inside `judge_and_resolve` that blocks
+    // admission when disk% is known to be at/over the ceiling, regardless of
+    // what the brain decided (irreversible ENOSPC must never be reachable).
+    //
+    // Placed AFTER the count cap + depth guard and BEFORE worktree allocation
+    // (and before target-repo resolution) so a DEFER grows nothing. Both
+    // dispatch call sites inherit this gate. The live-engineer re-attach branch
+    // above is exempt — it allocates no new resources.
+    {
+        let ceiling = configured_ceiling_pct();
+        let admission_ctx = gather_resource_admission_ctx(&engineer_state_root, ceiling);
+        match judge_and_resolve(admission, &admission_ctx) {
+            Ok(AdmissionGate::Proceed) => {
+                // Admitted — emit an observability record and fall through to
+                // the normal spawn path below.
+                push_brain_judgment(BrainJudgmentRecord::from_admission(
+                    goal_id,
+                    "admit",
+                    "resources healthy; admitting fresh engineer",
+                    "",
+                ));
+            }
+            Ok(AdmissionGate::Defer { reason }) => {
+                // Benign skip: NO worktree, NO failure-count bump (success=true,
+                // see cycle.rs). The goal is simply retried next cycle. A
+                // resource defer is neither progress nor failure.
+                tracing::info!(
+                    target: "simard::ooda_brain",
+                    goal = %goal_id,
+                    reason = %reason,
+                    "resource-aware admission: DEFER (benign skip — no worktree, no failure)",
+                );
+                push_brain_judgment(BrainJudgmentRecord::from_admission(
+                    goal_id, "defer", &reason, "",
+                ));
+                return make_outcome(
+                    action,
+                    true,
+                    format!("deferred: resource pressure: {reason}"),
+                );
+            }
+            Ok(AdmissionGate::Reclaim { reason }) => {
+                // Reclaim disk first (reuse the existing disk-health recipe),
+                // then DEFER this cycle and re-evaluate next cycle. Still a
+                // benign skip (no worktree, no failure-count bump). A reclaim
+                // failure is logged but never turned into a cycle failure — we
+                // defer regardless so a deferred cycle grows nothing.
+                tracing::warn!(
+                    target: "simard::ooda_brain",
+                    goal = %goal_id,
+                    reason = %reason,
+                    "resource-aware admission: RECLAIM-FIRST (running disk-health reclaim, then defer)",
+                );
+                push_brain_judgment(BrainJudgmentRecord::from_admission(
+                    goal_id, "reclaim", &reason, "",
+                ));
+                match crate::disk_health::run_disk_health_check(
+                    repo_root,
+                    &engineer_state_root,
+                    None,
+                ) {
+                    Ok(report) => {
+                        tracing::info!(
+                            target: "simard::ooda_brain",
+                            goal = %goal_id,
+                            "disk-health reclaim completed; deferring this cycle to re-evaluate next cycle: {}",
+                            report.summary(),
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "simard::ooda_brain",
+                            goal = %goal_id,
+                            error = %e,
+                            "disk-health reclaim recipe failed (still deferring this cycle)",
+                        );
+                    }
+                }
+                return make_outcome(action, true, format!("deferred: reclaim-first: {reason}"));
+            }
+            Err(e) => {
+                // NO FALLBACK: a broken admission brain must surface as a
+                // visible cycle failure, never a silent phantom admit that
+                // could fill the disk (mirrors the lifecycle NO-FALLBACK
+                // contract). success=false → cycle.rs bumps the failure count.
+                tracing::error!(
+                    target: "simard::ooda_brain",
+                    goal = %goal_id,
+                    error = %e,
+                    "resource-aware admission brain FAILED — surfacing as cycle failure (NO silent admit)",
+                );
+                eprintln!("[simard] RESOURCE-ADMISSION BRAIN FAILURE goal={goal_id} error={e}");
+                return make_outcome(
+                    action,
+                    false,
+                    format!("resource-admission brain failure: {e}"),
+                );
+            }
+        }
     }
 
     let agent_name = build_engineer_name(goal_id);

--- a/src/ooda_actions/concurrent.rs
+++ b/src/ooda_actions/concurrent.rs
@@ -32,10 +32,11 @@ use crate::base_types::BaseTypeSession;
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::goal_curation::GoalProgress;
 use crate::goal_curation::progress_evidence::ProgressEvidenceChecker;
-use crate::ooda_brain::OodaBrain;
+use crate::ooda_brain::{OodaAdmissionBrain, OodaBrain};
 use crate::ooda_loop::{
     ActionOutcome, OodaBridges, OodaState, OrchestratorSessionFactory, PlannedAction,
 };
+use std::path::Path;
 
 use super::advance_goal::spawn::{dispatch_spawn_engineer, is_brain_failure_marker, lock_state};
 use super::goal_session::{GoalAction, apply_goal_advance_result, build_goal_advance_input};
@@ -98,6 +99,11 @@ struct AdvanceCtx<'a> {
     memory: &'a dyn CognitiveMemoryOps,
     checker: &'a dyn ProgressEvidenceChecker,
     brain: &'a dyn OodaBrain,
+    /// Resource-aware admission reasoner (fresh-spawn gate). Consulted by
+    /// `dispatch_spawn_engineer` before allocating an engineer worktree.
+    admission: &'a dyn OodaAdmissionBrain,
+    /// Repo root for the RECLAIM-FIRST disk-health recipe.
+    repo_root: &'a Path,
     /// Mints a fresh per-goal session so `run_turn` calls run concurrently.
     session_factory: Option<&'a dyn OrchestratorSessionFactory>,
     /// Fallback single session used (under lock, serialized) only when no
@@ -132,6 +138,17 @@ pub(super) fn dispatch_advance_concurrent(
     let session_factory: Option<&dyn OrchestratorSessionFactory> =
         bridges.session_factory.as_deref();
 
+    // Resource-aware admission brain (fresh-spawn gate) + repo_root for the
+    // RECLAIM-FIRST disk-health recipe. `None` → the deterministic admission
+    // floor (still guarded by the deterministic disk hard-rail). The default
+    // is declared here so it outlives the thread scope below.
+    let default_admission = crate::ooda_brain::DeterministicAdmissionBrain;
+    let admission: &dyn OodaAdmissionBrain = match bridges.admission_brain.as_deref() {
+        Some(b) => b,
+        None => &default_admission,
+    };
+    let repo_root: &Path = &bridges.repo_root;
+
     // Take ownership of the shared fallback session for the duration of the
     // round so the per-thread context can lend it out by `Box` (avoids tying a
     // `&mut` into the ctx struct). Restored afterwards so daemon shutdown can
@@ -146,6 +163,8 @@ pub(super) fn dispatch_advance_concurrent(
         memory,
         checker,
         brain,
+        admission,
+        repo_root,
         session_factory,
         shared_session: &shared_session,
         state: &state_mx,
@@ -373,7 +392,15 @@ fn dispatch_advance_goal_concurrent(action: &PlannedAction, ctx: &AdvanceCtx) ->
     // ── Engineer spawn — short state critical sections only (the git
     //    worktree allocation + detached subprocess run with NO lock held). ──
     if let Some(GoalAction::SpawnEngineer { task, .. }) = result.action {
-        return dispatch_spawn_engineer(action, ctx.state, &goal_id, &task, ctx.brain);
+        return dispatch_spawn_engineer(
+            action,
+            ctx.state,
+            &goal_id,
+            &task,
+            ctx.brain,
+            ctx.admission,
+            ctx.repo_root,
+        );
     }
 
     result.outcome

--- a/src/ooda_actions/test_helpers.rs
+++ b/src/ooda_actions/test_helpers.rs
@@ -149,6 +149,7 @@ pub(crate) fn test_bridges() -> OodaBridges {
             crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     }
 }
 
@@ -210,5 +211,6 @@ pub(crate) fn bridges_with_session(session: MockSession) -> OodaBridges {
             crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     }
 }

--- a/src/ooda_brain/admission.rs
+++ b/src/ooda_brain/admission.rs
@@ -1,0 +1,255 @@
+//! Types, trait, and the deterministic hard-rail for RESOURCE-AWARE engineer
+//! **admission** — the resource-aware augmentation of the AIMD count cap.
+//!
+//! # Problem
+//! The AIMD controller bounds concurrent engineer *count* but nothing accounts
+//! for DISK / build-cache / system load. Parallel `cargo` builds across 40+
+//! worktrees drove disk to 91% and ENOSPC killed recipes. Count-control is not
+//! resource-admission.
+//!
+//! # Design (mirrors [`super::decide`])
+//! The *intelligence* is agentic: a structured-reasoning brain reasons over the
+//! current resource picture and emits ADMIT / DEFER / RECLAIM-FIRST at every
+//! fresh-spawn admission cycle (repeated structured thought). The LLM-backed
+//! impl drives the `ooda-resource-admission.yaml` recipe. The only deterministic
+//! code in this module is:
+//!
+//!   * [`resolve_admission`] — a THIN safety rail that BLOCKS admission when
+//!     disk% is *known* to be at/above a configurable ceiling, **regardless of
+//!     what the reasoner says**. Irreversible ENOSPC must never be reachable.
+//!   * [`judge_and_resolve`] — the seam core (reason → apply). It surfaces a
+//!     brain error loudly (NO FALLBACK, per the standing operator constraint).
+//!   * [`parse_ceiling`] / [`configured_ceiling_pct`] — read + clamp the single
+//!     configurable threshold.
+//!
+//! No hardcoded admission heuristics live in Rust beyond that single ceiling —
+//! the ADMIT/DEFER/RECLAIM judgement itself lives in the prompt.
+
+use crate::error::SimardResult;
+
+/// Recipe asset that drives the agentic admission reasoner. Read fresh per call
+/// by the recipe-backed brain (hot-reload), mirroring the other OODA-phase
+/// recipes (`ooda-decide.yaml`, `ooda-engineer-lifecycle.yaml`).
+pub const RECIPE_NAME: &str = "ooda-resource-admission.yaml";
+
+/// Env var naming the deterministic disk-admission ceiling (percent full). Read
+/// at the seam, parsed best-effort, and clamped to
+/// [`CEILING_MIN`]..=[`CEILING_MAX`].
+pub const CEILING_ENV: &str = "SIMARD_DISK_ADMISSION_CEILING_PCT";
+
+/// Default disk ceiling (percent full). The incident tripped at 91%; 90 leaves
+/// headroom below ENOSPC without over-throttling.
+pub const DEFAULT_CEILING_PCT: u8 = 90;
+
+/// Lower clamp bound for the configured ceiling (a `0` ceiling would block all
+/// admission forever and deadlock progress).
+pub const CEILING_MIN: u8 = 1;
+
+/// Upper clamp bound for the configured ceiling (a `100` ceiling would let the
+/// rail fire only at true-full, i.e. never usefully — keep headroom).
+pub const CEILING_MAX: u8 = 99;
+
+/// Clamp a raw ceiling into the admissible [`CEILING_MIN`]..=[`CEILING_MAX`]
+/// range.
+pub fn clamp_ceiling(pct: u8) -> u8 {
+    pct.clamp(CEILING_MIN, CEILING_MAX)
+}
+
+/// Parse + clamp a raw env string into a usable ceiling. Best-effort: any
+/// missing / non-numeric / out-of-`u8` value degrades to [`DEFAULT_CEILING_PCT`]
+/// rather than failing (never panic; safe default).
+pub fn parse_ceiling(raw: Option<&str>) -> u8 {
+    raw.and_then(|v| v.trim().parse::<u8>().ok())
+        .map(clamp_ceiling)
+        .unwrap_or(DEFAULT_CEILING_PCT)
+}
+
+/// Read the configured disk-admission ceiling from the environment (see
+/// [`CEILING_ENV`]), applying [`parse_ceiling`].
+pub fn configured_ceiling_pct() -> u8 {
+    parse_ceiling(std::env::var(CEILING_ENV).ok().as_deref())
+}
+
+// ---------------------------------------------------------------------------
+// Context fed to the admission brain (A8)
+// ---------------------------------------------------------------------------
+
+/// Best-effort snapshot of the resource picture the admission brain reasons
+/// over. Every probe degrades to `None` on error (never panic); the `None` is
+/// passed through to the reasoner so it can weigh "unknown" explicitly.
+///
+/// The rail in [`resolve_admission`] only consults [`Self::disk_usage_pct`] and
+/// [`Self::ceiling_pct`]; the other fields exist so the *prompt* can normalize
+/// load-by-cpu and weigh build-cache size / in-flight builds.
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ResourceAdmissionCtx {
+    /// Disk usage of the state/worktree filesystem, 0..=100. `None` when the
+    /// `df` probe failed (rail fails open — see [`resolve_admission`]).
+    pub disk_usage_pct: Option<u8>,
+    /// Total bytes under the engineer-worktrees / build-cache root (`du -sb`).
+    pub worktree_cache_bytes: Option<u64>,
+    /// 1-minute load average (`/proc/loadavg`).
+    pub load_avg_1m: Option<f64>,
+    /// Logical CPU count, so the prompt can normalize load per core.
+    pub cpu_count: Option<usize>,
+    /// Number of live engineer claims already in flight this cycle.
+    pub in_flight_engineers: u32,
+    /// The deterministic hard-rail ceiling in effect for this decision.
+    pub ceiling_pct: u8,
+}
+
+// ---------------------------------------------------------------------------
+// Decision: tagged enum the LLM emits as `{"choice":"...","rationale":"..."}`
+// ---------------------------------------------------------------------------
+
+/// What the admission brain decided. Tagged on `choice` for
+/// forward-compatibility (unknown tags fail to parse → the caller surfaces the
+/// parse error rather than silently admitting).
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "choice", rename_all = "snake_case")]
+pub enum AdmissionDecision {
+    /// Resources are healthy enough — admit one more engineer (still subject to
+    /// the deterministic hard rail in [`resolve_admission`]).
+    Admit { rationale: String },
+    /// Resource pressure — skip this cycle without allocating anything. Benign:
+    /// the goal is retried next cycle and this is NOT a failure.
+    Defer { rationale: String },
+    /// Reclaim disk first (invoke the disk-health recipe), then defer this cycle
+    /// and re-evaluate next cycle.
+    ReclaimFirst { rationale: String },
+}
+
+impl AdmissionDecision {
+    /// The rationale carried by every variant.
+    pub fn rationale(&self) -> &str {
+        match self {
+            Self::Admit { rationale }
+            | Self::Defer { rationale }
+            | Self::ReclaimFirst { rationale } => rationale,
+        }
+    }
+
+    /// Stable snake_case label (matches the serde `choice` tag) for
+    /// observability records / metrics.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Admit { .. } => "admit",
+            Self::Defer { .. } => "defer",
+            Self::ReclaimFirst { .. } => "reclaim_first",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The trait (A1) — single decision site, sync to match the other OODA brains
+// ---------------------------------------------------------------------------
+
+/// Single-decision-site trait for resource-aware admission. Sync on purpose to
+/// match [`super::OodaBrain`] / [`super::OodaDecideBrain`]; the LLM-backed impl
+/// bridges to async internally so callers need no runtime.
+pub trait OodaAdmissionBrain: Send + Sync {
+    fn judge_admission(&self, ctx: &ResourceAdmissionCtx) -> SimardResult<AdmissionDecision>;
+}
+
+// ---------------------------------------------------------------------------
+// Resolved gate — what the seam actually applies (post hard-rail)
+// ---------------------------------------------------------------------------
+
+/// The resolved admission outcome after the deterministic hard rail has had the
+/// final say over the brain's [`AdmissionDecision`]. This is what the spawn seam
+/// applies.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AdmissionGate {
+    /// Admit: proceed with the fresh spawn (allocate worktree, spawn engineer).
+    Proceed,
+    /// Skip this cycle without allocating resources. **Benign** — the caller
+    /// MUST NOT record failure (no `goal_failure_counts` bump, no 3-strike
+    /// safeguard). The goal is retried next cycle.
+    Defer { reason: String },
+    /// Run disk reclamation now (disk-health recipe), then defer this cycle and
+    /// re-evaluate next cycle.
+    Reclaim { reason: String },
+}
+
+impl AdmissionGate {
+    /// `true` only for [`AdmissionGate::Proceed`] — i.e. an actual admission.
+    pub fn is_proceed(&self) -> bool {
+        matches!(self, Self::Proceed)
+    }
+}
+
+/// Apply the THIN deterministic hard rail (FR-5) over the brain's decision, then
+/// map it to an [`AdmissionGate`] (FR-4).
+///
+/// **Safety invariant:** when `ctx.disk_usage_pct` is `Some(pct)` and
+/// `pct >= ctx.ceiling_pct`, the result is NEVER [`AdmissionGate::Proceed`],
+/// regardless of what the brain decided — irreversible ENOSPC must never be
+/// reachable.
+///
+/// **Fail-open:** a `None` `disk_usage_pct` (probe failed) does NOT fire the
+/// rail; the "unknown" was already handed to the reasoner, and a spurious block
+/// on a transient `df` error would deadlock all progress. Layered ENOSPC
+/// protection (emergency cleanup tier) remains the backstop.
+///
+/// The rail only overrides [`AdmissionDecision::Admit`] (the sole `Proceed`
+/// source). `Defer` / `ReclaimFirst` are already non-admitting and pass through
+/// unchanged.
+pub fn resolve_admission(ctx: &ResourceAdmissionCtx, decision: AdmissionDecision) -> AdmissionGate {
+    let rail_blocks = matches!(ctx.disk_usage_pct, Some(pct) if pct >= ctx.ceiling_pct);
+    match decision {
+        AdmissionDecision::Admit { rationale } => {
+            if rail_blocks {
+                let pct = ctx.disk_usage_pct.unwrap_or_default();
+                AdmissionGate::Defer {
+                    reason: format!(
+                        "hard-rail: disk {pct}% >= admission ceiling {}%; ADMIT overridden to \
+                         block (brain rationale: {rationale})",
+                        ctx.ceiling_pct
+                    ),
+                }
+            } else {
+                AdmissionGate::Proceed
+            }
+        }
+        AdmissionDecision::Defer { rationale } => AdmissionGate::Defer { reason: rationale },
+        AdmissionDecision::ReclaimFirst { rationale } => {
+            AdmissionGate::Reclaim { reason: rationale }
+        }
+    }
+}
+
+/// Seam core: reason → apply. Calls the brain for an [`AdmissionDecision`] and
+/// resolves it through the hard rail into an [`AdmissionGate`].
+///
+/// **NO FALLBACK:** a brain error propagates unchanged so the seam can surface
+/// it as a visible cycle failure (mirrors `decide_engineer_lifecycle` — a
+/// broken brain must never look like a silent "admit").
+pub fn judge_and_resolve(
+    brain: &dyn OodaAdmissionBrain,
+    ctx: &ResourceAdmissionCtx,
+) -> SimardResult<AdmissionGate> {
+    let decision = brain.judge_admission(ctx)?;
+    Ok(resolve_admission(ctx, decision))
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic brain — no-LLM floor (NOT the intelligence)
+// ---------------------------------------------------------------------------
+
+/// Deterministic admission floor used when no LLM brain is configured. It
+/// preserves pre-feature behaviour bit-for-bit: always `Admit` (count-cap only).
+/// This is NOT the resource intelligence — that lives in the recipe/prompt. The
+/// deterministic ENOSPC protection is provided by the hard rail in
+/// [`resolve_admission`], which still fires over this brain's `Admit`.
+#[derive(Debug, Default)]
+pub struct DeterministicAdmissionBrain;
+
+impl OodaAdmissionBrain for DeterministicAdmissionBrain {
+    fn judge_admission(&self, _ctx: &ResourceAdmissionCtx) -> SimardResult<AdmissionDecision> {
+        Ok(AdmissionDecision::Admit {
+            rationale: "deterministic-brain: no LLM configured; admit (count-cap only); ENOSPC \
+                        still guarded by the disk hard-rail"
+                .to_string(),
+        })
+    }
+}

--- a/src/ooda_brain/admission_tests.rs
+++ b/src/ooda_brain/admission_tests.rs
@@ -1,0 +1,415 @@
+//! Hermetic tests for RESOURCE-AWARE engineer admission.
+//!
+//! These prove the two things the framing requires of Step-7 tests:
+//!   1. **The seam** — reason → apply: a (stubbed) brain decision flows through
+//!      the hard rail into the resolved [`AdmissionGate`], and a brain *error*
+//!      surfaces (NO FALLBACK).
+//!   2. **The hard rail** — a known disk% at/above the ceiling BLOCKS admission
+//!      regardless of what the brain decided (ENOSPC is never reachable), and
+//!      fails *open* when disk% is unknown.
+//!
+//! The reasoning *quality* (when to ADMIT vs DEFER vs RECLAIM) lives in the
+//! prompt, not here — so the brain is stubbed and only the deterministic seam +
+//! rail are asserted. Everything here is pure and side-effect free.
+
+use super::admission::{
+    AdmissionDecision, AdmissionGate, CEILING_MAX, CEILING_MIN, DEFAULT_CEILING_PCT,
+    DeterministicAdmissionBrain, OodaAdmissionBrain, ResourceAdmissionCtx, clamp_ceiling,
+    configured_ceiling_pct, judge_and_resolve, parse_ceiling, resolve_admission,
+};
+use crate::error::{SimardError, SimardResult};
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+/// A hermetic stub brain returning a preset decision (or error). No IO, no LLM.
+struct StubAdmissionBrain {
+    result: SimardResult<AdmissionDecision>,
+}
+
+impl StubAdmissionBrain {
+    fn admit() -> Self {
+        Self {
+            result: Ok(AdmissionDecision::Admit {
+                rationale: "stub: admit".to_string(),
+            }),
+        }
+    }
+    fn defer() -> Self {
+        Self {
+            result: Ok(AdmissionDecision::Defer {
+                rationale: "stub: defer".to_string(),
+            }),
+        }
+    }
+    fn reclaim() -> Self {
+        Self {
+            result: Ok(AdmissionDecision::ReclaimFirst {
+                rationale: "stub: reclaim".to_string(),
+            }),
+        }
+    }
+    fn failing() -> Self {
+        Self {
+            result: Err(SimardError::AdapterInvocationFailed {
+                base_type: "resource-admission".to_string(),
+                reason: "stub brain intentionally failing".to_string(),
+            }),
+        }
+    }
+}
+
+impl OodaAdmissionBrain for StubAdmissionBrain {
+    fn judge_admission(&self, _ctx: &ResourceAdmissionCtx) -> SimardResult<AdmissionDecision> {
+        // Clone the preset result so the stub can be consulted repeatedly
+        // (repeated structured thought — one call per admission cycle).
+        match &self.result {
+            Ok(d) => Ok(d.clone()),
+            Err(e) => Err(SimardError::AdapterInvocationFailed {
+                base_type: "resource-admission".to_string(),
+                reason: format!("{e}"),
+            }),
+        }
+    }
+}
+
+fn ctx(disk_usage_pct: Option<u8>, ceiling_pct: u8) -> ResourceAdmissionCtx {
+    ResourceAdmissionCtx {
+        disk_usage_pct,
+        worktree_cache_bytes: Some(12_345),
+        load_avg_1m: Some(1.5),
+        cpu_count: Some(8),
+        in_flight_engineers: 2,
+        ceiling_pct,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AdmissionDecision — serde round-trip (matches the LLM JSON schema)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn decision_admit_roundtrips() {
+    let raw = r#"{"choice":"admit","rationale":"disk 40%, load light"}"#;
+    let parsed: AdmissionDecision = serde_json::from_str(raw).expect("parse");
+    assert_eq!(
+        parsed,
+        AdmissionDecision::Admit {
+            rationale: "disk 40%, load light".to_string()
+        }
+    );
+    assert_eq!(parsed.label(), "admit");
+    assert_eq!(parsed.rationale(), "disk 40%, load light");
+}
+
+#[test]
+fn decision_defer_roundtrips() {
+    let raw = r#"{"choice":"defer","rationale":"disk 88%, backing off"}"#;
+    let parsed: AdmissionDecision = serde_json::from_str(raw).expect("parse");
+    assert_eq!(parsed.label(), "defer");
+    assert!(matches!(parsed, AdmissionDecision::Defer { .. }));
+}
+
+#[test]
+fn decision_reclaim_first_roundtrips() {
+    let raw = r#"{"choice":"reclaim_first","rationale":"cache huge, reclaim then retry"}"#;
+    let parsed: AdmissionDecision = serde_json::from_str(raw).expect("parse");
+    assert_eq!(parsed.label(), "reclaim_first");
+    assert!(matches!(parsed, AdmissionDecision::ReclaimFirst { .. }));
+}
+
+#[test]
+fn decision_ignores_extra_fields() {
+    // Forward-compat: the prompt may add fields the enum doesn't model yet.
+    let raw = r#"{"choice":"admit","rationale":"ok","confidence":0.9,"future":42}"#;
+    let parsed: AdmissionDecision = serde_json::from_str(raw).expect("parse");
+    assert!(matches!(parsed, AdmissionDecision::Admit { .. }));
+}
+
+#[test]
+fn decision_unknown_choice_fails_to_parse() {
+    // An unknown tag must NOT silently deserialize to Admit — the caller
+    // surfaces the parse error instead of a phantom admission.
+    let raw = r#"{"choice":"launch_the_missiles","rationale":"nope"}"#;
+    let parsed: Result<AdmissionDecision, _> = serde_json::from_str(raw);
+    assert!(parsed.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// HARD RAIL (FR-5) — the safety-critical deterministic guard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rail_blocks_admit_at_ceiling_boundary() {
+    // disk == ceiling must block (>= comparison, not >).
+    let gate = resolve_admission(
+        &ctx(Some(90), 90),
+        AdmissionDecision::Admit {
+            rationale: "brain wanted to admit".to_string(),
+        },
+    );
+    assert!(
+        !gate.is_proceed(),
+        "disk == ceiling must block admission, got {gate:?}"
+    );
+    assert!(matches!(gate, AdmissionGate::Defer { .. }));
+}
+
+#[test]
+fn rail_blocks_admit_above_ceiling() {
+    let gate = resolve_admission(
+        &ctx(Some(97), 90),
+        AdmissionDecision::Admit {
+            rationale: "brain wanted to admit".to_string(),
+        },
+    );
+    assert!(!gate.is_proceed());
+    if let AdmissionGate::Defer { reason } = gate {
+        assert!(reason.contains("hard-rail"), "reason={reason}");
+        assert!(reason.contains("97"));
+        assert!(reason.contains("90"));
+    } else {
+        panic!("expected Defer, got {gate:?}");
+    }
+}
+
+#[test]
+fn rail_allows_admit_below_ceiling() {
+    let gate = resolve_admission(
+        &ctx(Some(89), 90),
+        AdmissionDecision::Admit {
+            rationale: "healthy".to_string(),
+        },
+    );
+    assert_eq!(gate, AdmissionGate::Proceed);
+}
+
+#[test]
+fn rail_fails_open_when_disk_unknown() {
+    // A failed `df` probe (None) must NOT block — a spurious block would
+    // deadlock all progress. The unknown was already handed to the reasoner.
+    let gate = resolve_admission(
+        &ctx(None, 90),
+        AdmissionDecision::Admit {
+            rationale: "healthy, disk read failed".to_string(),
+        },
+    );
+    assert_eq!(gate, AdmissionGate::Proceed);
+}
+
+#[test]
+fn rail_never_proceeds_when_over_ceiling_for_any_decision() {
+    // The core safety invariant: over-ceiling ⇒ never Proceed, for EVERY
+    // possible brain decision.
+    let over = ctx(Some(95), 90);
+    for decision in [
+        AdmissionDecision::Admit {
+            rationale: "a".to_string(),
+        },
+        AdmissionDecision::Defer {
+            rationale: "d".to_string(),
+        },
+        AdmissionDecision::ReclaimFirst {
+            rationale: "r".to_string(),
+        },
+    ] {
+        let gate = resolve_admission(&over, decision.clone());
+        assert!(
+            !gate.is_proceed(),
+            "decision {decision:?} produced Proceed while disk 95% >= ceiling 90% (ENOSPC reachable!)"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decision mapping (FR-4) under healthy disk
+// ---------------------------------------------------------------------------
+
+#[test]
+fn admit_maps_to_proceed_when_healthy() {
+    let gate = resolve_admission(
+        &ctx(Some(30), 90),
+        AdmissionDecision::Admit {
+            rationale: "plenty of headroom".to_string(),
+        },
+    );
+    assert_eq!(gate, AdmissionGate::Proceed);
+}
+
+#[test]
+fn defer_maps_to_defer_and_preserves_reason() {
+    let gate = resolve_admission(
+        &ctx(Some(30), 90),
+        AdmissionDecision::Defer {
+            rationale: "load spiking, back off one cycle".to_string(),
+        },
+    );
+    assert_eq!(
+        gate,
+        AdmissionGate::Defer {
+            reason: "load spiking, back off one cycle".to_string()
+        }
+    );
+}
+
+#[test]
+fn reclaim_first_maps_to_reclaim_and_preserves_reason() {
+    let gate = resolve_admission(
+        &ctx(Some(30), 90),
+        AdmissionDecision::ReclaimFirst {
+            rationale: "build cache is 200GB, reclaim then retry".to_string(),
+        },
+    );
+    assert_eq!(
+        gate,
+        AdmissionGate::Reclaim {
+            reason: "build cache is 200GB, reclaim then retry".to_string()
+        }
+    );
+}
+
+#[test]
+fn reclaim_first_honored_even_over_ceiling() {
+    // Over the ceiling, a ReclaimFirst is strictly more proactive than a plain
+    // block — it must be honored (still non-admitting).
+    let gate = resolve_admission(
+        &ctx(Some(93), 90),
+        AdmissionDecision::ReclaimFirst {
+            rationale: "over ceiling, reclaim".to_string(),
+        },
+    );
+    assert!(matches!(gate, AdmissionGate::Reclaim { .. }));
+    assert!(!gate.is_proceed());
+}
+
+// ---------------------------------------------------------------------------
+// SEAM (FR-1/FR-2) — reason → apply via a stub brain
+// ---------------------------------------------------------------------------
+
+#[test]
+fn seam_admit_decision_proceeds_when_healthy() {
+    let gate = judge_and_resolve(&StubAdmissionBrain::admit(), &ctx(Some(50), 90)).unwrap();
+    assert_eq!(gate, AdmissionGate::Proceed);
+}
+
+#[test]
+fn seam_defer_decision_defers() {
+    let gate = judge_and_resolve(&StubAdmissionBrain::defer(), &ctx(Some(50), 90)).unwrap();
+    assert!(matches!(gate, AdmissionGate::Defer { .. }));
+}
+
+#[test]
+fn seam_reclaim_decision_reclaims() {
+    let gate = judge_and_resolve(&StubAdmissionBrain::reclaim(), &ctx(Some(50), 90)).unwrap();
+    assert!(matches!(gate, AdmissionGate::Reclaim { .. }));
+}
+
+#[test]
+fn seam_rail_overrides_brain_admit_when_over_ceiling() {
+    // Even when the (stubbed) brain says ADMIT, the seam's hard rail blocks it
+    // if disk is at/over the ceiling. This is the whole point of the feature.
+    let gate = judge_and_resolve(&StubAdmissionBrain::admit(), &ctx(Some(92), 90)).unwrap();
+    assert!(
+        !gate.is_proceed(),
+        "rail must override brain ADMIT, got {gate:?}"
+    );
+    assert!(matches!(gate, AdmissionGate::Defer { .. }));
+}
+
+#[test]
+fn seam_surfaces_brain_error_no_fallback() {
+    // NO FALLBACK: a brain error must propagate, not silently become an admit.
+    let result = judge_and_resolve(&StubAdmissionBrain::failing(), &ctx(Some(10), 90));
+    assert!(
+        result.is_err(),
+        "brain error must surface as an Err, not a phantom admission: {result:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// DeterministicAdmissionBrain — no-LLM floor, still beaten by the rail
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deterministic_brain_admits() {
+    let d = DeterministicAdmissionBrain
+        .judge_admission(&ctx(Some(10), 90))
+        .unwrap();
+    assert!(matches!(d, AdmissionDecision::Admit { .. }));
+}
+
+#[test]
+fn deterministic_brain_admit_proceeds_when_healthy() {
+    let gate = judge_and_resolve(&DeterministicAdmissionBrain, &ctx(Some(10), 90)).unwrap();
+    assert_eq!(gate, AdmissionGate::Proceed);
+}
+
+#[test]
+fn deterministic_brain_still_blocked_by_rail_over_ceiling() {
+    // The no-LLM floor always admits — but the deterministic rail still guards
+    // ENOSPC over the ceiling.
+    let gate = judge_and_resolve(&DeterministicAdmissionBrain, &ctx(Some(99), 90)).unwrap();
+    assert!(
+        !gate.is_proceed(),
+        "rail must protect even the deterministic floor"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Ceiling parse / clamp (A4)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_ceiling_defaults_when_absent_or_garbage() {
+    assert_eq!(parse_ceiling(None), DEFAULT_CEILING_PCT);
+    assert_eq!(parse_ceiling(Some("")), DEFAULT_CEILING_PCT);
+    assert_eq!(parse_ceiling(Some("not-a-number")), DEFAULT_CEILING_PCT);
+    // 300 does not fit in u8, so parse fails → default (not clamped).
+    assert_eq!(parse_ceiling(Some("300")), DEFAULT_CEILING_PCT);
+}
+
+#[test]
+fn parse_ceiling_reads_and_trims_valid_values() {
+    assert_eq!(parse_ceiling(Some("90")), 90);
+    assert_eq!(parse_ceiling(Some("  85 ")), 85);
+}
+
+#[test]
+fn parse_ceiling_clamps_out_of_range() {
+    // 0 would block everything forever; 250 (a valid u8) is too high.
+    assert_eq!(parse_ceiling(Some("0")), CEILING_MIN);
+    assert_eq!(parse_ceiling(Some("250")), CEILING_MAX);
+    assert_eq!(clamp_ceiling(0), CEILING_MIN);
+    assert_eq!(clamp_ceiling(255), CEILING_MAX);
+    assert_eq!(clamp_ceiling(50), 50);
+}
+
+#[test]
+fn configured_ceiling_is_in_range() {
+    // Whatever the ambient env, the configured ceiling is always usable.
+    let c = configured_ceiling_pct();
+    assert!(
+        (CEILING_MIN..=CEILING_MAX).contains(&c),
+        "ceiling {c} out of range"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Context serde (A8) — the recipe reads this as JSON context
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ctx_roundtrips_including_unknown_probes() {
+    let original = ResourceAdmissionCtx {
+        disk_usage_pct: None, // probe failed
+        worktree_cache_bytes: Some(999),
+        load_avg_1m: None,
+        cpu_count: Some(4),
+        in_flight_engineers: 3,
+        ceiling_pct: 90,
+    };
+    let json = serde_json::to_string(&original).expect("serialize");
+    let back: ResourceAdmissionCtx = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(original, back);
+}

--- a/src/ooda_brain/context.rs
+++ b/src/ooda_brain/context.rs
@@ -1,6 +1,7 @@
 //! Pure context gathering — best-effort, never panics, never propagates IO.
 
 use super::EngineerLifecycleCtx;
+use super::admission::ResourceAdmissionCtx;
 use crate::ooda_loop::OodaState;
 use std::path::Path;
 use std::time::SystemTime;
@@ -132,6 +133,58 @@ pub fn count_live_engineer_claims(state_root: &Path) -> u32 {
         }
     }
     count
+}
+
+/// Best-effort byte size of a directory subtree via `du -sb`. Returns `None`
+/// on missing dir / IO failure / parse failure so the caller can pass the
+/// "unknown" through to the admission reasoner (never panic, never 0-as-known).
+fn dir_size_bytes_opt(path: &Path) -> Option<u64> {
+    let out = std::process::Command::new("du")
+        .arg("-sb")
+        .arg(path)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .split_whitespace()
+        .next()?
+        .parse::<u64>()
+        .ok()
+}
+
+/// Read the 1-minute load average from `/proc/loadavg` (first field).
+/// `None` on any platform / read / parse failure.
+fn read_load_avg_1m() -> Option<f64> {
+    std::fs::read_to_string("/proc/loadavg")
+        .ok()?
+        .split_whitespace()
+        .next()?
+        .parse::<f64>()
+        .ok()
+}
+
+/// Assemble the best-effort [`ResourceAdmissionCtx`] the admission brain
+/// reasons over before a FRESH engineer is spawned (resource-aware augmentation
+/// of the AIMD count cap). Every probe degrades to `None` on error — never
+/// panics, never propagates IO — so a transient probe failure hands the
+/// reasoner an explicit "unknown" instead of blocking or crashing.
+///
+/// The disk-usage probe reuses [`crate::disk_health::get_disk_usage_pct`] so
+/// there is one disk-reading implementation, not two. `ceiling_pct` is the
+/// deterministic hard-rail ceiling in effect for this decision (see
+/// [`crate::ooda_brain::admission::resolve_admission`]).
+pub fn gather_resource_admission_ctx(state_root: &Path, ceiling_pct: u8) -> ResourceAdmissionCtx {
+    let worktrees_root = state_root.join(crate::engineer_worktree::WORKTREES_SUBDIR);
+    ResourceAdmissionCtx {
+        disk_usage_pct: crate::disk_health::get_disk_usage_pct(state_root),
+        worktree_cache_bytes: dir_size_bytes_opt(&worktrees_root),
+        load_avg_1m: read_load_avg_1m(),
+        cpu_count: std::thread::available_parallelism().ok().map(|n| n.get()),
+        in_flight_engineers: count_live_engineer_claims(state_root),
+        ceiling_pct,
+    }
 }
 
 /// Minutes since the last safe-update attempt (success or failure), inferred
@@ -349,6 +402,21 @@ fn redact_line(line: &str) -> String {
 #[cfg(test)]
 mod inner_tests {
     use super::*;
+
+    #[test]
+    fn gather_resource_admission_ctx_is_hermetic_and_preserves_ceiling() {
+        // A nonexistent state root must not panic: every probe degrades to
+        // best-effort (None / 0) and the caller-supplied ceiling is preserved
+        // verbatim so the hard rail downstream compares against the right value.
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("no-such-state-root");
+        let ctx = gather_resource_admission_ctx(&missing, 90);
+        assert_eq!(ctx.ceiling_pct, 90);
+        // No engineer worktrees under a missing root → zero in flight.
+        assert_eq!(ctx.in_flight_engineers, 0);
+        // worktree cache probe over a missing dir degrades to None (not 0).
+        assert!(ctx.worktree_cache_bytes.is_none());
+    }
 
     #[test]
     fn tail_file_caps_at_50_lines() {

--- a/src/ooda_brain/judgment_record.rs
+++ b/src/ooda_brain/judgment_record.rs
@@ -41,6 +41,9 @@ pub enum BrainPhase {
     /// Recipe-backed merge-readiness judge (`simard merge-pr`). Serialises as
     /// `"merge_judge"`.
     MergeJudge,
+    /// Recipe-backed RESOURCE-AWARE engineer admission (fresh-spawn gate).
+    /// Serialises as `"resource_admission"`.
+    ResourceAdmission,
 }
 
 impl BrainPhase {
@@ -54,6 +57,7 @@ impl BrainPhase {
             BrainPhase::Decide => "decide",
             BrainPhase::Orient => "orient",
             BrainPhase::MergeJudge => "merge_judge",
+            BrainPhase::ResourceAdmission => "resource_admission",
         }
     }
 }
@@ -234,6 +238,29 @@ impl BrainJudgmentRecord {
             rationale: judgment.rationale.clone(),
             confidence: judgment.confidence as f32,
             fallback,
+            prompt_version: prompt_version.into(),
+            parse_failure: None,
+        }
+    }
+
+    /// Build a ResourceAdmission-phase record from the resolved admission gate.
+    /// Emitted for observability at every fresh-spawn admission cycle so the
+    /// ADMIT / DEFER / RECLAIM-FIRST reasoning is inspectable in cycle reports.
+    /// `label` is the stable snake_case gate label (`admit` / `defer` /
+    /// `reclaim`); `reason` is the brain's (or hard-rail's) rationale.
+    pub fn from_admission(
+        goal_id: &str,
+        label: &str,
+        reason: &str,
+        prompt_version: impl Into<String>,
+    ) -> Self {
+        Self {
+            phase: BrainPhase::ResourceAdmission,
+            context_summary: truncate(&format!("resource-admission goal_id={goal_id}")),
+            decision: label.to_string(),
+            rationale: reason.to_string(),
+            confidence: 1.0,
+            fallback: false,
             prompt_version: prompt_version.into(),
             parse_failure: None,
         }

--- a/src/ooda_brain/mod.rs
+++ b/src/ooda_brain/mod.rs
@@ -51,7 +51,10 @@ pub use confidence::{
     effective_k, is_high_stakes, is_irreversible_lifecycle, lifecycle_conservative_rank,
     self_consistency_vote, should_self_consistency_sample, validate_confidence,
 };
-pub use context::{count_live_engineer_claims, gather_engineer_lifecycle_ctx, redact_secrets};
+pub use context::{
+    count_live_engineer_claims, gather_engineer_lifecycle_ctx, gather_resource_admission_ctx,
+    redact_secrets,
+};
 pub use decide::{
     DecideContext, DecideJudgment, DeterministicDecideBrain, OodaDecideBrain,
     PROMPT_NAME as DECIDE_PROMPT_NAME,
@@ -322,6 +325,26 @@ mod inline_tests_1979 {
             serde_json::to_string(&BrainPhase::Orient).unwrap(),
             "\"orient\""
         );
+        // Resource-aware admission phase (fresh-spawn gate observability).
+        assert_eq!(
+            serde_json::to_string(&BrainPhase::ResourceAdmission).unwrap(),
+            "\"resource_admission\""
+        );
+        assert_eq!(BrainPhase::ResourceAdmission.as_str(), "resource_admission");
+    }
+
+    #[test]
+    fn admission_judgment_record_captures_gate() {
+        let rec =
+            BrainJudgmentRecord::from_admission("goal-x", "defer", "disk 88% near ceiling 90", "");
+        assert_eq!(rec.phase, BrainPhase::ResourceAdmission);
+        assert_eq!(rec.decision, "defer");
+        assert!(rec.rationale.contains("88%"));
+        assert!(!rec.fallback);
+        // Round-trips through the cycle-report JSON like every other record.
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: BrainJudgmentRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(rec, back);
     }
 
     #[test]

--- a/src/ooda_brain/mod.rs
+++ b/src/ooda_brain/mod.rs
@@ -15,6 +15,7 @@ use crate::error::SimardResult;
 use crate::ooda_loop::OodaState;
 use std::path::PathBuf;
 
+mod admission;
 pub mod confidence;
 mod context;
 mod decide;
@@ -28,6 +29,8 @@ mod rustyclawd;
 mod sanitize;
 
 #[cfg(test)]
+mod admission_tests;
+#[cfg(test)]
 mod decide_tests;
 #[cfg(test)]
 mod orient_tests;
@@ -36,6 +39,12 @@ mod prompt_store_tests;
 #[cfg(test)]
 mod tests;
 
+pub use admission::{
+    AdmissionDecision, AdmissionGate, CEILING_ENV, CEILING_MAX, CEILING_MIN, DEFAULT_CEILING_PCT,
+    DeterministicAdmissionBrain, OodaAdmissionBrain, RECIPE_NAME as ADMISSION_RECIPE_NAME,
+    ResourceAdmissionCtx, clamp_ceiling, configured_ceiling_pct, judge_and_resolve, parse_ceiling,
+    resolve_admission,
+};
 pub use confidence::{
     CalibrationWindow, ECE_BINS, ECE_METRIC, ECE_WINDOW, HIGH_STAKES_URGENCY, JudgedDecision,
     JudgedLifecycle, LOW_TRUST_CONFIDENCE, SELF_CONSISTENCY_K, Vote, confidence_or_low_trust,

--- a/src/ooda_brain/recipe_brain.rs
+++ b/src/ooda_brain/recipe_brain.rs
@@ -22,6 +22,7 @@ use std::process::Command;
 
 use serde::Deserialize;
 
+use super::admission::{AdmissionDecision, OodaAdmissionBrain, ResourceAdmissionCtx};
 use super::decide::{DecideContext, DecideJudgment, OodaDecideBrain};
 use super::orient::{
     FAILURE_PENALTY_PER_CONSECUTIVE, OodaOrientBrain, OrientContext, OrientJudgment,
@@ -46,6 +47,13 @@ const MAX_RATIONALE_CHARS: usize = 500;
 /// (issue #2419). `value` is always `1.0`; the `outcome` label in the context
 /// JSON is the numerator/denominator signal.
 const LIFECYCLE_DECISION_METRIC: &str = "brain_lifecycle_decision";
+
+/// Metric emitted once per resource-aware admission decision (fresh-spawn gate)
+/// so the ADMIT / DEFER / RECLAIM-FIRST distribution and the hard-rail block
+/// rate are measurable from `metrics.jsonl`. `value` is always `1.0`; the
+/// context JSON carries `{choice, disk_usage_pct, in_flight_engineers,
+/// ceiling_pct}`. Mirrors [`LIFECYCLE_DECISION_METRIC`].
+const ADMISSION_DECISION_METRIC: &str = "brain_admission_decision";
 
 /// Shared metric emitted once per recipe-backed brain phase invocation
 /// (decide / orient / merge-judge) so the verdict/decision parse-success rate
@@ -848,6 +856,147 @@ impl OodaOrientBrain for RecipeBrain {
             termination,
             attempts,
         )
+    }
+}
+
+impl OodaAdmissionBrain for RecipeBrain {
+    /// RESOURCE-AWARE engineer admission — the agentic augmentation of the AIMD
+    /// count cap. Invoke `recipe-runner-rs --output-format json` on
+    /// `ooda-resource-admission.yaml`, parse the agent's structured
+    /// `{"choice": "...", "rationale": "..."}` decision, and return it.
+    ///
+    /// **NO FALLBACK** (operator zero-fallback contract): a recipe-runner
+    /// failure OR an unparseable decision surfaces as an explicit `Err`. The
+    /// admission seam then treats a broken brain as a visible failure — it must
+    /// never silently become a phantom `admit` that could fill the disk. The
+    /// deterministic hard rail in [`super::admission::resolve_admission`] still
+    /// guards ENOSPC over any `Admit` this brain returns.
+    fn judge_admission(&self, ctx: &ResourceAdmissionCtx) -> SimardResult<AdmissionDecision> {
+        let raw = self.invoke_admission_raw(ctx)?;
+        let decision =
+            parse_admission_decision(&raw).ok_or_else(|| SimardError::AdapterInvocationFailed {
+                base_type: self.adapter_tag.to_string(),
+                reason: format!(
+                    "no parseable admission decision in recipe output (expected \
+                     {{\"choice\":\"admit|defer|reclaim_first\",\"rationale\":\"...\"}}); \
+                     raw={}",
+                    truncate(raw.trim(), MAX_RATIONALE_CHARS)
+                ),
+            })?;
+        record_admission_decision_metric(ctx, &decision);
+        Ok(decision)
+    }
+}
+
+impl RecipeBrain {
+    /// Invoke the admission recipe once, returning the agent's raw decision
+    /// text (the JSON envelope's final step output). Genuine recipe-runner
+    /// failures (spawn / nonzero exit / envelope decode) propagate as `Err`.
+    ///
+    /// The full [`ResourceAdmissionCtx`] is passed as `-c` context vars so the
+    /// prompt can reason over disk %, build-cache size, load-per-core, and
+    /// in-flight builds. `None` probes render as the literal `unknown` so the
+    /// prompt can weigh missing signals explicitly.
+    fn invoke_admission_raw(&self, ctx: &ResourceAdmissionCtx) -> SimardResult<String> {
+        let opt_u8 = |v: Option<u8>| v.map(|n| n.to_string()).unwrap_or_else(|| "unknown".into());
+        let opt_u64 = |v: Option<u64>| v.map(|n| n.to_string()).unwrap_or_else(|| "unknown".into());
+        let opt_f64 = |v: Option<f64>| {
+            v.map(|n| format!("{n:.2}"))
+                .unwrap_or_else(|| "unknown".into())
+        };
+        let opt_usize =
+            |v: Option<usize>| v.map(|n| n.to_string()).unwrap_or_else(|| "unknown".into());
+
+        let output = Command::new("recipe-runner-rs")
+            .arg(self.recipe_path.as_os_str())
+            .arg("--output-format")
+            .arg("json")
+            .env("AMPLIHACK_AGENT_BINARY", self.agent_binary)
+            .arg("-c")
+            .arg(format!("disk_usage_pct={}", opt_u8(ctx.disk_usage_pct)))
+            .arg("-c")
+            .arg(format!(
+                "worktree_cache_bytes={}",
+                opt_u64(ctx.worktree_cache_bytes)
+            ))
+            .arg("-c")
+            .arg(format!("load_avg_1m={}", opt_f64(ctx.load_avg_1m)))
+            .arg("-c")
+            .arg(format!("cpu_count={}", opt_usize(ctx.cpu_count)))
+            .arg("-c")
+            .arg(format!("in_flight_engineers={}", ctx.in_flight_engineers))
+            .arg("-c")
+            .arg(format!("ceiling_pct={}", ctx.ceiling_pct))
+            .output()
+            .map_err(|e| SimardError::AdapterInvocationFailed {
+                base_type: self.adapter_tag.to_string(),
+                reason: format!("recipe-runner-rs spawn failed: {e}"),
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(SimardError::AdapterInvocationFailed {
+                base_type: self.adapter_tag.to_string(),
+                reason: format!(
+                    "recipe exited with {}: {}",
+                    output.status,
+                    truncate(&stderr, MAX_RATIONALE_CHARS)
+                ),
+            });
+        }
+
+        extract_recipe_decision_output(&output.stdout, self.adapter_tag)
+    }
+}
+
+/// Parse the admission reasoner's raw output into an [`AdmissionDecision`].
+///
+/// Routes through the shared #2484 sanitizing chokepoint
+/// ([`crate::recipe_output::extract_json_payload`]) so a banner/log-polluted
+/// `{"choice": "...", "rationale": "..."}` object still parses, then
+/// deserializes it directly into the tagged [`AdmissionDecision`] enum. Returns
+/// `None` when no well-formed decision object is present — the caller surfaces
+/// that as an explicit `Err` (NO silent default admission).
+fn parse_admission_decision(text: &str) -> Option<AdmissionDecision> {
+    let payload = crate::recipe_output::extract_json_payload(text)?;
+    serde_json::from_str::<AdmissionDecision>(&payload).ok()
+}
+
+/// Build the JSON `context` payload for the `brain_admission_decision` metric.
+/// Separated from I/O so the payload shape can be unit-tested without touching
+/// the real `metrics.jsonl`.
+fn build_admission_metric_context(
+    ctx: &ResourceAdmissionCtx,
+    decision: &AdmissionDecision,
+) -> String {
+    serde_json::json!({
+        "choice": decision.label(),
+        "disk_usage_pct": ctx.disk_usage_pct,
+        "worktree_cache_bytes": ctx.worktree_cache_bytes,
+        "load_avg_1m": ctx.load_avg_1m,
+        "cpu_count": ctx.cpu_count,
+        "in_flight_engineers": ctx.in_flight_engineers,
+        "ceiling_pct": ctx.ceiling_pct,
+    })
+    .to_string()
+}
+
+/// Record one `brain_admission_decision` metric event (value `1.0`) per
+/// admission decision. Best-effort: a metrics-write failure is logged, never
+/// propagated. No-op under `cfg!(test)` so unit tests never append to the
+/// operator's real `metrics.jsonl`.
+fn record_admission_decision_metric(ctx: &ResourceAdmissionCtx, decision: &AdmissionDecision) {
+    if cfg!(test) {
+        return;
+    }
+    let context = build_admission_metric_context(ctx, decision);
+    if let Err(e) = crate::self_metrics::record_metric(ADMISSION_DECISION_METRIC, 1.0, &context) {
+        tracing::warn!(
+            target: "simard::ooda_brain",
+            error = %e,
+            choice = decision.label(),
+            "failed to record brain_admission_decision metric (decision unaffected)",
+        );
     }
 }
 
@@ -2088,6 +2237,94 @@ mod tests {
             msg.contains("recipe-decide-brain"),
             "error should contain the adapter tag; got: {msg}"
         );
+    }
+
+    // ===================================================================
+    // Resource-aware admission — parse seam + metric payload + NO FALLBACK
+    // ===================================================================
+
+    fn admission_ctx() -> ResourceAdmissionCtx {
+        ResourceAdmissionCtx {
+            disk_usage_pct: Some(42),
+            worktree_cache_bytes: Some(1_024),
+            load_avg_1m: Some(3.1),
+            cpu_count: Some(16),
+            in_flight_engineers: 2,
+            ceiling_pct: 90,
+        }
+    }
+
+    #[test]
+    fn parse_admission_decision_reads_all_three_choices() {
+        let admit = parse_admission_decision(r#"{"choice":"admit","rationale":"headroom"}"#)
+            .expect("admit parses");
+        assert!(matches!(admit, AdmissionDecision::Admit { .. }));
+
+        let defer = parse_admission_decision(r#"{"choice":"defer","rationale":"tight"}"#)
+            .expect("defer parses");
+        assert!(matches!(defer, AdmissionDecision::Defer { .. }));
+
+        let reclaim =
+            parse_admission_decision(r#"{"choice":"reclaim_first","rationale":"stale cache"}"#)
+                .expect("reclaim parses");
+        assert!(matches!(reclaim, AdmissionDecision::ReclaimFirst { .. }));
+    }
+
+    #[test]
+    fn parse_admission_decision_recovers_from_banner_and_fence() {
+        // The agent step output routinely wraps the JSON in a ```json fence and
+        // a runner banner; the shared #2484 chokepoint must still recover it.
+        let raw = "Recipe: ooda-resource-admission SUCCESS\n```json\n{\"choice\": \"defer\", \"rationale\": \"load 2.1/core\"}\n```\n";
+        let d = parse_admission_decision(raw).expect("banner-wrapped JSON must parse");
+        assert_eq!(d.label(), "defer");
+    }
+
+    #[test]
+    fn parse_admission_decision_none_for_unparseable() {
+        // No default admission: garbage / unknown tag / empty must be None so
+        // the caller surfaces an explicit Err (never a phantom admit).
+        assert!(parse_admission_decision("").is_none());
+        assert!(parse_admission_decision("not json at all").is_none());
+        assert!(
+            parse_admission_decision(r#"{"choice":"launch_the_missiles","rationale":"x"}"#)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn judge_admission_surfaces_error_no_fallback() {
+        // A recipe-runner failure (nonexistent recipe) must surface as Err,
+        // NEVER a silent Admit that could fill the disk.
+        let brain = RecipeBrain {
+            recipe_path: PathBuf::from("/nonexistent/recipe.yaml"),
+            agent_binary: "copilot",
+            adapter_tag: "recipe-resource-admission-brain",
+        };
+        let result = brain.judge_admission(&admission_ctx());
+        assert!(
+            result.is_err(),
+            "broken admission brain must Err, not phantom-admit: {result:?}"
+        );
+        assert!(
+            format!("{}", result.unwrap_err()).contains("recipe-resource-admission-brain"),
+            "error should name the adapter tag"
+        );
+    }
+
+    #[test]
+    fn admission_metric_context_carries_choice_and_numbers() {
+        let ctx = admission_ctx();
+        let json = build_admission_metric_context(
+            &ctx,
+            &AdmissionDecision::Defer {
+                rationale: "tight".to_string(),
+            },
+        );
+        let v: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(v["choice"], "defer");
+        assert_eq!(v["disk_usage_pct"], 42);
+        assert_eq!(v["in_flight_engineers"], 2);
+        assert_eq!(v["ceiling_pct"], 90);
     }
 
     #[test]

--- a/src/ooda_loop/bridge_factory.rs
+++ b/src/ooda_loop/bridge_factory.rs
@@ -107,6 +107,7 @@ pub fn bridges_from_state_root(state_root: &Path) -> SimardResult<OodaBridges> {
             crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     })
 }
 

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -479,6 +479,14 @@ pub struct OodaBridges {
     /// non-daemon callers. Bounded by the AIMD `cap` (`scaler.current_max()`)
     /// so concurrency stays resource-aware.
     pub session_factory: Option<std::sync::Arc<dyn OrchestratorSessionFactory>>,
+    /// Resource-aware admission brain (fresh-spawn gate). When `Some`, the
+    /// spawn seam consults it — gathering the resource picture (disk %,
+    /// build-cache size, load, in-flight engineers) and reasoning ADMIT /
+    /// DEFER / RECLAIM-FIRST — before allocating an engineer worktree. When
+    /// `None`, the seam uses the [`crate::ooda_brain::DeterministicAdmissionBrain`]
+    /// floor (always admit). The deterministic disk hard-rail
+    /// ([`crate::ooda_brain::resolve_admission`]) blocks ENOSPC either way.
+    pub admission_brain: Option<std::sync::Arc<dyn crate::ooda_brain::OodaAdmissionBrain>>,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/operator_cli/mod.rs
+++ b/src/operator_cli/mod.rs
@@ -9,6 +9,7 @@ mod meeting;
 mod memory;
 mod merge;
 mod ooda;
+mod platform;
 mod review;
 mod safe_update;
 mod self_deploy;
@@ -101,6 +102,12 @@ Product modes:
   gym compare <scenario-id>
   gym run-suite <suite-id>
   ooda run [--cycles=N] [--no-auto-reload] [state-root]
+  platform install --identity <path> [--local|--remote azlin:<vm>] ...
+                          — stand up / upgrade / uninstall a Simard-family agent
+                            daemon on a host (thin rail to the Crocutus scaffold;
+                            idempotent, fail-closed). See docs/reference/platform-installer-cli.md
+  platform doctor --identity <path> [--check-only]
+                          — run the installer preflight doctor standalone
   dashboard serve [--port=8080]
   signal run             — connect to the configured signal-cli JSON-RPC daemon
                            and run the operator Signal conversation channel
@@ -242,6 +249,7 @@ where
         "review" => review::dispatch_review_command(args),
         "gym" => gym::dispatch_gym_command(args),
         "ooda" => ooda::dispatch_ooda_command(args),
+        "platform" => platform::dispatch_platform_command(args),
         "dashboard" => dashboard::dispatch_dashboard_command(args),
         "signal" => signal::dispatch_signal_command(args),
         "memory" => memory::dispatch_memory_command(args),
@@ -352,7 +360,7 @@ where
 }
 
 pub fn operator_cli_usage() -> &'static str {
-    "usage: simard <engineer|meeting|goal-curation|improvement-curation|gym|ooda|memory|status|spawn|merge-pr|worktree-gc|handover|update|safe-update|rollback|rollback-watchdog|install|review|bootstrap|signal> ..."
+    "usage: simard <engineer|meeting|goal-curation|improvement-curation|gym|ooda|platform|memory|status|spawn|merge-pr|worktree-gc|handover|update|safe-update|rollback|rollback-watchdog|install|review|bootstrap|signal> ..."
 }
 
 pub fn operator_cli_help() -> &'static str {

--- a/src/operator_cli/platform.rs
+++ b/src/operator_cli/platform.rs
@@ -1,0 +1,205 @@
+//! `simard platform …` — a thin rail to the canonical platform-installer
+//! scaffold (issue #3119).
+//!
+//! The platform installer's source of truth is the **Crocutus** repository's
+//! `scripts/install.sh` and `scripts/doctor.sh` (see
+//! `docs/concepts/platform-installer.md`). This rail is a convenience front door
+//! from the Simard binary; it forwards to that scaffold rather than
+//! re-implementing it, so there is a single code path to test and maintain.
+//!
+//! The verb is namespaced under `platform` specifically so it never collides
+//! with the pre-existing bare `simard install` verb (which persists the current
+//! binary to `~/.simard/bin` for the `npx` wrapper). Unknown `platform`
+//! subcommands fail closed with an error that names the offending subcommand.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+pub(super) const PLATFORM_HELP: &str = "\
+Simard platform installer rail
+
+Usage: simard platform <install|doctor> [args...]
+
+  install [--identity <path>] [--local | --remote azlin:<vm>]
+          [--upgrade | --uninstall] [--check-only] [--yes] ...
+                      — stand up / upgrade / uninstall a Simard-family agent
+                        daemon on a host (idempotent, fail-closed).
+  doctor  [--identity <path>] [--local | --remote azlin:<vm>] [--check-only]
+                      — run the preflight doctor standalone.
+
+This is a thin rail. The canonical implementation is the Crocutus scaffold
+(scripts/install.sh, scripts/doctor.sh); this command forwards to it. Locate the
+scaffold with SIMARD_INSTALLER_SCAFFOLD=<dir containing install.sh/doctor.sh>,
+or it is discovered under ~/crocutus/scripts or ~/src/Crocutus/scripts.
+
+See docs/reference/platform-installer-cli.md for the full contract.
+";
+
+const PLATFORM_INSTALL_HELP: &str = "\
+Simard platform install — stand up / upgrade / uninstall an agent daemon
+
+Usage:
+  simard platform install --identity <path> [--local | --remote azlin:<vm>]
+                          [--upgrade | --uninstall] [--check-only] [--yes]
+                          [--dashboard-port <n>] [--state-root <path>]
+                          [--unit-name <name>]
+
+Forwards to the canonical Crocutus scaffold scripts/install.sh. See
+docs/reference/platform-installer-cli.md.
+";
+
+const PLATFORM_DOCTOR_HELP: &str = "\
+Simard platform doctor — run the installer preflight standalone
+
+Usage:
+  simard platform doctor --identity <path> [--local | --remote azlin:<vm>]
+                         [--check-only]
+
+Forwards to the canonical Crocutus scaffold scripts/doctor.sh. See
+docs/howto/run-the-installer-preflight-doctor.md.
+";
+
+fn is_help(arg: &str) -> bool {
+    matches!(arg, "--help" | "-h" | "help")
+}
+
+/// Dispatch a `simard platform …` invocation.
+///
+/// `--help` on the group or either subcommand is side-effect-free (prints help,
+/// exits Ok). Real `install`/`doctor` invocations forward to the canonical
+/// scaffold. An unknown subcommand fails closed, naming the subcommand.
+pub(super) fn dispatch_platform_command(
+    mut args: impl Iterator<Item = String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(subcommand) = args.next() else {
+        // Bare `simard platform` prints group help rather than erroring.
+        print!("{PLATFORM_HELP}");
+        return Ok(());
+    };
+
+    if is_help(&subcommand) {
+        print!("{PLATFORM_HELP}");
+        return Ok(());
+    }
+
+    match subcommand.as_str() {
+        "install" => forward_to_scaffold("install.sh", PLATFORM_INSTALL_HELP, args),
+        "doctor" => forward_to_scaffold("doctor.sh", PLATFORM_DOCTOR_HELP, args),
+        other => Err(format!(
+            "unsupported command 'platform {other}'. Try 'simard platform --help' \
+             (supported: install, doctor)."
+        )
+        .into()),
+    }
+}
+
+/// Forward a subcommand's remaining args to the named scaffold script.
+///
+/// Peeks for a help flag first (side-effect-free), then locates the scaffold and
+/// execs `bash <scaffold>/<script> <args...>`, mapping its exit status. Fails
+/// closed with an actionable error if the scaffold cannot be found.
+fn forward_to_scaffold(
+    script: &str,
+    help_text: &'static str,
+    args: impl Iterator<Item = String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let forwarded: Vec<String> = args.collect();
+
+    if forwarded.iter().any(|a| is_help(a)) {
+        print!("{help_text}");
+        return Ok(());
+    }
+
+    let scaffold = locate_scaffold().ok_or_else(|| -> Box<dyn std::error::Error> {
+        format!(
+            "platform installer scaffold not found (looked for '{script}'). Set \
+             SIMARD_INSTALLER_SCAFFOLD to the directory containing install.sh / \
+             doctor.sh (the Crocutus repo's scripts/), or clone Crocutus to \
+             ~/crocutus or ~/src/Crocutus."
+        )
+        .into()
+    })?;
+
+    let script_path = scaffold.join(script);
+    if !script_path.is_file() {
+        return Err(format!(
+            "platform installer scaffold at '{}' does not contain '{script}' \
+             (fail-closed: refusing to run an incomplete scaffold).",
+            scaffold.display()
+        )
+        .into());
+    }
+
+    let status = Command::new("bash")
+        .arg(&script_path)
+        .args(&forwarded)
+        .status()
+        .map_err(|e| format!("failed to launch scaffold '{}': {e}", script_path.display()))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "platform installer '{script}' failed (exit {}). See the phase report above.",
+            status
+                .code()
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "signal".into())
+        )
+        .into())
+    }
+}
+
+/// Locate the installer scaffold directory (the one holding `install.sh` /
+/// `doctor.sh`). Explicit env override wins; otherwise probe known locations.
+fn locate_scaffold() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("SIMARD_INSTALLER_SCAFFOLD") {
+        let p = PathBuf::from(dir);
+        if p.is_dir() {
+            return Some(p);
+        }
+    }
+
+    let home = std::env::var_os("HOME").map(PathBuf::from)?;
+    [
+        home.join("crocutus").join("scripts"),
+        home.join("src").join("Crocutus").join("scripts"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.is_dir())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(args: &[&str]) -> std::vec::IntoIter<String> {
+        args.iter()
+            .map(|s| (*s).to_string())
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    #[test]
+    fn bare_platform_prints_help_ok() {
+        assert!(dispatch_platform_command(argv(&[])).is_ok());
+    }
+
+    #[test]
+    fn platform_help_ok() {
+        assert!(dispatch_platform_command(argv(&["--help"])).is_ok());
+    }
+
+    #[test]
+    fn install_and_doctor_help_ok() {
+        assert!(dispatch_platform_command(argv(&["install", "--help"])).is_ok());
+        assert!(dispatch_platform_command(argv(&["doctor", "--help"])).is_ok());
+    }
+
+    #[test]
+    fn unknown_subcommand_fails_closed_naming_it() {
+        let err = dispatch_platform_command(argv(&["totally-unknown-subcommand"]))
+            .expect_err("unknown platform subcommand must fail closed");
+        assert!(err.to_string().contains("totally-unknown-subcommand"));
+    }
+}

--- a/src/operator_commands_ooda/daemon/brains.rs
+++ b/src/operator_commands_ooda/daemon/brains.rs
@@ -161,6 +161,39 @@ pub(super) fn build_orient_brain(
     }
 }
 
+/// Construct the RESOURCE-AWARE admission brain (fresh-spawn gate). Always
+/// returns an `Arc` — falls back to
+/// [`crate::ooda_brain::DeterministicAdmissionBrain`] (the no-LLM floor, which
+/// always `Admit`s and is still guarded by the deterministic disk hard-rail)
+/// when the recipe/runner is unavailable, loudly per [`record_fallback`].
+///
+/// Unlike `build_decide_brain` / `build_orient_brain`, admission always yields
+/// a concrete brain rather than `None`: the seam must always have a reasoner to
+/// consult, and the deterministic floor + hard-rail preserve safe behaviour
+/// even with no LLM.
+pub(super) fn build_admission_brain(
+    state_root: &Path,
+    repo_root: &Path,
+) -> Arc<dyn crate::ooda_brain::OodaAdmissionBrain> {
+    if let Some(b) = crate::ooda_brain::RecipeBrain::new(
+        repo_root,
+        crate::ooda_brain::ADMISSION_RECIPE_NAME,
+        "recipe-resource-admission-brain",
+    ) {
+        daemon_log(
+            state_root,
+            "[simard] OODA daemon: admission_brain = RecipeBrain (recipe-runner-rs backed, resource-admission)",
+        );
+        return Arc::new(b);
+    }
+    record_fallback(
+        state_root,
+        "admission",
+        "recipe-runner-rs or ooda-resource-admission.yaml not available",
+    );
+    Arc::new(crate::ooda_brain::DeterministicAdmissionBrain)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -240,5 +273,78 @@ mod tests {
             log.contains(unique_reason),
             "the LlmProvider::resolve() error must be in the dashboard log verbatim; got: {log}"
         );
+    }
+
+    /// RAII guard that points `$HOME` at an empty directory for the duration of
+    /// a test and restores the prior value on drop. `resolve_recipe_path`
+    /// consults `~/.simard/prompt_assets/simard/recipes/…` *before* `repo_root`,
+    /// so a nonexistent repo alone does NOT make `RecipeBrain::new` return
+    /// `None` on a provisioned host where the ambient hot-reload recipe exists.
+    /// Neutralizing `$HOME` closes that non-hermetic hole. Safe because the
+    /// caller holds [`lock()`], which serializes all env-var mutation in this
+    /// module.
+    struct HomeGuard {
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl HomeGuard {
+        fn empty(dir: &Path) -> Self {
+            let prev = std::env::var_os("HOME");
+            // SAFETY: env mutation is serialized via `lock()`; restored on drop.
+            unsafe {
+                std::env::set_var("HOME", dir);
+            }
+            Self { prev }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: env mutation is serialized via `lock()`.
+            unsafe {
+                match self.prev.take() {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
+    }
+
+    /// `build_admission_brain` ALWAYS yields a working brain (never `None`):
+    /// with an unresolvable recipe, it falls back — loudly — to the
+    /// deterministic admission floor, which admits so the deterministic disk
+    /// hard-rail (not this brain) remains the ENOSPC guard.
+    #[test]
+    fn build_admission_brain_falls_back_to_deterministic_floor() {
+        use crate::ooda_brain::ResourceAdmissionCtx;
+        let _g = lock();
+        reset_fallback_brain_count_for_test();
+        let tmp = TempDir::new().expect("tempdir");
+
+        // Point HOME at a fresh empty dir so the hot-reload lookup
+        // (`~/.simard/prompt_assets/…`) finds nothing, THEN pass a nonexistent
+        // repo so the in-tree lookup also misses → resolve_recipe_path returns
+        // None → RecipeBrain::new returns None regardless of recipe-runner
+        // availability → deterministic floor. Hermetic against the ambient
+        // ~/.simard/prompt_assets directory on provisioned hosts.
+        let fake_home = TempDir::new().expect("fake home tempdir");
+        let _home = HomeGuard::empty(fake_home.path());
+        let brain = build_admission_brain(tmp.path(), Path::new("/nonexistent-repo-root"));
+        assert!(
+            fallback_brain_count() >= 1,
+            "fallback to the deterministic floor must be recorded loudly"
+        );
+        // The floor admits (count-cap only); the deterministic disk hard-rail
+        // downstream is what guards ENOSPC.
+        let ctx = ResourceAdmissionCtx {
+            disk_usage_pct: Some(10),
+            worktree_cache_bytes: None,
+            load_avg_1m: None,
+            cpu_count: Some(8),
+            in_flight_engineers: 0,
+            ceiling_pct: 90,
+        };
+        let decision = brain.judge_admission(&ctx).expect("floor never errors");
+        assert_eq!(decision.label(), "admit");
     }
 }

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -214,8 +214,9 @@ pub fn run_ooda_daemon(
     let brain = brains::build_act_brain(&state_root, &repo_root);
     let decide_brain = brains::build_decide_brain(&state_root, &repo_root);
     let orient_brain = brains::build_orient_brain(&state_root, &repo_root);
+    let admission_brain = brains::build_admission_brain(&state_root, &repo_root);
 
-    // After all three brains are constructed, surface the cumulative
+    // After all four brains are constructed, surface the cumulative
     // fallback count in the dashboard. Nonzero == daemon is running in
     // degraded mode (see issues #1711, #1748). Future health endpoints
     // should refuse "healthy" when this is nonzero.
@@ -224,13 +225,13 @@ pub fn run_ooda_daemon(
         daemon_log(
             &state_root,
             &format!(
-                "[simard] OODA daemon: DEGRADED MODE — {degraded}/3 brains fell back to deterministic (see issues #1711, #1748)"
+                "[simard] OODA daemon: DEGRADED MODE — {degraded}/4 brains fell back to deterministic (see issues #1711, #1748)"
             ),
         );
     } else {
         daemon_log(
             &state_root,
-            "[simard] OODA daemon: all 3 brains LLM-backed (no fallback in use)",
+            "[simard] OODA daemon: all 4 brains LLM-backed (no fallback in use)",
         );
     }
 
@@ -344,6 +345,7 @@ pub fn run_ooda_daemon(
         repo_root,
         progress_evidence,
         completion_evidence,
+        admission_brain: Some(admission_brain),
     };
 
     // Issue #1: the authoritative goal board lives in
@@ -1536,6 +1538,7 @@ mod tests {
                 crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
             ),
             completion_evidence: None,
+            admission_brain: None,
         }
     }
 

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -1265,7 +1265,8 @@ pub fn run_ooda_daemon(
                             &format!(
                                 "[simard] overseer tick: problems={} issues_filed={} \
                                  recipes_launched={} prs_merged={} deploys={} escalations={} \
-                                 held={} errors={} panicked={} ({}ms)",
+                                 held={} goals_unblocked={} goals_escalated={} errors={} \
+                                 panicked={} ({}ms)",
                                 report.problems,
                                 report.issues_filed,
                                 report.recipes_launched,
@@ -1273,6 +1274,8 @@ pub fn run_ooda_daemon(
                                 report.deploys,
                                 report.escalations,
                                 report.held,
+                                report.goals_unblocked,
+                                report.goals_escalated,
                                 report.errors,
                                 report.panicked,
                                 report.duration_ms,

--- a/src/overseer/activity.rs
+++ b/src/overseer/activity.rs
@@ -55,6 +55,10 @@ pub struct OverseerTotals {
     pub prs_merged: u64,
     pub deploys: u64,
     pub escalations: u64,
+    /// False-parked perpetual goals self-healed (auto-unblocked + reactivated).
+    pub goals_unblocked: u64,
+    /// Genuinely-blocked "needs human review" goals escalated to the operator.
+    pub goals_escalated: u64,
     pub held: u64,
     pub errors: u64,
 }
@@ -216,6 +220,8 @@ impl OverseerActivity {
             t.prs_merged += rep.prs_merged as u64;
             t.deploys += rep.deploys as u64;
             t.escalations += rep.escalations as u64;
+            t.goals_unblocked += rep.goals_unblocked as u64;
+            t.goals_escalated += rep.goals_escalated as u64;
             t.held += rep.held as u64;
             t.errors += rep.errors as u64;
         }
@@ -223,11 +229,18 @@ impl OverseerActivity {
     }
 
     /// Count of *actions taken* over the retained window (issues filed, fix
-    /// workstreams launched, PRs merged, deploys, escalations). `held` is
-    /// deliberately excluded: holding is observing-and-waiting, not an action.
+    /// workstreams launched, PRs merged, deploys, escalations, goal-board
+    /// self-heals + escalations). `held` is deliberately excluded: holding is
+    /// observing-and-waiting, not an action.
     pub fn interventions(&self) -> u64 {
         let t = &self.totals;
-        t.issues_filed + t.recipes_launched + t.prs_merged + t.deploys + t.escalations
+        t.issues_filed
+            + t.recipes_launched
+            + t.prs_merged
+            + t.deploys
+            + t.escalations
+            + t.goals_unblocked
+            + t.goals_escalated
     }
 
     /// The honest one-line status summary rendered on every surface.
@@ -397,6 +410,20 @@ pub fn humanize_tick(r: &OverseerTickReport) -> String {
     }
     if r.escalations > 0 {
         did.push(format!("escalated {} to the operator", r.escalations));
+    }
+    if r.goals_unblocked > 0 {
+        did.push(format!(
+            "self-healed {} blocked goal{}",
+            r.goals_unblocked,
+            plural(r.goals_unblocked)
+        ));
+    }
+    if r.goals_escalated > 0 {
+        did.push(format!(
+            "escalated {} blocked goal{} for human review",
+            r.goals_escalated,
+            plural(r.goals_escalated)
+        ));
     }
 
     let saw = format!("saw {} problem{}", r.problems, plural(r.problems));

--- a/src/overseer/capabilities.rs
+++ b/src/overseer/capabilities.rs
@@ -349,6 +349,20 @@ pub trait GoalCurator {
         Ok(Vec::new())
     }
 
+    /// Project BOTH the goal-board *health* (blocked goals) and the in-flight
+    /// dedup set from ONE board read, so the acting Observe pass reads the board
+    /// once per cycle instead of twice. This halves the per-tick board load
+    /// (`search_facts` + snapshot deserialize) AND guarantees both projections
+    /// come from the SAME snapshot — no intra-cycle drift where the board mutates
+    /// between the two reads.
+    ///
+    /// The default composes the two existing methods (two loads), preserving
+    /// fakes that model neither or only one; the real board-backed adapter
+    /// overrides this to load once.
+    fn observe_board(&self) -> Result<(Vec<BlockedGoal>, Vec<InFlightItem>), OverseerError> {
+        Ok((self.blocked_goals()?, self.in_flight()?))
+    }
+
     /// Auto-unblock + reactivate a false-parked goal — the exact operation
     /// `simard goal unblock` performs: restore a `Blocked` goal to `NotStarted`
     /// so the next OODA cycle re-enters the spawn path.

--- a/src/overseer/capabilities.rs
+++ b/src/overseer/capabilities.rs
@@ -86,6 +86,12 @@ pub struct ObservedState {
     pub ready_prs: Vec<PrRef>,
     /// CI-failure clusters observed across recent runs.
     pub ci_failures: Vec<CiFailure>,
+    /// Blocked goals observed on Simard's goal board this Observe pass — the
+    /// goal-board *health* signal. Populated by the sensor from the durable
+    /// board markers (`BLOCKED`, the `🔒 [OODA-SAFEGUARD] … needs human review`
+    /// no-progress marker, and the brain-failure marker). Empty when the board
+    /// is clean or unreadable (degrade-to-empty, never a panic).
+    pub blocked_goals: Vec<BlockedGoal>,
     /// Consecutive OODA cycles the active goal has produced no action / no
     /// progress. Mirrors the OODA no-progress tracker; drives the loop-whisper.
     /// `None` when unknown (e.g. no active goal).
@@ -110,6 +116,33 @@ pub struct PrRef {
 pub struct CiFailure {
     pub repo: String,
     pub failing: u32,
+}
+
+/// One blocked goal observed on Simard's goal board — the unit of goal-board
+/// *health* the Overseer observes and (in the acting loop) acts on.
+///
+/// Derived from a `GoalProgress::Blocked(reason)` on the live board by the
+/// sensor's pure projection (`sensor::blocked_goals_from_board`). It reuses the
+/// EXISTING standing/perpetual detection (`ActiveGoal::is_perpetual`, #2589/#2609)
+/// and the EXISTING safeguard-marker predicates
+/// (`goal_curation::no_progress_breaker::is_no_progress_marker`,
+/// `ooda_actions::advance_goal::is_brain_failure_marker`) — it never invents a
+/// second notion of either.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlockedGoal {
+    /// The blocked goal's id on the active board.
+    pub id: String,
+    /// The verbatim `GoalProgress::Blocked` reason string (carries the marker).
+    pub reason: String,
+    /// True when the goal is standing/perpetual (`ActiveGoal::is_perpetual`).
+    pub perpetual: bool,
+    /// True when the block carries a "needs human review" safeguard marker
+    /// (the no-progress OODA-SAFEGUARD marker or the brain-failure marker) —
+    /// the signal that a human must be reached.
+    pub needs_review: bool,
+    /// Consecutive no-action / no-progress cycles parsed from the safeguard
+    /// marker, or `0` when the block is not a counted safeguard marker.
+    pub consecutive_no_action: u32,
 }
 
 // ─────────────────────────── Capability briefs ─────────────────────────────
@@ -304,6 +337,29 @@ pub trait IssueFiler {
 pub trait GoalCurator {
     fn propose(&self, goal: &GoalBrief) -> Result<(), OverseerError>;
     fn in_flight(&self) -> Result<Vec<InFlightItem>, OverseerError>;
+
+    /// Read the goal-board *health* — the goals currently `Blocked` — so the
+    /// Observe pass can surface them into [`ObservedState::blocked_goals`].
+    ///
+    /// **Reuse:** `crate::goal_curation::load_goal_board` projected by
+    /// `crate::overseer::sensor::blocked_goals_from_board`. Read-only; a board
+    /// read failure degrades to an empty list, never a panic. The default
+    /// returns an empty list for fakes that do not model a board.
+    fn blocked_goals(&self) -> Result<Vec<BlockedGoal>, OverseerError> {
+        Ok(Vec::new())
+    }
+
+    /// Auto-unblock + reactivate a false-parked goal — the exact operation
+    /// `simard goal unblock` performs: restore a `Blocked` goal to `NotStarted`
+    /// so the next OODA cycle re-enters the spawn path.
+    ///
+    /// **Reuse:** the `simard goal unblock` board mutation
+    /// (`src/operator_cli/goal.rs`) via `load_goal_board` → set status
+    /// `NotStarted` → `save_goal_board`. The default is a no-op for fakes that
+    /// do not model a board (real adapters override it).
+    fn unblock(&self, _goal_id: &str) -> Result<(), OverseerError> {
+        Ok(())
+    }
 }
 
 /// Run a quality-audit loop (crusty-old-engineer-gated).

--- a/src/overseer/config.rs
+++ b/src/overseer/config.rs
@@ -35,6 +35,12 @@ pub const OVERSEER_INTERVAL_ENV: &str = "SIMARD_OVERSEER_INTERVAL_SECS";
 /// whisperer off regardless of this flag.
 pub const SIMARD_OVERSEER_WHISPER_ENV: &str = "SIMARD_OVERSEER_WHISPER";
 
+/// Opt-out flag for **goal-board health handling** (the self-heal + escalate
+/// paths). ON by default whenever the acting Overseer runs; an explicit falsey
+/// value (`0`/`false`/`no`/`off`) disables it. Goal-board health only makes
+/// sense while the Overseer runs, so a disabled Overseer forces it off.
+pub const SIMARD_OVERSEER_GOAL_HEALTH_ENV: &str = "SIMARD_OVERSEER_GOAL_HEALTH";
+
 /// GitHub login the acting Overseer authors its own workstreams under. Sourced
 /// here so the daemon and the merge/recursion path agree on ONE stable, DISTINCT
 /// identity (never the human operator's login). Defaults to
@@ -115,6 +121,29 @@ pub fn whisper_enabled_from(lookup: impl Fn(&str) -> Option<String>) -> bool {
 /// Production entry point: read the real process environment.
 pub fn whisper_enabled() -> bool {
     whisper_enabled_from(|k| std::env::var(k).ok())
+}
+
+/// Resolve whether **goal-board health handling** (self-heal false-parked
+/// perpetual goals + escalate genuine "needs human review" blocks) is enabled,
+/// with **default ON** opt-out semantics consistent with the acting Overseer.
+/// Enabled UNLESS [`SIMARD_OVERSEER_GOAL_HEALTH_ENV`] is an explicit falsey
+/// value — AND only while the acting Overseer itself is enabled (an
+/// explicitly-disabled Overseer forces goal-board health off).
+pub fn goal_health_enabled_from(lookup: impl Fn(&str) -> Option<String>) -> bool {
+    // No Overseer ⇒ no goal-board health handling.
+    if !overseer_acting_enabled_from(&lookup) {
+        return false;
+    }
+    // Opt-out: enabled unless an explicit falsey value is set.
+    !matches!(
+        lookup(SIMARD_OVERSEER_GOAL_HEALTH_ENV).as_deref().map(str::trim),
+        Some(v) if is_falsey(v)
+    )
+}
+
+/// Production entry point: read the real process environment.
+pub fn goal_health_enabled() -> bool {
+    goal_health_enabled_from(|k| std::env::var(k).ok())
 }
 
 /// Resolve the Overseer's DISTINCT author login. Falls back to

--- a/src/overseer/guardrails.rs
+++ b/src/overseer/guardrails.rs
@@ -46,6 +46,13 @@ pub fn classify(iv: &Intervention) -> RiskClass {
         // is advisory context only. Routine; its own dedup/identity gates
         // ([`WhisperGate`] / [`RecursionGuard`]) apply in the act path.
         Intervention::Whisper { .. } => RiskClass::Routine,
+        // Goal-board self-heal and escalation are routine stewardship: unblocking
+        // a false-parked perpetual goal restores the shipped `simard goal unblock`
+        // state, and escalation is a notification. Both are deduped and
+        // identity-gated (fail-closed) in the act path, and spend no LLM budget.
+        Intervention::UnblockGoal { .. } | Intervention::EscalateBlockedGoal { .. } => {
+            RiskClass::Routine
+        }
         _ => RiskClass::Routine,
     }
 }

--- a/src/overseer/intervention.rs
+++ b/src/overseer/intervention.rs
@@ -46,6 +46,18 @@ pub enum Intervention {
         note: String,
         urgency: WhisperUrgency,
     },
+    /// SELF-HEAL a false-parked standing/perpetual goal: auto-unblock + reactivate
+    /// it — the exact operation `simard goal unblock` performs — so a perpetual
+    /// goal wrongly hard-blocked by the no-progress safeguard re-enters the OODA
+    /// spawn path. Deduped so it never fights itself; optionally followed by an
+    /// advisory whisper steering Simard to carve a bounded shippable sub-goal.
+    /// Capability: `GoalCurator::unblock` (+ optional `whisper_ops::WhisperSink`).
+    UnblockGoal { goal_id: String, reason: String },
+    /// ESCALATE a genuinely-blocked goal carrying a "needs human review" marker to
+    /// the operator (email + Signal) with the goal id + reason, so the marker
+    /// actually reaches a human — closing the silent-failure gap.
+    /// Capability: `notify::OperatorNotifier`.
+    EscalateBlockedGoal { goal_id: String, reason: String },
 }
 
 impl Intervention {
@@ -62,6 +74,8 @@ impl Intervention {
             Self::RunAudit { .. } => "run_audit",
             Self::Escalate { .. } => "escalate",
             Self::Whisper { .. } => "whisper",
+            Self::UnblockGoal { .. } => "unblock_goal",
+            Self::EscalateBlockedGoal { .. } => "escalate_blocked_goal",
         }
     }
 }

--- a/src/overseer/mod.rs
+++ b/src/overseer/mod.rs
@@ -66,6 +66,8 @@ pub mod whisper_ops;
 pub mod wiring;
 
 #[cfg(test)]
+mod tests_goal_health;
+#[cfg(test)]
 mod tests_m1;
 #[cfg(test)]
 mod tests_m2;
@@ -73,11 +75,12 @@ mod tests_m2;
 mod tests_whisper;
 
 pub use capabilities::{
-    Auditor, Deployer, GoalCurator, IssueFiler, MeetingHost, ObservedState, OrchestratorRunBrief,
-    OverseerError, PrOps, RecipeBrief, RecipeLauncher, StatusReader,
+    Auditor, BlockedGoal, Deployer, GoalCurator, IssueFiler, MeetingHost, ObservedState,
+    OrchestratorRunBrief, OverseerError, PrOps, RecipeBrief, RecipeLauncher, StatusReader,
 };
 pub use config::{
-    daily_budget_usd, overseer_acting_enabled, overseer_author_login, overseer_enabled,
+    daily_budget_usd, goal_health_enabled, overseer_acting_enabled, overseer_author_login,
+    overseer_enabled,
 };
 pub use guardrails::{
     AutonomyGate, BudgetGate, ConflictSequencer, RecursionGuard, RiskClass, Subject,
@@ -87,7 +90,7 @@ pub use intervention::{Intervention, PlannedIntervention};
 pub use observer::{StewardshipIssueFiler, decide_read_only, is_m1_permitted};
 pub use sensor::{
     ObserverReport, OverseerSensorThread, SnapshotSource, SnapshotStatusReader,
-    in_flight_from_board, observed_from_snapshot, run_observer_cycle,
+    blocked_goals_from_board, in_flight_from_board, observed_from_snapshot, run_observer_cycle,
 };
 pub use signal::{Priority, Problem, ProblemKind, Signal, signals_from};
 pub use whisper_ops::{
@@ -100,7 +103,10 @@ pub use wiring::{
     run_overseer_tick_isolated,
 };
 
-use crate::goal_curation::no_progress_breaker::NO_PROGRESS_BREAKER_THRESHOLD;
+use crate::goal_curation::no_progress_breaker::{
+    NO_PROGRESS_BREAKER_THRESHOLD, is_no_progress_marker,
+};
+use crate::overseer::notify::{OperatorNotification, OperatorNotifier};
 use capabilities::{DeployReport, GoalBrief, InFlightItem, IssueOutcome, WorkstreamHandle};
 use std::path::PathBuf;
 
@@ -137,6 +143,16 @@ pub struct Overseer {
     /// Whether the whisperer is enabled (config opt-out). When off, whispers are
     /// held (never delivered) even if the observed condition holds.
     whisper_enabled: bool,
+    /// The operator-notification seam (email + Signal) the ESCALATE-blocked-goal
+    /// path fires through so a "needs human review" marker reaches a human.
+    /// `None` until wired; escalation requires it.
+    notifier: Option<Box<dyn OperatorNotifier>>,
+    /// Dedup + rate-limit gate for goal-board self-heal / escalation actions, so
+    /// the same blocked goal is not re-unblocked or re-escalated every tick.
+    blocked_goal_gate: WhisperGate,
+    /// Whether goal-board health handling (self-heal + escalate) is enabled
+    /// (config opt-out). When off, both actions are held (never taken).
+    goal_health_enabled: bool,
 }
 
 /// The result of one meta-OODA turn. Side-effect free: it reports what was
@@ -172,6 +188,21 @@ pub enum ActOutcome {
     WhisperSuppressed {
         reason: &'static str,
     },
+    /// A false-parked standing/perpetual goal was auto-unblocked + reactivated
+    /// (the `simard goal unblock` operation) by the self-heal path.
+    GoalUnblocked {
+        goal_id: String,
+    },
+    /// A genuinely-blocked "needs human review" goal was escalated to the
+    /// operator on both channels (email + Signal).
+    GoalEscalated {
+        goal_id: String,
+    },
+    /// A goal-board self-heal / escalation was suppressed by the dedup gate
+    /// (duplicate within the window, or the per-hour cap was reached).
+    GoalHealthSuppressed {
+        reason: &'static str,
+    },
 }
 
 impl Overseer {
@@ -188,12 +219,32 @@ impl Overseer {
             // 15-minute dedup window; at most 5 whispers per rolling hour.
             whisper_gate: WhisperGate::new(900, 5),
             whisper_enabled: false,
+            notifier: None,
+            // 15-minute dedup window so a persistent blocked goal is self-healed
+            // / escalated once per window (never in a per-tick loop); a generous
+            // per-hour cap covers many distinct goals without flooding.
+            blocked_goal_gate: WhisperGate::new(900, 20),
+            goal_health_enabled: false,
         }
     }
 
     /// Wire the Simard Whisperer's delivery seam (advisory steering notes).
     pub fn with_whisper_sink(mut self, sink: Box<dyn WhisperSink>) -> Self {
         self.whisper_sink = Some(sink);
+        self
+    }
+
+    /// Wire the operator-notification seam (email + Signal) used by the
+    /// ESCALATE-blocked-goal path. `None` until wired; escalation requires it.
+    pub fn with_operator_notifier(mut self, notifier: Box<dyn OperatorNotifier>) -> Self {
+        self.notifier = Some(notifier);
+        self
+    }
+
+    /// Enable/disable goal-board health handling (self-heal + escalate). Off by
+    /// default; the daemon sets this from [`config::goal_health_enabled`].
+    pub fn with_goal_health_enabled(mut self, enabled: bool) -> Self {
+        self.goal_health_enabled = enabled;
         self
     }
 
@@ -229,7 +280,11 @@ impl Overseer {
     /// execute side effects; returns the plan for M2+ Act to run.
     pub fn run_cycle(&mut self) -> Result<CycleReport, OverseerError> {
         // Observe.
-        let observed = self.caps.status.snapshot()?;
+        let mut observed = self.caps.status.snapshot()?;
+        // Enrich with goal-board health: the goals currently BLOCKED on Simard's
+        // board (false-parks + genuine "needs human review" blocks). Read-only;
+        // a board-read failure degrades to "no blocked goals", never aborts.
+        observed.blocked_goals = self.caps.goals.blocked_goals().unwrap_or_default();
         let signals = signals_from(&observed);
 
         // Orient (dedup against Simard's in-flight work; failure to read the
@@ -269,6 +324,20 @@ impl Overseer {
                 intervention: iv.clone(),
                 admitted: false,
                 note: "held: whisper disabled (SIMARD_OVERSEER_WHISPER)".to_string(),
+            };
+        }
+
+        // Goal-board health opt-out: when disabled, hold the self-heal /
+        // escalation (no action taken) even though a blocked goal was observed.
+        if matches!(
+            iv,
+            Intervention::UnblockGoal { .. } | Intervention::EscalateBlockedGoal { .. }
+        ) && !self.goal_health_enabled
+        {
+            return PlannedIntervention {
+                intervention: iv.clone(),
+                admitted: false,
+                note: "held: goal-board health disabled (SIMARD_OVERSEER_GOAL_HEALTH)".to_string(),
             };
         }
 
@@ -357,6 +426,10 @@ impl Overseer {
             }
             Intervention::Escalate { .. } => Ok(ActOutcome::Escalated),
             Intervention::Whisper { note, urgency } => self.act_whisper(note, *urgency),
+            Intervention::UnblockGoal { goal_id, reason } => self.act_unblock_goal(goal_id, reason),
+            Intervention::EscalateBlockedGoal { goal_id, reason } => {
+                self.act_escalate_blocked_goal(goal_id, reason)
+            }
         }
     }
 
@@ -445,6 +518,158 @@ impl Overseer {
                 })
             }
         }
+    }
+
+    /// SELF-HEAL a false-parked standing/perpetual goal: auto-unblock +
+    /// reactivate it (the exact `simard goal unblock` operation), deduped so it
+    /// never re-fires in a tight loop, then OPTIONALLY whisper Simard to carve a
+    /// bounded shippable sub-goal. Fails CLOSED without a DISTINCT steward
+    /// identity (anti-recursion — the Overseer must never self-heal a goal
+    /// without a configured distinct identity, which also prevents a self-heal
+    /// loop). The whisper is best-effort: a whisper failure never fails the
+    /// unblock.
+    fn act_unblock_goal(
+        &mut self,
+        goal_id: &str,
+        reason: &str,
+    ) -> Result<ActOutcome, OverseerError> {
+        if !self.recursion.is_configured() {
+            return Err(OverseerError::Recursion {
+                subject: format!("unblock goal (unconfigured steward identity): {goal_id}"),
+            });
+        }
+        let signature = format!("unblock:{goal_id}");
+        let now = now_secs();
+        match self.blocked_goal_gate.peek(&signature, now) {
+            WhisperDecision::Deliver => {
+                self.caps.goals.unblock(goal_id)?;
+                // Consume the dedup slot only after a successful unblock.
+                self.blocked_goal_gate.commit(&signature, now);
+                tracing::info!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    reason,
+                    action = "unblock",
+                    "overseer self-healed a false-parked perpetual goal: auto-unblocked + reactivated"
+                );
+                // Optional advisory whisper: steer Simard to carve a bounded,
+                // shippable sub-goal instead of re-attempting the whole standing
+                // goal at once. Best-effort and reuses the whisper gate/identity.
+                self.try_whisper_carve_subgoal(goal_id);
+                Ok(ActOutcome::GoalUnblocked {
+                    goal_id: goal_id.to_string(),
+                })
+            }
+            WhisperDecision::SuppressDuplicate => {
+                tracing::debug!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    action = "unblock",
+                    reason = "duplicate",
+                    "overseer suppressed a duplicate self-heal within the dedup window"
+                );
+                Ok(ActOutcome::GoalHealthSuppressed {
+                    reason: "duplicate",
+                })
+            }
+            WhisperDecision::SuppressCapReached => {
+                tracing::debug!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    action = "unblock",
+                    reason = "cap_reached",
+                    "overseer suppressed a self-heal: per-hour cap reached"
+                );
+                Ok(ActOutcome::GoalHealthSuppressed {
+                    reason: "cap_reached",
+                })
+            }
+        }
+    }
+
+    /// ESCALATE a genuinely-blocked "needs human review" goal to the operator on
+    /// BOTH channels (email + Signal) with the goal id + reason, so the marker
+    /// actually reaches a human. Deduped so it never re-fires in a loop; fails
+    /// CLOSED without a DISTINCT steward identity (anti-recursion).
+    fn act_escalate_blocked_goal(
+        &mut self,
+        goal_id: &str,
+        reason: &str,
+    ) -> Result<ActOutcome, OverseerError> {
+        if !self.recursion.is_configured() {
+            return Err(OverseerError::Recursion {
+                subject: format!(
+                    "escalate blocked goal (unconfigured steward identity): {goal_id}"
+                ),
+            });
+        }
+        let signature = format!("escalate:{goal_id}");
+        let now = now_secs();
+        match self.blocked_goal_gate.peek(&signature, now) {
+            WhisperDecision::Deliver => {
+                let notifier = self.notifier.as_ref().ok_or(OverseerError::Capability {
+                    what: "notify.operator",
+                    detail: "no operator notifier configured".to_string(),
+                })?;
+                let notification = OperatorNotification::goal_blocked(goal_id, reason);
+                let report = notifier.notify(&notification);
+                // Consume the dedup slot only after a dispatch attempt (the
+                // notifier itself never drops — it queues/logs on failure).
+                self.blocked_goal_gate.commit(&signature, now);
+                tracing::info!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    reason,
+                    action = "escalate",
+                    dispatched = report.dispatched(),
+                    all_sent = report.all_sent(),
+                    "overseer escalated a genuinely-blocked needs-human-review goal to the operator"
+                );
+                Ok(ActOutcome::GoalEscalated {
+                    goal_id: goal_id.to_string(),
+                })
+            }
+            WhisperDecision::SuppressDuplicate => {
+                tracing::debug!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    action = "escalate",
+                    reason = "duplicate",
+                    "overseer suppressed a duplicate escalation within the dedup window"
+                );
+                Ok(ActOutcome::GoalHealthSuppressed {
+                    reason: "duplicate",
+                })
+            }
+            WhisperDecision::SuppressCapReached => {
+                tracing::debug!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    action = "escalate",
+                    reason = "cap_reached",
+                    "overseer suppressed an escalation: per-hour cap reached"
+                );
+                Ok(ActOutcome::GoalHealthSuppressed {
+                    reason: "cap_reached",
+                })
+            }
+        }
+    }
+
+    /// Best-effort advisory whisper steering Simard to carve ONE bounded,
+    /// shippable sub-goal from a just-unblocked standing goal. Silently skipped
+    /// when the whisperer is disabled/unwired; a delivery error or suppression is
+    /// ignored (the self-heal already succeeded).
+    fn try_whisper_carve_subgoal(&mut self, goal_id: &str) {
+        if !self.whisper_enabled || self.whisper_sink.is_none() {
+            return;
+        }
+        let note = format!(
+            "Overseer steering note for goal {goal_id}: this standing goal was auto-unblocked \
+             after a no-progress false-park. Carve ONE bounded, shippable sub-goal from it and \
+             ship that next, rather than re-attempting the whole standing goal at once."
+        );
+        let _ = self.act_whisper(&note, WhisperUrgency::Normal);
     }
 }
 
@@ -584,6 +809,28 @@ fn classify_signal(s: &Signal) -> (ProblemKind, Priority, String, String) {
             format!("drift:{goal_id}"),
             format!("goal {goal_id} drifting from intent: {detail}"),
         ),
+        Signal::GoalBlocked {
+            goal_id,
+            needs_review,
+            consecutive_no_action,
+            ..
+        } => (
+            ProblemKind::GoalHygiene,
+            if *needs_review {
+                Priority::High
+            } else {
+                Priority::Normal
+            },
+            format!("goal:blocked:{goal_id}"),
+            format!(
+                "goal {goal_id} blocked{} ({consecutive_no_action} no-action cycle(s))",
+                if *needs_review {
+                    " — needs human review"
+                } else {
+                    ""
+                }
+            ),
+        ),
     }
 }
 
@@ -637,14 +884,35 @@ pub fn decide(problem: &Problem) -> Intervention {
         ProblemKind::ResourcePressure => Intervention::Escalate {
             reason: problem.summary.clone(),
         },
-        ProblemKind::GoalHygiene => Intervention::TransferGoal {
-            goal: GoalBrief {
-                title: problem.summary.clone(),
-                rationale: "stale / re-litigated goal — transfer to Simard for closure".to_string(),
-                priority: 3,
-                target_repo: "rysweet/Simard".to_string(),
-            },
-        },
+        ProblemKind::GoalHygiene => {
+            // Goal-board health takes precedence when the evidence is a blocked
+            // goal: self-heal a false-parked perpetual goal, or escalate a
+            // genuine "needs human review" block. A stale/re-litigated goal
+            // (no `GoalBlocked` evidence) still transfers to Simard for closure.
+            if let Some((goal_id, reason, perpetual, needs_review)) =
+                problem.evidence.iter().find_map(|s| match s {
+                    Signal::GoalBlocked {
+                        goal_id,
+                        reason,
+                        perpetual,
+                        needs_review,
+                        ..
+                    } => Some((goal_id.clone(), reason.clone(), *perpetual, *needs_review)),
+                    _ => None,
+                })
+            {
+                return decide_blocked_goal(goal_id, reason, perpetual, needs_review);
+            }
+            Intervention::TransferGoal {
+                goal: GoalBrief {
+                    title: problem.summary.clone(),
+                    rationale: "stale / re-litigated goal — transfer to Simard for closure"
+                        .to_string(),
+                    priority: 3,
+                    target_repo: "rysweet/Simard".to_string(),
+                },
+            }
+        }
         // A looping goal is steered with a LIGHTWEIGHT whisper by default. Only
         // once the loop reaches Simard's no-progress breaker threshold (the
         // whisper was insufficient) does the Overseer escalate to a full meeting
@@ -684,6 +952,36 @@ pub fn decide(problem: &Problem) -> Intervention {
             urgency: WhisperUrgency::Normal,
         },
     }
+}
+
+/// Route a blocked goal to the right stewardship action (defense-in-depth for
+/// #2609):
+///
+/// - a PERPETUAL/standing goal false-parked by the **no-progress** safeguard is
+///   SELF-HEALED — auto-unblocked + reactivated (never escalated: it is a false
+///   park, not a genuine block);
+/// - ANY OTHER goal carrying a "needs human review" marker (a normal no-progress
+///   block, or any brain-failure block) is ESCALATED to the operator so the
+///   marker reaches a human;
+/// - a plain operator-set / dependency block is surfaced in the periodic Report
+///   and left untouched (respect the deliberate block).
+///
+/// Reuses the EXISTING no-progress marker predicate ([`is_no_progress_marker`])
+/// and the perpetual flag derived from #2589/#2609 — it invents no new notion of
+/// either.
+fn decide_blocked_goal(
+    goal_id: String,
+    reason: String,
+    perpetual: bool,
+    needs_review: bool,
+) -> Intervention {
+    if perpetual && is_no_progress_marker(&reason) {
+        return Intervention::UnblockGoal { goal_id, reason };
+    }
+    if needs_review {
+        return Intervention::EscalateBlockedGoal { goal_id, reason };
+    }
+    Intervention::Report
 }
 
 #[cfg(test)]

--- a/src/overseer/mod.rs
+++ b/src/overseer/mod.rs
@@ -281,15 +281,17 @@ impl Overseer {
     pub fn run_cycle(&mut self) -> Result<CycleReport, OverseerError> {
         // Observe.
         let mut observed = self.caps.status.snapshot()?;
-        // Enrich with goal-board health: the goals currently BLOCKED on Simard's
-        // board (false-parks + genuine "needs human review" blocks). Read-only;
-        // a board-read failure degrades to "no blocked goals", never aborts.
-        observed.blocked_goals = self.caps.goals.blocked_goals().unwrap_or_default();
+        // Enrich with goal-board health + in-flight dedup from ONE board read:
+        // the goals currently BLOCKED on Simard's board (false-parks + genuine
+        // "needs human review" blocks) plus Simard's in-flight work, both
+        // projected from the SAME snapshot. Read-only; a board-read failure
+        // degrades both to empty ("no blocked goals" + "no dedup"), never aborts.
+        let (blocked_goals, in_flight) = self.caps.goals.observe_board().unwrap_or_default();
+        observed.blocked_goals = blocked_goals;
         let signals = signals_from(&observed);
 
-        // Orient (dedup against Simard's in-flight work; failure to read the
-        // board degrades to "no dedup", never aborts the cycle).
-        let in_flight = self.caps.goals.in_flight().unwrap_or_default();
+        // Orient (dedup against Simard's in-flight work, read above from the same
+        // board snapshot as the goal-board health above).
         let problems = orient(&signals, &in_flight);
 
         // Decide + gate.

--- a/src/overseer/notify.rs
+++ b/src/overseer/notify.rs
@@ -415,6 +415,35 @@ impl EmailSender for TcpSmtpSender {
     }
 }
 
+/// Fold any CR/LF out of an SMTP header value or envelope address (replace with
+/// a space). Prevents **SMTP header / command injection**: an embedded newline
+/// in a subject, From/To display value, or envelope address could otherwise
+/// inject extra headers (e.g. `Bcc:`) or raw SMTP commands into the stream.
+/// Notification subjects/addresses now carry board-derived, potentially
+/// LLM-influenced goal text, so this is enforced at the transport sink for every
+/// notification kind.
+fn sanitize_smtp_field(value: &str) -> String {
+    value.replace(['\r', '\n'], " ")
+}
+
+/// Apply SMTP dot-stuffing (RFC 5321 §4.5.2) to an already CRLF-normalized body:
+/// any line beginning with `.` gets an extra leading `.`. Without this, a body
+/// line consisting of a lone `.` would terminate the DATA section early and let
+/// following body content be interpreted as SMTP commands — the message body now
+/// carries attacker-influenceable `reason` text, so it must be escaped.
+fn dot_stuff_body(body: &str) -> String {
+    body.split("\r\n")
+        .map(|line| {
+            if line.starts_with('.') {
+                format!(".{line}")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\r\n")
+}
+
 /// Minimal plaintext SMTP conversation. Kept small and defensive.
 fn smtp_send_plaintext(host: &str, port: u16, msg: &EmailMessage) -> Result<(), String> {
     use std::io::{BufRead, BufReader, Write};
@@ -447,10 +476,11 @@ fn smtp_send_plaintext(host: &str, port: u16, msg: &EmailMessage) -> Result<(), 
     expect(&mut reader, 2)?; // greeting 220
     writeln!(writer, "EHLO simard-overseer").map_err(|e| e.to_string())?;
     expect(&mut reader, 2)?;
-    writeln!(writer, "MAIL FROM:<{}>", msg.from).map_err(|e| e.to_string())?;
+    writeln!(writer, "MAIL FROM:<{}>", sanitize_smtp_field(&msg.from))
+        .map_err(|e| e.to_string())?;
     expect(&mut reader, 2)?;
     for rcpt in &msg.to {
-        writeln!(writer, "RCPT TO:<{rcpt}>").map_err(|e| e.to_string())?;
+        writeln!(writer, "RCPT TO:<{}>", sanitize_smtp_field(rcpt)).map_err(|e| e.to_string())?;
         expect(&mut reader, 2)?;
     }
     writeln!(writer, "DATA").map_err(|e| e.to_string())?;
@@ -458,10 +488,10 @@ fn smtp_send_plaintext(host: &str, port: u16, msg: &EmailMessage) -> Result<(), 
     write!(
         writer,
         "From: {}\r\nTo: {}\r\nSubject: {}\r\n\r\n{}\r\n.\r\n",
-        msg.from,
-        msg.to.join(", "),
-        msg.subject,
-        msg.body.replace("\r\n", "\n").replace('\n', "\r\n"),
+        sanitize_smtp_field(&msg.from),
+        sanitize_smtp_field(&msg.to.join(", ")),
+        sanitize_smtp_field(&msg.subject),
+        dot_stuff_body(&msg.body.replace("\r\n", "\n").replace('\n', "\r\n")),
     )
     .map_err(|e| e.to_string())?;
     expect(&mut reader, 2)?; // 250 accepted
@@ -600,6 +630,28 @@ mod tests {
         assert!(body.contains("abcdef1234567890"));
         assert!(body.contains("0011223344556677"));
         assert!(body.contains("canary green"));
+    }
+
+    // ── SMTP wire-format hardening (injection defenses) ───────────────────────
+
+    #[test]
+    fn sanitize_smtp_field_folds_crlf_to_space() {
+        // A CRLF-bearing subject must not be able to inject a second header.
+        let injected = "needs review\r\nBcc: attacker@evil.test";
+        let safe = super::sanitize_smtp_field(injected);
+        assert!(!safe.contains('\r') && !safe.contains('\n'));
+        assert_eq!(safe, "needs review  Bcc: attacker@evil.test");
+    }
+
+    #[test]
+    fn dot_stuff_body_escapes_leading_dot_lines() {
+        // A lone "." line (or any leading-dot line) must be escaped so it cannot
+        // terminate the DATA section early and smuggle SMTP commands.
+        let body = "line one\r\n.\r\n.MAIL FROM:<x>\r\nnormal";
+        let stuffed = super::dot_stuff_body(body);
+        assert_eq!(stuffed, "line one\r\n..\r\n..MAIL FROM:<x>\r\nnormal");
+        // A body that does not begin lines with '.' is left byte-for-byte intact.
+        assert_eq!(super::dot_stuff_body("a\r\nb\r\nc"), "a\r\nb\r\nc");
     }
 
     // ── fakes ────────────────────────────────────────────────────────────────

--- a/src/overseer/notify.rs
+++ b/src/overseer/notify.rs
@@ -141,6 +141,24 @@ impl OperatorNotification {
             autonomous: true,
         }
     }
+
+    /// Build a blocked-goal escalation: a goal carrying a "needs human review"
+    /// safeguard marker that a human must resolve. Sent on BOTH channels (email
+    /// and Signal) with the goal id and reason so the marker actually reaches a
+    /// person — closing the silent-failure gap where a "needs human review"
+    /// marker reached no human.
+    pub fn goal_blocked(goal_id: &str, reason: &str) -> Self {
+        Self {
+            kind: "goal-blocked",
+            headline: format!("goal {goal_id} needs human review"),
+            problem: format!(
+                "Goal `{goal_id}` is blocked and needs human review.\n  Reason: {reason}"
+            ),
+            link: None,
+            repo: "rysweet/Simard".to_string(),
+            autonomous: true,
+        }
+    }
 }
 
 fn short_commit(commit: &str) -> &str {
@@ -204,6 +222,21 @@ pub trait NotifyChannel: Send + Sync {
 /// Constructed with an email channel and a Signal channel so both fire.
 pub struct DualChannelNotifier {
     channels: Vec<Box<dyn NotifyChannel>>,
+}
+
+/// Object-safe seam the acting Overseer notifies the operator through. Lets the
+/// Overseer hold the mandatory [`DualChannelNotifier`] (email + Signal) in
+/// production while tests inject a fake that records the notification — reusing
+/// the ONE "notify on both channels, never drop" guarantee rather than adding a
+/// second notification path.
+pub trait OperatorNotifier: Send + Sync {
+    fn notify(&self, notification: &OperatorNotification) -> NotifyReport;
+}
+
+impl OperatorNotifier for DualChannelNotifier {
+    fn notify(&self, notification: &OperatorNotification) -> NotifyReport {
+        DualChannelNotifier::notify(self, notification)
+    }
 }
 
 impl DualChannelNotifier {

--- a/src/overseer/observer.rs
+++ b/src/overseer/observer.rs
@@ -233,6 +233,7 @@ fn signal_kind_label(s: &Signal) -> &'static str {
         Signal::Anomaly { .. } => "Anomaly",
         Signal::LoopDetected { .. } => "LoopDetected",
         Signal::DriftCorrection { .. } => "DriftCorrection",
+        Signal::GoalBlocked { .. } => "GoalBlocked",
     }
 }
 

--- a/src/overseer/sensor.rs
+++ b/src/overseer/sensor.rs
@@ -27,12 +27,18 @@ use crate::cognitive_threads::{
     CognitiveThread, Priority, SchedulePolicy, ThreadContext, ThreadHealth, ThreadKind,
     ThreadOutcome,
 };
-use crate::goal_curation::{GoalBoard, load_goal_board};
+use crate::goal_curation::no_progress_breaker::{
+    NO_PROGRESS_BLOCKED_PREFIX, is_no_progress_marker,
+};
+use crate::goal_curation::{ActiveGoal, GoalBoard, GoalProgress, load_goal_board};
+use crate::ooda_actions::advance_goal::spawn::{
+    BRAIN_FAILURE_BLOCKED_PREFIX, is_brain_failure_marker,
+};
 use crate::status::{AssembleOptions, StatusSnapshot, assemble};
 use crate::stewardship::RealGhClient;
 
 use crate::overseer::capabilities::{
-    InFlightItem, IssueFiler, IssueOutcome, ObservedState, OverseerError, StatusReader,
+    BlockedGoal, InFlightItem, IssueFiler, IssueOutcome, ObservedState, OverseerError, StatusReader,
 };
 use crate::overseer::config;
 use crate::overseer::intervention::Intervention;
@@ -121,6 +127,11 @@ pub fn observed_from_snapshot(snap: &StatusSnapshot) -> ObservedState {
         anomalies: telemetry.map(|t| t.anomalies.clone()).unwrap_or_default(),
         ready_prs: Vec::new(),
         ci_failures: Vec::new(),
+        // Goal-board health (blocked goals) is projected from the live board by
+        // the acting Overseer's Observe pass via the goal curator, not from the
+        // read-only status snapshot; left empty here so this projection stays
+        // additive and side-effect free.
+        blocked_goals: Vec::new(),
         // Loop/drift are surfaced from the OODA no-progress tracker, which the
         // read-only status snapshot does not yet expose. Left `None` here so the
         // adapter stays additive; a follow-up enriches this from the goal board's
@@ -160,6 +171,49 @@ pub fn in_flight_from_board(board: &GoalBoard) -> Vec<InFlightItem> {
         });
     }
     items
+}
+
+/// Project the goal board's *health* onto the Overseer's [`BlockedGoal`]s: one
+/// per active goal in a [`GoalProgress::Blocked`] state. Read-only and pure.
+///
+/// Reuses the EXISTING notions rather than inventing new ones:
+/// - `perpetual` ← [`ActiveGoal::is_perpetual`] (the standing/perpetual marker
+///   from #2589/#2609);
+/// - `needs_review` ← the two EXISTING "needs human review" safeguard-marker
+///   predicates ([`is_no_progress_marker`] and [`is_brain_failure_marker`]);
+/// - `consecutive_no_action` ← parsed from the safeguard marker's `{prefix}{n}`
+///   shape (`0` for a non-safeguard block, e.g. an operator-set one).
+///
+/// [`GoalProgress::Blocked`]: crate::goal_curation::GoalProgress::Blocked
+pub fn blocked_goals_from_board(board: &GoalBoard) -> Vec<BlockedGoal> {
+    board.active.iter().filter_map(blocked_goal_of).collect()
+}
+
+/// Project one active goal onto a [`BlockedGoal`] when it is `Blocked`.
+fn blocked_goal_of(goal: &ActiveGoal) -> Option<BlockedGoal> {
+    let GoalProgress::Blocked(reason) = &goal.status else {
+        return None;
+    };
+    let needs_review = is_no_progress_marker(reason) || is_brain_failure_marker(reason);
+    Some(BlockedGoal {
+        id: goal.id.clone(),
+        reason: reason.clone(),
+        perpetual: goal.is_perpetual(),
+        needs_review,
+        consecutive_no_action: safeguard_marker_count(reason).unwrap_or(0),
+    })
+}
+
+/// Parse the leading no-action/no-progress count from a safeguard-marker reason.
+/// Both markers share the `{prefix}{count}{suffix}` shape, so stripping whichever
+/// prefix matches and reading the leading digits yields the count. Returns `None`
+/// for a non-safeguard block.
+fn safeguard_marker_count(reason: &str) -> Option<u32> {
+    let rest = reason
+        .strip_prefix(NO_PROGRESS_BLOCKED_PREFIX)
+        .or_else(|| reason.strip_prefix(BRAIN_FAILURE_BLOCKED_PREFIX))?;
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse::<u32>().ok()
 }
 
 // ─────────────────────────── Read-only cycle ───────────────────────────────

--- a/src/overseer/signal.rs
+++ b/src/overseer/signal.rs
@@ -43,6 +43,19 @@ pub enum Signal {
     /// Active work appears to be drifting from a goal's stated intent. From
     /// `ObservedState.{drift_detail, active_goal_id}`.
     DriftCorrection { goal_id: String, detail: String },
+    /// A goal is `Blocked` on Simard's goal board — the goal-board *health*
+    /// signal. From `ObservedState.blocked_goals`. `perpetual` reuses the
+    /// standing/perpetual detection (#2589/#2609); `needs_review` is true when
+    /// the block carries a "needs human review" safeguard marker. Routed to
+    /// [`ProblemKind::GoalHygiene`]: a false-parked perpetual goal is
+    /// self-healed, a genuine "needs human review" block is escalated.
+    GoalBlocked {
+        goal_id: String,
+        reason: String,
+        perpetual: bool,
+        needs_review: bool,
+        consecutive_no_action: u32,
+    },
 }
 
 /// Coarse relative importance. `Ord` sorts ascending so `Critical` comes first,
@@ -176,6 +189,17 @@ pub fn signals_from(state: &ObservedState) -> Vec<Signal> {
         out.push(Signal::DriftCorrection {
             goal_id: goal_id.clone(),
             detail: detail.clone(),
+        });
+    }
+
+    // Goal-board health: one signal per blocked goal observed on the board.
+    for bg in &state.blocked_goals {
+        out.push(Signal::GoalBlocked {
+            goal_id: bg.id.clone(),
+            reason: bg.reason.clone(),
+            perpetual: bg.perpetual,
+            needs_review: bg.needs_review,
+            consecutive_no_action: bg.consecutive_no_action,
         });
     }
 

--- a/src/overseer/tests_goal_health.rs
+++ b/src/overseer/tests_goal_health.rs
@@ -1,0 +1,695 @@
+//! Tests for the Overseer's **goal-board health** OBSERVE→ACT surface — the
+//! defense-in-depth complement to #2609 (which exempts perpetual goals from the
+//! no-progress hard-block). These pin the contract that:
+//!
+//! - the sensor projection surfaces `Blocked` goals into
+//!   [`ObservedState::blocked_goals`] from the REAL board markers, reusing the
+//!   EXISTING perpetual detection (#2589/#2609) and the safeguard-marker
+//!   predicates — never a second notion;
+//! - a `Signal::GoalBlocked` maps to a [`ProblemKind::GoalHygiene`] problem;
+//! - a PERPETUAL goal false-parked by the no-progress safeguard is
+//!   auto-unblocked + reactivated EXACTLY ONCE (dedup prevents a loop) and is
+//!   NOT escalated;
+//! - ANY goal carrying a "needs human review" marker fires `NotifyOperator` on
+//!   BOTH channels (email + Signal) with the goal id + reason;
+//! - the recursion guard / distinct identity fails CLOSED (no self-heal /
+//!   self-whisper without a configured DISTINCT identity);
+//! - the enable flag holds both actions when off;
+//! - a single blocked-goal handling failure is isolated (the tick survives).
+//!
+//! Everything is exercised with injected fakes (goal store, notifier, clock via
+//! the dedup gate, identity) — no network, no `~/.simard`.
+
+use std::sync::{Arc, Mutex};
+
+use crate::goal_curation::no_progress_breaker::no_progress_blocked_reason;
+use crate::goal_curation::{ActiveGoal, GoalBoard, GoalProgress};
+use crate::ooda_actions::advance_goal::spawn::{
+    BRAIN_FAILURE_BLOCKED_PREFIX, BRAIN_FAILURE_BLOCKED_SUFFIX,
+};
+
+use crate::overseer::capabilities::{
+    AuditReport, AuditScope, Auditor, BlockedGoal, DeployReport, Deployer, GoalBrief, GoalCurator,
+    InFlightItem, IssueOutcome, MeetingHost, ObservedState, OrchestratorRunBrief, OverseerError,
+    PrOps, RecipeBrief, RecipeLauncher, StatusReader, VerifyReport, WorkstreamHandle,
+    WorkstreamStatus,
+};
+use crate::overseer::config::{SIMARD_OVERSEER_GOAL_HEALTH_ENV, goal_health_enabled_from};
+use crate::overseer::guardrails::{AutonomyGate, RiskClass, classify};
+use crate::overseer::intervention::Intervention;
+use crate::overseer::notify::{
+    ChannelDelivery, DualChannelNotifier, NotifyChannel, OperatorNotification,
+};
+use crate::overseer::sensor::blocked_goals_from_board;
+use crate::overseer::signal::{Problem, ProblemKind, Signal, signals_from};
+use crate::overseer::wiring::{overseer_identity, overseer_tick, run_overseer_tick_isolated};
+use crate::overseer::{Capabilities, Overseer, decide, orient};
+
+// ─────────────────────────── marker helpers ────────────────────────────────
+
+/// The brain-failure safeguard `Blocked` reason for `n` cycles (mirrors the
+/// deterministic marker `dispatch_spawn_engineer` writes).
+fn brain_failure_reason(n: u32) -> String {
+    format!("{BRAIN_FAILURE_BLOCKED_PREFIX}{n}{BRAIN_FAILURE_BLOCKED_SUFFIX}")
+}
+
+// ─────────────────────────── capability fakes ──────────────────────────────
+
+struct FakeStatus(ObservedState);
+impl StatusReader for FakeStatus {
+    fn snapshot(&self) -> Result<ObservedState, OverseerError> {
+        Ok(self.0.clone())
+    }
+}
+
+struct FakeRecipes;
+impl RecipeLauncher for FakeRecipes {
+    fn launch(&self, _b: &RecipeBrief) -> Result<WorkstreamHandle, OverseerError> {
+        Ok(WorkstreamHandle {
+            id: "ws-1".to_string(),
+        })
+    }
+    fn poll(&self, _h: &WorkstreamHandle) -> Result<WorkstreamStatus, OverseerError> {
+        Ok(WorkstreamStatus::Running)
+    }
+}
+
+struct FakePrs;
+impl PrOps for FakePrs {
+    fn verify(&self, _r: &str, _p: u32) -> Result<VerifyReport, OverseerError> {
+        Ok(VerifyReport {
+            ready: false,
+            checks: vec![],
+        })
+    }
+    fn merge(&self, _r: &str, _p: u32) -> Result<(), OverseerError> {
+        Ok(())
+    }
+    fn resolve_conflict(&self, _r: &str, _p: u32) -> Result<(), OverseerError> {
+        Ok(())
+    }
+}
+
+struct FakeDeployer;
+impl Deployer for FakeDeployer {
+    fn deploy(&self, commit: &str) -> Result<DeployReport, OverseerError> {
+        Ok(DeployReport {
+            deployed_commit: commit.to_string(),
+            gates_passed: true,
+        })
+    }
+    fn deployed_commit(&self) -> Result<String, OverseerError> {
+        Ok("deadbeef".to_string())
+    }
+}
+
+struct FakeIssues;
+impl crate::overseer::capabilities::IssueFiler for FakeIssues {
+    fn file(&self, _run: &OrchestratorRunBrief) -> Result<IssueOutcome, OverseerError> {
+        Ok(IssueOutcome::FiledNew {
+            url: "https://example/issues/1".to_string(),
+        })
+    }
+}
+
+struct FakeMeetings;
+impl MeetingHost for FakeMeetings {
+    fn transfer_goal(&self, _g: &GoalBrief) -> Result<(), OverseerError> {
+        Ok(())
+    }
+}
+
+struct FakeAuditor;
+impl Auditor for FakeAuditor {
+    fn run_audit(&self, scope: &AuditScope) -> Result<AuditReport, OverseerError> {
+        Ok(AuditReport {
+            scope: scope.clone(),
+            passed: true,
+            findings: vec![],
+        })
+    }
+}
+
+/// A goal-store fake: serves a fixed set of blocked goals and records every
+/// `unblock` call so the self-heal path is observable without a real board.
+/// `fail_unblock` makes `unblock` return an error so failure isolation can be
+/// proven.
+struct FakeGoalStore {
+    blocked: Vec<BlockedGoal>,
+    unblocked: Arc<Mutex<Vec<String>>>,
+    fail_unblock: bool,
+}
+impl FakeGoalStore {
+    fn new(blocked: Vec<BlockedGoal>) -> (Self, Arc<Mutex<Vec<String>>>) {
+        let unblocked = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                blocked,
+                unblocked: unblocked.clone(),
+                fail_unblock: false,
+            },
+            unblocked,
+        )
+    }
+    fn failing(blocked: Vec<BlockedGoal>) -> Self {
+        Self {
+            blocked,
+            unblocked: Arc::new(Mutex::new(Vec::new())),
+            fail_unblock: true,
+        }
+    }
+}
+impl GoalCurator for FakeGoalStore {
+    fn propose(&self, _g: &GoalBrief) -> Result<(), OverseerError> {
+        Ok(())
+    }
+    fn in_flight(&self) -> Result<Vec<InFlightItem>, OverseerError> {
+        Ok(vec![])
+    }
+    fn blocked_goals(&self) -> Result<Vec<BlockedGoal>, OverseerError> {
+        Ok(self.blocked.clone())
+    }
+    fn unblock(&self, goal_id: &str) -> Result<(), OverseerError> {
+        if self.fail_unblock {
+            return Err(OverseerError::Capability {
+                what: "goal_board.unblock",
+                detail: "board write failed".to_string(),
+            });
+        }
+        self.unblocked.lock().unwrap().push(goal_id.to_string());
+        Ok(())
+    }
+}
+
+/// A notify channel that records every notification and always reports `Sent`.
+struct RecordingChannel {
+    name: String,
+    seen: Arc<Mutex<Vec<OperatorNotification>>>,
+}
+impl RecordingChannel {
+    fn new(name: &str) -> (Self, Arc<Mutex<Vec<OperatorNotification>>>) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                name: name.to_string(),
+                seen: seen.clone(),
+            },
+            seen,
+        )
+    }
+}
+impl NotifyChannel for RecordingChannel {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn deliver(&self, n: &OperatorNotification) -> ChannelDelivery {
+        self.seen.lock().unwrap().push(n.clone());
+        ChannelDelivery::Sent
+    }
+}
+
+/// Build the Overseer's capabilities around a goal store; everything else is a
+/// canned fake (the status reader yields an otherwise-clean snapshot so the only
+/// signals are the goal-board ones).
+fn caps_with_goals(goals: Box<dyn GoalCurator>) -> Capabilities {
+    Capabilities {
+        status: Box::new(FakeStatus(ObservedState::default())),
+        recipes: Box::new(FakeRecipes),
+        prs: Box::new(FakePrs),
+        deployer: Box::new(FakeDeployer),
+        meetings: Box::new(FakeMeetings),
+        issues: Box::new(FakeIssues),
+        goals,
+        auditor: Box::new(FakeAuditor),
+    }
+}
+
+/// A `DualChannelNotifier` (the SAME mandatory notifier the merge path uses)
+/// wired with two recording channels so a test can prove BOTH email + Signal
+/// fired. Returns the notifier plus the two capture logs.
+type NotifierAndLogs = (
+    DualChannelNotifier,
+    Arc<Mutex<Vec<OperatorNotification>>>,
+    Arc<Mutex<Vec<OperatorNotification>>>,
+);
+fn dual_recording_notifier() -> NotifierAndLogs {
+    let (email, email_log) = RecordingChannel::new("email");
+    let (signal, signal_log) = RecordingChannel::new("signal");
+    let notifier = DualChannelNotifier::new(vec![Box::new(email), Box::new(signal)]);
+    (notifier, email_log, signal_log)
+}
+
+// ─────────────────── 1. Sensor: project the board → ObservedState ───────────
+
+#[test]
+fn blocked_goals_projection_surfaces_perpetual_and_needs_review_goals() {
+    let mut board = GoalBoard::new();
+    // A standing/perpetual research goal, false-parked by the no-progress
+    // safeguard (perpetual + needs_review, count parsed from the marker).
+    let mut research = ActiveGoal::new(
+        "research",
+        "Continuously research the frontier. Standing goal.",
+        1,
+    );
+    research.status = GoalProgress::Blocked(no_progress_blocked_reason(4));
+    // A NORMAL feature goal, genuinely blocked by the brain-failure safeguard
+    // (needs_review, not perpetual).
+    let mut feature = ActiveGoal::new("feature-x", "Ship feature X", 2);
+    feature.status = GoalProgress::Blocked(brain_failure_reason(3));
+    // A NORMAL goal blocked by an operator-set reason (no safeguard marker):
+    // surfaced, but neither perpetual nor needs_review.
+    let mut opsblock = ActiveGoal::new("ops", "Wait on infra", 3);
+    opsblock.status = GoalProgress::Blocked("waiting on the operator".to_string());
+    // A healthy in-progress goal: never surfaced.
+    let mut healthy = ActiveGoal::new("healthy", "Make progress", 4);
+    healthy.status = GoalProgress::InProgress { percent: 40 };
+    board.active = vec![research, feature, opsblock, healthy];
+
+    let blocked = blocked_goals_from_board(&board);
+    assert_eq!(
+        blocked.len(),
+        3,
+        "only the three Blocked goals are surfaced"
+    );
+
+    let research = blocked.iter().find(|b| b.id == "research").unwrap();
+    assert!(
+        research.perpetual,
+        "standing goal is perpetual (#2589/#2609)"
+    );
+    assert!(
+        research.needs_review,
+        "no-progress marker needs human review"
+    );
+    assert_eq!(
+        research.consecutive_no_action, 4,
+        "count parsed from marker"
+    );
+
+    let feature = blocked.iter().find(|b| b.id == "feature-x").unwrap();
+    assert!(!feature.perpetual);
+    assert!(
+        feature.needs_review,
+        "brain-failure marker needs human review"
+    );
+    assert_eq!(feature.consecutive_no_action, 3);
+
+    let ops = blocked.iter().find(|b| b.id == "ops").unwrap();
+    assert!(!ops.perpetual);
+    assert!(
+        !ops.needs_review,
+        "an operator-set block is not a review marker"
+    );
+    assert_eq!(ops.consecutive_no_action, 0);
+}
+
+#[test]
+fn run_cycle_populates_observed_blocked_goals_and_emits_signals() {
+    let blocked = vec![
+        BlockedGoal {
+            id: "research".to_string(),
+            reason: no_progress_blocked_reason(4),
+            perpetual: true,
+            needs_review: true,
+            consecutive_no_action: 4,
+        },
+        BlockedGoal {
+            id: "feature-x".to_string(),
+            reason: brain_failure_reason(3),
+            perpetual: false,
+            needs_review: true,
+            consecutive_no_action: 3,
+        },
+    ];
+    let (store, _log) = FakeGoalStore::new(blocked);
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_identity(overseer_identity())
+        .with_goal_health_enabled(true);
+
+    let cycle = ov.run_cycle().expect("cycle");
+    assert_eq!(
+        cycle.observed.blocked_goals.len(),
+        2,
+        "the Observe pass surfaces the board's blocked goals into ObservedState"
+    );
+    let goal_blocked: Vec<_> = cycle
+        .signals
+        .iter()
+        .filter(|s| matches!(s, Signal::GoalBlocked { .. }))
+        .collect();
+    assert_eq!(
+        goal_blocked.len(),
+        2,
+        "one GoalBlocked signal per blocked goal"
+    );
+}
+
+// ─────────────────── 2. Signal → GoalHygiene problem ────────────────────────
+
+#[test]
+fn goal_blocked_signal_maps_to_a_goal_hygiene_problem() {
+    let observed = ObservedState {
+        blocked_goals: vec![BlockedGoal {
+            id: "research".to_string(),
+            reason: no_progress_blocked_reason(4),
+            perpetual: true,
+            needs_review: true,
+            consecutive_no_action: 4,
+        }],
+        ..ObservedState::default()
+    };
+    let signals = signals_from(&observed);
+    assert!(
+        signals
+            .iter()
+            .any(|s| matches!(s, Signal::GoalBlocked { .. })),
+        "a blocked goal produces a GoalBlocked signal"
+    );
+    let problems = orient(&signals, &[]);
+    let problem = problems
+        .iter()
+        .find(|p| p.kind == ProblemKind::GoalHygiene)
+        .expect("GoalBlocked classifies to GoalHygiene");
+    assert_eq!(problem.dedup_key, "goal:blocked:research");
+}
+
+// ─────────────────── 3. Self-heal: unblock once, never escalate ─────────────
+
+#[test]
+fn perpetual_no_progress_goal_is_unblocked_once_and_not_escalated() {
+    let blocked = vec![BlockedGoal {
+        id: "research".to_string(),
+        reason: no_progress_blocked_reason(4),
+        perpetual: true,
+        needs_review: true,
+        consecutive_no_action: 4,
+    }];
+    let (store, unblocked) = FakeGoalStore::new(blocked);
+    let (notifier, email_log, signal_log) = dual_recording_notifier();
+
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_identity(overseer_identity())
+        .with_goal_health_enabled(true)
+        .with_operator_notifier(Box::new(notifier));
+
+    let first = overseer_tick(&mut ov);
+    assert_eq!(first.goals_unblocked, 1, "the false-park is self-healed");
+    assert_eq!(first.goals_escalated, 0, "a false-park is NOT escalated");
+    assert_eq!(first.errors, 0);
+    assert!(!first.panicked);
+
+    // The SAME blocked goal is still served next tick (the fake store does not
+    // reflect the unblock). Dedup must prevent a re-unblock loop.
+    let second = overseer_tick(&mut ov);
+    assert_eq!(
+        second.goals_unblocked, 0,
+        "dedup prevents a re-unblock loop"
+    );
+    assert_eq!(
+        second.goals_health_suppressed, 1,
+        "the duplicate is counted"
+    );
+
+    assert_eq!(
+        &*unblocked.lock().unwrap(),
+        &vec!["research".to_string()],
+        "the goal store's unblock was called EXACTLY ONCE across two ticks"
+    );
+    assert!(
+        email_log.lock().unwrap().is_empty() && signal_log.lock().unwrap().is_empty(),
+        "a self-healed false-park never notifies the operator"
+    );
+}
+
+// ─────────────────── 4. Escalate: NotifyOperator on both channels ───────────
+
+#[test]
+fn needs_review_goal_escalates_to_operator_on_both_channels() {
+    let reason = brain_failure_reason(3);
+    let blocked = vec![BlockedGoal {
+        id: "feature-x".to_string(),
+        reason: reason.clone(),
+        perpetual: false,
+        needs_review: true,
+        consecutive_no_action: 3,
+    }];
+    let (store, unblocked) = FakeGoalStore::new(blocked);
+    let (notifier, email_log, signal_log) = dual_recording_notifier();
+
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_identity(overseer_identity())
+        .with_goal_health_enabled(true)
+        .with_operator_notifier(Box::new(notifier));
+
+    let report = overseer_tick(&mut ov);
+    assert_eq!(report.goals_escalated, 1, "the genuine block is escalated");
+    assert_eq!(
+        report.goals_unblocked, 0,
+        "a normal goal is not self-healed"
+    );
+    assert!(
+        unblocked.lock().unwrap().is_empty(),
+        "escalation never unblocks the goal"
+    );
+
+    for (chan, log) in [("email", &email_log), ("signal", &signal_log)] {
+        let seen = log.lock().unwrap();
+        assert_eq!(seen.len(), 1, "the {chan} channel received the escalation");
+        let n = &seen[0];
+        assert!(
+            n.headline.contains("feature-x"),
+            "the {chan} notification names the goal id: {n:?}"
+        );
+        assert!(
+            n.problem.contains(&reason) || n.problem.contains("needs human review"),
+            "the {chan} notification carries the block reason: {n:?}"
+        );
+    }
+}
+
+// ─────────────────── 5. Anti-recursion: fail closed on no identity ──────────
+
+#[test]
+fn self_heal_and_escalate_fail_closed_without_a_distinct_identity() {
+    // No `.with_identity(...)` ⇒ the default RecursionGuard is unconfigured, so
+    // both goal-health actions must be REFUSED (fail closed) — the Overseer can
+    // never self-heal / escalate (nor self-whisper) without a DISTINCT identity.
+    let (store, unblocked) = FakeGoalStore::new(vec![]);
+    let (notifier, email_log, signal_log) = dual_recording_notifier();
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_goal_health_enabled(true)
+        .with_operator_notifier(Box::new(notifier));
+
+    let unblock = ov.act(&Intervention::UnblockGoal {
+        goal_id: "research".to_string(),
+        reason: no_progress_blocked_reason(4),
+    });
+    assert!(
+        matches!(unblock, Err(OverseerError::Recursion { .. })),
+        "unconfigured identity refuses the self-heal (fail closed): {unblock:?}"
+    );
+
+    let escalate = ov.act(&Intervention::EscalateBlockedGoal {
+        goal_id: "feature-x".to_string(),
+        reason: brain_failure_reason(3),
+    });
+    assert!(
+        matches!(escalate, Err(OverseerError::Recursion { .. })),
+        "unconfigured identity refuses the escalation (fail closed): {escalate:?}"
+    );
+
+    assert!(
+        unblocked.lock().unwrap().is_empty(),
+        "no unblock reached the store"
+    );
+    assert!(
+        email_log.lock().unwrap().is_empty() && signal_log.lock().unwrap().is_empty(),
+        "no notification reached the operator"
+    );
+}
+
+// ─────────────────── 6. Enable flag: disabled ⇒ no action ───────────────────
+
+#[test]
+fn disabled_goal_health_holds_both_actions() {
+    let blocked = vec![
+        BlockedGoal {
+            id: "research".to_string(),
+            reason: no_progress_blocked_reason(4),
+            perpetual: true,
+            needs_review: true,
+            consecutive_no_action: 4,
+        },
+        BlockedGoal {
+            id: "feature-x".to_string(),
+            reason: brain_failure_reason(3),
+            perpetual: false,
+            needs_review: true,
+            consecutive_no_action: 3,
+        },
+    ];
+    let (store, unblocked) = FakeGoalStore::new(blocked);
+    let (notifier, email_log, signal_log) = dual_recording_notifier();
+
+    // Identity configured, notifier wired — only the enable flag is OFF.
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_identity(overseer_identity())
+        .with_goal_health_enabled(false)
+        .with_operator_notifier(Box::new(notifier));
+
+    let report = overseer_tick(&mut ov);
+    assert_eq!(report.goals_unblocked, 0);
+    assert_eq!(report.goals_escalated, 0);
+    assert!(
+        report.held >= 2,
+        "both goal-health interventions are held: {report:?}"
+    );
+    assert!(
+        unblocked.lock().unwrap().is_empty(),
+        "disabled ⇒ no unblock is performed"
+    );
+    assert!(
+        email_log.lock().unwrap().is_empty() && signal_log.lock().unwrap().is_empty(),
+        "disabled ⇒ no escalation is dispatched"
+    );
+}
+
+#[test]
+fn goal_health_enable_flag_is_opt_out_and_off_when_overseer_off() {
+    use crate::overseer::config::OVERSEER_ENABLED_ENV;
+    let env = |pairs: &[(&str, &str)]| {
+        let owned: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        move |k: &str| owned.iter().find(|(ek, _)| ek == k).map(|(_, v)| v.clone())
+    };
+    // Default (unset): ON, because the acting Overseer is opt-out ON.
+    assert!(goal_health_enabled_from(env(&[])));
+    // Explicit falsey on the goal-health flag: OFF.
+    assert!(!goal_health_enabled_from(env(&[(
+        SIMARD_OVERSEER_GOAL_HEALTH_ENV,
+        "off"
+    )])));
+    // A disabled Overseer forces goal-health OFF regardless of the flag.
+    assert!(!goal_health_enabled_from(env(&[
+        (OVERSEER_ENABLED_ENV, "false"),
+        (SIMARD_OVERSEER_GOAL_HEALTH_ENV, "on"),
+    ])));
+}
+
+// ─────────────────── 7. Failure isolation: the tick survives ────────────────
+
+#[test]
+fn a_failing_unblock_is_isolated_and_the_tick_survives() {
+    let blocked = vec![BlockedGoal {
+        id: "research".to_string(),
+        reason: no_progress_blocked_reason(4),
+        perpetual: true,
+        needs_review: true,
+        consecutive_no_action: 4,
+    }];
+    // The goal store errors on unblock — a capability failure, not a panic.
+    let store = FakeGoalStore::failing(blocked);
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_identity(overseer_identity())
+        .with_goal_health_enabled(true);
+
+    let report = run_overseer_tick_isolated(&mut ov);
+    assert_eq!(
+        report.goals_unblocked, 0,
+        "the failed self-heal took no effect"
+    );
+    assert_eq!(report.errors, 1, "the failure is counted, isolated");
+    assert!(!report.panicked, "a capability error never panics the tick");
+    assert!(report.duration_ms < 60_000);
+}
+
+// ─────────────────── decide/classify unit routing ──────────────────────────
+
+#[test]
+fn decide_routes_a_blocked_goal_by_shape() {
+    // Perpetual + no-progress marker ⇒ self-heal (unblock), never escalate.
+    let self_heal = decide(&Problem {
+        kind: ProblemKind::GoalHygiene,
+        priority: crate::overseer::signal::Priority::High,
+        dedup_key: "goal:blocked:research".to_string(),
+        summary: "blocked".to_string(),
+        evidence: vec![Signal::GoalBlocked {
+            goal_id: "research".to_string(),
+            reason: no_progress_blocked_reason(4),
+            perpetual: true,
+            needs_review: true,
+            consecutive_no_action: 4,
+        }],
+    });
+    assert!(matches!(self_heal, Intervention::UnblockGoal { .. }));
+
+    // Normal + needs_review ⇒ escalate.
+    let escalate = decide(&Problem {
+        kind: ProblemKind::GoalHygiene,
+        priority: crate::overseer::signal::Priority::High,
+        dedup_key: "goal:blocked:feature-x".to_string(),
+        summary: "blocked".to_string(),
+        evidence: vec![Signal::GoalBlocked {
+            goal_id: "feature-x".to_string(),
+            reason: brain_failure_reason(3),
+            perpetual: false,
+            needs_review: true,
+            consecutive_no_action: 3,
+        }],
+    });
+    assert!(matches!(escalate, Intervention::EscalateBlockedGoal { .. }));
+
+    // A plain operator-set block (no marker) ⇒ Report only, no autonomous action.
+    let report = decide(&Problem {
+        kind: ProblemKind::GoalHygiene,
+        priority: crate::overseer::signal::Priority::Normal,
+        dedup_key: "goal:blocked:ops".to_string(),
+        summary: "blocked".to_string(),
+        evidence: vec![Signal::GoalBlocked {
+            goal_id: "ops".to_string(),
+            reason: "waiting on the operator".to_string(),
+            perpetual: false,
+            needs_review: false,
+            consecutive_no_action: 0,
+        }],
+    });
+    assert!(matches!(report, Intervention::Report));
+}
+
+#[test]
+fn goal_health_interventions_are_routine_and_admitted_by_default_gate() {
+    for iv in [
+        Intervention::UnblockGoal {
+            goal_id: "g".to_string(),
+            reason: "r".to_string(),
+        },
+        Intervention::EscalateBlockedGoal {
+            goal_id: "g".to_string(),
+            reason: "r".to_string(),
+        },
+    ] {
+        assert_eq!(classify(&iv), RiskClass::Routine);
+        assert!(
+            AutonomyGate::default().admit(&iv).is_ok(),
+            "routine goal-health actions are admitted; their own dedup/identity gates apply in act"
+        );
+    }
+    assert_eq!(
+        Intervention::UnblockGoal {
+            goal_id: "g".to_string(),
+            reason: "r".to_string()
+        }
+        .label(),
+        "unblock_goal"
+    );
+    assert_eq!(
+        Intervention::EscalateBlockedGoal {
+            goal_id: "g".to_string(),
+            reason: "r".to_string()
+        }
+        .label(),
+        "escalate_blocked_goal"
+    );
+}

--- a/src/overseer/wiring.rs
+++ b/src/overseer/wiring.rs
@@ -331,6 +331,17 @@ impl GoalCurator for BoardGoalCurator {
         Ok(blocked_goals_from_board(&self.load()?))
     }
 
+    fn observe_board(&self) -> Result<(Vec<BlockedGoal>, Vec<InFlightItem>), OverseerError> {
+        // One board read per Observe pass: load the snapshot once, then project
+        // both the goal-board health and the in-flight dedup set from it, instead
+        // of loading (search_facts + deserialize) twice per tick.
+        let board = self.load()?;
+        Ok((
+            blocked_goals_from_board(&board),
+            in_flight_from_board(&board),
+        ))
+    }
+
     fn unblock(&self, goal_id: &str) -> Result<(), OverseerError> {
         // The exact `simard goal unblock` mutation: restore the blocked goal to
         // `NotStarted` so the next OODA cycle re-enters the spawn path. Reuses

--- a/src/overseer/wiring.rs
+++ b/src/overseer/wiring.rs
@@ -32,23 +32,28 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 
 use crate::cognitive_memory::CognitiveMemoryOps;
-use crate::goal_curation::{BacklogItem, GoalBoard};
+use crate::goal_curation::{BacklogItem, GoalBoard, GoalProgress};
 use crate::goal_curation::{
     DEFAULT_STEWARD_SCORE, add_backlog_item, load_goal_board, save_goal_board,
 };
 
 use crate::overseer::audit::SelfQualityAuditor;
 use crate::overseer::capabilities::{
-    DeployReport, Deployer, GoalBrief, GoalCurator, InFlightItem, OverseerError,
+    BlockedGoal, DeployReport, Deployer, GoalBrief, GoalCurator, InFlightItem, OverseerError,
 };
-use crate::overseer::config::{overseer_author_login, overseer_interval_secs, whisper_enabled};
+use crate::overseer::config::{
+    goal_health_enabled, overseer_author_login, overseer_interval_secs, whisper_enabled,
+};
 use crate::overseer::deploy::GuardedDeployer;
 use crate::overseer::guardrails::RecursionGuard;
 use crate::overseer::launch::SmartOrchestratorLauncher;
 use crate::overseer::meeting_ops::MeetingGoalTransfer;
 use crate::overseer::merge_ops::MergePrOps;
+use crate::overseer::notify::DualChannelNotifier;
 use crate::overseer::observer::StewardshipIssueFiler;
-use crate::overseer::sensor::{SnapshotStatusReader, in_flight_from_board};
+use crate::overseer::sensor::{
+    SnapshotStatusReader, blocked_goals_from_board, in_flight_from_board,
+};
 use crate::overseer::{ActOutcome, Capabilities, Overseer};
 
 // ─────────────────────────── cadence scheduler ─────────────────────────────
@@ -123,6 +128,15 @@ pub struct OverseerTickReport {
     pub whispers: usize,
     /// Whispers suppressed by the dedup window / per-hour cap this tick.
     pub whispers_suppressed: usize,
+    /// False-parked standing/perpetual goals auto-unblocked + reactivated this
+    /// tick (the self-heal path).
+    pub goals_unblocked: usize,
+    /// Genuinely-blocked "needs human review" goals escalated to the operator
+    /// (email + Signal) this tick.
+    pub goals_escalated: usize,
+    /// Goal-board self-heal / escalation actions suppressed by the dedup gate
+    /// this tick.
+    pub goals_health_suppressed: usize,
     /// Capability errors encountered while acting (isolated, never fatal).
     pub errors: usize,
     /// Set when the tick itself panicked and was isolated by
@@ -189,6 +203,9 @@ pub fn overseer_tick(overseer: &mut Overseer) -> OverseerTickReport {
         held = report.held,
         whispers = report.whispers,
         whispers_suppressed = report.whispers_suppressed,
+        goals_unblocked = report.goals_unblocked,
+        goals_escalated = report.goals_escalated,
+        goals_health_suppressed = report.goals_health_suppressed,
         errors = report.errors,
         duration_ms = report.duration_ms,
         "overseer tick complete"
@@ -229,6 +246,9 @@ fn tally_outcome(report: &mut OverseerTickReport, outcome: &ActOutcome) {
         ActOutcome::Escalated => report.escalations += 1,
         ActOutcome::Whispered { .. } => report.whispers += 1,
         ActOutcome::WhisperSuppressed { .. } => report.whispers_suppressed += 1,
+        ActOutcome::GoalUnblocked { .. } => report.goals_unblocked += 1,
+        ActOutcome::GoalEscalated { .. } => report.goals_escalated += 1,
+        ActOutcome::GoalHealthSuppressed { .. } => report.goals_health_suppressed += 1,
         ActOutcome::ConflictResolved
         | ActOutcome::GoalTransferred
         | ActOutcome::Reported
@@ -305,6 +325,31 @@ impl GoalCurator for BoardGoalCurator {
 
     fn in_flight(&self) -> Result<Vec<InFlightItem>, OverseerError> {
         Ok(in_flight_from_board(&self.load()?))
+    }
+
+    fn blocked_goals(&self) -> Result<Vec<BlockedGoal>, OverseerError> {
+        Ok(blocked_goals_from_board(&self.load()?))
+    }
+
+    fn unblock(&self, goal_id: &str) -> Result<(), OverseerError> {
+        // The exact `simard goal unblock` mutation: restore the blocked goal to
+        // `NotStarted` so the next OODA cycle re-enters the spawn path. Reuses
+        // the shipped `load_goal_board` / `save_goal_board` under the flock
+        // write-lock (`save_goal_board` acquires `BoardWriteLock`).
+        let mut board = self.load()?;
+        let goal = board
+            .active
+            .iter_mut()
+            .find(|g| g.id == goal_id)
+            .ok_or_else(|| OverseerError::Capability {
+                what: "goal_board.unblock",
+                detail: format!("goal '{goal_id}' not found on the active board"),
+            })?;
+        goal.status = GoalProgress::NotStarted;
+        save_goal_board(&board, self.mem.as_ref()).map_err(|e| OverseerError::Capability {
+            what: "goal_board.save",
+            detail: e.to_string(),
+        })
     }
 }
 
@@ -403,6 +448,12 @@ pub fn build_overseer(
                 crate::meeting_facilitator::default_handoff_dir(),
             ),
         ))
+        // Goal-board health: self-heal false-parked perpetual goals and escalate
+        // genuine "needs human review" blocks to the operator on BOTH channels
+        // (email + Signal) via the SAME mandatory notifier the merge path uses.
+        // Enabled by default (opt-out via SIMARD_OVERSEER_GOAL_HEALTH).
+        .with_goal_health_enabled(goal_health_enabled())
+        .with_operator_notifier(Box::new(DualChannelNotifier::from_env()))
 }
 
 /// Resolve the acting Overseer's tick cadence (seconds), clamped to the config

--- a/tests/memory_consolidation_lifecycle.rs
+++ b/tests/memory_consolidation_lifecycle.rs
@@ -187,6 +187,7 @@ fn ooda_cycle_runs_with_consolidation_wired_in() {
             simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     };
 
     let mut board = GoalBoard::new();
@@ -344,6 +345,7 @@ fn multiple_ooda_cycles_accumulate_consolidation() {
             simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     };
 
     let mut board = GoalBoard::new();

--- a/tests/ooda.rs
+++ b/tests/ooda.rs
@@ -88,6 +88,7 @@ fn test_bridges() -> OodaBridges {
             simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     }
 }
 
@@ -261,6 +262,7 @@ fn feral_gym_bridge_down() {
             simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     };
     let mut state = OodaState::new(board_with_goals());
     let report = run_ooda_cycle(&mut state, &mut bridges, &OodaConfig::default()).unwrap();
@@ -478,6 +480,7 @@ fn successful_outcome_stores_procedural_memory() {
             simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     };
 
     let mut state = OodaState::new(board_with_goals());

--- a/tests/ooda_daemon.rs
+++ b/tests/ooda_daemon.rs
@@ -103,6 +103,7 @@ fn test_bridges() -> OodaBridges {
             simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     }
 }
 

--- a/tests/overseer_activity.rs
+++ b/tests/overseer_activity.rs
@@ -62,12 +62,9 @@ fn report(
         issues_filed,
         recipes_launched,
         prs_merged,
-        deploys: 0,
-        escalations: 0,
         held,
-        errors: 0,
-        panicked: false,
         duration_ms: 42,
+        ..OverseerTickReport::default()
     }
 }
 

--- a/tests/platform_installer_contract.rs
+++ b/tests/platform_installer_contract.rs
@@ -1,0 +1,144 @@
+//! Tests-first (TDD) contract for the Simard side of the platform installer
+//! (issue #3119).
+//!
+//! Two Simard-owned behaviors are pinned here BEFORE they are implemented, so
+//! these tests are expected to be **red** until the implementation step lands:
+//!
+//!   1. `simard ensure-deps` must stop probing for the Python `kuzu` package.
+//!      Simard's cognitive memory is embedded **lbug** (compiled into the binary
+//!      via `amplihack-memory-lib`), not kuzu. The stale kuzu check is misleading
+//!      noise and must be removed; `ensure-deps` stays a minimal runtime check
+//!      (`git`, `python3`, `gh`). See docs/reference/platform-installer-cli.md
+//!      ("`simard ensure-deps` and the removed kuzu check").
+//!
+//!   2. Simard exposes a thin `simard platform install` / `simard platform
+//!      doctor` rail that forwards to the canonical Crocutus scaffold. The verb
+//!      is namespaced under `simard platform …` specifically to avoid colliding
+//!      with the pre-existing `simard install` (binary-persist) verb. See
+//!      docs/concepts/platform-installer.md ("Where the installer lives").
+//!
+//! These tests only exercise side-effect-free paths (`--help`, arg validation,
+//! and the read-only `ensure-deps` report). They never invoke the installer's
+//! host-mutating phases.
+
+use std::process::Command;
+
+use simard::dispatch_operator_cli;
+
+/// Build an owned `Vec<String>` arg list for `dispatch_operator_cli`.
+fn argv(args: &[&str]) -> Vec<String> {
+    args.iter().map(|s| (*s).to_string()).collect()
+}
+
+// ── 1. The stale kuzu dependency check is gone ──────────────────────────────
+
+/// `simard ensure-deps` must NOT mention kuzu anywhere in its output. Memory is
+/// embedded lbug, not kuzu; the probe is stale and misleading.
+#[test]
+fn ensure_deps_does_not_probe_for_kuzu() {
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("ensure-deps")
+        .output()
+        .expect("`simard ensure-deps` should launch");
+
+    let rendered = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        !rendered.to_lowercase().contains("kuzu"),
+        "`simard ensure-deps` must not reference the stale Python `kuzu` package \
+         (memory is embedded lbug via amplihack-memory-lib):\n{rendered}"
+    );
+}
+
+/// `ensure-deps` must still report the real minimal runtime dependencies.
+#[test]
+fn ensure_deps_still_reports_the_minimal_runtime_dependencies() {
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("ensure-deps")
+        .output()
+        .expect("`simard ensure-deps` should launch");
+
+    let rendered = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    for dep in ["git", "python3", "gh"] {
+        assert!(
+            rendered.contains(dep),
+            "`simard ensure-deps` should still check the minimal runtime dependency \
+             '{dep}':\n{rendered}"
+        );
+    }
+}
+
+// ── 2. The `simard platform` rail exists and is namespaced ──────────────────
+
+/// `simard platform --help` must be a recognized command that prints help and
+/// exits Ok — not the current `unsupported command 'platform'` error.
+#[test]
+fn platform_group_help_is_recognized() {
+    let result = dispatch_operator_cli(argv(&["platform", "--help"]));
+    assert!(
+        result.is_ok(),
+        "`simard platform --help` should be recognized and print help, got: {:?}",
+        result.err().map(|e| e.to_string())
+    );
+}
+
+/// `simard platform install --help` must be recognized (the install rail).
+#[test]
+fn platform_install_help_is_recognized() {
+    let result = dispatch_operator_cli(argv(&["platform", "install", "--help"]));
+    assert!(
+        result.is_ok(),
+        "`simard platform install --help` should be recognized, got: {:?}",
+        result.err().map(|e| e.to_string())
+    );
+}
+
+/// `simard platform doctor --help` must be recognized (the preflight rail).
+#[test]
+fn platform_doctor_help_is_recognized() {
+    let result = dispatch_operator_cli(argv(&["platform", "doctor", "--help"]));
+    assert!(
+        result.is_ok(),
+        "`simard platform doctor --help` should be recognized, got: {:?}",
+        result.err().map(|e| e.to_string())
+    );
+}
+
+/// An unknown `platform` subcommand must fail closed with an error that names
+/// the offending subcommand (proving the arg actually reached the `platform`
+/// dispatcher rather than falling through the top-level `unsupported command
+/// 'platform'` arm).
+#[test]
+fn platform_unknown_subcommand_fails_closed_naming_the_subcommand() {
+    let result = dispatch_operator_cli(argv(&["platform", "totally-unknown-subcommand"]));
+    let err = result.expect_err("an unknown `platform` subcommand must fail closed");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("totally-unknown-subcommand"),
+        "the error should name the unknown `platform` subcommand (proving it was \
+         routed into the platform rail), got: {msg}"
+    );
+}
+
+/// The pre-existing bare `simard install` (binary-persist) verb must keep
+/// working and must NOT be shadowed by the new `platform` group — this guards
+/// the verb-deconfliction decision. `install --help` is side-effect-free.
+#[test]
+fn preexisting_install_verb_is_not_shadowed() {
+    let result = dispatch_operator_cli(argv(&["install", "--help"]));
+    assert!(
+        result.is_ok(),
+        "the existing `simard install` verb must still work alongside `simard \
+         platform install`, got: {:?}",
+        result.err().map(|e| e.to_string())
+    );
+}


### PR DESCRIPTION
The Simard-owned slice of the Simard-family **platform installer** (issue #3119). Companion PRs: canonical scaffold rysweet/Crocutus#3, engine lbug fix rysweet/amplihack-memory-lib#129.

## Changes

- **Remove the stale `kuzu` check** from `simard ensure-deps` (`src/cmd_ensure_deps.rs`). Cognitive memory is embedded **lbug** (compiled into the binary via `amplihack-memory-lib`'s `persistent` feature), not the Python `kuzu` package — the probe was misleading noise. `ensure-deps` stays a minimal runtime check (`git` / `python3` / `gh`); the heavier build/host preconditions belong to `simard platform doctor`.
- **Add a thin `simard platform install` / `simard platform doctor` rail** (`src/operator_cli/platform.rs`), namespaced under `platform` so it never collides with the pre-existing bare `simard install` (binary-persist) verb. It **forwards** to the canonical Crocutus scaffold (`scripts/install.sh` / `scripts/doctor.sh`) — a single code path to test and maintain — locating it via `SIMARD_INSTALLER_SCAFFOLD` or known checkout paths, and **failing closed** (naming the offending subcommand) on unknown `platform` subcommands or a missing scaffold.
- **Platform-installer docs** (concept / how-to / reference / tutorial) + mkdocs nav. The lbug-portability concept is written to the **honest mechanism**: `amplihack-memory-lib` owns the from-source *contract* (a persistent-feature `build.rs` guard + a from-source ABI proof CI job), and the **installer** sets `LBUG_BUILD_FROM_SOURCE=1` where the deployment binary is built. (Cargo runs lbug's build script before amplihack-memory's, and lbug exposes no Cargo feature for source builds, so the library cannot flip lbug's build mode itself.)

## Test

- `tests/platform_installer_contract.rs` is **GREEN** (7/7): kuzu absent from `ensure-deps` output, minimal deps still reported, `platform`/`platform install`/`platform doctor` `--help` recognized, unknown `platform` subcommand fails closed naming it, and the bare `install` verb is not shadowed.
- Pre-commit (rust-only gate, `cargo fmt`, `cargo clippy --release -D warnings`) and pre-push (`cargo clippy --all-targets --all-features --locked -D warnings` + test subset) gates pass locally.

## Follow-up (sequenced, not in this PR)

Bumping the `amplihack-memory` pin to consume the engine guard/proof is deliberately deferred: Simard's `Cargo.toml` policy forbids pinning to an unmerged, GC-able feature-branch ref. The pin moves to the amplihack-memory-lib#129 **squash-merge commit on `main`** once that lands. The installer already forces `LBUG_BUILD_FROM_SOURCE=1` at build time, so the deployment fix is effective independent of the pin.