### PR TITLE
feat(coin-gym): head-to-head baseline-vs-team benchmark with a measurable verdict (#2825)

### DIFF
--- a/docs/howto/run-the-coin-gym-harness.md
+++ b/docs/howto/run-the-coin-gym-harness.md
@@ -46,6 +46,7 @@ default, overridable with the `COIN_GYM_HOME` environment variable.
 
 ```text
 coin-gym run <model> [--strategy baseline|team] [--profile <name>] [--targets <path>]
+coin-gym benchmark <model> [--profile <name>] [--targets <path>] [--margin <pct>] [--json]
 coin-gym score   <run-id> [--profile <name>]
 coin-gym compare <run-id> [--profile <name>]
 coin-gym improve <run-id> [--profile <name>] [--holdout fresh]
@@ -82,6 +83,48 @@ team      reach 60.0% (3/5)   precision 100.0% (3/3)  R:3/W:0/A:2/T:0/N:0/E:0
 For the per-target breakdown, the reproduction commands, and the leaderboard-
 comparison caveat, see
 [COIN Gym — baseline vs. team measurement](../research/coin-gym-baseline-vs-team-measurement.md).
+
+### `benchmark` — head-to-head baseline vs. team (does the team *measurably* win?)
+
+```bash
+coin-gym benchmark claude-opus-4.6 --profile opus
+coin-gym benchmark claude-opus-4.6 --profile opus --margin 2 --json
+```
+
+`run` evaluates one strategy at a time; `benchmark` runs **both** on the *same*
+target set and prints a single **verdict** on whether the multi-agent team
+*measurably* beats the single-model baseline — the goal's done-gate. It diffs
+COIN's two headline metrics (reach and precision) and classifies the result
+against a material `--margin` (default `1.0` percentage points) so a sub-noise
+wiggle is never mistaken for a capability win:
+
+| Verdict | Meaning |
+|---------|---------|
+| `TEAM-BEATS-BASELINE` | Team improved ≥1 headline metric beyond the margin and regressed neither. |
+| `BASELINE-BEATS-TEAM` | Team regressed ≥1 metric and improved none — the scaffold is a net regression. |
+| `TIE` | Both metrics stayed within ±margin — no measurable difference. |
+| `MIXED-TRADEOFF` | Team improved one metric beyond the margin but regressed the other — no dominant winner. |
+
+On the bundled sample the team ties on reach (60%) but lifts precision 60% → 100%
+via the abstain gate, so the verdict is `TEAM-BEATS-BASELINE`:
+
+```text
+baseline:  reach 60.0%  precision 60.0%   R:3/W:2/A:0/T:0/N:0/E:0   [claude-opus-4-6-baseline-…]
+team:      reach 60.0%  precision 100.0%  R:3/W:0/A:2/T:0/N:0/E:0   [claude-opus-4-6-team-…]
+delta:     reach +0.0 pts (flat)   precision +40.0 pts (improved)   [margin 1.0 pts]
+verdict:   TEAM-BEATS-BASELINE
+signal:    COIN Gym (offline scaffold): claude-opus-4.6 — team vs baseline on you/coin@v1-sample → TEAM-BEATS-BASELINE (Δreach +0.0, Δprecision +40.0 pts)
+```
+
+`benchmark` **persists both runs** under the profile, so you can drive the
+**iterative climb** by feeding the baseline run straight into
+`improve --holdout fresh` (below). `--json` emits the full head-to-head as the
+**Signal milestone-report payload** (verdict, deltas, both per-family scores);
+the `signal:` line is a ready-to-post one-line headline. Like every Phase-4
+command the grade is an offline mock oracle — a *real* baseline-vs-team result
+needs a `coin evaluate` grade on the Phase-3 VM (#2823); the output labels this
+explicitly.
+
 
 ### `score` — reach / precision + family split
 

--- a/docs/research/coin-benchmark-and-skwaq-study.md
+++ b/docs/research/coin-benchmark-and-skwaq-study.md
@@ -669,6 +669,7 @@ COIN is *already* the ideal substrate for a skwaq-style loop:
 
 ```bash
 coin-gym run    <model> [--strategy baseline|team]   # evaluate on the target set
+coin-gym benchmark <model> [--margin <pct>] [--json]  # baseline vs team head-to-head + verdict
 coin-gym score  <run-id>                             # reach/precision + family split
 coin-gym compare <run-id>                            # local vs published leaderboard
 coin-gym improve <suite> --holdout fresh             # one self-improvement cycle
@@ -680,7 +681,14 @@ coin-gym profiles                                    # list per-model isolated s
 > `score|compare|improve <run-id> [--profile <name>]`, and `profiles`. The
 > `improve` command runs the **offline** failure-analyst + overfitting-reviewer
 > gate over a saved run; the live `--holdout fresh` verify/rollback cycle
-> sketched above needs live grading and is Phase 5. See
+> gate over a saved run; the live `--holdout fresh` verify/rollback cycle
+> sketched above needs live grading and is Phase 5.
+> `coin-gym benchmark <model>` runs the single-model baseline and the multi-agent
+> team **head-to-head** on one target set and prints a **verdict** — does the team
+> *measurably* beat the baseline (reach/precision diff against a material
+> `--margin`)? — persisting both runs so the baseline feeds straight into
+> `improve --holdout fresh` (the iterative climb). `--json` emits the Signal
+> milestone-report payload. See
 > [Run the LOCAL COIN Gym harness](../howto/run-the-coin-gym-harness.md). The
 > reproducible baseline-vs-team result on the bundled sample target set — the
 > abstention gate lifting precision from 60% to 100% at equal reach — is recorded

--- a/scripts/provision-lbug-prebuilt.sh
+++ b/scripts/provision-lbug-prebuilt.sh
@@ -38,8 +38,21 @@ static_lib_name="liblbug.a"
 # unauthenticated `releases/latest` API call and no version skew with the crate
 # we actually compile against.
 lbug_version() {
-  sed -nE 's/^lbug[[:space:]]*=[[:space:]]*"=?([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' \
-    "$REPO_ROOT/Cargo.toml" | head -n1
+  # 1) Inline registry version in Cargo.toml (e.g. `lbug = "=0.17.1"`).
+  local v
+  v="$(sed -nE 's/^lbug[[:space:]]*=[[:space:]]*"=?([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' \
+    "$REPO_ROOT/Cargo.toml" | head -n1)"
+  # 2) Fallback for a git/path dependency (e.g. lbug repointed to a fork,
+  #    `lbug = { git = "…", rev = "…" }` — issue #3119): the inline regex above
+  #    matches nothing, so resolve the version Cargo actually locked from
+  #    Cargo.lock's `[[package]] name = "lbug"` entry. The prebuilt asset is
+  #    still published against that version tag on the release repo, so the
+  #    version-pinned download stays deterministic regardless of the source.
+  if [ -z "$v" ] && [ -f "$REPO_ROOT/Cargo.lock" ]; then
+    v="$(awk '/^name = "lbug"$/ { f = 1 } f && /^version = / { gsub(/[^0-9.]/, ""); print; exit }' \
+      "$REPO_ROOT/Cargo.lock")"
+  fi
+  printf '%s' "$v"
 }
 
 # Name of the prebuilt static archive for this OS/arch, mirroring lbug's own

--- a/src/coin_gym/benchmark.rs
+++ b/src/coin_gym/benchmark.rs
@@ -1,0 +1,291 @@
+//! Head-to-head **baseline vs. team** benchmark (research doc Part 3.3 — the
+//! goal's headline claim, "measure a single-model baseline vs. a multi-agent
+//! team").
+//!
+//! [`run`](super::dispatch_with_home) and `score` already evaluate one strategy
+//! at a time, but the goal's **done-gate** is a single, honest verdict: on the
+//! *same* target set, does the multi-agent **team** *measurably* beat the
+//! single-model **baseline**? This module answers exactly that. It runs both
+//! strategies over one scenario, diffs COIN's two headline metrics — **reach**
+//! and **precision** — and classifies the result against a material [`margin`]
+//! so a sub-noise wiggle is never mistaken for a capability win.
+//!
+//! Because COIN **precision** punishes over-claiming, the interesting win is
+//! usually on precision: the team's skeptic/abstain gate declines low-confidence
+//! (wrong) inputs the baseline would submit, lifting precision at equal reach.
+//! On the bundled sample that is precisely the outcome — reach ties at 60%,
+//! precision climbs 60% → 100% — so the verdict is [`Verdict::TeamBeatsBaseline`].
+//!
+//! The [`HeadToHead`] value serialises to JSON as the **Signal milestone-report
+//! payload**, and [`HeadToHead::signal_line`] renders a one-line headline for a
+//! Signal post. Like the rest of the Gym (Phase 4) the underlying grade is an
+//! **offline mock oracle**; a real baseline-vs-team result needs a `coin
+//! evaluate` grade on a provisioned host (Phase 3, #2823). **LOCAL-ONLY**:
+//! nothing here is submitted externally.
+//!
+//! [`margin`]: HeadToHead::margin_pct
+
+use serde::Serialize;
+
+use super::scorer::{Score, score_run};
+use super::types::RunReport;
+
+/// Default material margin (percentage points) a headline metric must move to
+/// count as a **measurable** difference rather than run-to-run noise.
+pub const DEFAULT_MARGIN_PCT: f64 = 1.0;
+
+/// How one headline metric moved from baseline to team, relative to the margin.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricMove {
+    /// Team improved the metric by more than the margin.
+    Improved,
+    /// Team regressed the metric by more than the margin.
+    Regressed,
+    /// Team stayed within the margin (no measurable change).
+    Flat,
+}
+
+impl MetricMove {
+    /// Classify a `team − baseline` delta (percentage points) against `margin`.
+    #[must_use]
+    pub fn classify(delta_pct: f64, margin_pct: f64) -> Self {
+        if delta_pct > margin_pct {
+            Self::Improved
+        } else if delta_pct < -margin_pct {
+            Self::Regressed
+        } else {
+            Self::Flat
+        }
+    }
+}
+
+/// The head-to-head verdict on whether the multi-agent team beats the baseline.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Verdict {
+    /// Team **measurably beats** baseline: it improved at least one headline
+    /// metric beyond the margin and regressed neither beyond it.
+    TeamBeatsBaseline,
+    /// Baseline **measurably beats** team — the multi-agent scaffold is a net
+    /// regression here (a signal to re-examine the team's gate).
+    BaselineBeatsTeam,
+    /// Both headline metrics stayed within the margin — no measurable difference.
+    Tie,
+    /// Team improved one headline metric beyond the margin but regressed the
+    /// other beyond it — a reach/precision trade-off with no dominant winner.
+    MixedTradeoff,
+}
+
+impl Verdict {
+    /// Classify from each metric's [`MetricMove`].
+    #[must_use]
+    pub fn from_moves(reach: MetricMove, precision: MetricMove) -> Self {
+        let improves = reach == MetricMove::Improved || precision == MetricMove::Improved;
+        let regresses = reach == MetricMove::Regressed || precision == MetricMove::Regressed;
+        match (improves, regresses) {
+            (true, false) => Self::TeamBeatsBaseline,
+            (false, true) => Self::BaselineBeatsTeam,
+            (true, true) => Self::MixedTradeoff,
+            (false, false) => Self::Tie,
+        }
+    }
+
+    /// Uppercase, stable label used in CLI output.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::TeamBeatsBaseline => "TEAM-BEATS-BASELINE",
+            Self::BaselineBeatsTeam => "BASELINE-BEATS-TEAM",
+            Self::Tie => "TIE",
+            Self::MixedTradeoff => "MIXED-TRADEOFF",
+        }
+    }
+
+    /// Whether the team measurably beat the baseline (the done-gate condition).
+    #[must_use]
+    pub fn is_team_win(self) -> bool {
+        matches!(self, Self::TeamBeatsBaseline)
+    }
+}
+
+/// A complete baseline-vs-team head-to-head over one target set.
+///
+/// Serialises to JSON as the **Signal milestone-report payload**.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct HeadToHead {
+    /// Model evaluated under both strategies.
+    pub model: String,
+    /// Snapshot the targets were drawn from.
+    pub snapshot: String,
+    /// Material margin (percentage points) used to classify a measurable move.
+    pub margin_pct: f64,
+    /// Run id of the baseline run.
+    pub baseline_run_id: String,
+    /// Run id of the team run.
+    pub team_run_id: String,
+    /// Full baseline score (carries the per-family split + histogram).
+    pub baseline: Score,
+    /// Full team score.
+    pub team: Score,
+    /// team − baseline overall reach (percentage points).
+    pub reach_delta_pct: f64,
+    /// team − baseline overall precision (percentage points).
+    pub precision_delta_pct: f64,
+    /// How reach moved.
+    pub reach_move: MetricMove,
+    /// How precision moved.
+    pub precision_move: MetricMove,
+    /// The head-to-head verdict.
+    pub verdict: Verdict,
+    /// `true` when both runs were graded by a mock oracle (offline scaffold).
+    pub offline_scaffold: bool,
+    /// Human-readable interpretation + guardrail note.
+    pub note: String,
+}
+
+impl HeadToHead {
+    /// Build a head-to-head from a baseline and a team [`RunReport`] over the
+    /// **same** target set, classifying the result against `margin_pct` (negative
+    /// margins are clamped to `0.0`).
+    ///
+    /// The two reports are expected to share a `model` and `snapshot`; the
+    /// baseline's are recorded. Grading is inherited from the reports, so an
+    /// offline scaffold in/offline scaffold out.
+    #[must_use]
+    pub fn from_reports(
+        baseline_report: &RunReport,
+        team_report: &RunReport,
+        margin_pct: f64,
+    ) -> Self {
+        let margin_pct = margin_pct.max(0.0);
+        let baseline = score_run(baseline_report);
+        let team = score_run(team_report);
+        let reach_delta = team.overall.reach_pct() - baseline.overall.reach_pct();
+        let precision_delta = team.overall.precision_pct() - baseline.overall.precision_pct();
+        let reach_move = MetricMove::classify(reach_delta, margin_pct);
+        let precision_move = MetricMove::classify(precision_delta, margin_pct);
+        let verdict = Verdict::from_moves(reach_move, precision_move);
+        let offline_scaffold = baseline_report.offline_scaffold || team_report.offline_scaffold;
+        let note = build_note(
+            verdict,
+            offline_scaffold,
+            reach_delta,
+            precision_delta,
+            margin_pct,
+        );
+        Self {
+            model: baseline_report.model.clone(),
+            snapshot: baseline_report.snapshot.clone(),
+            margin_pct,
+            baseline_run_id: baseline_report.run_id.clone(),
+            team_run_id: team_report.run_id.clone(),
+            baseline,
+            team,
+            reach_delta_pct: reach_delta,
+            precision_delta_pct: precision_delta,
+            reach_move,
+            precision_move,
+            verdict,
+            offline_scaffold,
+            note,
+        }
+    }
+
+    /// A single-line headline suitable for a **Signal milestone** post.
+    #[must_use]
+    pub fn signal_line(&self) -> String {
+        let scope = if self.offline_scaffold {
+            " (offline scaffold)"
+        } else {
+            ""
+        };
+        format!(
+            "COIN Gym{scope}: {} — team vs baseline on {} → {} (Δreach {:+.1}, Δprecision {:+.1} pts)",
+            self.model,
+            self.snapshot,
+            self.verdict.label(),
+            self.reach_delta_pct,
+            self.precision_delta_pct,
+        )
+    }
+
+    /// Render the full human-readable head-to-head table.
+    #[must_use]
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&format!("model:     {}\n", self.model));
+        out.push_str(&format!("snapshot:  {}\n", self.snapshot));
+        out.push_str(&format!(
+            "baseline:  reach {:.1}%  precision {:.1}%  {}   [{}]\n",
+            self.baseline.overall.reach_pct(),
+            self.baseline.overall.precision_pct(),
+            self.baseline.histogram.render(),
+            self.baseline_run_id,
+        ));
+        out.push_str(&format!(
+            "team:      reach {:.1}%  precision {:.1}%  {}   [{}]\n",
+            self.team.overall.reach_pct(),
+            self.team.overall.precision_pct(),
+            self.team.histogram.render(),
+            self.team_run_id,
+        ));
+        out.push_str(&format!(
+            "delta:     reach {:+.1} pts ({})   precision {:+.1} pts ({})   [margin {:.1} pts]\n",
+            self.reach_delta_pct,
+            move_label(self.reach_move),
+            self.precision_delta_pct,
+            move_label(self.precision_move),
+            self.margin_pct,
+        ));
+        out.push_str(&format!("verdict:   {}\n", self.verdict.label()));
+        out.push_str(&format!("signal:    {}\n", self.signal_line()));
+        out.push_str(&format!("note:      {}", self.note));
+        out
+    }
+}
+
+fn move_label(m: MetricMove) -> &'static str {
+    match m {
+        MetricMove::Improved => "improved",
+        MetricMove::Regressed => "regressed",
+        MetricMove::Flat => "flat",
+    }
+}
+
+fn build_note(
+    verdict: Verdict,
+    offline_scaffold: bool,
+    reach_delta: f64,
+    precision_delta: f64,
+    margin_pct: f64,
+) -> String {
+    let interpretation = match verdict {
+        Verdict::TeamBeatsBaseline => format!(
+            "multi-agent team measurably beats the single-model baseline \
+             (Δreach {reach_delta:+.1}, Δprecision {precision_delta:+.1} pts; margin {margin_pct:.1})"
+        ),
+        Verdict::BaselineBeatsTeam => format!(
+            "single-model baseline measurably beats the team — the multi-agent scaffold is a net \
+             regression here (Δreach {reach_delta:+.1}, Δprecision {precision_delta:+.1} pts; \
+             margin {margin_pct:.1})"
+        ),
+        Verdict::Tie => format!(
+            "no measurable difference — both headline metrics stayed within ±{margin_pct:.1} pts"
+        ),
+        Verdict::MixedTradeoff => format!(
+            "reach/precision trade-off — the team improves one headline metric beyond the margin \
+             but regresses the other (Δreach {reach_delta:+.1}, Δprecision {precision_delta:+.1} \
+             pts; margin {margin_pct:.1}); no dominant winner"
+        ),
+    };
+    if offline_scaffold {
+        format!(
+            "{interpretation}. OFFLINE SCAFFOLD (mock oracle) — this exercises the head-to-head \
+             measurement contract; a real baseline-vs-team result needs a `coin evaluate` grade on \
+             a provisioned host (Phase 3, #2823). LOCAL-ONLY."
+        )
+    } else {
+        interpretation
+    }
+}

--- a/src/coin_gym/mod.rs
+++ b/src/coin_gym/mod.rs
@@ -20,6 +20,7 @@
 //! [`improve_loop`] behind `coin-gym improve --holdout fresh`.
 
 pub mod agent_runner;
+pub mod benchmark;
 pub mod executor;
 pub mod improve;
 pub mod improve_loop;
@@ -31,6 +32,8 @@ pub mod types;
 
 #[cfg(test)]
 mod tests_agent_runner;
+#[cfg(test)]
+mod tests_benchmark;
 #[cfg(test)]
 mod tests_cli;
 #[cfg(test)]
@@ -54,6 +57,7 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use agent_runner::{AgentRunner, BaselineStrategy, FixtureReasoner, TeamStrategy};
+use benchmark::{DEFAULT_MARGIN_PCT, HeadToHead};
 use executor::{
     ANSWER_BLOB_BIN, ANSWER_BLOB_HARNESS, ANSWER_UNREACHABLE_MD, CoinEvaluateConfig,
     CoinEvaluateExecutor, EvaluateSource, LOCAL_ONLY, MockHarnessExecutor,
@@ -73,6 +77,7 @@ pub fn coin_gym_usage() -> &'static str {
      \n\
      commands:\n\
      \x20 run <model> [--strategy baseline|team] [--profile <name>] [--targets <path>]\n\
+     \x20 benchmark <model> [--profile <name>] [--targets <path>] [--margin <pct>] [--json]\n\
      \x20 score <run-id> [--profile <name>]\n\
      \x20 compare <run-id> [--profile <name>]\n\
      \x20 improve <run-id> [--profile <name>] [--holdout fresh]\n\
@@ -80,7 +85,10 @@ pub fn coin_gym_usage() -> &'static str {
      \x20 profiles\n\
      \n\
      Offline scaffold (Phase 4): runs grade against a mock oracle. Live grading\n\
-     needs `coin evaluate` on a Docker host (Phase 3, issue #2823). `improve\n\
+     needs `coin evaluate` on a Docker host (Phase 3, issue #2823). `benchmark`\n\
+     runs the single-model baseline and the multi-agent team head-to-head on one\n\
+     target set and prints whether the team *measurably* beats the baseline\n\
+     (`--json` emits the Signal milestone-report payload). `improve\n\
      --holdout fresh` runs the Phase-5 self-improvement loop (failure-analyst →\n\
      overfitting gate → verify on held-out fresh → keep/rollback + durable tactic\n\
      memory) offline. `contract` prints the real coin evaluate/verify wiring\n\
@@ -115,6 +123,7 @@ where
     let rest = &argv[1..];
     match command.as_str() {
         "run" => cmd_run(home, rest),
+        "benchmark" => cmd_benchmark(home, rest),
         "score" => cmd_score(home, rest),
         "compare" => cmd_compare(home, rest),
         "improve" => cmd_improve(home, rest),
@@ -263,6 +272,84 @@ pub(crate) fn execute_run(
             AgentRunner::new(&s, &executor, model, snapshot).run(&scenario.targets.pinned)
         }
     }
+}
+
+// ── benchmark ────────────────────────────────────────────────────────────────
+
+/// Run the single-model **baseline** and the multi-agent **team** head-to-head
+/// on one target set and report whether the team *measurably* beats the
+/// baseline — the goal's done-gate. Persists both runs under the profile (so
+/// `score`/`compare`/`improve` can reuse them for the iterative climb) and, with
+/// `--json`, emits the machine-readable Signal milestone-report payload.
+fn cmd_benchmark(home: &Path, rest: &[String]) -> CoinGymResult<()> {
+    // `--json` is a bare boolean switch; strip it before the value-pairing parser
+    // (which requires every `--flag` to be followed by a value).
+    let mut as_json = false;
+    let filtered: Vec<String> = rest
+        .iter()
+        .filter(|a| {
+            if a.as_str() == "--json" {
+                as_json = true;
+                false
+            } else {
+                true
+            }
+        })
+        .cloned()
+        .collect();
+    let parsed = parse_args(&filtered, &["profile", "targets", "margin"])?;
+    let model = parsed
+        .positionals
+        .first()
+        .ok_or_else(|| CoinGymError::Usage("benchmark: expected <model>".to_string()))?
+        .clone();
+    let margin = match parsed.flags.get("margin") {
+        Some(v) => {
+            let m: f64 = v.parse().map_err(|_| {
+                CoinGymError::Usage(format!("--margin expects a number (got '{v}')"))
+            })?;
+            if !m.is_finite() || m < 0.0 {
+                return Err(CoinGymError::Usage(format!(
+                    "--margin must be a non-negative number (got '{v}')"
+                )));
+            }
+            m
+        }
+        None => DEFAULT_MARGIN_PCT,
+    };
+    let scenario = match parsed.flags.get("targets") {
+        Some(path) => DemoScenario::from_path(Path::new(path))?,
+        None => DemoScenario::sample()?,
+    };
+    validate_offline_scenario(&scenario)?;
+    let profile_name = parsed.flags.get("profile").map_or_else(
+        || profiles::sanitize_name(&model),
+        |p| profiles::sanitize_name(p),
+    );
+
+    let baseline_report = execute_run(&model, Strategy::Baseline, &scenario)?;
+    let team_report = execute_run(&model, Strategy::Team, &scenario)?;
+    let head_to_head = HeadToHead::from_reports(&baseline_report, &team_report, margin);
+
+    ensure_profile(home, &profile_name, &model)?;
+    for report in [&baseline_report, &team_report] {
+        let persisted = PersistedRun {
+            report: report.clone(),
+            targets: scenario.targets.clone(),
+            offline: scenario.offline_scaffold(),
+        };
+        save_run(home, &profile_name, &persisted)?;
+    }
+
+    if as_json {
+        let json = serde_json::to_string_pretty(&head_to_head)
+            .map_err(|e| CoinGymError::Parse(format!("serialize head-to-head: {e}")))?;
+        println!("{json}");
+    } else {
+        println!("profile:   {profile_name}");
+        println!("{}", head_to_head.render());
+    }
+    Ok(())
 }
 
 // ── score ────────────────────────────────────────────────────────────────────

--- a/src/coin_gym/tests_benchmark.rs
+++ b/src/coin_gym/tests_benchmark.rs
@@ -1,0 +1,199 @@
+//! Unit tests for the head-to-head baseline-vs-team benchmark.
+
+use super::benchmark::{DEFAULT_MARGIN_PCT, HeadToHead, MetricMove, Verdict};
+use super::execute_run;
+use super::target_loader::DemoScenario;
+use super::types::{Outcome, OutcomeCode, RunReport, Strategy, TargetFamily};
+
+/// Build a synthetic report from a list of outcome codes (all `frontier`; family
+/// does not affect the overall reach/precision the verdict keys off).
+fn report(model: &str, strategy: Strategy, codes: &[OutcomeCode]) -> RunReport {
+    let outcomes = codes
+        .iter()
+        .enumerate()
+        .map(|(i, &code)| Outcome {
+            target_id: format!("t{i}"),
+            family: TargetFamily::Frontier,
+            code,
+            cost_usd: 0.0,
+        })
+        .collect();
+    RunReport {
+        run_id: format!("{}-{}-0-0", model, strategy.label()),
+        model: model.to_string(),
+        strategy,
+        snapshot: "you/coin@v1-sample".to_string(),
+        started_at_unix_ms: 0,
+        outcomes,
+        offline_scaffold: true,
+    }
+}
+
+use OutcomeCode::{Abstained, NoSubmission, Reached, WrongInput};
+
+#[test]
+fn metric_move_classifies_against_margin() {
+    assert_eq!(MetricMove::classify(5.0, 1.0), MetricMove::Improved);
+    assert_eq!(MetricMove::classify(-5.0, 1.0), MetricMove::Regressed);
+    assert_eq!(MetricMove::classify(0.0, 1.0), MetricMove::Flat);
+    // Exactly at the margin is NOT measurable (strict inequality).
+    assert_eq!(MetricMove::classify(1.0, 1.0), MetricMove::Flat);
+    assert_eq!(MetricMove::classify(-1.0, 1.0), MetricMove::Flat);
+    assert_eq!(MetricMove::classify(1.0001, 1.0), MetricMove::Improved);
+}
+
+#[test]
+fn verdict_covers_all_quadrants() {
+    use MetricMove::{Flat, Improved, Regressed};
+    assert_eq!(
+        Verdict::from_moves(Flat, Improved),
+        Verdict::TeamBeatsBaseline
+    );
+    assert_eq!(
+        Verdict::from_moves(Improved, Flat),
+        Verdict::TeamBeatsBaseline
+    );
+    assert_eq!(
+        Verdict::from_moves(Regressed, Flat),
+        Verdict::BaselineBeatsTeam
+    );
+    assert_eq!(Verdict::from_moves(Flat, Flat), Verdict::Tie);
+    assert_eq!(
+        Verdict::from_moves(Improved, Regressed),
+        Verdict::MixedTradeoff
+    );
+    assert!(Verdict::TeamBeatsBaseline.is_team_win());
+    assert!(!Verdict::MixedTradeoff.is_team_win());
+    assert!(!Verdict::Tie.is_team_win());
+    assert!(!Verdict::BaselineBeatsTeam.is_team_win());
+}
+
+#[test]
+fn sample_scenario_team_measurably_beats_baseline() {
+    let scenario = DemoScenario::sample().unwrap();
+    let baseline = execute_run("claude-opus-4.6", Strategy::Baseline, &scenario).unwrap();
+    let team = execute_run("claude-opus-4.6", Strategy::Team, &scenario).unwrap();
+    let h2h = HeadToHead::from_reports(&baseline, &team, DEFAULT_MARGIN_PCT);
+
+    // Reach ties at 60%; precision climbs 60% → 100% via the abstain gate.
+    assert!((h2h.reach_delta_pct - 0.0).abs() < 1e-9);
+    assert!((h2h.precision_delta_pct - 40.0).abs() < 1e-9);
+    assert_eq!(h2h.reach_move, MetricMove::Flat);
+    assert_eq!(h2h.precision_move, MetricMove::Improved);
+    assert_eq!(h2h.verdict, Verdict::TeamBeatsBaseline);
+    assert!(h2h.verdict.is_team_win());
+    assert!(h2h.offline_scaffold);
+    assert_eq!(h2h.baseline_run_id, baseline.run_id);
+    assert_eq!(h2h.team_run_id, team.run_id);
+}
+
+#[test]
+fn baseline_beats_team_when_team_regresses_both() {
+    let baseline = report("m", Strategy::Baseline, &[Reached, Reached]);
+    let team = report("m", Strategy::Team, &[Reached, WrongInput]);
+    let h2h = HeadToHead::from_reports(&baseline, &team, DEFAULT_MARGIN_PCT);
+    // baseline reach 100/prec 100; team reach 50/prec 50.
+    assert_eq!(h2h.reach_move, MetricMove::Regressed);
+    assert_eq!(h2h.precision_move, MetricMove::Regressed);
+    assert_eq!(h2h.verdict, Verdict::BaselineBeatsTeam);
+}
+
+#[test]
+fn tie_when_both_within_margin() {
+    let baseline = report("m", Strategy::Baseline, &[Reached, WrongInput]);
+    let team = report("m", Strategy::Team, &[Reached, WrongInput]);
+    let h2h = HeadToHead::from_reports(&baseline, &team, DEFAULT_MARGIN_PCT);
+    assert_eq!(h2h.verdict, Verdict::Tie);
+    assert!((h2h.reach_delta_pct).abs() < 1e-9);
+    assert!((h2h.precision_delta_pct).abs() < 1e-9);
+}
+
+#[test]
+fn mixed_tradeoff_when_reach_up_but_precision_down() {
+    // baseline: reach 25% (1/4), precision 100% (1/1 submitted; 3 abstain).
+    let baseline = report(
+        "m",
+        Strategy::Baseline,
+        &[Reached, Abstained, Abstained, Abstained],
+    );
+    // team: reach 50% (2/4), precision 50% (2/4 submitted).
+    let team = report(
+        "m",
+        Strategy::Team,
+        &[Reached, Reached, WrongInput, WrongInput],
+    );
+    let h2h = HeadToHead::from_reports(&baseline, &team, DEFAULT_MARGIN_PCT);
+    assert_eq!(h2h.reach_move, MetricMove::Improved);
+    assert_eq!(h2h.precision_move, MetricMove::Regressed);
+    assert_eq!(h2h.verdict, Verdict::MixedTradeoff);
+}
+
+#[test]
+fn negative_margin_is_clamped_to_zero() {
+    let baseline = report("m", Strategy::Baseline, &[Reached, WrongInput]);
+    let team = report("m", Strategy::Team, &[Reached, Abstained]);
+    let h2h = HeadToHead::from_reports(&baseline, &team, -5.0);
+    assert!((h2h.margin_pct - 0.0).abs() < 1e-9);
+    // precision 50% → 100% is measurable even at margin 0.
+    assert_eq!(h2h.verdict, Verdict::TeamBeatsBaseline);
+}
+
+#[test]
+fn no_submission_does_not_inflate_precision_denominator() {
+    // A NoSubmission is neither reached nor submitted; precision keys off
+    // submitted only, so team abstaining/no-submitting protects precision.
+    let baseline = report(
+        "m",
+        Strategy::Baseline,
+        &[Reached, WrongInput, NoSubmission],
+    );
+    let team = report("m", Strategy::Team, &[Reached, Abstained, NoSubmission]);
+    let h2h = HeadToHead::from_reports(&baseline, &team, DEFAULT_MARGIN_PCT);
+    // baseline precision 1/2 = 50%; team precision 1/1 = 100%.
+    assert!((h2h.precision_delta_pct - 50.0).abs() < 1e-9);
+    assert_eq!(h2h.verdict, Verdict::TeamBeatsBaseline);
+}
+
+#[test]
+fn head_to_head_json_round_trips_and_carries_payload() {
+    let baseline = report(
+        "claude-opus-4.6",
+        Strategy::Baseline,
+        &[Reached, WrongInput],
+    );
+    let team = report("claude-opus-4.6", Strategy::Team, &[Reached, Abstained]);
+    let h2h = HeadToHead::from_reports(&baseline, &team, DEFAULT_MARGIN_PCT);
+    let json = serde_json::to_string(&h2h).unwrap();
+    // The Signal milestone payload carries the verdict, deltas, and both scores.
+    assert!(json.contains("\"verdict\":\"team-beats-baseline\""));
+    assert!(json.contains("\"precision_delta_pct\""));
+    assert!(json.contains("\"baseline\""));
+    assert!(json.contains("\"team\""));
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["model"], "claude-opus-4.6");
+}
+
+#[test]
+fn signal_line_names_model_snapshot_and_verdict() {
+    let baseline = report("gpt-5.4", Strategy::Baseline, &[Reached, WrongInput]);
+    let team = report("gpt-5.4", Strategy::Team, &[Reached, Abstained]);
+    let h2h = HeadToHead::from_reports(&baseline, &team, DEFAULT_MARGIN_PCT);
+    let line = h2h.signal_line();
+    assert!(line.contains("gpt-5.4"));
+    assert!(line.contains("you/coin@v1-sample"));
+    assert!(line.contains("TEAM-BEATS-BASELINE"));
+    assert!(line.contains("offline scaffold"));
+}
+
+#[test]
+fn render_shows_both_strategies_and_verdict() {
+    let scenario = DemoScenario::sample().unwrap();
+    let baseline = execute_run("m", Strategy::Baseline, &scenario).unwrap();
+    let team = execute_run("m", Strategy::Team, &scenario).unwrap();
+    let text = HeadToHead::from_reports(&baseline, &team, DEFAULT_MARGIN_PCT).render();
+    assert!(text.contains("baseline:"));
+    assert!(text.contains("team:"));
+    assert!(text.contains("delta:"));
+    assert!(text.contains("verdict:"));
+    assert!(text.contains("TEAM-BEATS-BASELINE"));
+}

--- a/src/coin_gym/tests_cli.rs
+++ b/src/coin_gym/tests_cli.rs
@@ -182,9 +182,100 @@ fn explicit_profile_name_is_sanitised() {
 #[test]
 fn usage_lists_all_subcommands() {
     let usage = coin_gym_usage();
-    for cmd in ["run", "score", "compare", "improve", "contract", "profiles"] {
+    for cmd in [
+        "run",
+        "benchmark",
+        "score",
+        "compare",
+        "improve",
+        "contract",
+        "profiles",
+    ] {
         assert!(usage.contains(cmd), "usage should mention {cmd}");
     }
+}
+
+#[test]
+fn benchmark_command_persists_two_runs_and_reports_verdict() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    dispatch_with_home(
+        home,
+        args(&["benchmark", "claude-opus-4.6", "--profile", "duel"]),
+    )
+    .unwrap();
+
+    // Exactly two runs are persisted (baseline + team) under the profile.
+    let runs = runs_dir(home, "duel");
+    let entries: Vec<_> = std::fs::read_dir(&runs)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .collect();
+    assert_eq!(entries.len(), 2, "baseline + team runs should be persisted");
+}
+
+#[test]
+fn benchmark_json_and_margin_flags_are_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // Bare `--json` switch plus an explicit margin.
+    dispatch_with_home(
+        home,
+        args(&[
+            "benchmark",
+            "claude-opus-4.6",
+            "--profile",
+            "duel",
+            "--margin",
+            "2.5",
+            "--json",
+        ]),
+    )
+    .unwrap();
+    let runs = runs_dir(home, "duel");
+    let count = std::fs::read_dir(&runs)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .count();
+    assert_eq!(count, 2);
+}
+
+#[test]
+fn benchmark_requires_model() {
+    let dir = tempfile::tempdir().unwrap();
+    let err = dispatch_with_home(dir.path(), args(&["benchmark"])).unwrap_err();
+    assert!(err.to_string().contains("expected <model>"));
+}
+
+#[test]
+fn benchmark_rejects_bad_margin() {
+    let dir = tempfile::tempdir().unwrap();
+    for bad in ["-1", "abc"] {
+        let err =
+            dispatch_with_home(dir.path(), args(&["benchmark", "m", "--margin", bad])).unwrap_err();
+        assert!(
+            err.to_string().contains("--margin"),
+            "should reject margin '{bad}'"
+        );
+    }
+}
+
+#[test]
+fn benchmark_rejects_empty_pinned_manifest() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = write_manifest(
+        dir.path(),
+        "empty.json",
+        r#"{"snapshot":"s","targets":{"pinned":[],"held_out_fresh":[]}}"#,
+    );
+    let err = dispatch_with_home(
+        dir.path(),
+        args(&["benchmark", "m", "--targets", &manifest]),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("no pinned targets"));
 }
 
 fn write_manifest(dir: &std::path::Path, name: &str, body: &str) -> String {

--- a/tests/qa-scenarios/coin-gym-benchmark-verdict.yaml
+++ b/tests/qa-scenarios/coin-gym-benchmark-verdict.yaml
@@ -1,0 +1,32 @@
+name: simard-coin-gym-benchmark-verdict
+app_type: cli
+description: |
+  Verify `coin-gym benchmark` runs the single-model baseline and the multi-agent
+  team head-to-head on the bundled sample snapshot and reports the goal's
+  done-gate verdict: the multi-agent team *measurably* beats the single-model
+  baseline. On the sample, reach ties at 60% but the team's abstain gate lifts
+  precision 60% -> 100%, so the verdict is TEAM-BEATS-BASELINE. The scenario also
+  exercises the `--json` Signal milestone-report payload.
+
+  Schema note: the pinned @gadugi/agentic-test CLI runner only gates on run-step
+  exit codes and reads command text from params.command, so the assertions are
+  encoded in a `bash -lc` wrapper that exits zero only when (a) the human verdict
+  line is TEAM-BEATS-BASELINE with precision 100.0%, and (b) the JSON payload
+  carries "verdict": "team-beats-baseline". A temp COIN_GYM_HOME keeps the run
+  hermetic (no leaked profiles under target/coin-gym).
+metadata:
+  tags:
+    - cli
+    - coin-gym
+agents:
+  - name: cli-agent
+    type: cli
+    command: bash
+steps:
+  # Build once, then run the human and JSON benchmarks against a temp home. The
+  # wrapper fails (non-zero exit) if any expected assertion string is missing, so
+  # the runner's exit-code gate enforces the verdict end-to-end.
+  - action: run
+    params:
+      command: "bash -lc 'set -e; H=$(mktemp -d); HUMAN=$(COIN_GYM_HOME=$H cargo run --quiet --bin coin-gym -- benchmark claude-opus-4.6 --profile qa 2>&1); echo \"$HUMAN\"; echo \"$HUMAN\" | grep -q \"verdict:   TEAM-BEATS-BASELINE\"; echo \"$HUMAN\" | grep -q \"precision 100.0%\"; JSON=$(COIN_GYM_HOME=$H cargo run --quiet --bin coin-gym -- benchmark claude-opus-4.6 --profile qajson --json 2>&1); echo \"$JSON\"; echo \"$JSON\" | grep -q \"\\\"verdict\\\": \\\"team-beats-baseline\\\"\"; echo \"$JSON\" | grep -q \"\\\"precision_delta_pct\\\": 40.0\"'"
+    timeout: 600000


### PR DESCRIPTION
## Why

The COIN Gym harness could run the `baseline` and `team` strategies **separately**
(`coin-gym run <model> --strategy …`), but there was **no single command** that
runs both head-to-head on the *same* target set and renders a verdict on whether
the multi-agent team **measurably beats** the single-model baseline. That verdict
is the goal's stated done-gate ("multiagent measurably above baseline") and the
payload for the Signal milestone report. This PR delivers it.

## What

New command:

```
coin-gym benchmark <model> [--profile <name>] [--targets <path>] [--margin <pct>] [--json]
```

- Runs **baseline** and **team** on the same target set; scores both.
- Diffs COIN's two headline metrics — **reach** and **precision** — against a
  material `--margin` (default `1.0` pts) and classifies:
  `TEAM-BEATS-BASELINE` / `BASELINE-BEATS-TEAM` / `TIE` / `MIXED-TRADEOFF`.
- **Persists both runs** under the profile, so the baseline feeds straight into
  `improve --holdout fresh` — the iterative climb.
- `--json` emits the machine-readable head-to-head as the **Signal
  milestone-report payload**; a `signal:` one-liner aids posting.

On the bundled sample the team ties reach at 60% but the abstain gate lifts
precision 60% → 100%, so the verdict is **`TEAM-BEATS-BASELINE`** — the
skwaq-style precision win, now a first-class, reportable result:

```text
baseline:  reach 60.0%  precision 60.0%   R:3/W:2/A:0/T:0/N:0/E:0   [claude-opus-4-6-baseline-…]
team:      reach 60.0%  precision 100.0%  R:3/W:0/A:2/T:0/N:0/E:0   [claude-opus-4-6-team-…]
delta:     reach +0.0 pts (flat)   precision +40.0 pts (improved)   [margin 1.0 pts]
verdict:   TEAM-BEATS-BASELINE
signal:    COIN Gym (offline scaffold): claude-opus-4.6 — team vs baseline on you/coin@v1-sample → TEAM-BEATS-BASELINE (Δreach +0.0, Δprecision +40.0 pts)
```

Offline scaffold (Phase 4): the grade is a mock oracle — a *real* baseline-vs-team
result needs a `coin evaluate` grade on the Phase-3 VM (#2823). **LOCAL-ONLY.**

## Verdict rule (deltas = team − baseline, margin `m`)

`improve`d if `delta > m`, `regress`ed if `delta < −m`, else `flat`.
- improves ≥1 metric & regresses none → **TEAM-BEATS-BASELINE**
- regresses ≥1 & improves none → **BASELINE-BEATS-TEAM**
- improves one & regresses the other → **MIXED-TRADEOFF**
- neither → **TIE**

## Merge-ready evidence

**1. qa-team scenarios (gadugi-test validate + run).**
New scenario `tests/qa-scenarios/coin-gym-benchmark-verdict.yaml` drives the CLI
end-to-end and asserts the `TEAM-BEATS-BASELINE` verdict + JSON payload.
- `gadugi-test validate -f …` → `✓ Scenario "simard-coin-gym-benchmark-verdict" is valid`
- `gadugi-test run -d <tmp>` → `✓ Passed: 1  ✗ Failed: 0` (exit 0, verdict confirmed live)

**2. Docs updated (user-facing surface = new CLI command).**
- `docs/howto/run-the-coin-gym-harness.md` — new **`benchmark`** section (verdict
  table, sample output, `--json`/`--margin`, iterative-climb tie-in) + commands list.
- `docs/research/coin-benchmark-and-skwaq-study.md` — CLI sketch (3.5) updated.

**3. Quality-audit (SEEK→VALIDATE→FIX, ended clean).**
Reviewed edge cases: precision denominator = 0 (uses the harness's existing
`ratio` 0-convention → all-abstain vs all-wrong ties, consistent with the scorer);
strict-vs-margin boundary (exactly `m` = flat, tested); negative/NaN/inf `--margin`
rejected at the CLI and clamped in the pure API; bare `--json` stripped before the
value-pairing parser; both runs persisted with matching targets/offline-scaffold.
No unrelated code touched. Final cycle clean.

**4. CI-equivalent checks green locally.**
- `cargo test --lib coin_gym` → **128 passed; 0 failed** (16 new: 11 benchmark
  unit + 5 CLI).
- `cargo clippy --all-targets --all-features --locked -- -D warnings` → clean.
- `cargo fmt --check` → clean.
- `cargo build --bin coin-gym` → ok; manual human + `--json` runs verified.

**6. Diff focused.** 3 new files (`benchmark.rs`, `tests_benchmark.rs`, the qa
scenario) + surgical edits to `mod.rs` (module decl, dispatch, usage,
`cmd_benchmark`), `tests_cli.rs` (usage assertion + 5 tests), and two docs. No
unrelated edits.

## Scope note

This is the **offline** head-to-head measurement contract (Phase 4). The *real*
baseline-vs-team leaderboard delta still depends on the Phase-3 `azlin` VM
(#2823); `benchmark` labels every offline run explicitly and never submits
externally.

Advances #2825.
