### PR TITLE
chore(deps): bump amplihack-memory to #129 + repoint lbug to fork (lbug portability fix #3119)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=72c5ea1bfcca7e6f3e314dfd99fbe4998378ffe8#72c5ea1bfcca7e6f3e314dfd99fbe4998378ffe8"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=5807d056112b8e6f73dae9c1fac05f214f9c6ece#5807d056112b8e6f73dae9c1fac05f214f9c6ece"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2116,9 +2116,8 @@ dependencies = [
 
 [[package]]
 name = "lbug"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38365ef5ebc0a55e342db7296a6ca9a2ee64916dbdbe4f87f1496b4fc68d0da"
+version = "0.17.0"
+source = "git+https://github.com/rysweet/ladybug-rust?rev=202352434642e683fdf008b68004d0645a57cd35#202352434642e683fdf008b68004d0645a57cd35"
 dependencies = [
  "cmake",
  "cxx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,21 @@ path = "src/bin/supply_chain_steward.rs"
 # from one bulk edge scan per type: a pure performance refactor with
 # byte-identical ranking. Still an upstream-`main` commit; store format stays v41
 # (no lbug/engine change).
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "72c5ea1bfcca7e6f3e314dfd99fbe4998378ffe8", features = ["persistent"] }
+#
+# Bumped again (issue #3119) to the squash-merge commit of amplihack-memory-lib
+# PR #129 on `main` (1 commit ahead of the #126 pin): the lbug portability fix.
+# The published crates.io `lbug 0.17.1` SIGSEGVs in `std::vformat` during
+# `Database::initBufferManager` on hosts whose libstdc++ `std::format` ABI differs
+# from the prebuilt's (e.g. Ubuntu 26.04), and its build.rs also double-links the
+# bundled third-party archives in source-build mode (duplicate symbols). #129 pins
+# `lbug` to the `rysweet/ladybug-rust` fork (build.rs keeps `link_bundled_deps=false`
+# and links only the self-contained `liblbug.a`), so building from source both cures
+# the ABI SIGSEGV and links cleanly with no unsafe `--allow-multiple-definition`.
+# The fork engine writes on-disk storage format v42 (forward-only from v41; the
+# v40->v41+ no-data-loss gate now accepts v41-or-newer). Simard's direct `lbug` dep
+# below is repointed at the SAME fork rev in lockstep so the final binary links
+# exactly one engine. Still an upstream-`main` commit.
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "5807d056112b8e6f73dae9c1fac05f214f9c6ece", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream
@@ -136,10 +150,12 @@ amplihack-agent-eval = { git = "https://github.com/rysweet/amplihack-rs.git", re
 # `lbug` is still a direct dependency of the standalone `simard-tui` binary
 # (`src/bin/simard_tui/goals.rs`), which opens a LadybugDB read-only to render
 # the goal board. The cognitive-memory backend itself no longer uses lbug
-# directly — it goes through the amplihack-memory library. Bumped to 0.17.1 in
-# lockstep with the amplihack-memory pin so the final binary links exactly one
-# engine and one storage format (v41).
-lbug = "=0.17.1"
+# directly — it goes through the amplihack-memory library. Pinned to the
+# `rysweet/ladybug-rust` fork (issue #3119) at the SAME rev amplihack-memory uses,
+# so cargo unifies to exactly one `lbug` crate / one engine / one storage format.
+# The fork fixes the from-source duplicate-symbol link and the libstdc++
+# std::format ABI SIGSEGV; see amplihack-memory docs/lbug_libstdcxx_abi.md.
+lbug = { git = "https://github.com/rysweet/ladybug-rust", rev = "202352434642e683fdf008b68004d0645a57cd35" }
 rusqlite = { version = "=0.31.0", features = ["bundled"] }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.149"

--- a/deny.toml
+++ b/deny.toml
@@ -146,11 +146,14 @@ deny = []
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# Git sources are an explicit allowlist. Simard pins four crates by exact rev
-# across THREE upstream repositories (rustyclawd-core + rustyclawd-tools share
-# one). Any other git source — a typosquat or hijacked transitive dep — fails.
+# Git sources are an explicit allowlist. Simard pins crates by exact rev across
+# upstream repositories (rustyclawd-core + rustyclawd-tools share one; lbug comes
+# from the rysweet/ladybug-rust fork that fixes the from-source link + libstdc++
+# ABI, see amplihack-memory docs/lbug_libstdcxx_abi.md). Any other git source — a
+# typosquat or hijacked transitive dep — fails.
 allow-git = [
     "https://github.com/rysweet/RustyClawd.git",
     "https://github.com/rysweet/amplihack-memory-lib.git",
     "https://github.com/rysweet/amplihack-rs.git",
+    "https://github.com/rysweet/ladybug-rust",
 ]

--- a/tests/issue_2626_amplihack_pin_bump.rs
+++ b/tests/issue_2626_amplihack_pin_bump.rs
@@ -23,11 +23,11 @@
 //! # The lockstep invariant
 //!
 //! The `persistent` feature of `amplihack-memory` compiles the LadybugDB
-//! engine through the published `lbug` crate, and the standalone `simard-tui`
-//! binary links `lbug` directly to render the goal board read-only. The final
-//! binary must link **exactly one** `lbug` (one engine, one on-disk store
-//! format). So Simard's direct `lbug = "=X"` pin must equal whatever single
-//! version the memory-lib bump resolves — never a second, conflicting line.
+//! engine through the `lbug` crate, and the standalone `simard-tui` binary
+//! links `lbug` directly to render the goal board read-only. The final binary
+//! must link **exactly one** `lbug` (one engine, one on-disk store format). So
+//! Simard's direct `lbug` git dep must pin the SAME rysweet/ladybug-rust fork
+//! rev the memory-lib bump resolves — never a second, conflicting line.
 //!
 //! # Why these are file-shaped (rg/grep-shaped)
 //!
@@ -46,23 +46,30 @@ use std::path::PathBuf;
 /// amplihack-rs `main` HEAD carrying the `amplihack-agent-eval` crate to adopt.
 const AGENT_EVAL_TARGET_REV: &str = "14dc30b10e87764120c6f2bae7f3630522c29e5d";
 /// amplihack-memory-lib `main` commit carrying the `amplihack-memory` crate:
-/// PR #126's squash-merge — the bulk graph-adjacency index for ranked recall,
-/// which serves the graph-proximity term from one bulk edge scan per type
-/// instead of a per-node `query_neighbors` BFS (N+1 fan-out of ~3N Cypher scans
-/// per recall). Cuts OODA prepare-context from ~11 min/cycle toward seconds at
-/// ~7,590 facts with byte-identical ranking; no store-format change (v41).
-/// Simard consumes it to fix the "memory graph never loads" pathology
-/// (issue #40). One commit ahead of the prior #125 pin, no regression.
-const MEMORY_TARGET_REV: &str = "72c5ea1bfcca7e6f3e314dfd99fbe4998378ffe8";
+/// PR #129's squash-merge — the lbug portability fix. It pins `lbug` to the
+/// rysweet/ladybug-rust fork (build.rs keeps `link_bundled_deps=false`, links
+/// only the self-contained liblbug.a), so building from source both cures the
+/// libstdc++ std::format ABI SIGSEGV on newer hosts (Ubuntu 26.04) and links
+/// cleanly with no unsafe `--allow-multiple-definition`. One commit ahead of the
+/// prior #126 pin, no regression. The fork engine writes on-disk store format
+/// v42 (forward-only from v41).
+const MEMORY_TARGET_REV: &str = "5807d056112b8e6f73dae9c1fac05f214f9c6ece";
 
 /// The stale revs the bump must move *off of* (anti-regression sentinels).
 const AGENT_EVAL_STALE_REV: &str = "59548a96049ab8d558110bcaf9c82a4316f1bbf0";
-const MEMORY_STALE_REV: &str = "901f63ad79eb0c2d87cd8263d26025877af43cc5";
+const MEMORY_STALE_REV: &str = "72c5ea1bfcca7e6f3e314dfd99fbe4998378ffe8";
 
 /// The only git remotes these two crates may resolve from. A bump must never
 /// introduce a *new* git source (typosquat / allowlist-bypass guard, R1).
 const AGENT_EVAL_REMOTE: &str = "https://github.com/rysweet/amplihack-rs.git";
 const MEMORY_REMOTE: &str = "https://github.com/rysweet/amplihack-memory-lib.git";
+
+/// Simard's direct `lbug` dep (simard-tui goal board) is a git dep on the
+/// rysweet/ladybug-rust fork (issue #3119: fixes the from-source duplicate-symbol
+/// link + the libstdc++ std::format ABI SIGSEGV). It must pin the SAME fork rev
+/// amplihack-memory resolves to, so cargo unifies to exactly one lbug engine.
+const LBUG_FORK_TARGET_REV: &str = "202352434642e683fdf008b68004d0645a57cd35";
+const LBUG_FORK_REMOTE: &str = "https://github.com/rysweet/ladybug-rust";
 
 // ── Path / IO helpers ───────────────────────────────────────────────────────
 
@@ -343,27 +350,45 @@ fn lbug_resolves_to_exactly_one_version() {
 
 #[test]
 fn direct_lbug_pin_matches_the_single_locked_version() {
-    // Simard's direct `lbug = "=X"` pin must equal whatever single version the
-    // memory-lib bump resolves — the pin follows memory-lib, it is never chosen
-    // independently. This keeps the manifest honest about the linked engine.
+    // Simard's direct `lbug` dep (simard-tui goal board) is now a git dep on the
+    // rysweet/ladybug-rust fork (issue #3119). It must pin the SAME fork rev that
+    // amplihack-memory resolves to, so cargo unifies to exactly one lbug crate /
+    // one engine / one on-disk store format — the pin follows memory-lib, it is
+    // never chosen independently.
     let toml = cargo_toml();
     let line = manifest_dep_line(&toml, "lbug")
         .expect("Cargo.toml must declare a direct `lbug` dependency (simard-tui goal board)");
-    // The pin is a bare string requirement: `lbug = "=0.17.1"`.
-    let pin_raw = field_value(&line, "lbug").expect("could not parse the `lbug` version pin");
-    let pin = pin_raw.trim_start_matches('=').trim().to_string();
 
+    // It must be a git dep on the fork remote, pinned by a full-SHA `rev`.
+    let remote = field_value(&line, "git")
+        .expect("direct `lbug` must be a git dependency on the ladybug-rust fork");
+    assert_eq!(
+        remote.trim_end_matches(".git"),
+        LBUG_FORK_REMOTE.trim_end_matches(".git"),
+        "direct `lbug` must resolve from the fork {LBUG_FORK_REMOTE}, found `{remote}`."
+    );
+    let rev = dep_rev(&toml, "lbug").expect("direct `lbug` git dep must carry a `rev` pin");
+    assert_eq!(
+        rev, LBUG_FORK_TARGET_REV,
+        "direct `lbug` rev must be the fork target {LBUG_FORK_TARGET_REV}, found `{rev}`."
+    );
+    assert!(
+        is_full_sha(&rev),
+        "direct `lbug` rev `{rev}` must be a full 40-char lowercase hex git SHA."
+    );
+
+    // Exactly one locked lbug, resolved from the fork at that rev = one engine.
     let locked = distinct_locked_versions(&cargo_lock(), "lbug");
     assert_eq!(
         locked.len(),
         1,
-        "expected exactly one locked lbug version before comparing the pin; found {locked:?}"
+        "expected exactly one locked lbug version (single engine); found {locked:?}"
     );
-    let locked_version = locked.iter().next().cloned().unwrap_or_default();
-    assert_eq!(
-        pin, locked_version,
-        "Cargo.toml direct pin `lbug = \"={pin}\"` must equal the single locked \
-         lbug version `{locked_version}`. If the memory-lib bump moved lbug, \
-         update the direct pin (and its lockstep comments) to `{locked_version}`."
+    let src = locked_source(&cargo_lock(), "lbug")
+        .expect("Cargo.lock must contain the lbug [[package]] source");
+    assert!(
+        src.contains(LBUG_FORK_TARGET_REV) && src.contains(LBUG_FORK_REMOTE),
+        "Cargo.lock lbug must resolve from the fork {LBUG_FORK_REMOTE} at rev \
+         {LBUG_FORK_TARGET_REV}; found `{src}`."
     );
 }


### PR DESCRIPTION
## Problem
Prebuilt `lbug 0.17.1` SIGSEGVs in `std::vformat` during `Database::initBufferManager` on hosts whose libstdc++ `std::format` ABI differs from the prebuilt (Ubuntu 26.04), and its `build.rs` double-links the bundled third-party archives in source mode (duplicate symbols). This blocked running Simard-family agents (Crocutus, the platform installer) on modern hosts.

## Fix
Consumes **amplihack-memory-lib #129** (rev `5807d056`), which pins `lbug` to the `rysweet/ladybug-rust` fork (`build.rs` keeps `link_bundled_deps=false`, links only the self-contained `liblbug.a`). Building from source both cures the ABI SIGSEGV and links cleanly — **no unsafe `--allow-multiple-definition`**.

Simard's **direct** `lbug` dep (simard-tui's read-only goal-board reader) is repointed at the **same fork rev** so cargo unifies to exactly one `lbug` crate / one engine / one storage format.

## Verification
- `Cargo.lock` has a **single** `lbug` (0.17.0, fork) — no dual engine
- `cargo build --bin simard --bin simard-tui` succeeds; `cargo clippy --release -D warnings` clean
- Upstream #129: from-source `--features persistent` links clean, all 54 `lbug_store` tests pass (fork engine writes on-disk format v42, forward-only from v41; the no-data-loss gate now accepts v41-or-newer)

Fixes Simard #3119.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>