### PR TITLE
feat(identity,ooda): first-class read-only observer posture (#3125)

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: issue-2323-eliminate-the-private-gymeval-fork-in-simard-by-ad
+## Project: Simard
 
 ## Overview
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/docs/concepts/identity-write-authority.md
+++ b/docs/concepts/identity-write-authority.md
@@ -1,0 +1,190 @@
+---
+title: Identity write-authority — cognition-level observer posture
+description: Why Simard enforces a read-only OBSERVER identity at the cognition level (which goals to seed, whether the Act phase may dispatch engineers at all) instead of relying on destructive-op guardrails that never enforced read-only, so a read-only identity never seeds Simard's goals, dispatches doomed engineers, or writes to a repo it should only observe.
+last_updated: 2026-07-08
+owner: simard
+doc_type: concept
+related:
+  - ./pluggable-identity.md
+  - ./operational-autonomy-model.md
+  - ./goal-board-persistence.md
+  - ../reference/identity-posture-observer.md
+  - ../reference/goal-target-repo-routing.md
+  - ../howto/configure-observer-identity.md
+---
+
+# Identity write-authority — cognition-level observer posture
+
+## The problem: a read-only guard that fires too late
+
+Simard is an autonomous OODA daemon. [Pluggable identity](./pluggable-identity.md)
+lets a different persona drive the daemon — for example, a **Crocutus** identity
+whose job is to *observe* a set of Azure DevOps repositories (the "hyenas") and
+articulate repo-hygiene goals, **without changing any software**.
+
+Before issue [#3125](https://github.com/rysweet/Simard/issues/3125), write
+authority was **not a property of identity at all**. Whatever persona drove the
+daemon, cognition was always Simard's: it seeded Simard's goals and its Act
+phase dispatched write-bearing engineers.
+
+The only pre-existing guards on this branch are *destructive-operation*
+guardrails — `git_guardrails::check_git_safety` (gated by
+`SIMARD_GIT_GUARDRAILS`) and `ado_acl_guard::check_ado_acl_safety`. They block
+force-push, `reset --hard`, branch deletion, and ADO ACL escalation, but they
+**still permit ordinary commits, branches, and PRs**. They are a
+destructive-command backstop, **not** a read-only floor.
+
+!!! note "Relationship to #3071"
+    A separate effort, PR [#3071](https://github.com/rysweet/Simard/pull/3071),
+    added an *env-driven* observe-only floor (`read_only_guard` /
+    `SIMARD_OBSERVE_ONLY`), tracked toward this typed design in
+    [#3067](https://github.com/rysweet/Simard/issues/3067). **#3071 is not in
+    this branch's base**, so that floor is absent here — which is exactly why
+    cognition-level enforcement must carry the guarantee. The typed
+    `write_authority` posture is #3071's successor: if the branch is later
+    rebased onto #3071, the typed rail **supersedes** its env-keyed
+    `dispatch_spawn_engineer` short-circuit (posture is the source of truth; the
+    env var may remain only as an operator override). See the
+    [reference design-status note](../reference/identity-posture-observer.md).
+
+Consider the **Crocutus** read-only identity running on this base. With
+cognition still Simard's, the daemon would:
+
+1. Seed **Simard's** baked-in `DEFAULT_SEED_GOALS`
+   (`self-serve-dashboard-improvement`, `improve-amplihack-test-coverage`,
+   `fix-broken-features`, `improve-cognitive-memory-persistence`,
+   `enhance-simard-meeting-experience`) — not repo-hygiene goals for the hyenas.
+2. In the Act phase, dispatch **write-bearing engineers** against
+   `rysweet/Simard` — trying to **change software** rather than **observe
+   hyenas**.
+3. Actually **make those changes**: the destructive-op guardrails would let the
+   ordinary commits and PRs through, because nothing on this base enforces
+   read-only.
+
+So the identity is read-only in name only: read-write in the head, and — absent
+a read-only floor — read-write at the hands too. Even a credits-only view is
+bad: the daemon burns AI credits planning and dispatching engineers that never
+belonged to this persona.
+
+## The insight: posture belongs in cognition, not just at the chokepoint
+
+A read-only OBSERVER should never *decide* to dispatch a write-bearing engineer
+in the first place. The fix makes **write authority a first-class property of
+identity** and enforces it where the decisions are made:
+
+- **Which goals get seeded** — an identity declares its *own* seed goals, scoped
+  to its *own* target repos, replacing Simard's defaults.
+- **Whether the Act phase may dispatch engineers at all** — a read-only posture
+  runs an *observe-only* Act branch that records observations and proposes
+  goals, and is structurally incapable of dispatching an engineer.
+
+This is **cognition-level enforcement** — and on this branch it is what makes
+read-only *real*. The destructive-op guardrails stay where they are as a
+residual backstop; they were never a read-only boundary.
+
+## Write authority as identity posture
+
+An identity now carries a `write_authority` posture:
+
+| Posture | Meaning | Act phase |
+|---------|---------|-----------|
+| `read-write` (**default**) | Full authority — Simard's historical behavior | Engineer-dispatching `act()` |
+| `read-only` | Observe-only | `act_observe_only()` — records observations, proposes goals, **never** dispatches |
+
+The default is `read-write`, so **Simard herself is unchanged**: no identity, or
+a `read-write` identity, keeps the same five seed goals and the same
+engineer-dispatching Act phase. This invariant is proven by test (see
+[acceptance criteria](../reference/identity-posture-observer.md#acceptance-criteria)).
+
+## Three principles
+
+### 1. Keep the decision agentic, keep the guarantee deterministic
+
+*What to observe* and *what goals to propose* are genuinely open questions — they
+belong to a reasoner behind the `ObserveOnlyBrain` trait (the current wired
+baseline is a deterministic floor, `DeterministicObserveBrain`; a prompt-backed
+brain can replace it without touching the rail). But *"a read-only identity must
+never spawn an engineer"* is a hard invariant, so it sits behind a **thin
+deterministic rail** in `dispatch_spawn_engineer` that hard-blocks the spawn
+when posture is read-only. This mirrors the existing pattern in `spawn.rs`,
+where an agentic brain decision is backed by a deterministic 3-strikes
+safeguard.
+
+### 2. Defense in depth — two new layers over a residual backstop
+
+```mermaid
+flowchart LR
+    L1["L1 cognition branch (new)<br/>act_observe_only()"] --> L2["L2 deterministic rail (new)<br/>dispatch_spawn_engineer"]
+    L2 --> L3["residual backstop (pre-existing)<br/>destructive-op guardrails"]
+```
+
+- **L1** stops Simard from even *considering* a write-bearing engineer (saves
+  credits and, on this base, prevents any write at all).
+- **L2** is a deterministic backstop if any decision path reaches spawn.
+- The **residual backstop** is the pre-existing destructive-op guardrails
+  (`git_guardrails::check_git_safety`, `ado_acl_guard::check_ado_acl_safety`),
+  untouched — a last-ditch guard against *destructive* commands, not a read-only
+  floor.
+
+L1 and L2 are independent, and each is independent of the residual backstop. A
+regression in one does not defeat the others.
+
+### 3. Fail closed, never silently degrade
+
+Write authority is resolved **once at daemon boot** (`resolve_boot_posture`) and
+threaded into the OODA state (`OodaState.write_authority` / `observer_targets` /
+`identity_seed_goals`) — never re-derived per cycle, so it can't drift. The
+resolution is deterministic:
+
+| Situation | Posture | Reasoning |
+|-----------|---------|-----------|
+| No identity (`SIMARD_IDENTITY_PATH` unset) | `read-write` | A *determined* state — this is Simard herself (preserves the no-behavior-change invariant). |
+| Read-write / read-only identity resolved | as declared | Honor the manifest. |
+| Identity present but posture **unresolvable** | `read-only`, no-spawn | *Undetermined* ⇒ fail closed. If we cannot prove authority, we do not act. |
+
+Note the asymmetry: **absence** of an identity is safe-by-design (Simard), but a
+**present-yet-unreadable** posture is treated as read-only. There are no
+wall-clock timeouts on agentic steps, and no fallback to read-write — consistent
+with Simard's honest-degradation pillar.
+
+## Target scope, not Simard scope
+
+A read-only identity's goals and observations are scoped to its **target repo
+set** (`targets` in `identity.toml`), reusing the same per-goal target-repo slug
+mechanism documented in
+[Goal target-repo routing](../reference/goal-target-repo-routing.md). A
+read-only seed goal that names a repo outside `targets` — or names no repo at
+all — is a **fail-closed config error**; it is *never* silently re-scoped to
+`rysweet/Simard`. So Crocutus observes the hyenas, and only the hyenas.
+
+## Depend, don't fork
+
+The whole feature lands in **Simard** (the framework). The Crocutus identity
+consumes it purely through **configuration and prompts** — its `identity.toml`
+sets `write_authority = "read-only"`, lists the hyenas repos in `targets`, and
+declares repo-hygiene seed goals. No Crocutus-side logic duplicates Simard's
+cognition. This keeps the surface small: the change is mostly identity config
+plus one agentic Act-phase branch behind a thin deterministic rail, not a new
+imperative subsystem.
+
+## What this is not
+
+- **Not a destructive-op guardrail.** `git_guardrails::check_git_safety` and
+  `ado_acl_guard::check_ado_acl_safety` only block destructive/escalation
+  commands; they remain as a residual backstop. This feature adds the *earlier*,
+  cognition-level read-only enforcement those guardrails never provided.
+- **Not a behavior change for Simard.** Default posture is `read-write`; the
+  five default seed goals and the engineer-dispatching Act phase are preserved.
+- **Not a Crocutus-specific mechanism.** Any identity can declare a read-only
+  posture, targets, and seed goals. Crocutus is just the first consumer.
+- **Not a new "Bridge".** The feature reuses the existing `OodaBridges` bundle
+  and introduces **no new** `Bridge` orchestration symbol. (`BridgeRequest`,
+  `BridgeResponse`, `BridgeId`, and friends already exist in `src/bridge.rs`;
+  this feature adds none.)
+
+## Related
+
+- Reference: [Identity write-authority & observer posture API](../reference/identity-posture-observer.md)
+- How-to: [Configure a read-only observer identity](../howto/configure-observer-identity.md)
+- [Pluggable identity — TOML-driven agent personas](./pluggable-identity.md)
+- [Operational autonomy model](./operational-autonomy-model.md)

--- a/docs/concepts/pluggable-identity.md
+++ b/docs/concepts/pluggable-identity.md
@@ -9,6 +9,8 @@ related:
   - ../howto/configure-pluggable-identity.md
   - ../reference/runtime-contracts.md
   - ../architecture/agent-composition.md
+  - ./identity-write-authority.md
+  - ../reference/identity-posture-observer.md
 ---
 
 # Pluggable identity — TOML-driven agent personas

--- a/docs/concepts/resource-aware-engineer-admission.md
+++ b/docs/concepts/resource-aware-engineer-admission.md
@@ -1,0 +1,188 @@
+---
+title: Resource-aware engineer admission — agentic admission under the count cap
+description: Why Simard weighs disk, build-cache size, and system load — not just engineer count — before spawning another engineer, and how a structured-reasoning brain step decides ADMIT / DEFER / RECLAIM-FIRST each cycle.
+last_updated: 2026-07-07
+owner: simard
+doc_type: concept
+related:
+  - ../reference/resource-aware-admission-api.md
+  - ../reference/ooda-resource-admission-recipe.md
+  - ../howto/configure-resource-aware-admission.md
+  - ./adaptive-scaling.md
+  - ./automated-disk-health.md
+  - ../reference/concurrent-engineer-dispatch.md
+---
+
+# Resource-aware engineer admission — agentic admission under the count cap
+
+## The incident: count-control is not resource-admission
+
+The [AIMD adaptive scaler](adaptive-scaling.md) bounds how many actions the OODA
+cycle dispatches concurrently, and the [concurrent-engineer
+dispatcher](../reference/concurrent-engineer-dispatch.md) holds a semaphore that
+caps how many engineers run at once. Both are **count controls**: they answer
+the question *"how many?"* — never *"can this host afford one more?"*
+
+On a busy self-improvement host, that gap bit hard. The scaler happily kept the
+engineer count under its ceiling while **40+ engineer worktrees** accumulated,
+each with its own `cargo` build cache. Parallel builds piled up, disk climbed to
+**91%**, and the next allocation tripped `ENOSPC` (No space left on device) —
+which kills recipes mid-flight and corrupts in-progress work.
+
+The AIMD scaler did nothing wrong. It was never told about disk. A count cap
+cannot see a full disk, a thrashing load average, or a build cache that has
+quietly grown to tens of gigabytes. **Bounding the count is necessary but not
+sufficient. Admission also has to weigh resources.**
+
+## The idea: agentic admission, not another threshold pile
+
+The naive fix is a wall of hardcoded `if disk > X && load > Y && cache > Z`
+heuristics in Rust. Simard deliberately does **not** do that. Thresholds rot,
+interact badly, and never capture the judgment call ("disk is high but the cache
+is reclaimable and load is low, so reclaim then retry").
+
+Instead, admission follows the same pattern already proven in the [engineer
+lifecycle brain](../reference/ooda-engineer-lifecycle-recipe.md): **the
+intelligence lives in a structured-reasoning prompt that the brain executes
+repeatedly**, and only a thin deterministic rail guards the one irreversible,
+safety-critical outcome.
+
+Before admitting a **fresh** engineer, the daemon:
+
+1. **Gathers a resource picture** — disk usage %, worktree/build-cache size,
+   1-minute load average, CPU count, and in-flight engineer count.
+2. **Asks the admission brain to reason** over that picture and choose one of
+   three outcomes.
+3. **Applies the decision**, subject to one hard rail.
+
+```
+                         fresh-engineer spawn request
+                                    │
+                     (already under the AIMD count cap)
+                                    │
+                    ┌───────────────▼────────────────┐
+                    │ gather_resource_admission_ctx() │  best-effort probes
+                    │  disk% · cache bytes · load ·   │  (any field → None on error)
+                    │  cpu count · in-flight count    │
+                    └───────────────┬────────────────┘
+                                    │
+                    ┌───────────────▼────────────────┐
+                    │  admission brain reasons        │  ← intelligence (prompt)
+                    │  ADMIT / DEFER / RECLAIM-FIRST  │
+                    └───────────────┬────────────────┘
+                                    │
+                    ┌───────────────▼────────────────┐
+                    │  HARD RAIL (thin, deterministic)│  ← safety (code)
+                    │  disk known AND ≥ ceiling →     │
+                    │  force DEFER regardless         │
+                    └───────────────┬────────────────┘
+                                    │
+              ┌─────────────────────┼─────────────────────┐
+              ▼                     ▼                     ▼
+           ADMIT                 DEFER              RECLAIM-FIRST
+     allocate worktree,     benign skip: no       run disk-health
+       spawn engineer       worktree, no          reclaim recipe,
+                            failure-count bump      then DEFER
+```
+
+## The three outcomes
+
+| Outcome | Meaning | Effect |
+|---|---|---|
+| **ADMIT** | Resources are healthy enough to add an engineer. | Continue to worktree allocation and spawn — the normal path. |
+| **DEFER** | Resources are tight; adding an engineer now is unwise. | **Benign skip**: no worktree allocated, the goal is retried next cycle, and the goal's failure counter is **not** incremented. |
+| **RECLAIM-FIRST** | Disk pressure is reclaimable (stale worktrees, build caches). | Invoke the existing [disk-health reclaim recipe](automated-disk-health.md), then DEFER this cycle and re-evaluate next cycle. |
+
+DEFER is the critical design point. A resource defer is **not a failure** — no
+progress was attempted and none was lost. It must never look like a stuck goal.
+See ["Why DEFER is a benign skip"](#why-defer-is-a-benign-skip) below.
+
+## Repeated structured thought
+
+Admission is not a one-time gate. The brain reasons **at every fresh-engineer
+admission**, so the decision tracks the live resource picture as it changes cycle
+to cycle. This is the same "repeated execution of structured thought" model the
+rest of the OODA brain uses: gather structured context → reason → apply → observe
+→ repeat. Nothing is memoized; each admission is judged on current conditions.
+
+## The one hard rail: an ENOSPC floor the brain cannot override
+
+Agentic reasoning is the right tool for the *judgment* ("is now a good time?"),
+but an irreversible `ENOSPC` crash is not a judgment call — it is a floor.
+
+So exactly one deterministic rail sits below the brain: a configurable **disk
+admission ceiling** (`SIMARD_DISK_ADMISSION_CEILING_PCT`, default **90%**). If
+the disk usage is successfully read **and** is at or above the ceiling, admission
+is refused (downgraded to DEFER) **regardless of what the brain decided**. An
+`ADMIT` from the model can only ever be made *more* conservative by the rail,
+never less. The model cannot talk the daemon into filling the disk.
+
+This is the *only* hardcoded threshold in the whole feature. Everything else is
+prompt-driven.
+
+### Fail-open on unknown
+
+The rail engages **only** on a *successful, over-ceiling* disk read. If the disk
+probe fails (transient `df` error, unusual platform), disk usage degrades to
+`None` — "unknown" — and the rail does **not** fire. The unknown is instead
+passed to the brain, which reasons about it. A spurious probe failure must never
+be able to deadlock all spawning; the layered protection (this rail plus the
+[≥95% emergency cleanup tier](automated-disk-health.md)) means unknown-disk is
+safe to let through to reasoning.
+
+The invariant, stated precisely:
+
+> **known-and-over-ceiling ⇒ DEFER. unknown ⇒ reasoner. Never known-over-ceiling ⇒ ADMIT. Never deadlock on unknown.**
+
+## Why DEFER is a benign skip
+
+The OODA cycle bumps a goal's failure counter whenever an action outcome reports
+`success = false`, and three strikes blocks the goal. A resource defer must sit
+entirely outside that machinery:
+
+- DEFER returns a **success outcome** (`success = true`) with
+  `detail = "deferred: resource pressure"`.
+- No worktree is allocated (so a deferred cycle cannot itself grow disk).
+- The goal's `goal_failure_counts` entry is untouched.
+- The goal is simply retried on the next cycle.
+
+Deferring is neither progress nor failure — it is a no-op skip driven by host
+conditions, not by anything wrong with the goal. Conflating it with failure
+would let a temporarily-full disk permanently block healthy goals, which is
+exactly the kind of silent degradation Simard forbids.
+
+## What this feature deliberately does **not** change
+
+- **The AIMD scaler is untouched.** Resource admission is *additive*: it runs
+  underneath the count cap, only for fresh-engineer spawns. If the count cap
+  already said no, admission never runs.
+- **No new reclaim logic.** RECLAIM-FIRST reuses the existing
+  [disk-health](automated-disk-health.md) reclaim recipe. There is one reclaim
+  implementation, not two.
+- **Live re-attach is exempt.** Admission gates only the *fresh spawn* path.
+  Re-attaching to an already-running engineer allocates no new resources, so it
+  is never gated.
+
+## Where it lives in the loop
+
+The gate sits inside `dispatch_spawn_engineer`
+(`src/ooda_actions/advance_goal/spawn.rs`), in the fresh-spawn path: after the
+live-engineer lifecycle branch, after the subordinate-depth recursion guard,
+under the AIMD count cap, and **before** the engineer worktree is allocated.
+Placing it before allocation is what guarantees a deferred cycle grows nothing.
+
+Both dispatch call sites — the concurrent dispatcher (under its AIMD permit) and
+the direct `advance_goal` path — inherit the gate automatically because it lives
+inside the shared dispatch function.
+
+## See also
+
+- [Resource-aware admission API reference](../reference/resource-aware-admission-api.md)
+  — the `OodaAdmissionBrain` trait, `ResourceAdmissionCtx`, `AdmissionDecision`,
+  the pure gate, and the hard rail.
+- [OODA resource-admission recipe & prompt schema](../reference/ooda-resource-admission-recipe.md)
+  — where the intelligence lives.
+- [Configure resource-aware admission (how-to)](../howto/configure-resource-aware-admission.md)
+  — tuning the ceiling, reading decisions, tutorial.
+- [Adaptive scaling](adaptive-scaling.md) — the count control this layers on top of.
+- [Automated disk-health management](automated-disk-health.md) — the reclaim path RECLAIM-FIRST invokes.

--- a/docs/howto/configure-observer-identity.md
+++ b/docs/howto/configure-observer-identity.md
@@ -1,0 +1,230 @@
+---
+title: How to configure a read-only observer identity
+description: Give an identity a read-only write-authority posture, target repo set, and its own seed goals so its OODA Act phase observes and proposes goals instead of dispatching write-bearing engineers — using the Crocutus/hyenas observer as the worked example.
+last_updated: 2026-07-08
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ./configure-pluggable-identity.md
+  - ./route-a-goal-to-its-target-repo.md
+  - ./grant-engineer-write-permissions.md
+  - ../reference/identity-posture-observer.md
+  - ../concepts/identity-write-authority.md
+---
+
+# How to configure a read-only observer identity
+
+An **observer** identity drives the OODA daemon in read-only mode: its Act phase
+records observations about a set of **target** repositories and proposes
+repo-hygiene goals to its own board, but it **never** dispatches a write-bearing
+engineer and **never** writes to any target repo. This is enforced at the
+cognition level, not only at the write primitive — see
+[Identity write-authority](../concepts/identity-write-authority.md) for the why.
+
+This guide uses the **Crocutus** identity observing the **hyenas** Azure DevOps
+repos as the worked example. Crocutus consumes this feature through
+configuration only — all logic lives in Simard.
+
+## Prerequisites
+
+- Simard binary built (`cargo build --quiet`).
+- A working [pluggable identity](./configure-pluggable-identity.md) setup
+  (an `identity.toml` under a prompt-root-relative identity directory).
+- The target repos are reachable for read (clone/`gh`/`az repos` access).
+
+## Step 1 — Declare a read-only posture
+
+Add `write_authority = "read-only"` to your `[[identities]]` entry. The default
+is `"read-write"`, so you must set this explicitly to opt into observe-only.
+
+```toml
+[package]
+name = "crocutus-identity"
+version = "0.1.0"
+description = "Read-only observer of the hyenas repos"
+
+[[identities]]
+name = "crocutus-observer"
+default_mode = "curator"
+write_authority = "read-only"
+```
+
+| Value | Effect |
+|-------|--------|
+| `"read-write"` (default) | Full authority. Act phase dispatches engineers (Simard's normal behavior). |
+| `"read-only"` | Observe-only. Act phase records observations + proposes goals; engineer dispatch is hard-blocked. |
+
+!!! note "The operating mode does not gate observe-only"
+    The observe-only Act branch is selected by `write_authority`, **not** by
+    `default_mode`. Use whichever mode best fits your persona (`curator` reads
+    naturally for an observer).
+
+## Step 2 — List the target repos
+
+`targets` is the identity's **observe scope** — the repos it may look at. It is
+never used as a write scope.
+
+```toml
+[[identities]]
+name = "crocutus-observer"
+default_mode = "curator"
+write_authority = "read-only"
+targets = [
+  "hyenas/infra",
+  "hyenas/services",
+  "hyenas/webapp",
+]
+```
+
+`targets` slugs are the identity's observe scope and the allowed scope for its
+read-only seed goals (every read-only seed goal's `repo` must be one of them —
+Step 3). They are not used as a write scope, and no engineer is dispatched
+against them, so an observer never writes to a target repo regardless of slug
+shape.
+
+## Step 3 — Declare target-scoped seed goals
+
+Seed goals declared by an identity **replace** Simard's five baked-in
+`DEFAULT_SEED_GOALS`. For a read-only identity, **every** seed goal must name a
+`repo` that is within `targets` — this is what keeps the observer pointed at the
+hyenas and never at `rysweet/Simard`.
+
+```toml
+[[identities.seed_goals]]
+priority = 90
+title = "Observe branch hygiene"
+description = "OBSERVE ONLY: report stale/unmerged branches and missing branch protection."
+repo = "hyenas/infra"
+
+[[identities.seed_goals]]
+priority = 80
+title = "Observe governance files"
+description = "OBSERVE ONLY: report missing CODEOWNERS and LICENSE files."
+repo = "hyenas/services"
+
+[[identities.seed_goals]]
+priority = 70
+title = "Observe dependency & blob hygiene"
+description = "OBSERVE ONLY: report absent dependabot config and large binary blobs in history."
+repo = "hyenas/webapp"
+```
+
+| Field | Required? | Notes |
+|-------|-----------|-------|
+| `priority` | yes | Integer; higher runs first. |
+| `title` | yes | Short goal title. |
+| `description` | yes | Prefix with `OBSERVE ONLY:` by convention. |
+| `repo` | yes (read-only) | Must be one of the `targets` slugs. Missing or out-of-`targets` ⇒ hard error. |
+
+!!! warning "Fail-closed scoping"
+    A read-only seed goal with no `repo`, or a `repo` outside `targets`, is a
+    **hard `IdentityTomlParseError`** at load time. Simard will **not** silently
+    scope it to its own repo. Fix the config — do not rely on a default.
+
+## Step 4 — (Advanced) The observe reasoner
+
+The observe-only Act phase runs behind the `ObserveOnlyBrain` trait — the seam
+where *what* to observe and *which* goals to propose is decided. The wired
+baseline is a deterministic floor (`DeterministicObserveBrain`): it records that
+it inspected the identity's `targets` and proposes no new goals beyond the seed
+goals already placed on the board at boot. This mirrors the deterministic-floor
+pattern used elsewhere in the OODA brain.
+
+A prompt-backed `ObserveOnlyBrain` (an LLM reasoner that inspects live repo
+health and proposes goals) is a forward-looking extension: the trait makes it
+pluggable without touching the deterministic no-spawn rail. Until one is wired,
+declare the goals you want observed directly as `seed_goals` (Step 3) — that is
+the supported way to steer Crocutus today.
+
+## Step 5 — Run the daemon under the identity
+
+Point the daemon at the identity via the existing environment plumbing
+(`SIMARD_IDENTITY_PATH` / `SIMARD_IDENTITY`). Resolution happens **once at
+boot**:
+
+```bash
+export SIMARD_IDENTITY_PATH="$PWD/.simard/identity"
+export SIMARD_IDENTITY="crocutus-observer"
+simard daemon run
+```
+
+Confirm the posture in the boot diagnostics (`[simard]` eprintln convention):
+
+```text
+[simard] OODA daemon: identity write posture = read-only (targets: hyenas/infra, hyenas/services, hyenas/webapp; identity seed goals: 3) (issue #3125)
+[simard] OODA start: seeded 3 identity goal(s) — overriding defaults, target-scoped observe-only (issue #3125)
+```
+
+If you instead see `posture = read-write` or the five Simard defaults being
+seeded, the identity did not resolve — re-check `SIMARD_IDENTITY_PATH`,
+`SIMARD_IDENTITY`, and that the identity name matches.
+
+## Step 6 — Verify observe-only behavior
+
+Watch the daemon through one or more cycles and confirm:
+
+1. **Goals are the identity's, target-scoped.** The board shows your three
+   hyenas goals, each with its `repo` slug — not Simard's defaults.
+2. **No engineers are dispatched.** The Act phase records observations and may
+   append proposed goals, but the deterministic rail refuses any spawn:
+
+   ```text
+   [simard] spawn_engineer BLOCKED for goal 'observe-branch-hygiene': identity posture is read-only (deny-by-default: only read-write may dispatch engineers) — no write-bearing engineer dispatched (issue #3125)
+   ```
+
+   These skips are **success no-ops** — they do not trip the 3-strikes
+   brain-failure safeguard or block the goal.
+3. **No target-repo writes.** No worktrees, branches, or PRs are created against
+   any `targets` repo.
+
+## Fail-closed behavior reference
+
+| Condition | Behavior |
+|-----------|----------|
+| `write_authority` absent | Defaults to `read-write` (Simard unchanged). |
+| `write_authority = "read-only"` | Observe-only Act phase; engineer dispatch hard-blocked. |
+| Identity present but posture unresolvable | Fails **closed** to read-only / no-spawn. |
+| Read-only seed goal missing `repo` / `repo` ∉ `targets` | Hard `IdentityTomlParseError` at load. |
+| Invalid `write_authority` string | Hard `IdentityTomlParseError`. |
+| No identity (`SIMARD_IDENTITY_PATH` unset) | Simard defaults: five seed goals + engineer-dispatching Act phase. |
+
+## Full example: crocutus `identity.toml`
+
+```toml
+[package]
+name = "crocutus-identity"
+version = "0.1.0"
+description = "Read-only observer of the hyenas repos"
+
+[[identities]]
+name = "crocutus-observer"
+default_mode = "curator"
+write_authority = "read-only"
+targets = ["hyenas/infra", "hyenas/services", "hyenas/webapp"]
+
+[[identities.seed_goals]]
+priority = 90
+title = "Observe branch hygiene"
+description = "OBSERVE ONLY: report stale/unmerged branches and missing branch protection."
+repo = "hyenas/infra"
+
+[[identities.seed_goals]]
+priority = 80
+title = "Observe governance files"
+description = "OBSERVE ONLY: report missing CODEOWNERS and LICENSE files."
+repo = "hyenas/services"
+
+[[identities.seed_goals]]
+priority = 70
+title = "Observe dependency & blob hygiene"
+description = "OBSERVE ONLY: report absent dependabot config and large binary blobs in history."
+repo = "hyenas/webapp"
+```
+
+## Related
+
+- Reference: [Identity write-authority & observer posture API](../reference/identity-posture-observer.md)
+- Concept: [Identity write-authority — cognition-level observer posture](../concepts/identity-write-authority.md)
+- [How to configure pluggable identities](./configure-pluggable-identity.md)
+- [Route a goal to its target repo](./route-a-goal-to-its-target-repo.md)

--- a/docs/howto/configure-pluggable-identity.md
+++ b/docs/howto/configure-pluggable-identity.md
@@ -10,6 +10,7 @@ related:
   - ../reference/pluggable-identity-api.md
   - ../reference/simard-cli.md
   - ../howto/move-from-terminal-recipes-into-engineer-runs.md
+  - ../howto/configure-observer-identity.md
 ---
 
 # How to configure pluggable identities

--- a/docs/howto/configure-resource-aware-admission.md
+++ b/docs/howto/configure-resource-aware-admission.md
@@ -1,0 +1,282 @@
+---
+title: Configure and monitor resource-aware engineer admission
+description: Operator guide for Simard's resource-aware admission gate — set the disk ceiling, read ADMIT/DEFER/RECLAIM-FIRST decisions, edit the reasoning prompt, and walk a worked example.
+last_updated: 2026-07-07
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../concepts/resource-aware-engineer-admission.md
+  - ../reference/resource-aware-admission-api.md
+  - ../reference/ooda-resource-admission-recipe.md
+  - ./configure-adaptive-scaling.md
+  - ./configure-disk-health-check.md
+  - ./reclaim-disk-space-and-run-low-space-rust-builds.md
+  - ./spawn-engineers-from-ooda-daemon.md
+---
+
+# Configure and monitor resource-aware engineer admission
+
+Resource-aware admission stops the daemon from spawning another engineer when
+the host cannot afford one — even if the [AIMD count
+cap](./configure-adaptive-scaling.md) still has headroom. Before each **fresh**
+engineer spawn, an admission brain reasons over disk, build-cache size, and load,
+and decides **ADMIT**, **DEFER**, or **RECLAIM-FIRST**. One deterministic disk
+ceiling backs it up so `ENOSPC` is unreachable.
+
+This guide is for operators: what to tune, how to read decisions, and how to
+change the reasoning. For the *why*, see the
+[concept](../concepts/resource-aware-engineer-admission.md); for the Rust
+contract, see the [API reference](../reference/resource-aware-admission-api.md).
+
+---
+
+## At a glance
+
+| What | Where |
+|---|---|
+| Tune the hard ceiling | `SIMARD_DISK_ADMISSION_CEILING_PCT` env (default `90`) |
+| Change the reasoning | `prompt_assets/simard/recipes/ooda-resource-admission.yaml` (hot-reload) |
+| Read decisions | `brain_admission_decision` metric, `resource_admission` judgment phase, `[simard] resource admission` tracing |
+| Reclaim path | reuses the [disk-health reclaim recipe](./configure-disk-health-check.md) |
+
+Nothing here changes the count cap — admission runs **underneath** it.
+
+---
+
+## 1. Set the disk admission ceiling
+
+The ceiling is the only hard threshold. When disk usage is read successfully and
+is **at or above** the ceiling, admission is refused regardless of what the brain
+decided.
+
+```bash
+# Default is 90%. Lower it on a small/busy partition for more headroom:
+SIMARD_DISK_ADMISSION_CEILING_PCT=85 simard ooda run
+
+# Raise it on a large partition where 90% still leaves plenty of room:
+SIMARD_DISK_ADMISSION_CEILING_PCT=93 simard ooda run
+```
+
+Rules:
+
+- Default **90** if unset or unparseable.
+- Clamped to **1–99**. `0` (would deadlock all spawns) and `≥100` (would disable
+  the rail) are impossible after clamping.
+- Read fresh each cycle — no rebuild or restart needed to change it.
+
+Choosing a value:
+
+| Partition size / pressure | Suggested ceiling |
+|---|---|
+| Small (< 200G) or many engineers | `80`–`85` |
+| Default host | `90` |
+| Large (> 1T), light engineer count | `92`–`93` |
+
+Keep the ceiling **below** the [≥95% emergency-cleanup
+tier](./configure-disk-health-check.md) so the admission gate throttles *before*
+the emergency tier ever has to fire.
+
+> **Fail-open, by design.** If the `df` probe fails, disk reads as *unknown* and
+> the ceiling does **not** engage — the decision falls through to the brain. A
+> transient probe error can never deadlock spawning. The layered
+> [disk-health](./configure-disk-health-check.md) protection covers the unknown
+> case.
+
+---
+
+## 2. Read admission decisions
+
+Every fresh-spawn admission emits these signals.
+
+### Tracing
+
+```
+INFO simard::ooda_brain::admission: resource admission decided
+    goal=improve-test-coverage
+    choice=defer
+    disk_pct=91 ceiling=90 cache_bytes=53687091200 load_1m=18.4 cpus=8 in_flight=12
+    rationale="disk over ceiling — hard rail engaged"
+```
+
+`choice` is one of `admit`, `defer`, `reclaim_first`. The context fields show
+exactly what the brain saw. `reason`/`rationale` is untrusted model text, emitted
+as a structured `tracing` field (target `simard::ooda_brain`) — never
+shell-interpreted — so it is safe to read directly. (The example above is
+illustrative; the live lines read like `resource-aware admission: DEFER …` with
+`goal` and `reason` fields.)
+
+### Metric — `brain_admission_decision`
+
+One event per admission, labeled **only** by `choice` (`admit` / `defer` /
+`reclaim_first`, bounded cardinality) — emitted by the recipe brain, so it
+records the brain's *intent* before the disk hard rail. Use it to watch how
+often the daemon is deferring:
+
+```bash
+# via the status/metrics surface (see the telemetry reference)
+simard status --metrics | grep brain_admission_decision
+```
+
+A rising `defer` / `reclaim_first` share is the early-warning signal that the
+host is under resource pressure — long before `ENOSPC`.
+
+### Parse health — surfaced as an explicit error, not a metric series
+
+Unlike the decide / orient / lifecycle brains, admission does **not** route
+through the shared verdict-parse chokepoint, so there is **no**
+`brain_verdict_parsed_total{phase="resource_admission"}` series. Admission uses a
+direct parse with **NO FALLBACK**: if the recipe output can't be parsed into a
+`{"choice":..,"rationale":..}` decision, `judge_admission` returns an error and
+the seam surfaces it as a visible cycle failure (`success=false`) — it never
+fabricates an admit. So "the recipe output can no longer be parsed" shows up as
+admission **failures** in the daemon log / cycle outcomes (grep for
+`resource-admission brain failure`), not as a parse-rate metric.
+
+### Judgment record — `resource_admission` phase
+
+Admission decisions appear in [brain
+introspection](../reference/brain-introspection-api.md) under the
+`resource_admission` phase, alongside `decide` / `act` / `orient`, each carrying
+the rationale and the prompt version that produced it.
+
+---
+
+## 3. Interpret each outcome
+
+| You see | It means | Operator action |
+|---|---|---|
+| `admit` (steady) | Host is healthy. | None — normal operation. |
+| `defer` (occasional) | Brief resource tightness; goals retry next cycle. | None — this is the gate working. |
+| `defer` (sustained) | Persistent pressure (full disk / high load). | Reclaim space, lower engineer count, or lower the ceiling if it is too tight. |
+| `reclaim_first` (repeating) | Disk is high but reclaimable each cycle. | Investigate what keeps growing (stale worktrees, caches); see [reclaim disk space](./reclaim-disk-space-and-run-low-space-rust-builds.md). |
+| Hard-rail `defer` at `disk_pct ≥ ceiling` | The deterministic floor engaged. | Free disk or raise the ceiling *only if* genuinely safe. |
+
+A `defer` is **not** a goal failure — it never bumps the goal's failure counter
+and never blocks the goal. If you see a goal "not progressing" purely because of
+`defer`, the fix is host resources, not the goal.
+
+---
+
+## 4. Edit the reasoning (prompt hot-reload)
+
+All the judgment lives in the recipe prompt — change it without a rebuild:
+
+```bash
+# In-tree (takes effect next cycle):
+$EDITOR prompt_assets/simard/recipes/ooda-resource-admission.yaml
+
+# Or hot-reload copy (wins over in-tree):
+$EDITOR ~/.simard/prompt_assets/simard/recipes/ooda-resource-admission.yaml
+```
+
+Typical edits:
+
+- Make the brain more conservative under load (tighten the `defer` guidance).
+- Prefer `reclaim_first` earlier when the cache is large.
+- Adjust the ROLE wording for a specific host profile.
+
+Bump the recipe `version:` field when you change decision-affecting wording so
+the change is traceable in the judgment record. See the
+[recipe & prompt schema](../reference/ooda-resource-admission-recipe.md) for the
+context variables and the required output envelope.
+
+> Do **not** try to encode thresholds in the prompt as the enforcement mechanism.
+> The prompt is judgment; the *only* hard threshold is
+> `SIMARD_DISK_ADMISSION_CEILING_PCT`.
+
+---
+
+## 5. Disable / floor behavior
+
+There is no "off" switch for admission — a gate that can be turned off cannot
+protect against `ENOSPC`. But you can control its aggressiveness:
+
+- **Effectively permissive:** raise `SIMARD_DISK_ADMISSION_CEILING_PCT` toward
+  `99` and relax the prompt's `defer` guidance. The gate still blocks a genuinely
+  full disk.
+- **No recipe available:** if `recipe-runner-rs` or the recipe YAML is missing,
+  admission falls back to the **deterministic floor** (`DeterministicAdmissionBrain`),
+  which always returns `Admit`. The hard ceiling still guards ENOSPC, so the
+  daemon stays safe even with no LLM.
+
+---
+
+## Worked example / tutorial
+
+Simulate the incident this feature was built for and watch it throttle.
+
+1. **Start the daemon with a tight ceiling** to make the gate observable:
+
+   ```bash
+   SIMARD_DISK_ADMISSION_CEILING_PCT=85 SIMARD_SCALING=auto simard ooda run
+   ```
+
+2. **Fill the partition toward the ceiling** (e.g., let several engineers build,
+   or drop a large scratch file). As disk approaches 85%, watch the admission
+   log:
+
+   ```
+   INFO … resource admission decided goal=… choice=reclaim_first
+        disk_pct=84 ceiling=85 cache_bytes=61055517081 … rationale="disk near ceiling; caches reclaimable"
+   ```
+
+   The brain chooses `reclaim_first`: it runs the disk-health reclaim recipe and
+   defers this cycle — no new worktree is created while disk is tight.
+
+3. **Push past the ceiling.** Now the deterministic rail takes over regardless of
+   the model:
+
+   ```
+   INFO … resource admission decided goal=… choice=defer
+        disk_pct=86 ceiling=85 … rationale="disk over ceiling — hard rail engaged"
+   ```
+
+   Even if the model had said `admit`, the gate downgrades to `defer`. The
+   partition never reaches `ENOSPC`.
+
+4. **Confirm goals are not penalized.** The deferred goals show `success=true`
+   skip outcomes (`deferred: resource pressure`) and their failure counters are
+   unchanged:
+
+   ```bash
+   simard status | grep -i defer
+   ```
+
+5. **Reclaim and recover.** After the reclaim recipe frees space (or you clean up
+   manually — see
+   [reclaim disk space](./reclaim-disk-space-and-run-low-space-rust-builds.md)),
+   disk drops back under the ceiling and admissions return to `admit`:
+
+   ```
+   INFO … resource admission decided goal=… choice=admit
+        disk_pct=63 ceiling=85 … rationale="disk 63% under ceiling; room to spawn"
+   ```
+
+You have now seen the full cycle: reason → reclaim → hard-rail floor →
+benign-skip → recover, all without an `ENOSPC` crash and without any goal being
+marked failed.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Spawns blocked, disk looks fine | Ceiling set too low, or high load driving `defer` | Raise `SIMARD_DISK_ADMISSION_CEILING_PCT`; check `load_1m` vs `cpus` in the log |
+| Constant `reclaim_first` | Something regrows disk each cycle | Inspect worktrees/caches; [inspect & clean engineer worktrees](./inspect-and-clean-engineer-worktrees.md) |
+| Never any `defer` even when full | Recipe missing → deterministic floor; **or** `df` probe failing (unknown disk) | Confirm recipe path resolves; check for `df` errors; the ceiling only fires on a *successful* read |
+| Prompt edit not taking effect | Editing in-tree while a hot-reload copy exists | The `~/.simard/…` copy wins — edit that, or remove it |
+| Goal seems stuck but only `defer` outcomes | Host resource pressure, not a goal problem | Free resources; `defer` never blocks a goal |
+
+---
+
+## See also
+
+- [Resource-aware engineer admission (concept)](../concepts/resource-aware-engineer-admission.md)
+- [Resource-aware admission API reference](../reference/resource-aware-admission-api.md)
+- [OODA resource-admission recipe & prompt schema](../reference/ooda-resource-admission-recipe.md)
+- [Configure adaptive scaling](./configure-adaptive-scaling.md) — the count cap this layers under
+- [Configure and monitor the disk health check](./configure-disk-health-check.md) — the reclaim path and emergency tier
+- [Reclaim disk space and run low-space Rust builds](./reclaim-disk-space-and-run-low-space-rust-builds.md)
+- [Spawn engineers from the OODA daemon](./spawn-engineers-from-ooda-daemon.md)

--- a/docs/reference/identity-posture-observer.md
+++ b/docs/reference/identity-posture-observer.md
@@ -1,0 +1,626 @@
+---
+title: Identity write-authority & observer posture API reference
+description: Rust API reference for the WriteAuthority posture, identity seed goals, target scope, the observe-only Act phase, and the deterministic no-spawn rail that lets a read-only OBSERVER identity be enforced at the cognition level, above the destructive-op command guardrails that never enforced read-only.
+last_updated: 2026-07-08
+owner: simard
+doc_type: reference
+status: reference
+related:
+  - ./pluggable-identity-api.md
+  - ./goal-target-repo-routing.md
+  - ./concurrent-engineer-dispatch.md
+  - ./spawn-agent-for-goal.md
+  - ../concepts/identity-write-authority.md
+  - ../concepts/pluggable-identity.md
+  - ../howto/configure-observer-identity.md
+---
+
+# Identity write-authority & observer posture API reference
+
+> **Issue [#3125](https://github.com/rysweet/Simard/issues/3125).** An identity
+> can now declare a **write-authority posture** and its **own seed goals**
+> scoped to a **target repo set**. A `read-only` identity runs an
+> **observe-only Act phase** that records observations and proposes goals to its
+> own board and **never** dispatches a write-bearing engineer. This makes a
+> read-only OBSERVER (for example, the Crocutus identity watching the hyenas
+> Azure DevOps repos) first-class at the **cognition** level — where goals are
+> seeded and engineer dispatch is decided — rather than relying on downstream
+> command guardrails that only block *destructive* git/ADO operations.
+
+!!! note "Relationship to #3071"
+    This documents the **shipped** #3125 feature. The typed posture symbols
+    (`WriteAuthority`, `SeedGoal`, `IdentityPosture`, `ResolvedPosture`,
+    `with_posture`, `seed_identity_board`, `act_observe_only`) are in the tree
+    and exercised by tests. Two facts a reader must know:
+
+    1. **This branch has no generic read-only write floor.** The only
+       pre-existing write guards in this tree are the *destructive-operation*
+       guardrails `git_guardrails::check_git_safety` (gated by
+       `SIMARD_GIT_GUARDRAILS`) and `ado_acl_guard::check_ado_acl_safety`. They
+       block force-push, `reset --hard`, branch deletion, ADO ACL escalation and
+       similar — but they still permit ordinary commits, branches, and PRs. They
+       do **not** make a repo read-only. That is precisely why #3125's
+       cognition-level enforcement (L1 + L2 below) is *load-bearing* here, not a
+       mere credit optimization: on this base it is the only thing that makes a
+       read-only identity actually read-only.
+    2. **The typed posture is the successor to #3071's env floor.** PR
+       [#3071](https://github.com/rysweet/Simard/pull/3071) added an env-driven
+       observe-only floor (`read_only_guard` / `SIMARD_OBSERVE_ONLY`) and is
+       tracked toward this typed design in
+       [#3067](https://github.com/rysweet/Simard/issues/3067). **#3071 is not an
+       ancestor of this branch**, so those symbols do not resolve here. Design
+       decision: the typed `write_authority` rail (L2) is **authoritative**. If
+       this branch is later rebased onto #3071, the typed rail **supersedes**
+       #3071's env-keyed `dispatch_spawn_engineer` short-circuit — the
+       `SIMARD_OBSERVE_ONLY` env var may remain as an operator override, but the
+       resolved posture is the single source of truth. There is no "layer vs
+       replace" ambiguity: posture wins.
+
+Modules: `simard::identity::types`, `simard::identity::manifest`,
+`simard::identity::toml_types`, `simard::identity::file_loader`,
+`simard::identity::compose`, `simard::goal_curation::operations`,
+`simard::ooda_loop::types`, `simard::ooda_actions::observe_only`,
+`simard::ooda_actions::advance_goal::spawn`
+
+The feature is **additive**. With no identity (or a `read-write` identity),
+Simard's behavior is unchanged: the same five `DEFAULT_SEED_GOALS` and the same
+engineer-dispatching Act phase. The posture is resolved **once at daemon boot**
+and threaded through the [`OodaState`](#oodastate-threading); it is never
+re-derived per cycle.
+
+---
+
+## Enforcement model
+
+#3125 adds **two cognition-level enforcement layers** (L1, L2). They sit above
+the pre-existing *destructive-operation* guardrails, which act only as a
+residual backstop — those guardrails are **not** a read-only floor:
+
+| Layer | Where | What it does |
+|-------|-------|--------------|
+| **L1 — cognition branch** (new) | `ooda_loop::cycle` Act-phase entry | When posture is `read-only`, run the agentic `act_observe_only` branch instead of the engineer-dispatching `act`. No write-bearing engineer is ever *considered*. |
+| **L2 — deterministic rail** (new) | `ooda_actions::advance_goal::spawn::dispatch_spawn_engineer` | A thin deterministic guard hard-blocks `dispatch_spawn_engineer` when posture is `read-only` **or undetermined**, at **both** call sites (`advance_goal/mod.rs`, `concurrent.rs`). This *typed*, `write_authority`-keyed rail is the sole spawn-time posture guard; it supersedes #3071's env-keyed `SIMARD_OBSERVE_ONLY` short-circuit if the two ever coexist. |
+| **Residual backstop** (pre-existing) | `git_guardrails::check_git_safety` (`SIMARD_GIT_GUARDRAILS`) and `ado_acl_guard::check_ado_acl_safety` | Block *destructive* git ops and ADO ACL escalation. They permit ordinary writes, so they are **not** a read-only boundary — just a last-ditch guard against destructive commands. Untouched by this feature. |
+
+L1 stops Simard from *thinking* about writes (so no AI credits are burned on
+doomed engineer dispatch, and — because no read-only write floor exists on this
+base — so no ordinary write ever happens either). L2 is the deterministic
+backstop. The destructive-op guardrails remain only as a residual safety net.
+
+```mermaid
+flowchart TD
+    BOOT["daemon boot<br/>resolve identity once"] --> POSTURE{write_authority?}
+    POSTURE -->|read-write| ACT["act() — engineer dispatch"]
+    POSTURE -->|read-only| OBS["act_observe_only() — L1"]
+    POSTURE -->|undetermined| OBS
+    ACT --> RAIL{"L2 rail:<br/>dispatch_spawn_engineer"}
+    OBS --> RAIL
+    RAIL -->|read-only / undetermined| BLOCK["hard-block: skip, [simard] eprintln"]
+    RAIL -->|read-write| SPAWN["spawn engineer"]
+    SPAWN --> GUARD["residual: git_guardrails::check_git_safety<br/>(destructive-op guard, not a read-only floor)"]
+```
+
+---
+
+## WriteAuthority
+
+Module: `simard::identity::types`
+
+```rust
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum WriteAuthority {
+    /// Observe-only. The Act phase records observations and proposes goals but
+    /// never dispatches a write-bearing engineer. Fail-closed default for an
+    /// identity whose posture cannot be determined.
+    ReadOnly,
+    /// Full authority (Simard's historical behavior). The Act phase may
+    /// dispatch engineers. This is the default when no field is present.
+    #[default]
+    ReadWrite,
+}
+```
+
+`Copy` + `Default` (`ReadWrite`). The serde rename maps the enum to the kebab
+tokens `read-only` / `read-write`, matching the TOML surface and the
+`OperatingMode` precedent. Because the field carries `#[serde(default)]`, an
+**absent** `write_authority` deserializes to `ReadWrite` (see
+[AC6](#acceptance-criteria)).
+
+### Methods
+
+```rust
+impl WriteAuthority {
+    /// `true` only for `ReadWrite`. The deterministic rail matches on this so
+    /// that any non-`ReadWrite` value (including future variants) fails closed.
+    pub fn may_dispatch_engineers(&self) -> bool;
+
+    /// `true` for `ReadOnly`.
+    pub fn is_read_only(&self) -> bool;
+}
+```
+
+> **Deny-by-default.** The rail and Act-phase switch are written to **allow**
+> only the proven `ReadWrite` case (`may_dispatch_engineers()`), so any unknown
+> or unresolved posture fails closed. Never match "block `ReadOnly`, allow the
+> rest".
+
+---
+
+## SeedGoal
+
+Module: `simard::identity::types`
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SeedGoal {
+    pub priority: u32,
+    pub title: String,
+    pub description: String,
+    /// Target-repo slug. `Some(slug)` scopes the goal to an ecosystem repo;
+    /// `None` targets the daemon's own repo (Simard). For a `read-only`
+    /// identity, `None` (or a slug outside `targets`) is a fail-closed config
+    /// error — see validation rules below.
+    pub repo: Option<String>,
+}
+```
+
+A `SeedGoal` is the identity-declared analogue of one `DEFAULT_SEED_GOALS`
+tuple `(priority, title, description, repo)`. When an identity supplies seed
+goals, they **fully replace** `DEFAULT_SEED_GOALS` (they do not merge).
+
+---
+
+## IdentityPosture
+
+Module: `simard::identity::posture`
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IdentityPosture {
+    pub write_authority: WriteAuthority,
+    pub targets: Vec<String>,
+    pub seed_goals: Vec<SeedGoal>,
+}
+```
+
+The target-scoped posture read off a resolved manifest.
+
+### Constructor
+
+```rust
+impl IdentityPosture {
+    /// Read the posture (authority + targets + seed goals) off a manifest.
+    pub fn from_manifest(manifest: &IdentityManifest) -> Self;
+}
+```
+
+## ResolvedPosture
+
+Module: `simard::identity::posture`
+
+The boot-time resolution — and the single place the fail-closed rule lives:
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ResolvedPosture {
+    /// No identity present — Simard's own read-write default (a *determined*
+    /// state, AC1).
+    None,
+    /// An identity IS present but its posture is unresolved — fail CLOSED (AC5).
+    Undetermined,
+    /// A resolved identity posture.
+    Identity(IdentityPosture),
+}
+
+impl ResolvedPosture {
+    /// `None` ⇒ ReadWrite; `Undetermined` ⇒ ReadOnly; `Identity` ⇒ declared.
+    pub fn write_authority(&self) -> WriteAuthority;
+    /// Target repo slugs (empty for `None` / `Undetermined`).
+    pub fn targets(&self) -> &[String];
+    /// Identity seed goals (empty for `None` / `Undetermined`).
+    pub fn seed_goals(&self) -> &[SeedGoal];
+}
+```
+
+| State | How it arises | `write_authority()` |
+|-------|---------------|---------------------|
+| **No identity** | `SIMARD_IDENTITY_PATH` unset | `ReadWrite` (AC1) |
+| **Read-write identity** | manifest resolves to `ReadWrite` | `ReadWrite` (AC1) |
+| **Read-only identity** | manifest resolves to `ReadOnly` | `ReadOnly` (AC2–AC4) |
+| **Undetermined** | identity present but posture unresolvable (load/parse/thread gap) | `ReadOnly`, no-spawn (AC5) |
+
+> **"No identity" is a *determined* state.** It maps to `read-write` so Simard
+> herself is unchanged. "Undetermined" only applies when an identity context
+> exists but its posture cannot be read — that fails closed to `read-only`.
+
+---
+
+## IdentityManifest posture fields
+
+Module: `simard::identity::manifest`
+
+`IdentityManifest` gains three additive fields:
+
+```rust
+pub struct IdentityManifest {
+    // ... existing fields ...
+    pub write_authority: WriteAuthority,   // default ReadWrite
+    pub targets: Vec<String>,              // default empty
+    pub seed_goals: Vec<SeedGoal>,         // default empty
+}
+```
+
+Existing `IdentityManifest::new(..)` callers are **unchanged** — `new()`
+constructs a manifest with `write_authority = ReadWrite`, `targets = []`,
+`seed_goals = []`. The posture is attached with a dedicated builder rather than
+growing `new()`'s argument list (which is already `#[expect(too_many_arguments)]`):
+
+```rust
+impl IdentityManifest {
+    /// Attach a write-authority posture, target set, and seed goals.
+    /// Validates the read-only seed-goal scoping rules (below); on violation it
+    /// returns `SimardError::InvalidIdentityComposition` (fail-closed). The
+    /// file loader maps that to `IdentityTomlParseError` so a bad `identity.toml`
+    /// surfaces as a parse error.
+    pub fn with_posture(
+        self,
+        write_authority: WriteAuthority,
+        targets: Vec<String>,
+        seed_goals: Vec<SeedGoal>,
+    ) -> SimardResult<Self>;
+}
+```
+
+### Validation rules (fail-closed)
+
+`with_posture()` enforces read-only seed-goal scoping. The failure is
+`SimardError::InvalidIdentityComposition`; when reached through the file loader
+it is re-surfaced as `SimardError::IdentityTomlParseError`:
+
+| Rule | Applies to | Violation |
+|------|-----------|-----------|
+| Every seed goal's `repo` must be `Some(slug)` and `slug ∈ targets` | `read-only` identity | Missing/out-of-`targets` repo — **never** silently scoped to `rysweet/Simard` |
+| `repo = None` retains "own repo" semantics | `read-write` identity | — (allowed; matches `DEFAULT_SEED_GOALS` `None`-slug behavior) |
+
+---
+
+## TOML surface
+
+Module: `simard::identity::toml_types`
+
+`TomlIdentity` gains three `#[serde(default)]` fields (so old `identity.toml`
+files parse unchanged and `deny_unknown_fields` is preserved):
+
+```rust
+pub(crate) struct TomlIdentity {
+    // ... existing fields ...
+    #[serde(default)]
+    pub write_authority: WriteAuthority,     // absent ⇒ ReadWrite
+    #[serde(default)]
+    pub targets: Vec<String>,                // absent ⇒ []
+    #[serde(default)]
+    pub seed_goals: Vec<TomlSeedGoal>,       // absent ⇒ []
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlSeedGoal {
+    pub priority: u32,
+    pub title: String,
+    pub description: String,
+    #[serde(default)]
+    pub repo: Option<String>,
+}
+```
+
+### `identity.toml` schema (additive)
+
+```toml
+[[identities]]
+name = "hyena-observer"
+default_mode = "curator"
+write_authority = "read-only"                 # "read-only" | "read-write" (default "read-write")
+targets = ["hyenas/repo-a", "hyenas/repo-b"]  # observe scope — never a write scope
+
+[[identities.seed_goals]]
+priority = 80
+title = "Observe branch hygiene"
+description = "OBSERVE ONLY: assess branch hygiene, CODEOWNERS, LICENSE, dependabot, large blobs"
+repo = "hyenas/repo-a"                         # must be within `targets` for a read-only identity
+```
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `write_authority` | string | `"read-write"` | `read-only` or `read-write`. Absent ⇒ `read-write` (AC6). Invalid string ⇒ `IdentityTomlParseError`. |
+| `targets` | `[string]` | `[]` | Target-repo slugs. **Observe scope only** — never used as a write scope. |
+| `seed_goals` | array of tables | `[]` | Identity seed goals. When non-empty, they **replace** `DEFAULT_SEED_GOALS`. |
+| `seed_goals[].priority` | integer | — | Required. |
+| `seed_goals[].title` | string | — | Required. |
+| `seed_goals[].description` | string | — | Required. Prefix with `OBSERVE ONLY:` by convention for read-only identities. |
+| `seed_goals[].repo` | string | — | Target slug. Required-in-`targets` for read-only identities; optional (own-repo) for read-write. |
+
+---
+
+## Composition semantics
+
+Module: `simard::identity::compose`
+
+When a composite identity merges components (see
+[pluggable identity](./pluggable-identity-api.md#composition-semantics)), the
+new fields merge as follows:
+
+| Field | Merge strategy | Rationale |
+|-------|---------------|-----------|
+| `write_authority` | **Most restrictive wins** — `ReadOnly` if *any* component is `ReadOnly`, else `ReadWrite` | A read-only restriction can never be diluted by composition |
+| `targets` | Union (deduplicated) | Observe scope is the union of component scopes |
+| `seed_goals` | Concatenation | Each component contributes its goals |
+
+The most-restrictive rule means composition can only ever *tighten* write
+authority, never loosen it.
+
+---
+
+## Builtin identities
+
+Module: `simard::identity::loader`
+
+`BuiltinIdentityLoader` returns manifests with `write_authority = ReadWrite`,
+`targets = []`, `seed_goals = []` for all built-ins
+(`simard-engineer`, `simard-meeting`, `simard-gym`, `simard-goal-curator`,
+`simard-improvement-curator`, `simard-composite-engineer`). This guarantees
+**AC1**: Simard's own identities keep full authority and the baked-in defaults.
+
+---
+
+## OodaState threading
+
+Module: `simard::ooda_loop::types`
+
+The boot-resolved posture is threaded through three additive `OodaState` fields
+(not `OodaConfig`), each defaulting to the Simard-unchanged value in
+`OodaState::new`:
+
+```rust
+pub struct OodaState {
+    // ... existing fields ...
+    /// Active identity's write posture. `ReadWrite` by default.
+    pub write_authority: WriteAuthority,
+    /// Target repo slugs the identity is scoped to. Empty for Simard.
+    pub observer_targets: Vec<String>,
+    /// Identity-declared seed goals. Empty for Simard (keeps DEFAULT_SEED_GOALS).
+    pub identity_seed_goals: Vec<SeedGoal>,
+}
+```
+
+`OodaState::new(..)` sets `write_authority = ReadWrite`, `observer_targets = []`,
+`identity_seed_goals = []`, so any code path that builds a fresh state (tests,
+recipe steps) is unchanged. The daemon overwrites them once at boot.
+
+---
+
+## Daemon boot identity resolution
+
+Module: `simard::bootstrap::assembly` (`resolve_boot_posture`) +
+`simard::operator_commands_ooda::daemon` (`run_ooda_daemon`)
+
+At daemon boot the active identity is resolved **once** using the existing
+`SIMARD_IDENTITY_PATH` / `load_identity` plumbing — the same loader chain
+documented in [pluggable identity](./pluggable-identity-api.md)
+(depend-not-fork). `resolve_boot_posture()` returns a [`ResolvedPosture`](#resolvedposture);
+the daemon writes its `write_authority()`, `targets()`, and `seed_goals()` into
+`OodaState`:
+
+```text
+SIMARD_IDENTITY_PATH unset      ⇒ ResolvedPosture::None          (read-write)
+identity resolves (read-write)  ⇒ ResolvedPosture::Identity(..)  (read-write)
+identity resolves (read-only)   ⇒ ResolvedPosture::Identity(..)  (read-only)
+identity present, unresolvable  ⇒ ResolvedPosture::Undetermined  (read-only, no-spawn)
+```
+
+Operator diagnostics follow the `[simard] eprintln` convention, e.g.:
+
+```text
+[simard] OODA daemon: identity write posture = read-only (targets: hyenas/repo-a, hyenas/repo-b; identity seed goals: 2) (issue #3125)
+[simard] identity posture UNDETERMINED — failing CLOSED to read-only (no engineer dispatch): <error> (issue #3125)
+```
+
+> **No wall-clock timeout** is placed on identity resolution or any agentic
+> step. Failure to resolve does not silently degrade to read-write — it fails
+> **closed** to `read-only`.
+
+---
+
+## seed_identity_board
+
+Module: `simard::goal_curation::operations`
+
+```rust
+/// Seed a goal board from an identity's declared seed goals if the board has no
+/// active goals. Each goal is seeded UNASSIGNED (no engineer dispatch) and
+/// scoped to the seed goal's own `repo` (a target slug), never rysweet/Simard.
+/// Read-only scope validation happens upstream at identity load
+/// (`IdentityManifest::with_posture`); this trusts the already-validated `repo`.
+/// Returns the number of goals added (0 if the board was non-empty).
+pub fn seed_identity_board(board: &mut GoalBoard, seeds: &[SeedGoal]) -> usize;
+```
+
+`DEFAULT_SEED_GOALS` and `seed_default_board` are **untouched**. The cycle
+chooses the source:
+
+```text
+state.identity_seed_goals is empty   ⇒ seed_default_board(..)   (Simard defaults — AC1)
+state.identity_seed_goals non-empty  ⇒ seed_identity_board(..)  (full replacement — AC2)
+```
+
+### Cycle seeding hook
+
+Module: `simard::ooda_loop::cycle`
+
+At the existing board-seeding point (after the cognitive-memory board load and
+the `.reseed_goals` marker path), the cycle branches on
+`state.identity_seed_goals`: when non-empty it seeds via `seed_identity_board`
+(overriding the defaults); otherwise it calls `seed_default_board` exactly as
+before. See [Goal-board persistence](../concepts/goal-board-persistence.md) for
+the marker protocol.
+
+---
+
+## Observe-only Act phase
+
+Module: `simard::ooda_actions::observe_only`
+
+```rust
+/// Run one observe-only Act pass and return the number of goals proposed.
+/// Consults the agentic brain over the identity's targets, records observations
+/// as `[simard]` diagnostics, and appends UNASSIGNED, target-scoped goals.
+/// NEVER calls `dispatch_spawn_engineer`. Fail-closed: a brain error surfaces
+/// (no fallback to engineer dispatch), and a proposal whose repo is absent or
+/// outside `targets` is a hard error that leaves the board untouched.
+pub(crate) fn act_observe_only(
+    brain: &dyn ObserveOnlyBrain,
+    targets: &[String],
+    state: &mut OodaState,
+) -> SimardResult<usize>;
+
+/// Agentic reasoner for the observe-only Act phase: decides — over the
+/// identity's target repo set — what to observe and what goals to propose.
+/// A trait so the intelligence can live in a prompt/reasoner; the no-spawn
+/// guarantee is the deterministic rail (below), independent of the brain.
+/// No caller-imposed wall-clock timeout is applied to `observe`.
+pub trait ObserveOnlyBrain: Send + Sync {
+    fn observe(&self, targets: &[String]) -> SimardResult<ObserveOutcome>;
+}
+
+pub struct ObserveOutcome {
+    pub observations: Vec<String>,
+    pub proposals: Vec<SeedGoal>,
+}
+```
+
+The Act phase (`ooda_loop::act`) branches on `state.write_authority.is_read_only()`:
+when read-only it calls `run_observe_only_act`, which runs the brain over
+`state.observer_targets` via `act_observe_only` and returns one benign
+observe-only `ActionOutcome` per planned action — **never** reaching the
+engineer-dispatching path.
+
+The wired baseline brain is `DeterministicObserveBrain`, a non-agentic floor
+(mirroring `DeterministicLifecycleBrain` / `DeterministicAdmissionBrain`): it
+records that it inspected the identity's targets and proposes no new goals (the
+identity's declared seed goals were placed on the board at boot by
+`seed_identity_board`). A prompt-backed `ObserveOnlyBrain` can replace it
+without touching the rail. There is **no wall-clock timeout** on `observe`; if
+the brain errors, the failure surfaces (no fallback, no silent continue) and
+still performs **zero** dispatch.
+
+---
+
+## Deterministic spawn rail
+
+Module: `simard::ooda_actions::advance_goal::spawn`
+
+`dispatch_spawn_engineer` gains a thin deterministic guard at its top, before
+any assignment re-check or worktree work:
+
+```rust
+pub fn dispatch_spawn_engineer(
+    action: &PlannedAction,
+    state: &Mutex<&mut OodaState>,
+    goal_id: &str,
+    task: &str,
+    brain: &dyn OodaBrain,
+    admission: &dyn OodaAdmissionBrain,
+    repo_root: &Path,
+) -> ActionOutcome {
+    // L2 rail: deny-by-default. Only ReadWrite may dispatch engineers; any
+    // ReadOnly (or, should a future variant appear, non-ReadWrite) posture is
+    // hard-blocked here, before any assignment re-check or worktree work.
+    {
+        let guard = lock_state(state);
+        if !guard.write_authority.may_dispatch_engineers() {
+            eprintln!(
+                "[simard] spawn_engineer BLOCKED for goal '{goal_id}': identity posture is {} \
+                 (deny-by-default: only read-write may dispatch engineers) — no write-bearing \
+                 engineer dispatched (issue #3125)",
+                guard.write_authority
+            );
+            return make_outcome(
+                action,
+                true, // success=true skip — a policy no-op, not a brain failure
+                format!(
+                    "spawn_engineer skipped: identity posture is read-only (observe-only) for \
+                     goal '{goal_id}' — no engineer dispatched"
+                ),
+            );
+        }
+    }
+    // ... existing dispatch logic ...
+}
+```
+
+Key properties:
+
+| Property | Behavior | Why |
+|----------|----------|-----|
+| **Deny-by-default** | Matches `may_dispatch_engineers()` (allow only `ReadWrite`) | Unknown/undetermined postures fail closed |
+| **`success = true` skip** | Returns a success outcome, not a failure | A policy no-op must **not** trip the 3-strikes brain-failure safeguard (`BRAIN_FAILURE_BLOCKED_PREFIX`) or bump `goal_failure_counts` |
+| **Both call sites** | Guards `advance_goal/mod.rs` **and** `concurrent.rs` | Prevents a concurrent-path escape |
+| **`[simard]` eprintln** | Visible operator diagnostic on every block | No silent degradation |
+
+This rail is the authoritative spawn-time posture guard. The pre-existing
+destructive-op guardrails (`git_guardrails::check_git_safety`,
+`ado_acl_guard::check_ado_acl_safety`) are independent and remain only as a
+residual backstop — they do not enforce read-only.
+
+---
+
+## Error variants
+
+The feature reuses existing `SimardError` variants; **no new variant is
+introduced**.
+
+### IdentityTomlParseError
+
+```rust
+SimardError::IdentityTomlParseError { path: PathBuf, reason: String }
+```
+
+Produced for posture validation failures (fail-closed):
+
+- Invalid `write_authority` string (not `read-only`/`read-write`) — a TOML
+  deserialize error.
+- Read-only seed goal with `repo = None` or `repo ∉ targets` — surfaced from
+  `with_posture`'s `InvalidIdentityComposition`, re-mapped by the file loader.
+
+Note: `IdentityManifest::with_posture` returns
+`SimardError::InvalidIdentityComposition` directly; the file loader converts it
+to `IdentityTomlParseError` so a bad `identity.toml` reads as a parse error.
+
+---
+
+## Acceptance criteria
+
+The implementation is verified by tests mapping to these criteria:
+
+| ID | Criterion |
+|----|-----------|
+| **AC1** | No-identity **and** read-write identity ⇒ exactly the five named `DEFAULT_SEED_GOALS` and the engineer-dispatching Act phase (Simard unchanged). |
+| **AC2** | A read-only identity's seed goals **override** `DEFAULT_SEED_GOALS`. |
+| **AC3** | Read-only posture ⇒ **zero** `dispatch_spawn_engineer` calls, on both the single and concurrent paths. |
+| **AC4** | Observe-only Act records observations and proposes goals scoped to `targets`, not `rysweet/Simard`. |
+| **AC5** | Undetermined posture ⇒ no spawn (fail-closed). |
+| **AC6** | Absent `write_authority` parses to `ReadWrite`. |
+| **AC7** | `cargo fmt --check`, `clippy -D warnings`, `cargo test`, `cargo-deny` all green. |
+| **AC8** | All changes additive; `deny_unknown_fields` preserved via `#[serde(default)]`. |
+| **AC9** | Delivered as a PR against `rysweet/Simard`. |
+| **AC10** | No **new** `Bridge` orchestration symbol introduced; the existing `OodaBridges` bundle is reused. (`BridgeRequest`/`BridgeResponse`/`BridgeId`/`BridgeTransport` already exist in `src/bridge.rs`; this feature adds none.) |
+
+---
+
+## Related
+
+- Concept: [Identity write-authority — cognition-level observer posture](../concepts/identity-write-authority.md)
+- How-to: [Configure a read-only observer identity](../howto/configure-observer-identity.md)
+- [Pluggable identity API reference](./pluggable-identity-api.md)
+- [Goal target-repo routing API reference](./goal-target-repo-routing.md)
+- [Concurrent engineer dispatch](./concurrent-engineer-dispatch.md)

--- a/docs/reference/ooda-resource-admission-recipe.md
+++ b/docs/reference/ooda-resource-admission-recipe.md
@@ -1,0 +1,274 @@
+---
+title: OODA resource-admission recipe and prompt schema
+description: Reference for the ooda-resource-admission recipe and prompt — the structured-reasoning asset that decides ADMIT / DEFER / RECLAIM-FIRST, its context variables, the decision envelope, and runtime hot-reload.
+last_updated: 2026-07-07
+owner: simard
+doc_type: reference
+related:
+  - ../concepts/resource-aware-engineer-admission.md
+  - ./resource-aware-admission-api.md
+  - ../howto/configure-resource-aware-admission.md
+  - ./ooda-engineer-lifecycle-recipe.md
+  - ./ooda-decide-prompt.md
+  - ./recipe-context-var-sanitization.md
+---
+
+# OODA resource-admission recipe and prompt schema
+
+**Recipe:** `prompt_assets/simard/recipes/ooda-resource-admission.yaml`
+**Prompt asset:** `prompt_assets/simard/prompts/ooda-resource-admission.md`
+**Shim:** `impl OodaAdmissionBrain for RecipeBrain` (`src/ooda_brain/recipe_brain.rs`)
+
+This recipe is the **single source of truth for the resource-admission
+decision**. It is where the intelligence of the feature lives — the Rust seam
+only gathers structured context, calls this recipe, and applies the result under
+one hard rail (see the [API reference](./resource-aware-admission-api.md)).
+
+It follows the same recipe-brain pattern as
+[`ooda-decide.yaml`](./ooda-decide-prompt.md) and
+[`ooda-engineer-lifecycle.yaml`](./ooda-engineer-lifecycle-recipe.md): a single
+terminal `agent` step run via `recipe-runner-rs`, whose stdout is a JSON
+envelope from which `RecipeBrain` extracts the final step's output and parses the
+decision.
+
+---
+
+## Recipe layout
+
+```yaml
+name: "ooda-resource-admission"
+description: "OODA engineer-admission brain — resource-aware ADMIT/DEFER/RECLAIM-FIRST"
+version: "1.0.0"
+author: "Simard"
+tags: ["simard", "ooda", "admission", "resource"]
+
+context: {}
+
+steps:
+  - id: "decide-admission"
+    type: "agent"
+    agent: "default"
+    prompt: |
+      {{escalation_note}}
+
+      # OODA Brain — Engineer-Admission Decision (resource-aware)
+
+      ## ROLE
+      You are the admission brain for Simard's engineer dispatcher. The count
+      cap already said there is room for one more engineer by COUNT. Your job is
+      the resource question the count cap cannot answer: given the current disk,
+      build-cache, and load picture on THIS host, is now a good moment to spawn
+      one more engineer — each of which starts its own parallel `cargo` build?
+
+      A full disk is fatal (ENOSPC kills recipes). Be conservative when disk is
+      high or load is thrashing. Prefer reclaiming reclaimable space over
+      blocking progress outright.
+
+      ## CONTEXT
+      - disk_usage_pct:        {{disk_usage_pct}}
+      - disk_ceiling_pct:      {{ceiling_pct}}
+      - worktree_cache_bytes:  {{worktree_cache_bytes}}
+      - load_avg_1m:           {{load_avg_1m}}
+      - cpu_count:             {{cpu_count}}
+      - in_flight_engineers:   {{in_flight_engineers}}
+
+      ## OPTIONS
+      Choose exactly one:
+      - admit         — resources are healthy; add the engineer.
+      - defer         — resources are tight; skip this cycle, retry next.
+      - reclaim_first — disk is high but reclaimable (stale worktrees / caches);
+                        reclaim now, then defer this cycle.
+
+      ## OUTPUT
+      Emit ONE JSON object and nothing else:
+      {"choice": "<admit|defer|reclaim_first>", "rationale": "<one sentence>"}
+
+      ## EXAMPLES
+      … (see Examples below) …
+```
+
+The recipe is a single terminal `agent` step. `recipe-runner-rs` handles
+Handlebars rendering, agent invocation, and stdout capture; `RecipeBrain` parses
+the decision from the JSON envelope.
+
+---
+
+## Context variables
+
+`recipe-runner-rs` performs Handlebars `{{name}}` substitution from the context
+vars the shim passes (via `-c name=value`), sourced from
+[`ResourceAdmissionCtx`](./resource-aware-admission-api.md#resourceadmissionctx).
+`Option` fields render as the literal string `unknown` when `None`.
+
+| Variable | Source field | `None` renders as |
+|---|---|---|
+| `{{disk_usage_pct}}` | `disk_usage_pct` | `unknown` |
+| `{{ceiling_pct}}` | `ceiling_pct` | (never `None`) |
+| `{{worktree_cache_bytes}}` | `worktree_cache_bytes` | `unknown` |
+| `{{load_avg_1m}}` | `load_avg_1m` | `unknown` |
+| `{{cpu_count}}` | `cpu_count` | `unknown` |
+| `{{in_flight_engineers}}` | `in_flight_engineers` | (never `None`; `0` on error) |
+
+Every context var is a **daemon-computed number** (or the literal `unknown` for a
+failed probe) — no goal- or LLM-supplied string ever reaches this recipe, so the
+prompt-injection surface is minimal. (Unlike the decide/orient/lifecycle recipes,
+admission takes no free-text context var and therefore no `escalation_note`.)
+
+---
+
+## Decision envelope (wire format)
+
+The agent's final step output is the JSON decision object. `RecipeBrain`:
+
+1. Runs `recipe-runner-rs … --output-format json`.
+2. Deserializes the envelope and extracts the **final** step's `output`
+   (`extract_recipe_decision_output` — the shared parse chokepoint; a
+   `success=false` recipe or empty step surfaces
+   `SimardError::AdapterInvocationFailed`, never a silent empty).
+3. Parses that output into
+   [`AdmissionDecision`](./resource-aware-admission-api.md#admissiondecision) —
+   `parse_admission_decision` runs the output through the shared
+   `recipe_output::extract_json_payload` sanitizer (strips banner / ANSI / log
+   noise) and then `serde_json::from_str` on the
+   `#[serde(tag = "choice", rename_all = "snake_case")]` enum.
+
+```json
+{"choice": "admit",         "rationale": "disk 61%, load 2.1 on 16 cpus — healthy"}
+{"choice": "defer",         "rationale": "load 22 on 8 cpus; builds thrashing"}
+{"choice": "reclaim_first", "rationale": "disk 88% but 30 stale worktrees reclaimable"}
+```
+
+| `choice` | Parses to |
+|---|---|
+| `admit` | `AdmissionDecision::Admit { rationale }` |
+| `defer` | `AdmissionDecision::Defer { rationale }` |
+| `reclaim_first` | `AdmissionDecision::ReclaimFirst { rationale }` |
+
+### Parse failure — NO FALLBACK
+
+Admission uses a **direct parse**, not the confidence-gated escalation ladder the
+other recipe brains use. On a parse-miss (non-JSON output, unknown `choice`,
+missing `rationale`), `judge_admission` returns
+`SimardError::AdapterInvocationFailed` immediately — **no ladder retry, no
+`escalation_note`, and NO FALLBACK**. The seam surfaces that `Err` as a visible
+cycle failure (`success=false`); it never fabricates an `Admit` from a malformed
+response. (An accidental admit could fill the disk, so a broken brain must fail
+loud.) The deterministic disk ceiling in `resolve_admission` is the separate,
+always-on ENOSPC guard.
+
+The admission path emits a **single** metric, `brain_admission_decision` (which
+`choice` the brain made, plus the numeric picture). It deliberately does **not**
+flow through the shared verdict-parse chokepoint, so there is no
+`brain_verdict_parsed_total{phase="resource_admission"}` series; see the
+[API reference observability section](./resource-aware-admission-api.md#observability).
+
+---
+
+## Runtime loading (hot-reload, not compile-time)
+
+The recipe is loaded at runtime by `recipe-runner-rs`. `RecipeBrain` resolves the
+recipe path in this order (same as the other recipes):
+
+1. **Hot-reload:** `~/.simard/prompt_assets/simard/recipes/ooda-resource-admission.yaml`
+2. **In-tree:** `<repo_root>/prompt_assets/simard/recipes/ooda-resource-admission.yaml`
+
+Prompt edits take effect on the **next admission cycle without a rebuild**. Bump
+the `version:` field when you change decision-affecting wording so the change is
+traceable in the judgment record's prompt-version field.
+
+---
+
+## Examples
+
+### `admit` — healthy host
+
+Context: `disk_usage_pct=58 ceiling_pct=90 worktree_cache_bytes=8589934592 load_avg_1m=3.2 cpu_count=16 in_flight_engineers=4`
+
+Agent output:
+
+```json
+{"choice": "admit", "rationale": "disk 58% well under the 90% ceiling; load 3.2 on 16 cpus is comfortable — room for another engineer"}
+```
+
+Parsed:
+
+```rust
+AdmissionDecision::Admit {
+    rationale: "disk 58% well under the 90% ceiling; load 3.2 on 16 cpus is comfortable — room for another engineer".into(),
+}
+```
+
+Gate outcome: **Admit** → proceed to spawn.
+
+### `defer` — load thrashing
+
+Context: `disk_usage_pct=70 ceiling_pct=90 worktree_cache_bytes=12884901888 load_avg_1m=26.5 cpu_count=8 in_flight_engineers=9`
+
+Agent output:
+
+```json
+{"choice": "defer", "rationale": "load 26.5 on only 8 cpus with 9 engineers already building; another parallel cargo build would thrash — wait a cycle"}
+```
+
+Gate outcome: **Defer** → benign skip, retry next cycle.
+
+### `reclaim_first` — high but reclaimable disk
+
+Context: `disk_usage_pct=87 ceiling_pct=90 worktree_cache_bytes=64424509440 load_avg_1m=5.1 cpu_count=16 in_flight_engineers=6`
+
+Agent output:
+
+```json
+{"choice": "reclaim_first", "rationale": "disk 87% approaching the 90% ceiling, but 60G sits in worktree build caches — reclaim before admitting"}
+```
+
+Gate outcome: reclaim recipe runs, then **Defer** this cycle.
+
+### Hard rail overrides `admit` above ceiling
+
+Context: `disk_usage_pct=93 ceiling_pct=90 …`
+
+Even if the agent emits:
+
+```json
+{"choice": "admit", "rationale": "load looks fine"}
+```
+
+`resolve_admission` **downgrades to `Defer`** because `disk_usage_pct=93 ≥ ceiling=90`.
+The model can only be overridden toward caution, never toward filling the disk.
+
+### Unknown disk fails open
+
+Context: `disk_usage_pct=unknown ceiling_pct=90 …` (a `df` probe failure)
+
+Agent output `{"choice":"admit", …}` → gate outcome **`Proceed`**. The hard rail
+does not fire on unknown disk; the reasoner's judgment stands.
+
+---
+
+## Versioning & compatibility
+
+Cosmetic edits (ROLE phrasing, examples, rationale guidance) are safe to ship
+alone and take effect on the next cycle without a rebuild.
+
+Adding a new admission outcome requires a coordinated change:
+
+1. Add the variant to `AdmissionDecision` in `src/ooda_brain/admission.rs`.
+2. Extend the `label` / `rationale` accessors.
+3. Handle it in `resolve_admission` (map to the appropriate `AdmissionGate`).
+4. Add it to the `OPTIONS` and `OUTPUT` sections of this recipe.
+5. Add an example here and to the [wire-formats reference](./text-parsing-wire-formats.md).
+6. Add a hermetic gate test to `admission_tests.rs`.
+7. Bump the recipe `version:`.
+
+---
+
+## See also
+
+- [Resource-aware engineer admission (concept)](../concepts/resource-aware-engineer-admission.md)
+- [Resource-aware admission API reference](./resource-aware-admission-api.md)
+- [Configure resource-aware admission (how-to)](../howto/configure-resource-aware-admission.md)
+- [OODA Engineer-Lifecycle Recipe](./ooda-engineer-lifecycle-recipe.md) — the sibling recipe this mirrors
+- [OODA Decide Prompt Schema](./ooda-decide-prompt.md) — the tagged-envelope sibling
+- [Recipe context-var sanitization](./recipe-context-var-sanitization.md) — how string context is cleaned
+- [Recipe-Brain API](./recipe-brain-api.md) — the envelope-parse chokepoint and escalation ladder

--- a/docs/reference/pluggable-identity-api.md
+++ b/docs/reference/pluggable-identity-api.md
@@ -8,6 +8,7 @@ related:
   - ../concepts/pluggable-identity.md
   - ../howto/configure-pluggable-identity.md
   - ../reference/runtime-contracts.md
+  - ./identity-posture-observer.md
 ---
 
 # Pluggable identity API reference

--- a/docs/reference/resource-aware-admission-api.md
+++ b/docs/reference/resource-aware-admission-api.md
@@ -1,0 +1,599 @@
+---
+title: Resource-aware admission API reference
+description: Rust API reference for the OodaAdmissionBrain trait, ResourceAdmissionCtx, the AdmissionDecision tagged enum, the pure resolve_admission hard rail and judge_and_resolve seam, context gathering, observability, and daemon wiring.
+last_updated: 2026-07-07
+owner: simard
+doc_type: reference
+related:
+  - ../concepts/resource-aware-engineer-admission.md
+  - ./ooda-resource-admission-recipe.md
+  - ../howto/configure-resource-aware-admission.md
+  - ./ooda-brain-api.md
+  - ./recipe-brain-api.md
+  - ./disk-health-api.md
+  - ./adaptive-scaling-api.md
+---
+
+# Resource-aware admission API reference
+
+**Module:** `src/ooda_brain/admission.rs`
+**Seam:** `src/ooda_actions/advance_goal/spawn.rs` (`dispatch_spawn_engineer`)
+
+Resource-aware admission adds an agentic gate on top of the
+[AIMD count cap](./adaptive-scaling-api.md). Before a **fresh** engineer is
+spawned, the daemon gathers a resource picture, asks the admission brain to
+reason over it, and applies the resulting `AdmissionDecision` — subject to one
+deterministic disk ceiling that the brain cannot override.
+
+The module mirrors the Decide-phase template
+(`OodaDecideBrain` + `DecideJudgment` + `DeterministicDecideBrain`, see
+[`decide.rs`](./ooda-brain-api.md)): a single-decision-site trait, a tagged
+judgment enum the LLM emits as a JSON envelope, and a deterministic floor brain
+that needs no LLM.
+
+---
+
+## `ResourceAdmissionCtx`
+
+The read-only resource snapshot fed to the brain. Every probed field is
+`Option` — any probe that fails degrades to `None` (rendered as `"unknown"` in
+the prompt) rather than panicking or blocking.
+
+```rust
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ResourceAdmissionCtx {
+    /// Disk usage of the state/repo partition, 0–100. `None` if `df` failed.
+    pub disk_usage_pct: Option<u8>,
+    /// Total bytes under the engineer-worktree root
+    /// (`<state_root>/<WORKTREES_SUBDIR>`, i.e. `engineer-worktrees/`).
+    /// `None` if `du` failed.
+    pub worktree_cache_bytes: Option<u64>,
+    /// 1-minute load average from `/proc/loadavg`. `None` off Linux / on error.
+    pub load_avg_1m: Option<f64>,
+    /// Logical CPU count, from `std::thread::available_parallelism()`.
+    /// Lets the prompt normalize load. `None` if unavailable.
+    pub cpu_count: Option<usize>,
+    /// Live engineer worktrees with a heartbeat claim (never `None`; 0 on error).
+    pub in_flight_engineers: u32,
+    /// The configured disk admission ceiling in effect this cycle (1–99).
+    pub ceiling_pct: u8,
+}
+```
+
+| Field | Type | Source | Degrades to |
+|---|---|---|---|
+| `disk_usage_pct` | `Option<u8>` | `df --output=pcent <path>` | `None` |
+| `worktree_cache_bytes` | `Option<u64>` | `du -sb <state_root>/<WORKTREES_SUBDIR>` | `None` |
+| `load_avg_1m` | `Option<f64>` | first field of `/proc/loadavg` | `None` |
+| `cpu_count` | `Option<usize>` | `std::thread::available_parallelism()` | `None` |
+| `in_flight_engineers` | `u32` | `count_live_engineer_claims` (`src/ooda_brain/context.rs`) | `0` |
+| `ceiling_pct` | `u8` | `SIMARD_DISK_ADMISSION_CEILING_PCT` env (default 90, clamped 1–99) | default `90` |
+
+`disk_usage_pct`, `worktree_cache_bytes`, and `in_flight_engineers` are the same
+primitives already used by the [disk-health](./disk-health-api.md) and
+engineer-lifecycle paths.
+
+---
+
+## `AdmissionDecision`
+
+The tagged judgment the brain emits. Mirrors `DecideJudgment`: a closed enum
+tagged on `choice`, each variant carrying human-readable `rationale`.
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "choice", rename_all = "snake_case")]
+pub enum AdmissionDecision {
+    Admit { rationale: String },
+    Defer { rationale: String },
+    ReclaimFirst { rationale: String },
+}
+```
+
+Wire form (the JSON envelope the recipe agent produces):
+
+```json
+{"choice": "admit",         "rationale": "disk 61%, cache 8G, load 2.1 on 16 cpus — healthy"}
+{"choice": "defer",         "rationale": "load 22 on 8 cpus; builds are thrashing, wait a cycle"}
+{"choice": "reclaim_first", "rationale": "disk 88% but 30 stale worktrees are reclaimable"}
+```
+
+| Variant | `choice` tag | Meaning |
+|---|---|---|
+| `Admit` | `admit` | Proceed to worktree allocation and spawn. |
+| `Defer` | `defer` | Benign skip — no worktree, no failure-count bump, retry next cycle. |
+| `ReclaimFirst` | `reclaim_first` | Run the disk-health reclaim recipe, then defer this cycle. |
+
+The enum is **closed**. An unknown `choice` tag or a missing `rationale` field is
+a parse **error** (`SimardError::AdapterInvocationFailed`) — the parser never
+silently defaults to `Admit`. Fail-loud on malformed model output; the seam then
+falls back to the deterministic floor (below), where the hard rail still applies.
+
+```rust
+impl AdmissionDecision {
+    /// The `choice` label, for metrics and logs (bounded cardinality).
+    pub fn label(&self) -> &'static str { /* "admit" | "defer" | "reclaim_first" */ }
+
+    pub fn rationale(&self) -> &str { /* the variant's rationale */ }
+}
+```
+
+---
+
+## `OodaAdmissionBrain` trait
+
+Single-decision-site trait, synchronous to match the other OODA brain traits
+(the LLM-backed impl bridges to async internally).
+
+```rust
+pub trait OodaAdmissionBrain: Send + Sync {
+    /// Reason over the current resource picture and choose an admission outcome.
+    fn judge_admission(&self, ctx: &ResourceAdmissionCtx) -> SimardResult<AdmissionDecision>;
+}
+```
+
+### Implementations
+
+| Impl | Where | Behavior |
+|---|---|---|
+| `RecipeBrain` | `src/ooda_brain/recipe_brain.rs` | Constructed via `RecipeBrain::new(repo_root, ADMISSION_RECIPE_NAME, "recipe-resource-admission-brain")` (see [Construction](#construction)), where `ADMISSION_RECIPE_NAME = "ooda-resource-admission.yaml"` (re-exported from `admission.rs`) and the adapter-tag literal `"recipe-resource-admission-brain"` mirrors the existing `DECIDE_ADAPTER_TAG` / `ORIENT_ADAPTER_TAG` / `LIFECYCLE_ADAPTER_TAG` naming. `judge_admission` invokes the recipe via `recipe-runner-rs`, reuses the shared decision-output chokepoint (`extract_recipe_decision_output` → `recipe_output::extract_json_payload`), deserializes the `{"choice":..,"rationale":..}` object directly into `AdmissionDecision`, and emits the `brain_admission_decision` metric. A parse miss (or any recipe-runner failure) surfaces as an explicit `Err` — **NO FALLBACK**. Production path. |
+| `DeterministicAdmissionBrain` | `src/ooda_brain/admission.rs` | LLM-free floor. Always returns `Admit`. Used in tests and whenever no recipe brain can be constructed. Safe because the hard rail still guards ENOSPC. |
+
+```rust
+/// LLM-free floor. NOT a fallback hack — the explicit deterministic impl.
+/// Always admits; the deterministic disk ceiling in `resolve_admission` is the
+/// ENOSPC safety net, so a None/deterministic brain can never fill the disk.
+#[derive(Debug, Default)]
+pub struct DeterministicAdmissionBrain;
+
+impl OodaAdmissionBrain for DeterministicAdmissionBrain {
+    fn judge_admission(&self, _ctx: &ResourceAdmissionCtx) -> SimardResult<AdmissionDecision> {
+        Ok(AdmissionDecision::Admit {
+            rationale: "deterministic-brain: admit (hard rail guards disk)".into(),
+        })
+    }
+}
+```
+
+---
+
+## `AdmissionGate`, `resolve_admission`, `judge_and_resolve` — the pure gate + hard rail
+
+The gate is split into a **pure, brain-free** rail (`resolve_admission`) and a
+thin **reason→apply** wrapper (`judge_and_resolve`). Both are **zero-I/O**: the
+reclaim side effect (invoking the disk-health recipe) is performed by the
+**seam**, not by the gate, so the gate is fully hermetic in tests. The resolved
+gate is a 3-variant enum — `Reclaim` is a distinct outcome the seam acts on,
+not a closure folded into the gate.
+
+```rust
+/// The resolved admission outcome after the deterministic hard rail has had the
+/// final say over the brain's `AdmissionDecision`. This is what the spawn seam
+/// applies.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AdmissionGate {
+    /// Admit: proceed with the fresh spawn (allocate worktree, spawn engineer).
+    Proceed,
+    /// Skip this cycle without allocating resources. Benign — no failure bump.
+    Defer { reason: String },
+    /// Run disk reclamation now (disk-health recipe), then defer this cycle.
+    Reclaim { reason: String },
+}
+
+impl AdmissionGate {
+    /// `true` only for `AdmissionGate::Proceed` — i.e. an actual admission.
+    pub fn is_proceed(&self) -> bool { matches!(self, Self::Proceed) }
+}
+
+/// Apply the THIN deterministic hard rail over the brain's decision, then map it
+/// to an `AdmissionGate`. Pure — takes the decision, never calls the brain.
+///
+/// Rail: if `ctx.disk_usage_pct` is `Some(p)` AND `p >= ctx.ceiling_pct`, an
+/// `Admit` is forced to `Defer` regardless of the brain. Fail-open: a `None`
+/// disk reading never triggers the rail. `Defer` / `ReclaimFirst` are already
+/// non-admitting and pass through unchanged.
+pub fn resolve_admission(ctx: &ResourceAdmissionCtx, decision: AdmissionDecision) -> AdmissionGate;
+
+/// Seam core: reason → apply. Calls the brain for an `AdmissionDecision` and
+/// resolves it through the hard rail into an `AdmissionGate`.
+///
+/// NO FALLBACK: a brain error propagates unchanged so the seam surfaces it as a
+/// visible cycle failure (a broken brain must never look like a silent admit).
+pub fn judge_and_resolve(
+    brain: &dyn OodaAdmissionBrain,
+    ctx: &ResourceAdmissionCtx,
+) -> SimardResult<AdmissionGate>;
+```
+
+### Decision table
+
+Let `over_ceiling = matches!(ctx.disk_usage_pct, Some(p) if p >= ctx.ceiling_pct)`.
+
+| Brain result | `over_ceiling` | `resolve_admission` gate | Seam action |
+|---|---|---|---|
+| `Admit` | `false` | **Proceed** | allocate + spawn |
+| `Admit` | `true` | **Defer** (hard-rail downgrade) | benign skip |
+| `Defer` | any | **Defer** | benign skip |
+| `ReclaimFirst` | any | **Reclaim** | run disk-health recipe, then benign skip (defer) |
+| `Err(..)` (brain/parse failed) | — | — | **NO FALLBACK**: `judge_and_resolve` returns `Err`; the seam returns `success=false` (visible cycle failure), never a phantom admit |
+
+Key invariants:
+
+- A brain `Admit` can only be made **more** conservative by the rail, never less.
+- The rail fires **only** on a *successful, over-ceiling* disk read
+  (`Some(p) if p >= ceiling`). Unknown disk (`None`) never blocks.
+- `ReclaimFirst` always defers *after* invoking reclaim — it never races a spawn
+  against an in-flight cleanup.
+
+---
+
+## `gather_resource_admission_ctx` — best-effort probes
+
+```rust
+/// Build a `ResourceAdmissionCtx` with best-effort, never-panic probes.
+/// Every probe that fails degrades its field to `None` (or `0` for the count).
+pub fn gather_resource_admission_ctx(
+    state_root: &Path,
+    ceiling_pct: u8,
+) -> ResourceAdmissionCtx;
+```
+
+| Probe | Command / call | Failure handling |
+|---|---|---|
+| disk % | `df --output=pcent <state_root>` (argv form) | parse fail → `None` |
+| cache bytes | `du -sb <state_root>/<WORKTREES_SUBDIR>` (`WORKTREES_SUBDIR = "engineer-worktrees"`, `src/engineer_worktree/mod.rs`) | parse fail → `None` |
+| load 1m | read `/proc/loadavg`, take field 0 | non-Linux / read fail → `None` |
+| cpu count | `std::thread::available_parallelism()` | `Err` → `None` |
+| in-flight | `count_live_engineer_claims(state_root)` (`src/ooda_brain/context.rs`) | already returns `0` on error |
+
+> **Which root is measured.** The `du` probe sizes the daemon's *engineer*
+> worktrees under `<state_root>/engineer-worktrees/` (the
+> [`WORKTREES_SUBDIR`](https://github.com/rysweet/Simard/blob/main/src/engineer_worktree/mod.rs)
+> constant). This is a **different** directory from the one
+> [`disk_health::emergency_cleanup`](./disk-health-api.md) reclaims
+> (`<repo_root>/worktrees/*/target/`, `disk_health.rs`). The admission probe
+> reports occupancy of the engineer-worktree area it is gating; RECLAIM-FIRST
+> then delegates to the disk-health recipe, which cleans build-cache targets
+> across both roots.
+
+All subprocess probes are **argv-form** (`Command::new("df").arg(..)`), never
+`sh -c`, so shell injection is structurally impossible. Probe paths are always
+daemon-derived (state/repo root) — never goal- or LLM-supplied.
+
+---
+
+## `SIMARD_DISK_ADMISSION_CEILING_PCT` — the ceiling config
+
+The only tunable, and the only hardcoded threshold in the feature.
+
+```rust
+/// Read the disk admission ceiling from the environment.
+/// Default 90. Clamped to 1–99 (0 would deadlock; ≥100 would disable the rail).
+pub fn configured_ceiling_pct() -> u8 {
+    // parse_ceiling(std::env::var("SIMARD_DISK_ADMISSION_CEILING_PCT").ok().as_deref())
+    // → best-effort parse; unparseable/absent → DEFAULT_CEILING_PCT (90);
+    //   in-range values clamped to CEILING_MIN..=CEILING_MAX (1..=99).
+}
+```
+
+| Env var | Default | Range | Notes |
+|---|---|---|---|
+| `SIMARD_DISK_ADMISSION_CEILING_PCT` | `90` | clamped to `1..=99` | Best-effort parse; unparseable → default. `0` and `≥100` are impossible after clamping. |
+
+Read at the seam each cycle (mirroring the `SIMARD_SUBORDINATE_DEPTH` env read in
+`spawn.rs`), so it takes effect without a rebuild or restart.
+
+---
+
+## Integration seam (`dispatch_spawn_engineer`)
+
+The gate is inserted in the **fresh-spawn path** of `dispatch_spawn_engineer`:
+
+- **after** the live-engineer lifecycle branch (re-attach is exempt),
+- **after** the subordinate-depth recursion guard,
+- **under** the AIMD count cap (the caller already holds its permit),
+- **before** `EngineerWorktree::allocate` (so a defer grows nothing).
+
+```rust
+// … live-engineer branch returned above; depth guard passed …
+
+let state_root = engineer_worktree_state_root();
+let ceiling = configured_ceiling_pct();
+let ctx = gather_resource_admission_ctx(&state_root, ceiling);
+
+// `admission: &dyn OodaAdmissionBrain` is threaded in from the caller
+// (`bridges.admission_brain`, falling back to `&DeterministicAdmissionBrain`
+// when `None`). `repo_root: &Path` is threaded in for the reclaim recipe.
+match judge_and_resolve(admission, &ctx) {
+    Ok(AdmissionGate::Proceed) => {
+        // Observability: record the admission at the seam.
+        push_brain_judgment(BrainJudgmentRecord::from_admission(
+            goal_id, "admit", "resources healthy; admitting fresh engineer", "",
+        ));
+        // fall through to allocate + spawn
+    }
+    Ok(AdmissionGate::Defer { reason }) => {
+        // Benign skip: success=true, no worktree, no failure-count bump.
+        push_brain_judgment(BrainJudgmentRecord::from_admission(goal_id, "defer", &reason, ""));
+        return make_outcome(action, true, format!("deferred: resource pressure: {reason}"));
+    }
+    Ok(AdmissionGate::Reclaim { reason }) => {
+        // Reclaim first (reuse the disk-health recipe), then defer this cycle.
+        push_brain_judgment(BrainJudgmentRecord::from_admission(goal_id, "reclaim", &reason, ""));
+        if let Err(e) = crate::disk_health::run_disk_health_check(repo_root, &state_root, None) {
+            warn!(error = %e, "resource-admission reclaim failed (still deferring this cycle)");
+        }
+        return make_outcome(action, true, format!("deferred: reclaim-first: {reason}"));
+    }
+    Err(e) => {
+        // NO FALLBACK: a broken admission brain surfaces as a visible cycle
+        // failure (success=false → cycle.rs bumps the failure count), never a
+        // silent phantom admit that could fill the disk.
+        return make_outcome(action, false, format!("resource-admission brain failure: {e}"));
+    }
+}
+
+// … EngineerWorktree::allocate(..) …
+```
+
+Both dispatch call sites — the concurrent dispatcher and the direct
+`advance_goal` path — inherit the gate because it lives inside the shared
+function.
+
+### Why `Option<Arc<dyn OodaAdmissionBrain>>` on `OodaBridges`
+
+The admission brain is added as `admission_brain`, matching the existing
+`decide_brain` / `orient_brain` sibling fields:
+
+```rust
+pub struct OodaBridges {
+    // … existing brains/bridges …
+    pub decide_brain: Option<Arc<dyn OodaDecideBrain>>,
+    pub orient_brain: Option<Arc<dyn OodaOrientBrain>>,
+    pub admission_brain: Option<Arc<dyn OodaAdmissionBrain>>, // new
+}
+```
+
+`Option` keeps construction churn minimal (defaults to `None`) and the seam
+falls back to `DeterministicAdmissionBrain` when it is `None` — which remains
+ENOSPC-safe because the hard rail is in `resolve_admission`, not in the brain.
+
+### Construction
+
+`src/operator_commands_ooda/daemon/brains.rs` gains `build_admission_brain`,
+mirroring `build_act_brain`. Unlike `build_decide_brain` / `build_orient_brain`
+(which return `Option`), admission **always** yields a concrete brain — the seam
+must always have a reasoner to consult, and the deterministic floor + hard rail
+keep behaviour safe even with no LLM. `RecipeBrain::new` takes **three** args —
+`(repo_root, recipe_filename, adapter_tag)` — exactly like the decide/orient
+builders:
+
+```rust
+pub(super) fn build_admission_brain(
+    state_root: &Path,
+    repo_root: &Path,
+) -> Arc<dyn OodaAdmissionBrain> {
+    if let Some(b) = RecipeBrain::new(
+        repo_root,
+        crate::ooda_brain::ADMISSION_RECIPE_NAME, // "ooda-resource-admission.yaml"
+        "recipe-resource-admission-brain",
+    ) {
+        daemon_log(state_root, "[simard] OODA daemon: admission_brain = RecipeBrain …");
+        return Arc::new(b);
+    }
+    // No recipe-runner-rs / recipe YAML: fall back — loudly, via record_fallback —
+    // to the deterministic floor. The hard rail still guards ENOSPC.
+    record_fallback(state_root, "admission", "recipe-runner-rs or recipe not available");
+    Arc::new(DeterministicAdmissionBrain)
+}
+```
+
+The production `OodaBridges` literal wires `admission_brain: Some(build_admission_brain(&state_root, &repo_root))`; tests and non-daemon callers leave it `None` (→ the seam's `DeterministicAdmissionBrain` floor).
+
+---
+
+## Observability
+
+Every admission emits these signals, mirroring the lifecycle brain's telemetry
+(two of them are metrics — see the reconciliation table below):
+
+### 1. Judgment record — `BrainPhase::ResourceAdmission`
+
+A new `BrainPhase` variant (`src/ooda_brain/judgment_record.rs`) with
+byte-stable serde (`"resource_admission"`), plus a
+`BrainJudgmentRecord::from_admission(goal_id, label, reason, prompt_version)`
+constructor. `label` is the resolved gate label (`admit` / `defer` /
+`reclaim`); `reason` is the brain's (or hard-rail's) rationale; the 4th arg —
+`prompt_version: impl Into<String>` — mirrors `from_engineer_lifecycle` (the
+seam passes `""` since the admission recipe is not registered in the prompt
+store). Pushed via `push_brain_judgment` at each of the three seam arms
+(Proceed / Defer / Reclaim), so cycle reports and
+[brain introspection](./brain-introspection-api.md) show the final gate action.
+
+```rust
+pub enum BrainPhase {
+    Act,
+    Decide,
+    Orient,
+    MergeJudge,
+    ResourceAdmission, // new
+}
+// BrainPhase::as_str(self): BrainPhase::ResourceAdmission => "resource_admission"
+```
+
+> **Adding this variant touches the exhaustive `match` on `BrainPhase`** — the
+> enum's own `as_str` (`judgment_record.rs`). `parse_failure::phase_to_string`
+> delegates to `as_str`, so there is effectively **one** phase-string site plus
+> the byte-stability test (`mod.rs`), all agreeing on `"resource_admission"`.
+> See [Add a New Recipe-Brain Phase](../howto/add-a-new-recipe-brain-phase.md).
+
+### 2. Metric — `brain_admission_decision` (emitted by the recipe brain)
+
+The recipe-backed admission path emits one `brain_admission_decision` event per
+brain invocation, mirroring `brain_lifecycle_decision`
+(`record_lifecycle_decision_metric`). `record_metric`'s signature is
+`record_metric(name: &str, value: f64, context: &str)` — the third argument is a
+**JSON `context` string**, not a struct — so the call passes a serialized
+payload carrying the bounded-cardinality `choice` label (the brain's raw 3-way
+`AdmissionDecision::label()`: `admit` / `defer` / `reclaim_first`) plus the
+numeric resource picture. It is labeled by the enum + numbers only, never by
+rationale or paths, and is a no-op under `cfg!(test)`:
+
+```rust
+// inside judge_admission, mirroring build_lifecycle_metric_context:
+let context = serde_json::json!({
+    "choice": decision.label(), // "admit" | "defer" | "reclaim_first"
+    "disk_usage_pct": ctx.disk_usage_pct,
+    "worktree_cache_bytes": ctx.worktree_cache_bytes,
+    "load_avg_1m": ctx.load_avg_1m,
+    "cpu_count": ctx.cpu_count,
+    "in_flight_engineers": ctx.in_flight_engineers,
+    "ceiling_pct": ctx.ceiling_pct,
+})
+.to_string();
+let _ = record_metric("brain_admission_decision", 1.0, &context);
+```
+
+Because it fires in the brain (**before** the hard rail), it records the brain's
+*intent* — so a `reclaim_first` is visible even though the seam's final gate
+collapses to `Reclaim`→defer. The seam's judgment record (above) records the
+*final* gate action after the rail.
+
+> **Note.** Unlike the decide / orient / lifecycle brains, the admission brain
+> does **not** route through the confidence-gated escalation ladder or the
+> shared `brain_verdict_parsed_total` verdict-parse chokepoint. `judge_admission`
+> parses the `{"choice":..,"rationale":..}` object directly (via
+> `extract_json_payload` → `serde_json::from_str`); a parse miss is an explicit
+> `Err` (NO FALLBACK), not a ladder retry. So there is **no**
+> `brain_verdict_parsed_total{phase="resource_admission"}` series — the single
+> admission metric is `brain_admission_decision`.
+
+### 3. Tracing
+
+A single structured line per admission (emitted at the seam — `info!` for
+Proceed/Defer, `warn!` for Reclaim and brain-error), for example:
+
+```
+INFO simard::ooda_brain::admission: resource admission decided
+    goal=improve-test-coverage
+    choice=defer
+    disk_pct=91 ceiling=90 cache_bytes=53687091200 load_1m=18.4 cpus=8 in_flight=12
+    rationale="disk over ceiling — hard rail engaged"
+```
+
+The `rationale`/`reason` is untrusted model text. It is stored in the cycle
+report only through serde (JSON-escaped, never shell-interpreted) and emitted as
+a **structured** `tracing` field (not string-interpolated into a format that
+could break log parsing). The bounded-cardinality metric
+(`brain_admission_decision`) deliberately **excludes** it — it carries only the
+`choice` label plus numeric fields — so untrusted text can never inflate metric
+cardinality.
+
+---
+
+## Test inventory (hermetic)
+
+All tests stub the brain — **no `recipe-runner-rs`, no LLM, no real `df`/`du`**
+in the test path (the resource *reasoning quality* lives in the prompt, not the
+tests). The pure gate + hard rail are the contract these pin.
+
+**`src/ooda_brain/admission_tests.rs`** (27 hermetic tests via a stub brain):
+
+| Test | Proves |
+|---|---|
+| `rail_allows_admit_below_ceiling` | `Admit` + disk < ceiling → `Proceed` |
+| `rail_blocks_admit_at_ceiling_boundary` | `Admit` + disk == ceiling → `Defer` (`>=`, not `>`) |
+| `rail_blocks_admit_above_ceiling` | `Admit` + disk > ceiling → `Defer` (reason cites disk + ceiling) |
+| `rail_fails_open_when_disk_unknown` | `Admit` + `disk = None` → `Proceed` (rail does not fire) |
+| `rail_never_proceeds_when_over_ceiling_for_any_decision` | over-ceiling ⇒ never `Proceed`, for EVERY decision |
+| `defer_maps_to_defer_and_preserves_reason` / `reclaim_first_maps_to_reclaim_and_preserves_reason` | decision → gate mapping (FR-4) |
+| `reclaim_first_honored_even_over_ceiling` | `ReclaimFirst` over ceiling → `Reclaim` (still non-admitting) |
+| `seam_admit_decision_proceeds_when_healthy` / `seam_defer_decision_defers` / `seam_reclaim_decision_reclaims` | `judge_and_resolve` reason→apply seam |
+| `seam_rail_overrides_brain_admit_when_over_ceiling` | rail overrides a stub `Admit` when over ceiling |
+| `seam_surfaces_brain_error_no_fallback` | brain `Err` → `Err` (**NO FALLBACK**, never a phantom admit) |
+| `parse_ceiling_*` / `configured_ceiling_is_in_range` | unparseable → 90; `0` → 1; `250` → 99; env read always in range |
+| `decision_*_roundtrips` / `decision_ignores_extra_fields` | envelope `{"choice":..,"rationale":..}` ↔ enum, forward-compat |
+| `decision_unknown_choice_fails_to_parse` | `{"choice":"boom"}` → parse `Err`, not `Admit` |
+| `deterministic_brain_*` | floor always `Admit`, still beaten by the rail over ceiling |
+| `ctx_roundtrips_including_unknown_probes` | `ResourceAdmissionCtx` serde incl. `None` probes |
+
+**`src/ooda_brain/recipe_brain.rs`** (inline `#[cfg(test)]`):
+
+| Test | Proves |
+|---|---|
+| `parse_admission_decision_reads_all_three_choices` | direct `{"choice":..}` → `AdmissionDecision` for admit/defer/reclaim |
+| `parse_admission_decision_recovers_from_banner_and_fence` | banner + ```json fence still parses (shared chokepoint) |
+| `parse_admission_decision_none_for_unparseable` | empty / garbage / unknown tag → `None` (→ seam `Err`) |
+| `judge_admission_surfaces_error_no_fallback` | recipe-runner failure → `Err` naming the adapter tag (NO FALLBACK) |
+| `admission_metric_context_carries_choice_and_numbers` | `brain_admission_decision` payload carries `choice` + numeric picture |
+
+**`src/ooda_brain/mod.rs`** / **`context.rs`** / **`daemon/brains.rs`**:
+
+| Test | Proves |
+|---|---|
+| `brain_phase_serializes_as_lowercase` (mod.rs) | `BrainPhase::ResourceAdmission` ↔ `"resource_admission"` + `as_str` |
+| `admission_judgment_record_captures_gate` (mod.rs) | `from_admission` record shape + JSON round-trip |
+| `gather_resource_admission_ctx_is_hermetic_and_preserves_ceiling` (context.rs) | missing root → no panic, ceiling preserved, cache `None` |
+| `build_admission_brain_falls_back_to_deterministic_floor` (brains.rs) | unresolvable repo → loud fallback to the floor, which admits |
+
+---
+
+## Security
+
+| Concern | Handling |
+|---|---|
+| Shell injection | All probes argv-form; no `sh -c`. Probe paths daemon-derived only. |
+| Prompt injection | Context is numeric where possible (disk %, bytes, load, cpu, counts); any string context var passes `sanitize_context_var`. |
+| Fail-loud parsing | `AdmissionDecision` is a closed `#[serde(tag="choice")]` enum; unknown tag / missing field → parse `Err`, never default-to-`Admit`. |
+| Untrusted rationale | Stored only via serde (JSON-escaped) + emitted as a structured `tracing` field; never shell-interpreted or re-executed. Excluded from the metric so it cannot inflate cardinality. |
+| Ceiling misconfig | `parse().ok().unwrap_or(90).clamp(1,99)` — never `unwrap`, never 0, never ≥100. |
+| Availability invariant | known-over-ceiling ⇒ Defer; unknown ⇒ reasoner; never known-over-ceiling ⇒ Admit; never deadlock on unknown. |
+| Metric cardinality | `brain_admission_decision` labeled by enum only, never rationale/paths. |
+
+No authN/authZ: single-tenant, single-process, local daemon — no network
+boundary is crossed, so none is invented. No data-at-rest, no secrets, no PII.
+
+---
+
+## Module layout
+
+```
+src/ooda_brain/
+├── admission.rs          # OodaAdmissionBrain, ResourceAdmissionCtx, AdmissionDecision,
+│                         #   AdmissionGate, DeterministicAdmissionBrain,
+│                         #   resolve_admission (pure rail), judge_and_resolve (seam core),
+│                         #   parse_ceiling / configured_ceiling_pct,
+│                         #   RECIPE_NAME ("ooda-resource-admission.yaml")
+├── admission_tests.rs    # 27 hermetic tests (stub brain): seam + hard rail
+├── context.rs            # gather_resource_admission_ctx (best-effort probes)
+├── recipe_brain.rs       # impl OodaAdmissionBrain for RecipeBrain; parse_admission_decision;
+│                         #   brain_admission_decision metric (adapter tag literal)
+├── judgment_record.rs    # BrainPhase::ResourceAdmission + BrainJudgmentRecord::from_admission
+└── mod.rs                # mod admission; re-exports (ADMISSION_RECIPE_NAME = RECIPE_NAME)
+
+src/ooda_actions/advance_goal/
+└── spawn.rs              # gate seam in dispatch_spawn_engineer (Proceed/Defer/Reclaim/Err)
+
+src/ooda_loop/
+└── types.rs              # OodaBridges.admission_brain: Option<Arc<dyn OodaAdmissionBrain>>
+
+src/operator_commands_ooda/daemon/
+└── brains.rs             # build_admission_brain(..) -> Arc<dyn OodaAdmissionBrain>
+
+src/disk_health.rs        # get_disk_usage_pct (pub(crate), reused); run_disk_health_check (reclaim)
+
+prompt_assets/simard/recipes/
+└── ooda-resource-admission.yaml   # the intelligence (see recipe reference)
+```
+
+---
+
+## See also
+
+- [Resource-aware engineer admission (concept)](../concepts/resource-aware-engineer-admission.md)
+- [OODA resource-admission recipe & prompt schema](./ooda-resource-admission-recipe.md)
+- [Configure resource-aware admission (how-to)](../howto/configure-resource-aware-admission.md)
+- [`OodaBrain` API](./ooda-brain-api.md) — the sibling Decide/Act/Orient traits and the deterministic-floor pattern
+- [Recipe-Brain API](./recipe-brain-api.md) — the `RecipeBrain` envelope-parse chokepoint and escalation ladder
+- [Disk-Health API](./disk-health-api.md) — `run_disk_health_check` (RECLAIM-FIRST) and `emergency_cleanup` (≥95% tier)
+- [Adaptive Scaling API](./adaptive-scaling-api.md) — the count cap this layers under

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
     - Operational Autonomy Model: concepts/operational-autonomy-model.md
     - Adaptive Scaling: concepts/adaptive-scaling.md
     - Pluggable Identity: concepts/pluggable-identity.md
+    - Identity Write-Authority (Observer Posture): concepts/identity-write-authority.md
     - OODA Loop Self-Detection: concepts/ooda-loop-self-detection.md
     - Unified RecipeBrain: concepts/unified-recipe-brain.md
     - Prompt-Driven OODA Brain: concepts/prompt-driven-ooda-brain.md
@@ -165,6 +166,7 @@ nav:
     - Self-Maintain Dependency Pins: howto/self-maintain-dependency-pins.md
     - Configure Adaptive Scaling: howto/configure-adaptive-scaling.md
     - Configure Pluggable Identity: howto/configure-pluggable-identity.md
+    - Configure a Read-Only Observer Identity: howto/configure-observer-identity.md
     - Configure Episode Hygiene and Promotion: howto/configure-episode-hygiene-and-promotion.md
     - Inspect Improvement Curation State: howto/inspect-improvement-curation-state.md
     - Inspect the Procedural-Learning Loop: howto/inspect-the-procedural-learning-loop.md
@@ -276,6 +278,7 @@ nav:
     - Meeting Handoff Schema: reference/meeting-handoff-schema.md
     - Handoff Lifecycle API: reference/handoff-lifecycle-api.md
     - Pluggable Identity API: reference/pluggable-identity-api.md
+    - Identity Posture & Observer Act Phase: reference/identity-posture-observer.md
     - Adaptive Scaling API: reference/adaptive-scaling-api.md
     - Brain Introspection API: reference/brain-introspection-api.md
     - Self-Quality-Audit API: reference/self-quality-audit-api.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
     - Goal Stewardship Mode: concepts/stewardship-mode.md
     - The Simard Whisperer: concepts/simard-whisperer.md
     - Automated Disk-Health Management: concepts/automated-disk-health.md
+    - Resource-Aware Engineer Admission: concepts/resource-aware-engineer-admission.md
     - Update-Check Design: concepts/update-check-design.md
     - The amplihack Freshness Gate: concepts/amplihack-freshness-gate.md
   - Tutorials:
@@ -172,6 +173,7 @@ nav:
     - Configure the Monthly Self-Quality-Audit: howto/configure-self-quality-audit.md
     - Configure the Disk-Health Check: howto/configure-disk-health-check.md
     - Reclaim Disk Space (Low-Space Rust Builds): howto/reclaim-disk-space-and-run-low-space-rust-builds.md
+    - Configure Resource-Aware Admission: howto/configure-resource-aware-admission.md
     - Fix CI Linker OOM: howto/fix-ci-linker-oom.md
     - Triage Stale Pull Requests: howto/triage-stale-pull-requests.md
     - Diagnose merge-pr Verdict-Parse Failures: howto/diagnose-merge-pr-verdict-parse-failures.md
@@ -215,6 +217,7 @@ nav:
     - OODA Orient Prompt Schema: reference/ooda-orient-prompt.md
     - OODA Orient Recipe: reference/ooda-orient-recipe.md
     - OODA Engineer-Lifecycle Recipe: reference/ooda-engineer-lifecycle-recipe.md
+    - OODA Resource-Admission Recipe: reference/ooda-resource-admission-recipe.md
     - OODA Procedural Memory: reference/ooda-procedural-memory.md
     - Recipe-Brain Verdict/Decision Parsing: reference/recipe-brain-verdict-parsing.md
     - OODA Binary-Identity Reload Gate: reference/ooda-binary-identity-reload-gate.md
@@ -277,6 +280,7 @@ nav:
     - Brain Introspection API: reference/brain-introspection-api.md
     - Self-Quality-Audit API: reference/self-quality-audit-api.md
     - Disk-Health API: reference/disk-health-api.md
+    - Resource-Aware Admission API: reference/resource-aware-admission-api.md
     - Dashboard E2E Tests: reference/dashboard-e2e-tests.md
     - Dashboard Action-Detail Humanization: reference/dashboard-action-detail-humanization.md
     - Azlin Hosts Self-Membership: reference/azlin-hosts-self-membership.md

--- a/prompt_assets/simard/recipes/ooda-resource-admission.yaml
+++ b/prompt_assets/simard/recipes/ooda-resource-admission.yaml
@@ -1,0 +1,158 @@
+# ooda-resource-admission.yaml — Recipe-runner recipe for the OODA
+# RESOURCE-AWARE engineer admission brain (fresh-spawn gate).
+#
+# WHY THIS EXISTS
+# The AIMD adaptive scaler bounds how MANY engineers run concurrently, but a
+# count cap cannot see a full disk, a thrashing load average, or a cargo build
+# cache that has quietly grown to tens of gigabytes. On a busy self-improvement
+# host that gap bit hard: 40+ engineer worktrees accumulated, parallel `cargo`
+# builds piled up, disk climbed to 91%, and the next allocation tripped ENOSPC
+# (No space left on device) — which kills recipes mid-flight. Count-control is
+# necessary but NOT sufficient; admission must also weigh RESOURCES.
+#
+# This recipe is the intelligence for that admission decision. It runs at EVERY
+# fresh-engineer spawn (repeated structured thought), reasons over the current
+# resource picture, and emits exactly one of ADMIT / DEFER / RECLAIM-FIRST.
+#
+# The Rust shim (src/ooda_brain/recipe_brain.rs :: judge_admission) parses the
+# structured JSON decision below into an `AdmissionDecision`. A THIN
+# deterministic hard-rail in Rust (src/ooda_brain/admission.rs ::
+# resolve_admission) sits BELOW this reasoning: if disk% is known to be at/above
+# `ceiling_pct`, admission is refused regardless of what you decide here. You
+# can only ever be made MORE conservative by the rail, never less — so you never
+# have to hedge toward safety on disk; state your honest judgment.
+#
+# Context vars (passed via -c). Any probe that failed on the host renders as the
+# literal string `unknown`; weigh an `unknown` explicitly rather than assuming
+# the best case:
+#   disk_usage_pct        — % full of the state/worktree filesystem (0-100)
+#   worktree_cache_bytes  — total bytes under the engineer-worktrees/build-cache
+#   load_avg_1m           — 1-minute system load average
+#   cpu_count             — logical CPU count (normalize load per core)
+#   in_flight_engineers   — engineers already running this cycle
+#   ceiling_pct           — the deterministic disk hard-rail ceiling in effect
+#
+# Output: a single JSON object (see OUTPUT FORMAT) as the agent step output.
+
+name: "ooda-resource-admission"
+description: "OODA resource-aware engineer admission — ADMIT / DEFER / RECLAIM-FIRST"
+version: "1.0.0"
+author: "Simard"
+tags: ["simard", "ooda", "admission", "resource-aware"]
+
+context: {}
+
+steps:
+  - id: "resource-admission-decision"
+    type: "agent"
+    agent: "default"
+    prompt: |
+      # OODA Brain — Resource-Aware Engineer Admission
+
+      ## ROLE
+
+      You are the brain of Simard's OODA daemon. A goal has already passed the
+      AIMD engineer-COUNT cap and is about to spawn a FRESH engineer, which will
+      allocate a new git worktree and (very likely) kick off a parallel `cargo`
+      build with its own multi-gigabyte target cache. Before that allocation
+      happens, decide whether this host can currently AFFORD one more engineer.
+
+      Your job is resource ADMISSION, not count control. The count question was
+      already answered "yes" upstream. You answer the different question: **"can
+      this host afford one more engineer RIGHT NOW, given disk / build-cache /
+      load?"** Judge on the live numbers below, not on habit.
+
+      ## CONTEXT (current resource picture)
+
+      - disk_usage_pct: {{disk_usage_pct}}      # % full; `unknown` if the probe failed
+      - worktree_cache_bytes: {{worktree_cache_bytes}}  # bytes under engineer-worktrees / build caches
+      - load_avg_1m: {{load_avg_1m}}            # 1-minute load average
+      - cpu_count: {{cpu_count}}                # logical CPUs (load_avg_1m / cpu_count = load-per-core)
+      - in_flight_engineers: {{in_flight_engineers}}   # engineers already running this cycle
+      - ceiling_pct: {{ceiling_pct}}            # deterministic disk hard-rail ceiling
+
+      ## HOW TO REASON
+
+      Weigh three signals together — no single hardcoded threshold, that is the
+      whole point of doing this agentically:
+
+      1. **Disk headroom.** The dominant, irreversible risk is ENOSPC. The closer
+         `disk_usage_pct` is to `ceiling_pct`, the less headroom another build
+         cache leaves. Well below the ceiling with room to spare → disk is not a
+         reason to hold back. Approaching the ceiling → be cautious. At/above the
+         ceiling the deterministic rail will block you anyway, but if the disk is
+         high AND the growth is clearly reclaimable (a large `worktree_cache_bytes`
+         from stale worktrees / build caches), prefer RECLAIM-FIRST so the next
+         cycle has room, rather than a bare DEFER that just spins.
+      2. **Build-cache size.** A large `worktree_cache_bytes` relative to the
+         disk means much of the disk pressure is *reclaimable* (stale worktrees,
+         `target/` dirs) rather than load-bearing. That favors RECLAIM-FIRST over
+         DEFER when disk is tight, and is reassuring (reclaim is available) when
+         disk is moderate.
+      3. **System load.** Compare `load_avg_1m` to `cpu_count`. Load per core well
+         under ~1.0 means CPU headroom for another parallel build; load per core
+         well above ~1.5-2.0 means the host is already saturated and another
+         build would thrash without finishing faster. Many `in_flight_engineers`
+         plus high load is a strong DEFER signal even when disk is fine.
+
+      Treat any `unknown` field as a genuine unknown: do not assume it is
+      healthy. If disk is `unknown` you have lost your primary safety signal, so
+      lean conservative (DEFER) unless load and in-flight counts are clearly low.
+
+      ## OPTIONS — pick exactly one `choice`
+
+      - `admit` — Resources are healthy enough to add an engineer now. Disk has
+        clear headroom below the ceiling AND load-per-core leaves room for another
+        build. This is the normal, healthy answer; use it whenever the numbers
+        genuinely support it. Do NOT reflexively hold back — throttling a healthy
+        host wastes throughput.
+      - `defer` — Resources are tight and adding an engineer now is unwise (high
+        load-per-core, many in-flight engineers, or disk near the ceiling with
+        little reclaimable cache). A benign skip: no worktree is allocated, the
+        goal is simply retried next cycle, and this is NOT counted as a failure.
+      - `reclaim_first` — Disk pressure is high but clearly RECLAIMABLE (a large
+        build-cache / worktree footprint). Run disk reclamation first, then defer
+        this cycle and re-evaluate next cycle once space is freed.
+
+      ## OUTPUT FORMAT
+
+      Respond with a SINGLE JSON object of this exact shape (a fenced ```json
+      block is fine; the daemon strips any surrounding banner/prose before
+      parsing):
+
+      ```json
+      {"choice": "<admit|defer|reclaim_first>", "rationale": "<one concise sentence citing the numbers you weighed>"}
+      ```
+
+      `choice` MUST be exactly one of `admit`, `defer`, `reclaim_first`. There is
+      NO default: if your output is unparseable the daemon surfaces an explicit
+      error (and does NOT silently admit — an accidental admit could fill the
+      disk). Always cite the concrete numbers you weighed in the rationale so the
+      decision is auditable.
+
+      ## EXAMPLES
+
+      Healthy host — admit:
+
+      ```json
+      {"choice": "admit", "rationale": "disk 42% (ceiling 90), load 3.1 over 16 cpus = 0.19/core, 2 engineers in flight — ample headroom"}
+      ```
+
+      Saturated host — defer:
+
+      ```json
+      {"choice": "defer", "rationale": "disk 61% is fine but load 34 over 16 cpus = 2.1/core with 8 engineers in flight; another build would thrash, retry next cycle"}
+      ```
+
+      Tight but reclaimable disk — reclaim_first:
+
+      ```json
+      {"choice": "reclaim_first", "rationale": "disk 88% near ceiling 90, but worktree_cache_bytes is 210GB of stale caches — reclaim then re-evaluate rather than block"}
+      ```
+
+      Lost disk signal — conservative defer:
+
+      ```json
+      {"choice": "defer", "rationale": "disk_usage_pct unknown so primary safety signal is gone; with 6 engineers in flight, defer one cycle rather than risk ENOSPC"}
+      ```
+    output: "admission_result"

--- a/src/bootstrap/assembly.rs
+++ b/src/bootstrap/assembly.rs
@@ -17,7 +17,7 @@ use crate::goals::{CognitiveMemoryGoalStore, GoalStore};
 use crate::handoff::{FileBackedHandoffStore, RuntimeHandoffSnapshot, RuntimeHandoffStore};
 use crate::identity::{
     BuiltinIdentityLoader, FileIdentityLoader, IdentityLoadRequest, IdentityLoader,
-    IdentityManifest, ManifestContract, OperatingMode,
+    IdentityManifest, IdentityPosture, ManifestContract, OperatingMode, ResolvedPosture,
 };
 use crate::memory::{FileBackedMemoryStore, MemoryStore};
 use crate::memory_bridge_adapter::CognitiveBridgeMemoryStore;
@@ -343,4 +343,51 @@ pub(crate) fn load_identity(
         Some(path) => FileIdentityLoader::new(path, prompt_root).load(request),
         None => BuiltinIdentityLoader.load(request),
     }
+}
+
+/// Resolve the active identity's write posture at daemon boot (Simard #3125).
+///
+/// `SIMARD_IDENTITY_PATH` is the "identity present" signal (A1):
+///   * unset ⇒ [`ResolvedPosture::None`] — Simard's own read-write default; no
+///     behavior change (AC1).
+///   * set + resolves ⇒ [`ResolvedPosture::Identity`] with the identity's
+///     declared authority / targets / seed goals.
+///   * set but resolution fails (missing config, parse error, threading gap)
+///     ⇒ [`ResolvedPosture::Undetermined`], which fails CLOSED to read-only so
+///     a mis-wired observer can never spawn engineers (AC5). NO fallback to a
+///     read-write default.
+pub(crate) fn resolve_boot_posture() -> ResolvedPosture {
+    if std::env::var_os("SIMARD_IDENTITY_PATH").is_none() {
+        return ResolvedPosture::None;
+    }
+    match resolve_boot_manifest() {
+        Ok(manifest) => ResolvedPosture::Identity(IdentityPosture::from_manifest(&manifest)),
+        Err(e) => {
+            eprintln!(
+                "[simard] identity posture UNDETERMINED — failing CLOSED to read-only (no engineer dispatch): {e} (issue #3125)"
+            );
+            ResolvedPosture::Undetermined
+        }
+    }
+}
+
+/// Resolve the active identity manifest from the environment, reusing the same
+/// contract + loader plumbing as [`assemble_parts`].
+fn resolve_boot_manifest() -> SimardResult<IdentityManifest> {
+    let config = BootstrapConfig::from_env()?;
+    let contract = ManifestContract::new(
+        super::bootstrap_entrypoint(),
+        "bootstrap-config -> identity-loader -> ooda-posture",
+        config.manifest_precedence(),
+        Provenance::new(
+            "bootstrap",
+            format!("{}:{}", super::bootstrap_entrypoint(), config.identity),
+        ),
+        Freshness::now()?,
+    )?;
+    load_identity(
+        config.identity_path.as_ref().map(|cv| &cv.value),
+        &config.prompt_root.value,
+        &IdentityLoadRequest::new(config.identity.clone(), env!("CARGO_PKG_VERSION"), contract),
+    )
 }

--- a/src/disk_health.rs
+++ b/src/disk_health.rs
@@ -223,7 +223,7 @@ pub fn emergency_cleanup(repo_root: &Path, state_root: &Path) -> Option<DiskHeal
 }
 
 /// Get disk usage percentage for the filesystem containing `path`.
-fn get_disk_usage_pct(path: &Path) -> Option<u8> {
+pub(crate) fn get_disk_usage_pct(path: &Path) -> Option<u8> {
     let output = Command::new("df")
         .arg("--output=pcent")
         .arg(path)

--- a/src/goal_curation/mod.rs
+++ b/src/goal_curation/mod.rs
@@ -24,8 +24,9 @@ pub use operations::{
     add_backlog_item, archive_completed, board_snapshot_hash, clear_goal_assignment,
     enqueue_stewardship_issue, load_goal_board, overwrite_memory_cache, persist_board,
     promote_to_active, read_latest_carryover, rollup_parent_progress, save_goal_board,
-    save_goal_board_with_removals, seed_default_board, simard_state_root, update_goal_progress,
-    update_goal_progress_with_evidence, verify_goal_carryover, write_goal_carryover,
+    save_goal_board_with_removals, seed_default_board, seed_identity_board, simard_state_root,
+    update_goal_progress, update_goal_progress_with_evidence, verify_goal_carryover,
+    write_goal_carryover,
 };
 pub use types::{
     ActiveGoal, BacklogItem, CARRYOVER_CONCEPT, GoalBoard, GoalCarryoverRecord, GoalEdge,

--- a/src/goal_curation/operations.rs
+++ b/src/goal_curation/operations.rs
@@ -1354,6 +1354,40 @@ pub fn seed_default_board(board: &mut GoalBoard) -> usize {
     DEFAULT_SEED_GOALS.len()
 }
 
+/// Seed the board with an identity's declared seed goals (Simard #3125) if it
+/// has no active goals. Returns the number of goals added.
+///
+/// This is the identity-scoped counterpart of [`seed_default_board`]: when an
+/// identity declares its own `seed_goals` they OVERRIDE Simard's baked-in
+/// `DEFAULT_SEED_GOALS`. Each goal is seeded UNASSIGNED (no engineer dispatch)
+/// and scoped to the seed goal's own `repo` (a target slug), never
+/// `rysweet/Simard`. Read-only scope validation happens upstream at identity
+/// load (`IdentityManifest::with_posture`); this function trusts the already-
+/// validated `repo` field.
+pub fn seed_identity_board(board: &mut GoalBoard, seeds: &[crate::identity::SeedGoal]) -> usize {
+    if !board.active.is_empty() {
+        return 0;
+    }
+
+    for seed in seeds {
+        let id = crate::goals::goal_slug(&seed.title);
+        board.active.push(ActiveGoal {
+            parent_goal_id: None,
+            id,
+            description: seed.description.clone(),
+            priority: seed.priority,
+            status: GoalProgress::NotStarted,
+            assigned_to: None,
+            repo: seed.repo.clone(),
+            current_activity: None,
+            wip_refs: vec![],
+            last_progress_update_at: None,
+        });
+    }
+
+    seeds.len()
+}
+
 // ---------------------------------------------------------------------------
 // GoalBoard -> Vec<GoalRecord> adapter
 // ---------------------------------------------------------------------------

--- a/src/identity/compose.rs
+++ b/src/identity/compose.rs
@@ -4,7 +4,7 @@ use crate::base_types::BaseTypeId;
 use crate::error::{SimardError, SimardResult};
 use crate::prompt_assets::PromptAssetRef;
 
-use super::{IdentityManifest, ManifestContract, OperatingMode};
+use super::{IdentityManifest, ManifestContract, OperatingMode, SeedGoal, WriteAuthority};
 
 impl IdentityManifest {
     pub fn compose(
@@ -68,6 +68,34 @@ impl IdentityManifest {
             });
         }
 
+        // Write posture (Simard #3125): most-restrictive authority wins — a
+        // single read-only component makes the whole composed identity
+        // read-only (defense in depth: a composite can never be more
+        // permissive than its least-trusted part). Targets are the de-duped
+        // union; seed goals are concatenated. Because the union ⊇ each
+        // component's own (already-validated) target set, every concatenated
+        // seed goal stays within scope.
+        let write_authority = if components
+            .iter()
+            .any(|c| c.write_authority == WriteAuthority::ReadOnly)
+        {
+            WriteAuthority::ReadOnly
+        } else {
+            WriteAuthority::ReadWrite
+        };
+        let mut targets: Vec<String> = Vec::new();
+        for component in &components {
+            for target in &component.targets {
+                if !targets.contains(target) {
+                    targets.push(target.clone());
+                }
+            }
+        }
+        let seed_goals: Vec<SeedGoal> = components
+            .iter()
+            .flat_map(|c| c.seed_goals.iter().cloned())
+            .collect();
+
         IdentityManifest::new(
             name,
             version,
@@ -78,7 +106,8 @@ impl IdentityManifest {
             memory_policy,
             contract,
         )?
-        .with_components(component_names)
+        .with_components(component_names)?
+        .with_posture(write_authority, targets, seed_goals)
     }
 }
 

--- a/src/identity/file_loader.rs
+++ b/src/identity/file_loader.rs
@@ -14,7 +14,9 @@ use tracing::warn;
 
 use super::loader::BuiltinIdentityLoader;
 use super::toml_types::{TomlIdentity, TomlIdentityFile};
-use super::{IdentityLoadRequest, IdentityLoader, IdentityManifest, MemoryPolicy, OperatingMode};
+use super::{
+    IdentityLoadRequest, IdentityLoader, IdentityManifest, MemoryPolicy, OperatingMode, SeedGoal,
+};
 use crate::base_types::{BaseTypeCapability, BaseTypeId};
 use crate::error::{SimardError, SimardResult};
 use crate::memory::MemoryScope;
@@ -227,6 +229,23 @@ impl FileIdentityLoader {
             None => MemoryPolicy::default(),
         };
 
+        // Write posture (Simard #3125): the identity's declared authority +
+        // target scope + seed goals, attached via `with_posture`, which
+        // fail-closed-validates read-only seed-goal scoping. A validation
+        // failure is surfaced as a parse error (never a silent re-scope to
+        // Simard). `write_authority` deserialized directly off the TOML
+        // (absent ⇒ read-write; unknown value ⇒ a toml parse error already).
+        let seed_goals: Vec<SeedGoal> = identity
+            .seed_goals
+            .iter()
+            .map(|g| SeedGoal {
+                priority: g.priority,
+                title: g.title.clone(),
+                description: g.description.clone(),
+                repo: g.repo.clone(),
+            })
+            .collect();
+
         IdentityManifest::new(
             &identity.name,
             &request.package_version,
@@ -236,7 +255,16 @@ impl FileIdentityLoader {
             default_mode,
             memory_policy,
             request.contract.clone(),
+        )?
+        .with_posture(
+            identity.write_authority,
+            identity.targets.clone(),
+            seed_goals,
         )
+        .map_err(|e| SimardError::IdentityTomlParseError {
+            path: toml_path.to_path_buf(),
+            reason: format!("{e}"),
+        })
     }
 }
 

--- a/src/identity/manifest.rs
+++ b/src/identity/manifest.rs
@@ -4,7 +4,7 @@ use crate::base_types::{BaseTypeCapability, BaseTypeId};
 use crate::error::{SimardError, SimardResult};
 use crate::prompt_assets::PromptAssetRef;
 
-use super::{ManifestContract, MemoryPolicy, OperatingMode};
+use super::{ManifestContract, MemoryPolicy, OperatingMode, SeedGoal, WriteAuthority};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IdentityManifest {
@@ -17,6 +17,16 @@ pub struct IdentityManifest {
     pub default_mode: OperatingMode,
     pub memory_policy: MemoryPolicy,
     pub contract: ManifestContract,
+    /// Write posture (Simard #3125). Defaults to [`WriteAuthority::ReadWrite`]
+    /// so an identity that declares no posture — and Simard herself — is
+    /// behaviorally unchanged.
+    pub write_authority: WriteAuthority,
+    /// Target repo slugs this identity is scoped to (Simard #3125). Empty for
+    /// the Simard-unchanged default.
+    pub targets: Vec<String>,
+    /// Identity-declared seed goals (Simard #3125). When non-empty these
+    /// OVERRIDE Simard's baked-in `DEFAULT_SEED_GOALS`. Empty for the default.
+    pub seed_goals: Vec<SeedGoal>,
 }
 
 impl IdentityManifest {
@@ -46,6 +56,9 @@ impl IdentityManifest {
             default_mode,
             memory_policy,
             contract,
+            write_authority: WriteAuthority::ReadWrite,
+            targets: Vec::new(),
+            seed_goals: Vec::new(),
         })
     }
 
@@ -78,6 +91,44 @@ impl IdentityManifest {
             normalized.push(component);
         }
         self.components = normalized;
+        Ok(self)
+    }
+
+    /// Attach a write posture (Simard #3125): authority, target repo set, and
+    /// seed goals.
+    ///
+    /// Fail-closed contract: for a [`WriteAuthority::ReadOnly`] identity EVERY
+    /// seed goal MUST be scoped to a repo within `targets`. A seed goal whose
+    /// `repo` is `None` (which would default to Simard's own repo — the exact
+    /// bug #3125 fixes) or points outside `targets` is a hard error, never
+    /// silently re-scoped. A `ReadWrite` identity keeps the existing
+    /// own-repo (`repo = None`) semantics and is not scope-validated.
+    pub fn with_posture(
+        mut self,
+        write_authority: WriteAuthority,
+        targets: Vec<String>,
+        seed_goals: Vec<SeedGoal>,
+    ) -> SimardResult<Self> {
+        if write_authority == WriteAuthority::ReadOnly {
+            for goal in &seed_goals {
+                let scoped = goal
+                    .repo
+                    .as_deref()
+                    .is_some_and(|repo| targets.iter().any(|t| t == repo));
+                if !scoped {
+                    return Err(SimardError::InvalidIdentityComposition {
+                        identity: self.name.clone(),
+                        reason: format!(
+                            "read-only seed goal '{}' must be scoped to a repo within targets {:?}, got {:?}",
+                            goal.title, targets, goal.repo
+                        ),
+                    });
+                }
+            }
+        }
+        self.write_authority = write_authority;
+        self.targets = targets;
+        self.seed_goals = seed_goals;
         Ok(self)
     }
 

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -3,6 +3,7 @@ mod contract;
 mod file_loader;
 mod loader;
 mod manifest;
+mod posture;
 mod toml_types;
 mod types;
 
@@ -15,7 +16,8 @@ pub use contract::ManifestContract;
 pub use file_loader::FileIdentityLoader;
 pub use loader::{BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader};
 pub use manifest::{IdentityManifest, compose_with_precedence};
-pub use types::{MemoryPolicy, OperatingMode};
+pub use posture::{IdentityPosture, ResolvedPosture};
+pub use types::{MemoryPolicy, OperatingMode, SeedGoal, WriteAuthority};
 
 #[cfg(test)]
 mod tests {

--- a/src/identity/posture.rs
+++ b/src/identity/posture.rs
@@ -1,0 +1,124 @@
+//! Identity write-posture resolution (Simard #3125).
+//!
+//! [`IdentityPosture`] is the target-scoped write posture extracted from an
+//! [`IdentityManifest`]: its write authority, its target repo set, and its
+//! seed goals. [`ResolvedPosture`] is the boot-time resolution the daemon
+//! threads into the OODA state — and the single place the fail-closed rule
+//! lives:
+//!
+//!   * `None` — no identity is present. This is a DETERMINED state: Simard
+//!     herself runs read-write and unchanged (AC1).
+//!   * `Undetermined` — an identity IS present but its posture could not be
+//!     resolved (load / parse / threading gap). This fails CLOSED to
+//!     `ReadOnly` so a mis-wired observer can never spawn engineers (AC5).
+//!   * `Identity(p)` — a resolved identity posture; use its declared authority.
+
+use super::{IdentityManifest, SeedGoal, WriteAuthority};
+
+/// The target-scoped write posture of a single resolved identity.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IdentityPosture {
+    pub write_authority: WriteAuthority,
+    pub targets: Vec<String>,
+    pub seed_goals: Vec<SeedGoal>,
+}
+
+impl IdentityPosture {
+    /// Read the posture (authority + targets + seed goals) off a manifest.
+    pub fn from_manifest(manifest: &IdentityManifest) -> Self {
+        Self {
+            write_authority: manifest.write_authority,
+            targets: manifest.targets.clone(),
+            seed_goals: manifest.seed_goals.clone(),
+        }
+    }
+}
+
+/// Boot-time resolution of the active identity's write posture.
+///
+/// The fail-closed contract (no fallbacks / no silent degradation) lives in
+/// [`ResolvedPosture::write_authority`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ResolvedPosture {
+    /// No identity present — Simard's own read-write default (AC1).
+    None,
+    /// An identity is present but its posture is unresolved — fail CLOSED (AC5).
+    Undetermined,
+    /// A resolved identity posture.
+    Identity(IdentityPosture),
+}
+
+impl ResolvedPosture {
+    /// The effective write authority for this resolution.
+    ///
+    /// `None` ⇒ `ReadWrite` (Simard unchanged); `Undetermined` ⇒ `ReadOnly`
+    /// (fail closed — never spawn on an unresolved posture); `Identity` ⇒ the
+    /// identity's declared authority.
+    pub fn write_authority(&self) -> WriteAuthority {
+        match self {
+            Self::None => WriteAuthority::ReadWrite,
+            Self::Undetermined => WriteAuthority::ReadOnly,
+            Self::Identity(posture) => posture.write_authority,
+        }
+    }
+
+    /// The target repo set for this resolution (empty for `None` /
+    /// `Undetermined`).
+    pub fn targets(&self) -> &[String] {
+        match self {
+            Self::None | Self::Undetermined => &[],
+            Self::Identity(posture) => &posture.targets,
+        }
+    }
+
+    /// The identity's seed goals (empty for `None` / `Undetermined`).
+    pub fn seed_goals(&self) -> &[SeedGoal] {
+        match self {
+            Self::None | Self::Undetermined => &[],
+            Self::Identity(posture) => &posture.seed_goals,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn none_resolves_to_read_write() {
+        assert_eq!(
+            ResolvedPosture::None.write_authority(),
+            WriteAuthority::ReadWrite
+        );
+        assert!(ResolvedPosture::None.targets().is_empty());
+        assert!(ResolvedPosture::None.seed_goals().is_empty());
+    }
+
+    #[test]
+    fn undetermined_fails_closed_to_read_only() {
+        assert_eq!(
+            ResolvedPosture::Undetermined.write_authority(),
+            WriteAuthority::ReadOnly
+        );
+        assert!(ResolvedPosture::Undetermined.targets().is_empty());
+        assert!(ResolvedPosture::Undetermined.seed_goals().is_empty());
+    }
+
+    #[test]
+    fn identity_uses_declared_authority_and_scope() {
+        let posture = IdentityPosture {
+            write_authority: WriteAuthority::ReadOnly,
+            targets: vec!["hyenas/repo-a".to_string()],
+            seed_goals: vec![SeedGoal {
+                priority: 80,
+                title: "Observe branch hygiene".to_string(),
+                description: "OBSERVE ONLY".to_string(),
+                repo: Some("hyenas/repo-a".to_string()),
+            }],
+        };
+        let resolved = ResolvedPosture::Identity(posture);
+        assert_eq!(resolved.write_authority(), WriteAuthority::ReadOnly);
+        assert_eq!(resolved.targets(), ["hyenas/repo-a".to_string()]);
+        assert_eq!(resolved.seed_goals().len(), 1);
+    }
+}

--- a/src/identity/toml_types.rs
+++ b/src/identity/toml_types.rs
@@ -6,6 +6,8 @@
 
 use serde::Deserialize;
 
+use super::WriteAuthority;
+
 /// Top-level structure of an identity.toml file.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -43,6 +45,28 @@ pub(crate) struct TomlIdentity {
     pub components: Vec<String>,
     #[serde(default)]
     pub memory_policy: Option<TomlMemoryPolicy>,
+    /// Write posture (Simard #3125). Absent ⇒ read-write (Simard unchanged).
+    /// Deserializes the kebab tokens `read-only` / `read-write`; an unknown
+    /// value is a hard parse error (surfaced as `IdentityTomlParseError`).
+    #[serde(default)]
+    pub write_authority: WriteAuthority,
+    /// Target repo slugs this identity is scoped to (Simard #3125).
+    #[serde(default)]
+    pub targets: Vec<String>,
+    /// Identity-declared seed goals (Simard #3125). Override `DEFAULT_SEED_GOALS`.
+    #[serde(default)]
+    pub seed_goals: Vec<TomlSeedGoal>,
+}
+
+/// A `[[identities.seed_goals]]` entry (Simard #3125).
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlSeedGoal {
+    pub priority: u32,
+    pub title: String,
+    pub description: String,
+    #[serde(default)]
+    pub repo: Option<String>,
 }
 
 /// A `[[identities.prompt_assets]]` entry.

--- a/src/identity/types.rs
+++ b/src/identity/types.rs
@@ -55,6 +55,69 @@ impl FromStr for OperatingMode {
     }
 }
 
+/// Write posture of an identity (Simard #3125).
+///
+/// A read-only OBSERVER identity (e.g. Crocutus watching the hyenas repos) is
+/// authorized to observe and propose goals but NEVER to spawn write-bearing
+/// engineers. `ReadWrite` is the default so Simard herself — and any identity
+/// that does not declare a posture — is behaviorally unchanged.
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Serialize, Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum WriteAuthority {
+    /// OBSERVE ONLY: may record observations and propose goals, but the Act
+    /// phase must not dispatch engineers or write to any target repo.
+    ReadOnly,
+    /// Full authority — the Simard-unchanged default. May spawn engineers and
+    /// open PRs against the goal's target repo.
+    #[default]
+    ReadWrite,
+}
+
+impl Display for WriteAuthority {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::ReadOnly => "read-only",
+            Self::ReadWrite => "read-write",
+        };
+        f.write_str(label)
+    }
+}
+
+impl WriteAuthority {
+    /// `true` only for [`WriteAuthority::ReadWrite`].
+    ///
+    /// The deterministic spawn rail matches on this (deny-by-default): it
+    /// authorizes engineer dispatch ONLY for the proven read-write case, so any
+    /// read-only — or, should a future variant appear, any non-read-write —
+    /// posture fails closed and cannot spawn a write-bearing engineer.
+    pub fn may_dispatch_engineers(&self) -> bool {
+        matches!(self, Self::ReadWrite)
+    }
+
+    /// `true` for [`WriteAuthority::ReadOnly`] — an observe-only posture.
+    pub fn is_read_only(&self) -> bool {
+        matches!(self, Self::ReadOnly)
+    }
+}
+
+/// A single identity-declared seed goal (Simard #3125).
+///
+/// When an identity declares seed goals they OVERRIDE Simard's baked-in
+/// `DEFAULT_SEED_GOALS`. `repo` is the target-repo slug the goal is scoped to
+/// (e.g. `"hyenas/repo-a"`); for a read-only identity every seed goal MUST be
+/// scoped to a repo within the identity's target set (enforced by
+/// [`IdentityManifest::with_posture`]) so a goal can never silently escape to
+/// `rysweet/Simard`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SeedGoal {
+    pub priority: u32,
+    pub title: String,
+    pub description: String,
+    pub repo: Option<String>,
+}
+
 /// Controls what a session is allowed to write to long-term memory.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MemoryPolicy {
@@ -101,6 +164,53 @@ mod tests {
     #[test]
     fn default_memory_policy_validates_successfully() {
         MemoryPolicy::default().validate().unwrap();
+    }
+
+    // --- WriteAuthority (Simard #3125) ---
+
+    #[test]
+    fn write_authority_default_is_read_write() {
+        assert_eq!(WriteAuthority::default(), WriteAuthority::ReadWrite);
+    }
+
+    #[test]
+    fn write_authority_display_is_kebab() {
+        assert_eq!(WriteAuthority::ReadOnly.to_string(), "read-only");
+        assert_eq!(WriteAuthority::ReadWrite.to_string(), "read-write");
+    }
+
+    #[test]
+    fn write_authority_may_dispatch_only_read_write() {
+        assert!(WriteAuthority::ReadWrite.may_dispatch_engineers());
+        assert!(!WriteAuthority::ReadOnly.may_dispatch_engineers());
+    }
+
+    #[test]
+    fn write_authority_is_read_only_only_read_only() {
+        assert!(WriteAuthority::ReadOnly.is_read_only());
+        assert!(!WriteAuthority::ReadWrite.is_read_only());
+    }
+
+    #[test]
+    fn write_authority_serde_kebab_roundtrip() {
+        assert_eq!(
+            serde_json::to_string(&WriteAuthority::ReadOnly).unwrap(),
+            "\"read-only\""
+        );
+        let back: WriteAuthority = serde_json::from_str("\"read-write\"").unwrap();
+        assert_eq!(back, WriteAuthority::ReadWrite);
+    }
+
+    #[test]
+    fn seed_goal_holds_target_scope() {
+        let g = SeedGoal {
+            priority: 80,
+            title: "Observe branch hygiene".to_string(),
+            description: "OBSERVE ONLY".to_string(),
+            repo: Some("hyenas/repo-a".to_string()),
+        };
+        assert_eq!(g.repo.as_deref(), Some("hyenas/repo-a"));
+        assert_eq!(g.priority, 80);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,8 +235,9 @@ pub use goal_curation::{
     ActiveGoal, BacklogItem, CARRYOVER_CONCEPT, CarryoverVerification, DEFAULT_SEED_GOALS,
     GoalBoard, GoalCarryoverRecord, GoalProgress, MAX_ACTIVE_GOALS, WipRef, add_active_goal,
     add_backlog_item, archive_completed, board_snapshot_hash, load_goal_board, persist_board,
-    promote_to_active, read_latest_carryover, seed_default_board, update_goal_progress,
-    update_goal_progress_with_evidence, verify_goal_carryover, write_goal_carryover,
+    promote_to_active, read_latest_carryover, seed_default_board, seed_identity_board,
+    update_goal_progress, update_goal_progress_with_evidence, verify_goal_carryover,
+    write_goal_carryover,
 };
 pub use goals::{
     FileBackedGoalStore, GoalRecord, GoalStatus, GoalStore, GoalUpdate, InMemoryGoalStore,

--- a/src/meeting_backend/agent_proxy.rs
+++ b/src/meeting_backend/agent_proxy.rs
@@ -1,8 +1,20 @@
 //! Direct-invoke agent proxy for meeting conversations.
 //!
-//! Spawns the coding agent per-turn via `copilot -p "MESSAGE"` with piped
-//! stdout — no PTY, no script(1), no bash wrapper. This is the "thin proxy"
-//! replacing the 30-90s PTY overhead (issue #2179).
+//! Spawns the coding agent per-turn via `copilot -p "MESSAGE"`. Each turn runs
+//! under a lightweight one-shot `script(1)` pseudo-terminal by default so the
+//! Node-based CLI detects an interactive TTY and flushes its reply
+//! incrementally — letting the streaming reader tee each line to the client as
+//! it arrives (issue #2581) instead of the reply appearing only once the whole
+//! turn completes. Over a plain pipe those CLIs detect a non-tty and
+//! block-buffer the entire turn into a single final write, which is exactly the
+//! "wait for the whole thread" latency this wrapper removes.
+//!
+//! This is distinct from the persistent, prompt-driven PTY session that added
+//! 30-90s of handshake overhead (issue #2179): the wrapper here is a single
+//! non-interactive invocation that self-terminates, so its startup cost is
+//! negligible and per-turn latency stays in the ~4-15s range. Set
+//! `SIMARD_AGENT_PTY_STREAM=0` to fall back to a direct piped invocation
+//! (marginally faster to start, but the reply only appears once the turn ends).
 //!
 //! Copilot CLI does not support persistent interactive stdin when piped, so
 //! each turn is a separate subprocess. The conversation context is maintained
@@ -24,6 +36,141 @@ use crate::base_types::{
 use crate::error::{SimardError, SimardResult};
 use crate::metadata::{BackendDescriptor, Freshness};
 use crate::runtime::RuntimeTopology;
+
+/// External PTY launcher used to give a one-shot agent turn an interactive
+/// terminal so the CLI streams its output incrementally (issue #2581). Matches
+/// the `terminal_session` launcher; `script(1)` is present on Linux
+/// (util-linux) and macOS (BSD).
+const PTY_LAUNCHER: &str = "script";
+
+/// Whether agent turns run under a `script(1)` PTY (default) so the CLI streams
+/// its reply incrementally, versus a direct piped invocation where the reply
+/// only lands once the turn ends. Pure over the raw env value so the parsing is
+/// unit-testable without mutating process env (mirrors `parse_turn_timeout`).
+///
+/// Any of `0`, `false`, `no`, `off` (case-insensitive) disables the PTY; every
+/// other value — including an unset var — keeps it on.
+fn pty_streaming_from_env(raw: Option<String>) -> bool {
+    match raw {
+        Some(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        ),
+        None => true,
+    }
+}
+
+/// Live check of [`pty_streaming_from_env`] against the process environment.
+fn pty_streaming_enabled() -> bool {
+    pty_streaming_from_env(std::env::var("SIMARD_AGENT_PTY_STREAM").ok())
+}
+
+/// POSIX single-quote escaping so an arbitrary string — including the untrusted
+/// user prompt — can be embedded in the `sh -c` command line that `script`
+/// evaluates without any risk of shell injection. Wraps the value in single
+/// quotes and rewrites each embedded quote as the canonical `'\''` sequence.
+fn shell_single_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for c in s.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+/// Reconstruct the full agent invocation (`<cmd> <base_args…> -p <prompt>`) as a
+/// single shell-escaped command line suitable for `sh -c` / `script -c`. Every
+/// token is quoted independently so neither the args nor the prompt can alter
+/// the command structure.
+fn agent_shell_line(agent_cmd: &str, base_args: &[String], prompt: &str) -> String {
+    let mut tokens: Vec<String> = Vec::with_capacity(base_args.len() + 3);
+    tokens.push(shell_single_quote(agent_cmd));
+    for a in base_args {
+        tokens.push(shell_single_quote(a));
+    }
+    tokens.push(shell_single_quote("-p"));
+    tokens.push(shell_single_quote(prompt));
+    tokens.join(" ")
+}
+
+/// Strip a trailing carriage return and any ANSI/VT escape sequences from one
+/// line of agent output. PTY-relayed output carries CRLF line endings and may
+/// embed colour/cursor control sequences the CLI emits once it detects a TTY;
+/// neither belongs in the substantive chat text (issue #2581). A line with no
+/// escapes is returned unchanged apart from a trailing `\r`, so this is safe to
+/// apply to plain piped (non-PTY) output too. Char-based so multi-byte UTF-8 is
+/// preserved intact.
+///
+/// Takes the line by value so the common escape-free case reuses the caller's
+/// existing buffer — the trailing `\r` is popped in place and the same `String`
+/// handed straight back with zero extra allocation. Only a line that actually
+/// carries an ESC pays for a stripped copy. This matters because the streaming
+/// reader calls this once per output line (issue #2581).
+fn sanitize_terminal_line(mut line: String) -> String {
+    // Drop a trailing CR from CRLF terminal endings in place — no reallocation.
+    if line.ends_with('\r') {
+        line.pop();
+    }
+    // Fast path: no escape sequences, so the buffer is already the clean line —
+    // return it as-is without copying.
+    if !line.contains('\u{1b}') {
+        return line;
+    }
+    let mut out = String::with_capacity(line.len());
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        match chars.peek() {
+            // CSI: ESC '[' … terminated by a final byte in 0x40..=0x7e.
+            Some('[') => {
+                chars.next();
+                while let Some(&nc) = chars.peek() {
+                    chars.next();
+                    if ('\u{40}'..='\u{7e}').contains(&nc) {
+                        break;
+                    }
+                }
+            }
+            // String-payload control sequences: an ESC introducer followed by
+            // an opaque data string terminated by ST (ESC '\') or, defensively,
+            // BEL (0x07). All carry data — never visible text — so the whole
+            // sequence including its payload is dropped:
+            //   OSC  ESC ']'   operating system command (e.g. window title)
+            //   DCS  ESC 'P'   device control string
+            //   SOS  ESC 'X'   start of string
+            //   PM   ESC '^'   privacy message
+            //   APC  ESC '_'   application program command
+            Some(']') | Some('P') | Some('X') | Some('^') | Some('_') => {
+                chars.next();
+                while let Some(nc) = chars.next() {
+                    if nc == '\u{07}' {
+                        break;
+                    }
+                    if nc == '\u{1b}' {
+                        if let Some('\\') = chars.peek() {
+                            chars.next();
+                        }
+                        break;
+                    }
+                }
+            }
+            // Two-character escape (e.g. ESC M): drop the following byte.
+            Some(_) => {
+                chars.next();
+            }
+            None => {}
+        }
+    }
+    out
+}
 
 /// True when a single agent output line is copilot CLI noise (usage stats,
 /// bootstrap banners, progress indicators) that should never be surfaced as
@@ -229,13 +376,15 @@ fn resolve_agent_command() -> SimardResult<(String, Vec<String>)> {
 }
 
 /// A direct-invoke agent proxy that spawns the coding agent per-turn via
-/// `copilot -p "MESSAGE"` with piped stdout.
+/// `copilot -p "MESSAGE"`.
 ///
-/// Unlike `CopilotSdkAdapter` (which uses PTY/script per turn), this proxy
-/// invokes the agent directly with `-p` flag and captures stdout — no PTY
-/// allocation, no script(1) wrapper, no bash intermediary.
-///
-/// Response time: ~4-15s per turn vs 30-90s with the old PTY path.
+/// Each turn is wrapped in a one-shot `script(1)` PTY by default so the CLI
+/// streams its reply incrementally (issue #2581). This is a single
+/// non-interactive invocation — not the persistent, prompt-driven PTY session
+/// `CopilotSdkAdapter` uses — so it keeps the ~4-15s/turn latency rather than
+/// the 30-90s of the old interactive PTY path (issue #2179).
+/// `SIMARD_AGENT_PTY_STREAM=0` opts back into a direct piped invocation (no PTY,
+/// but the reply then only appears once the turn ends).
 pub struct PersistentAgentProxy {
     descriptor: BaseTypeDescriptor,
     is_open: bool,
@@ -312,6 +461,58 @@ impl PersistentAgentProxy {
         Ok(())
     }
 
+    /// Build the per-turn agent spawn command (program + argv only; stdio,
+    /// process group, and working directory are applied by the caller so both
+    /// modes share them).
+    ///
+    /// When `pty` is true (the default; see [`pty_streaming_enabled`]) the agent
+    /// runs under a one-shot `script(1)` PTY so the Node-based CLI
+    /// (`copilot`/`claude`) sees an interactive terminal and flushes its reply
+    /// incrementally, letting [`Self::invoke_agent_streaming`] tee each line to
+    /// the client as it is produced (issue #2581). Over a plain pipe those CLIs
+    /// detect a non-tty and block-buffer the whole turn into a single final
+    /// write, so nothing streams until the turn completes. The untrusted prompt
+    /// is shell-escaped via [`agent_shell_line`] before it reaches `sh -c`.
+    ///
+    /// When `pty` is false the agent is spawned directly with its argv, giving
+    /// the piped, non-tty stdio of the original thin proxy (issue #2179).
+    fn build_agent_command(&self, prompt: &str, pty: bool) -> Command {
+        if !pty {
+            let mut cmd = Command::new(&self.agent_cmd);
+            cmd.args(&self.agent_base_args).arg("-p").arg(prompt);
+            return cmd;
+        }
+
+        let agent_line = agent_shell_line(&self.agent_cmd, &self.agent_base_args, prompt);
+        let mut cmd = Command::new(PTY_LAUNCHER);
+        if cfg!(target_os = "macos") {
+            // BSD `script` (macOS): `-F` flushes each write; the typescript file
+            // is positional and precedes the command, which we run via an
+            // explicit shell so the escaped argv is honored identically.
+            cmd.arg("-qFe")
+                .arg("/dev/null")
+                .arg("/bin/sh")
+                .arg("-c")
+                .arg(agent_line);
+        } else {
+            // util-linux `script` (Linux): `-f` flushes each write, `-e`
+            // propagates the child exit code, and `-c` takes the command
+            // string; the typescript is discarded to /dev/null.
+            //
+            // util-linux `script -c` runs the command via `$SHELL`, falling
+            // back to `/bin/sh` only when it is unset. Pin `SHELL=/bin/sh` so
+            // an operator's non-POSIX login shell (fish, csh, …) can never
+            // reinterpret the POSIX single-quote-escaped command line — the
+            // macOS branch above already names `/bin/sh` explicitly. This
+            // hardens the one shell-boundary crossing (security review #2581).
+            cmd.env("SHELL", "/bin/sh")
+                .arg("-qefc")
+                .arg(agent_line)
+                .arg("/dev/null");
+        }
+        cmd
+    }
+
     /// Invoke the agent with a prompt and return the full (noise-stripped)
     /// response. Thin wrapper over [`Self::invoke_agent_streaming`] with a
     /// no-op chunk sink, for callers that don't need incremental output.
@@ -341,11 +542,12 @@ impl PersistentAgentProxy {
             "Invoking agent (streaming)"
         );
 
-        let mut cmd = Command::new(&self.agent_cmd);
-        cmd.args(&self.agent_base_args)
-            .arg("-p")
-            .arg(prompt)
-            .stdin(std::process::Stdio::null())
+        // Build the turn command — under a one-shot `script(1)` PTY by default
+        // so the agent CLI streams its reply incrementally instead of
+        // block-buffering the whole turn behind a non-tty pipe (issue #2581).
+        // `SIMARD_AGENT_PTY_STREAM=0` opts back into the direct piped path.
+        let mut cmd = self.build_agent_command(prompt, pty_streaming_enabled());
+        cmd.stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
 
@@ -467,6 +669,11 @@ impl PersistentAgentProxy {
                     // Fresh output — reset the idle-liveness clock so a
                     // productive turn is never reaped regardless of total length.
                     last_activity = Instant::now();
+                    // PTY-relayed output carries CRLF endings and may embed ANSI
+                    // control sequences the CLI emits once it sees a TTY; strip
+                    // both so the streamed preview and the final joined response
+                    // are clean text (a no-op for plain piped output).
+                    let line = sanitize_terminal_line(line);
                     if !line_is_noise(line.trim()) {
                         on_chunk(&line);
                     }
@@ -692,6 +899,93 @@ mod tests {
         let input = "Normal response.\nWith multiple lines.";
         let result = strip_copilot_noise(input);
         assert_eq!(result, "Normal response.\nWith multiple lines.");
+    }
+
+    // ── issue #2581: PTY streaming helpers ──
+
+    #[test]
+    fn pty_streaming_defaults_on_when_unset() {
+        assert!(
+            pty_streaming_from_env(None),
+            "unset env must keep incremental PTY streaming enabled by default"
+        );
+    }
+
+    #[test]
+    fn pty_streaming_disabled_by_falsey_values() {
+        for v in ["0", "false", "FALSE", "no", "Off", " off "] {
+            assert!(
+                !pty_streaming_from_env(Some(v.to_string())),
+                "{v:?} must disable PTY streaming"
+            );
+        }
+    }
+
+    #[test]
+    fn pty_streaming_enabled_by_other_values() {
+        for v in ["1", "true", "yes", "on", ""] {
+            assert!(
+                pty_streaming_from_env(Some(v.to_string())),
+                "{v:?} must keep PTY streaming enabled"
+            );
+        }
+    }
+
+    #[test]
+    fn shell_single_quote_escapes_embedded_quote() {
+        // A prompt attempting to break out of the sh -c string stays inert.
+        assert_eq!(shell_single_quote("a'b"), "'a'\\''b'");
+        assert_eq!(shell_single_quote("plain"), "'plain'");
+    }
+
+    #[test]
+    fn agent_shell_line_quotes_every_token() {
+        let base = vec!["--allow-all-tools".to_string()];
+        let line = agent_shell_line("copilot", &base, "hi; rm -rf /");
+        // Structure: '<cmd>' '<arg>' '-p' '<prompt>' — all single-quoted so the
+        // injected ';' and spaces are literal prompt text, not shell syntax.
+        assert_eq!(line, "'copilot' '--allow-all-tools' '-p' 'hi; rm -rf /'");
+    }
+
+    #[test]
+    fn sanitize_terminal_line_strips_cr_and_ansi() {
+        // Trailing CR from CRLF terminal endings.
+        assert_eq!(sanitize_terminal_line("hello\r".to_string()), "hello");
+        // CSI colour codes around real text.
+        assert_eq!(
+            sanitize_terminal_line("\u{1b}[32mgreen\u{1b}[0m text\r".to_string()),
+            "green text"
+        );
+        // OSC sequence (window title) terminated by BEL.
+        assert_eq!(
+            sanitize_terminal_line("\u{1b}]0;title\u{07}visible".to_string()),
+            "visible"
+        );
+        // DCS/SOS/PM/APC string sequences carry an opaque payload terminated by
+        // ST (ESC '\') — the whole sequence, payload included, must be dropped.
+        assert_eq!(
+            sanitize_terminal_line("\u{1b}Pq#0;2;0;0;0\u{1b}\\shown".to_string()),
+            "shown"
+        );
+        assert_eq!(
+            sanitize_terminal_line("\u{1b}_private data\u{1b}\\kept".to_string()),
+            "kept"
+        );
+        assert_eq!(
+            sanitize_terminal_line("\u{1b}^pm payload\u{1b}\\end".to_string()),
+            "end"
+        );
+    }
+
+    #[test]
+    fn sanitize_terminal_line_preserves_plain_and_utf8() {
+        assert_eq!(sanitize_terminal_line("just text".to_string()), "just text");
+        // Multi-byte UTF-8 must survive intact (char-based scan).
+        assert_eq!(sanitize_terminal_line("café ☕\r".to_string()), "café ☕");
+        assert_eq!(
+            sanitize_terminal_line("\u{1b}[1mbold café ☕\u{1b}[0m".to_string()),
+            "bold café ☕"
+        );
     }
 
     // ── issues #2549/#2581: default idle-liveness window ──
@@ -965,15 +1259,16 @@ mod tests {
         );
     }
 
-    // ── thin-proxy invariant (issue #2179): no PTY, piped stdio ──
+    // ── streaming vs thin-proxy stdio (issues #2179 / #2581) ──
 
     #[test]
-    fn invoke_agent_uses_piped_stdio_not_a_pty() {
-        // The thin proxy spawns the agent with a null stdin and a piped stdout —
-        // never a PTY/script(1)/bash wrapper (issue #2179, replacing the 30-90s
-        // PTY overhead). A child that inspects its own descriptors must therefore
-        // observe NON-tty stdin and stdout; if a PTY leaked back in, `[ -t 0 ]` /
-        // `[ -t 1 ]` would report a terminal and this assertion would fail.
+    fn invoke_agent_streams_under_a_pty_by_default() {
+        // Streaming (issue #2581) requires the agent to see an interactive
+        // terminal so it flushes incrementally instead of block-buffering the
+        // whole turn behind a non-tty pipe. By default the turn therefore runs
+        // under a one-shot `script(1)` PTY: a child that inspects its own
+        // descriptors observes tty stdin AND stdout. (`SIMARD_AGENT_PTY_STREAM`
+        // is unset in the test process, so the default PTY path is exercised.)
         let mut proxy = PersistentAgentProxy::new().unwrap();
         proxy.agent_cmd = "sh".to_string();
         proxy.agent_base_args = vec![
@@ -986,12 +1281,74 @@ mod tests {
 
         let response = proxy
             .invoke_agent("hello")
-            .expect("no-PTY probe child must return Ok");
+            .expect("PTY probe child must return Ok");
         assert_eq!(
-            response, "stdin=notty stdout=notty",
-            "proxy must invoke the agent over piped (non-PTY) stdio — no \
-             script(1)/PTY/bash wrapper (issue #2179)"
+            response, "stdin=tty stdout=tty",
+            "streaming turns must run the agent under a PTY so it flushes \
+             incrementally (issue #2581)"
         );
+    }
+
+    #[test]
+    fn build_agent_command_direct_mode_is_a_plain_pipe() {
+        // With the PTY disabled the agent is spawned directly with its own argv
+        // — no `script(1)`/PTY/bash wrapper — preserving the thin-proxy path
+        // (issue #2179) as an opt-out.
+        let mut proxy = PersistentAgentProxy::new().unwrap();
+        proxy.agent_cmd = "copilot".to_string();
+        proxy.agent_base_args = vec!["--allow-all-tools".to_string()];
+
+        let cmd = proxy.build_agent_command("hi there", false);
+        assert_eq!(cmd.get_program(), "copilot");
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args, vec!["--allow-all-tools", "-p", "hi there"]);
+    }
+
+    #[test]
+    fn build_agent_command_pty_mode_wraps_script_with_escaped_prompt() {
+        // With the PTY enabled the agent runs under `script(1)`; the full
+        // invocation is passed as a single shell-escaped command string so an
+        // adversarial prompt cannot break out of `sh -c`.
+        let mut proxy = PersistentAgentProxy::new().unwrap();
+        proxy.agent_cmd = "copilot".to_string();
+        proxy.agent_base_args = vec!["--allow-all-tools".to_string()];
+
+        let cmd = proxy.build_agent_command("hi; rm -rf /", true);
+        assert_eq!(cmd.get_program(), PTY_LAUNCHER);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        // The escaped agent line must appear verbatim as one argument, with the
+        // injected `;` quoted inside the prompt rather than as shell syntax.
+        let expected_line = "'copilot' '--allow-all-tools' '-p' 'hi; rm -rf /'";
+        assert!(
+            args.iter().any(|a| a == expected_line),
+            "escaped agent line must be passed as a single argument: {args:?}"
+        );
+        assert!(
+            args.iter().any(|a| a == "/dev/null"),
+            "typescript output must be discarded to /dev/null: {args:?}"
+        );
+        // Security hardening: the util-linux `script -c` path must pin
+        // `SHELL=/bin/sh` so a non-POSIX operator login shell cannot reinterpret
+        // the single-quote-escaped command line (macOS names /bin/sh directly).
+        #[cfg(not(target_os = "macos"))]
+        {
+            let shell = cmd
+                .get_envs()
+                .find(|(k, _)| *k == std::ffi::OsStr::new("SHELL"))
+                .and_then(|(_, v)| v)
+                .map(|v| v.to_string_lossy().into_owned());
+            assert_eq!(
+                shell.as_deref(),
+                Some("/bin/sh"),
+                "script -c must run the command under /bin/sh, not $SHELL"
+            );
+        }
     }
 
     #[test]

--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -814,7 +814,15 @@ pub fn classify_distill_error(err: &SimardError) -> DistillFailureClass {
         DistillFailureClass::RecipeReportedFailure
     } else if msg.starts_with("distill: `distill` step output did not contain a parseable")
         || msg.starts_with("distill: recipe run did not yield a parseable")
+        || msg.starts_with("distill: distill step produced no parseable facts file")
     {
+        // The structured file-channel manifestations (issues #2622, #2619): the
+        // recipe process exited 0 but the distill agent's dedicated facts-output
+        // file was missing / empty / not parseable JSON. This is the *same*
+        // failure mode as the legacy stdout parse miss — the run reached output
+        // parsing but yielded no facts — so it maps to `ParseFailure` (transient,
+        // in-cycle retried, counted in `distill_parse_success_rate`), never a
+        // silent success.
         DistillFailureClass::ParseFailure
     } else {
         DistillFailureClass::Other
@@ -1252,6 +1260,121 @@ pub(crate) fn parse_recipe_output_full(raw: &str) -> SimardResult<DistillOutput>
         "distill: recipe run did not yield a parseable {{ \"facts\": [...] }} object: {}",
         truncate(raw, 200)
     )))
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Structured file-channel parsing (issues #2622, #2619)
+// ───────────────────────────────────────────────────────────────────────────
+//
+// The stdout-scraping tiers above are the brittle G3 antipattern the operator
+// flagged: the copilot launcher BANNER / INFO log lines are captured as the
+// distill step "output", and a balanced-brace grep for `{ "facts": [...] }`
+// then fails, so distillation cannot parse its own output (parse-failure 67% /
+// 100%). The fix gives the distill agent a DEDICATED output channel: the recipe
+// passes `-c facts_output_path=<temp>` and instructs the agent to WRITE its
+// `{ "facts": [...], "procedures": [...] }` envelope to that file. Simard reads
+// the file after the subprocess exits and deserializes it — launcher banners
+// and log noise on stdout can never contaminate the parse.
+//
+// STATUS: the two functions below are the real, test-driven implementations of
+// the structured file channel; the suite in `distillation_file_channel_tests.rs`
+// pins their full contract. They deserialize the agent-written facts file
+// directly through the shared [`RecipeEnvelope`] serde boundary — the same
+// field-lenient / concept-canonicalizing contract the stdout path uses — with
+// the ONLY tolerated noise being surrounding whitespace and an optional ```json
+// markdown fence. They are referenced from the test suite today; wiring them into
+// `RecipeRunnerSubprocess::invoke_recipe` (pass `-c facts_output_path=<temp>`,
+// have the recipe write its envelope there, then read the file after the
+// subprocess exits) is the remaining production integration and is why they still
+// carry `#[allow(dead_code)]` for non-test builds — drop the allow once the
+// subprocess is wired to the file channel.
+
+/// Stable error prefix for every file-channel extraction miss. It is
+/// deliberately one of the prefixes [`classify_distill_error`] maps to
+/// [`DistillFailureClass::ParseFailure`], so a missing / empty / non-JSON facts
+/// file is a transient, in-cycle-retried parse miss counted in
+/// `distill_parse_success_rate` — never a silent success.
+const FILE_CHANNEL_PARSE_FAILURE_PREFIX: &str =
+    "distill: distill step produced no parseable facts file";
+
+/// Strip an optional surrounding ```json … ``` markdown fence (and any
+/// surrounding whitespace) the distill agent occasionally wraps its envelope in.
+///
+/// This is a single, well-defined unwrap of ONE fence — deliberately NOT the
+/// balanced-brace / banner-stripping stdout scanning that is the G3 antipattern
+/// the file channel exists to retire. Non-fenced input is returned trimmed and
+/// otherwise untouched.
+fn strip_optional_json_fence(contents: &str) -> &str {
+    let trimmed = contents.trim();
+    let Some(after_open) = trimmed.strip_prefix("```") else {
+        return trimmed;
+    };
+    // Drop the remainder of the fence-open line (e.g. the `json` language tag).
+    let body = match after_open.find('\n') {
+        Some(nl) => &after_open[nl + 1..],
+        None => after_open,
+    };
+    // Drop a trailing ``` fence if present, then re-trim.
+    let body = body.trim();
+    body.strip_suffix("```").unwrap_or(body).trim()
+}
+
+/// Parse the JSON envelope the distill agent writes to its dedicated
+/// facts-output file into a [`DistillOutput`].
+///
+/// STRICT structured channel — NOT stdout scraping. The agent's file-write tool
+/// owns this channel and writes ONLY the `{ "facts": [...], "procedures": [...] }`
+/// envelope, so this deserializes it directly via the shared [`RecipeEnvelope`]
+/// serde boundary (the same field-lenient / concept-canonicalizing contract the
+/// stdout path used, so one malformed sibling does not sink a batch). The only
+/// tolerated noise is surrounding whitespace and an optional ```json markdown
+/// fence — never balanced-brace scanning or ANSI/banner stripping.
+///
+/// Contract (see `distillation_file_channel_tests.rs`):
+/// - valid envelope → `Ok(DistillOutput { facts, procedures })`
+/// - `{"facts":[],"procedures":[]}` → `Ok(DistillOutput::default())` (SUCCESS,
+///   zero yield — NEVER `parse-failure`)
+/// - empty / non-JSON / launcher-banner contents → `Err` classified
+///   [`DistillFailureClass::ParseFailure`] (no silent fallback, no hollow `Ok`)
+// `#[allow(dead_code)]`: referenced from the TDD suite today; the production
+// caller (`invoke_recipe`) is wired to the file channel in the follow-on
+// integration — remove the allow then.
+#[allow(dead_code)]
+pub(crate) fn parse_distill_facts_file(contents: &str) -> SimardResult<DistillOutput> {
+    let cleaned = strip_optional_json_fence(contents);
+    serde_json::from_str::<RecipeEnvelope>(cleaned)
+        .map(RecipeEnvelope::into_output)
+        .map_err(|e| {
+            SimardError::BridgeError(format!(
+                "{FILE_CHANNEL_PARSE_FAILURE_PREFIX}: {e}: {}",
+                truncate(contents, 200)
+            ))
+        })
+}
+
+/// Read the distill agent's dedicated facts-output file at `path` and parse it
+/// via [`parse_distill_facts_file`].
+///
+/// A missing / unreadable / empty / unparseable file is an EXPLICIT
+/// [`DistillFailureClass::ParseFailure`] — never a silent success. This is the
+/// no-silent-fallback invariant: on a genuine extraction failure the caller
+/// surfaces telemetry and leaves the batch unmarked for a retry, but the healthy
+/// path reliably yields facts from the uncontaminated file.
+// `#[allow(dead_code)]`: referenced from the TDD suite today; the production
+// caller (`invoke_recipe`) is wired to the file channel in the follow-on
+// integration — remove the allow then.
+#[allow(dead_code)]
+pub(crate) fn read_distill_facts_file(path: &Path) -> SimardResult<DistillOutput> {
+    // A missing / unreadable file is itself a parse-failure-classified miss (the
+    // run reached output collection but yielded no facts file), so map the read
+    // error onto the shared prefix before delegating to the strict parse.
+    let contents = std::fs::read_to_string(path).map_err(|e| {
+        SimardError::BridgeError(format!(
+            "{FILE_CHANNEL_PARSE_FAILURE_PREFIX} at {}: {e}",
+            path.display()
+        ))
+    })?;
+    parse_distill_facts_file(&contents)
 }
 
 /// Recover a [`DistillOutput`] from recipe-runner stdout whose JSON envelope is

--- a/src/memory_consolidation/distillation_file_channel_tests.rs
+++ b/src/memory_consolidation/distillation_file_channel_tests.rs
@@ -1,0 +1,305 @@
+//! TDD (RED) tests for the DISTILLATION structured file channel
+//! (issues #2622 = 67% parse-failure, #2619 = 100% parse-failure).
+//!
+//! ## The defect these tests pin
+//!
+//! Distillation's memory fact-yield collapsed to ~zero because the recipe
+//! runner could not parse its OWN output. Two defects compounded (confirmed
+//! live in the daemon logs 02:45–02:47):
+//!
+//!   1. the copilot LAUNCHER BANNER / `INFO` log lines were captured *as* the
+//!      distill step output, and
+//!   2. the code BRITTLE-GREPPED that stdout for a `{ "facts": [...] }` object
+//!      (the G3 antipattern the operator flagged).
+//!
+//! So the captured "output" was literally the launcher banner
+//! (`… launching copilot binary=… version="GitHub Copilot CLI 1.0.69-1."`),
+//! the balanced-brace scan found no facts object, and the pass failed with
+//! `class="parse-failure"`.
+//!
+//! ## The fix these tests drive
+//!
+//! Give the distill agent a DEDICATED output channel: the recipe passes
+//! `-c facts_output_path=<temp>` and instructs the agent to WRITE its
+//! `{ "facts": [...], "procedures": [...] }` envelope to that file. Simard reads
+//! the file after the subprocess exits and deserializes it. Because the parse
+//! reads a FILE (by path), launcher banners / log noise on STDOUT can never
+//! contaminate it — structurally, not heuristically.
+//!
+//! ## TDD status
+//!
+//! These tests were written FIRST (Step 7) and drove the implementation. They
+//! target two `pub(crate)` functions in `distillation`:
+//!   * `parse_distill_facts_file(contents: &str) -> SimardResult<DistillOutput>`
+//!   * `read_distill_facts_file(path: &Path) -> SimardResult<DistillOutput>`
+//!
+//! These are now implemented: they deserialize the agent-written envelope
+//! through the shared `RecipeEnvelope` serde boundary (strict — no stdout
+//! scraping), with bounded tolerance for an optional ```json fence. The full
+//! suite below — positive path, the launcher-banner-can't-contaminate
+//! regression, and the negative / no-silent-fallback / classification cases — is
+//! GREEN. The remaining production integration is wiring
+//! `RecipeRunnerSubprocess::invoke_recipe` to the file channel (pass
+//! `-c facts_output_path`, have the recipe write the envelope there, read it
+//! after the subprocess exits); these functions are the tested seam it will call.
+
+use crate::memory_consolidation::distillation::{
+    DistillFailureClass, classify_distill_error, parse_distill_facts_file, read_distill_facts_file,
+};
+
+// ───────────────────────────────────────────────────────────────────────────
+// Fixtures: the exact live-incident stdout noise, and clean file envelopes.
+// ───────────────────────────────────────────────────────────────────────────
+
+/// The exact launcher-banner / log noise that (defect a) was being captured as
+/// the distill step output and (defect b) brittle-grepped for facts. Reproduced
+/// from the daemon logs 02:45–02:47 (Copilot CLI 1.0.69-1). The point of the
+/// file channel is that THIS never reaches the parser: it lives on stdout, the
+/// facts live in a separate file.
+const LIVE_LAUNCHER_BANNER: &str = "\u{2139} NODE_OPTIONS=--max-old-space-size=32768 (saved preference)\n\
+     2026-07-06T02:45:12.001Z INFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot version=\"GitHub Copilot CLI 1.0.69-1.\"\n\
+     Run 'copilot update' to update to the latest version.\n";
+
+/// A clean facts+procedures envelope exactly as the distill agent is asked to
+/// WRITE it to `facts_output_path`.
+fn clean_envelope() -> String {
+    r#"{
+      "facts": [
+        { "concept": "bug-pattern",
+          "content": "launcher banner on stdout was captured as distill output",
+          "source_episode_id": "epi_2622" },
+        { "concept": "lesson-learned",
+          "content": "read distilled facts from a dedicated file, never scrape stdout",
+          "source_episode_id": "epi_2619" }
+      ],
+      "procedures": [
+        { "name": "distill:file-channel",
+          "steps": ["pass -c facts_output_path", "agent writes envelope to file", "runner reads file after exit"],
+          "source_episode_ids": ["epi_2622", "epi_2619"] }
+      ]
+    }"#
+    .to_string()
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 1. Healthy path: the file channel yields structured facts AND procedures.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn file_channel_extracts_facts_and_procedures() {
+    let out = parse_distill_facts_file(&clean_envelope())
+        .expect("a clean facts+procedures envelope written to the file must parse");
+    assert_eq!(out.facts.len(), 2, "both facts must be extracted");
+    assert_eq!(out.facts[0].concept, "bug-pattern");
+    assert_eq!(
+        out.facts[0].content,
+        "launcher banner on stdout was captured as distill output"
+    );
+    assert_eq!(out.facts[0].source_episode_id, "epi_2622");
+    assert_eq!(out.facts[1].concept, "lesson-learned");
+    assert_eq!(out.procedures.len(), 1, "the procedure must be extracted");
+    assert_eq!(out.procedures[0].name, "distill:file-channel");
+    assert_eq!(out.procedures[0].steps.len(), 3);
+    assert_eq!(
+        out.procedures[0].source_episode_ids,
+        vec!["epi_2622", "epi_2619"]
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 2. THE core regression: a launcher banner on stdout is IRRELEVANT because the
+//    facts are read from a dedicated file by path. This is the hermetic proof
+//    that stdout noise can never cause a parse-failure (task VALIDATION).
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn launcher_banner_on_stdout_cannot_contaminate_the_file_channel() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let facts_path = dir.path().join("distill-facts.json");
+    std::fs::write(&facts_path, clean_envelope()).expect("write facts file");
+
+    // The launcher banner is what the OLD stdout-scraping path captured and
+    // choked on. Here it is *separate* from the facts channel — the runner would
+    // print it to stdout while the agent writes the envelope to `facts_path`. The
+    // file read never consults stdout, so the banner is structurally inert.
+    let _stdout_noise = LIVE_LAUNCHER_BANNER; // present in production; must not matter
+
+    let out = read_distill_facts_file(&facts_path)
+        .expect("facts must be read from the file regardless of any stdout banner");
+    assert_eq!(
+        out.facts.len(),
+        2,
+        "structured facts must be extracted from the file even though the live \
+         launcher banner is on stdout"
+    );
+    assert_eq!(out.procedures.len(), 1);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 3. No silent fallback: if the banner/noise somehow lands as the FILE contents
+//    (agent wrote noise instead of JSON), that is an EXPLICIT parse-failure —
+//    never a silent `Ok` and never a hollow success.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn banner_as_file_contents_is_explicit_parse_failure_not_silent_ok() {
+    let err = parse_distill_facts_file(LIVE_LAUNCHER_BANNER)
+        .expect_err("a launcher banner is not a facts envelope — must be an explicit error");
+    assert_eq!(
+        classify_distill_error(&err),
+        DistillFailureClass::ParseFailure,
+        "banner-as-file-contents must classify as parse-failure (transient, retried, counted), \
+         never a silent success"
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 4. A genuinely empty batch is SUCCESS (zero yield), NOT a parse-failure (A4).
+//    This is the metric-correctness invariant: parse-failure is reserved for
+//    missing/empty/non-JSON files, not for a legitimately-empty distill.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn empty_facts_envelope_is_success_not_parse_failure() {
+    let out = parse_distill_facts_file(r#"{"facts":[],"procedures":[]}"#)
+        .expect("an empty-but-valid envelope is 'nothing worth distilling', a SUCCESS");
+    assert!(out.facts.is_empty());
+    assert!(out.procedures.is_empty());
+}
+
+#[test]
+fn facts_only_envelope_without_procedures_key_parses() {
+    // `procedures` is optional in the contract; a facts-only file must parse
+    // with an empty procedures vec (not a parse-failure).
+    let out = parse_distill_facts_file(
+        r#"{"facts":[{"concept":"pr-pattern","content":"c","source_episode_id":"e1"}]}"#,
+    )
+    .expect("facts-only envelope (no procedures key) must parse");
+    assert_eq!(out.facts.len(), 1);
+    assert!(out.procedures.is_empty());
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 5. Missing / empty file → explicit ParseFailure (no silent fallback, A5).
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn missing_facts_file_is_explicit_parse_failure() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir.path().join("does-not-exist.json");
+    assert!(!missing.exists());
+
+    let err = read_distill_facts_file(&missing)
+        .expect_err("a missing facts file must surface an explicit error, never a silent Ok");
+    assert_eq!(
+        classify_distill_error(&err),
+        DistillFailureClass::ParseFailure,
+        "a missing facts file is a parse-failure (the run reached parsing but yielded no facts)"
+    );
+}
+
+#[test]
+fn empty_facts_file_is_explicit_parse_failure() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let empty = dir.path().join("empty.json");
+    std::fs::write(&empty, "").expect("write empty file");
+
+    let err = read_distill_facts_file(&empty)
+        .expect_err("an empty facts file must surface an explicit error, never a silent Ok");
+    assert_eq!(
+        classify_distill_error(&err),
+        DistillFailureClass::ParseFailure
+    );
+}
+
+#[test]
+fn non_json_file_contents_is_explicit_parse_failure() {
+    let err = parse_distill_facts_file("this is not json at all")
+        .expect_err("non-JSON file contents must be an explicit parse-failure");
+    assert_eq!(
+        classify_distill_error(&err),
+        DistillFailureClass::ParseFailure
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 6. Bounded, non-brittle tolerance: strip a surrounding ```json markdown fence
+//    the agent sometimes wraps the envelope in. This is a single well-defined
+//    unwrap — NOT balanced-brace stdout scanning — so it does not reintroduce
+//    the G3 antipattern while keeping the healthy path yielding facts.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn markdown_fenced_envelope_is_tolerated() {
+    let fenced = format!("```json\n{}\n```", clean_envelope());
+    let out = parse_distill_facts_file(&fenced)
+        .expect("a ```json-fenced envelope must still parse (bounded tolerance, not scraping)");
+    assert_eq!(out.facts.len(), 2);
+    assert_eq!(out.procedures.len(), 1);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 7. The file channel reuses the SAME contract as the stdout path: off-spec
+//    concepts are dropped, surface-form variants are canonicalized, and
+//    field-level noise on one fact does not sink the whole envelope.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn file_channel_canonicalizes_surface_variant_and_drops_offspec_concepts() {
+    let contents = r#"{
+      "facts": [
+        { "concept": "PR-Pattern", "content": "surface variant is canonicalized", "source_episode_id": "e1" },
+        { "concept": "made-up-label", "content": "off-spec is dropped", "source_episode_id": "e2" }
+      ],
+      "procedures": []
+    }"#;
+    let out = parse_distill_facts_file(contents).expect("must parse");
+    assert_eq!(out.facts.len(), 1, "off-spec concept must be dropped");
+    assert_eq!(
+        out.facts[0].concept, "pr-pattern",
+        "surface-form variant must be canonicalized to the closed label set"
+    );
+}
+
+#[test]
+fn file_channel_tolerates_field_level_noise_on_one_fact() {
+    // Issue #2506 shape: one fact carries a null `source_episode_id`. Field-level
+    // leniency must recover the well-formed sibling instead of serde rejecting
+    // the whole envelope (which is what silently dropped batches before).
+    let contents = r#"{
+      "facts": [
+        { "concept": "lesson-learned", "content": "well-formed survivor", "source_episode_id": "e1" },
+        { "concept": "bug-pattern", "content": "noisy sibling", "source_episode_id": null }
+      ],
+      "procedures": []
+    }"#;
+    let out = parse_distill_facts_file(contents)
+        .expect("field-level noise on one fact must not sink the whole envelope");
+    assert!(
+        out.facts
+            .iter()
+            .any(|f| f.content == "well-formed survivor"),
+        "the well-formed fact must survive a noisy sibling"
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 8. Guard: the file-channel error must NOT be misclassified as a structural
+//    class (spawn/terminal/serialize) — it reached parsing and yielded nothing.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn file_channel_parse_failure_reached_parsing() {
+    let err = parse_distill_facts_file("").expect_err("empty contents must be a parse-failure");
+    let class = classify_distill_error(&err);
+    assert!(
+        class.reached_parsing(),
+        "a file-channel parse miss reached output parsing (denominator of \
+         distill_parse_success_rate); got {:?}",
+        class
+    );
+    assert!(
+        class.recipe_exited_ok(),
+        "the recipe process exited 0 — only the facts file was unparseable"
+    );
+}

--- a/src/memory_consolidation/mod.rs
+++ b/src/memory_consolidation/mod.rs
@@ -981,6 +981,15 @@ pub mod scheduler;
 #[cfg(test)]
 mod distillation_tests;
 
+// Issues #2622 / #2619: hermetic TDD tests for the structured file-channel that
+// replaces stdout-scraping of the distill agent's `{ "facts": [...] }` output.
+// Pins that a launcher banner / log noise on stdout can NEVER cause a
+// parse-failure (the facts are read from a dedicated file), that a genuinely
+// empty batch is a SUCCESS not a parse-failure, and that a missing/empty/
+// unparseable file surfaces an explicit ParseFailure (no silent fallback).
+#[cfg(test)]
+mod distillation_file_channel_tests;
+
 // Perpetual-cognition sub-goal: raise distillation fact-yield. A deterministic,
 // DB-free benchmark that records a baseline facts-per-consolidation-input number
 // over a fixed sample corpus and proves the concept-canonicalization change

--- a/src/ooda_actions/advance_goal/mod.rs
+++ b/src/ooda_actions/advance_goal/mod.rs
@@ -143,6 +143,12 @@ pub(super) fn dispatch_advance_goal(
     // when we mutably borrow `bridges.session` below (issue #1266).
     let brain = std::sync::Arc::clone(&bridges.brain);
 
+    // Resource-aware admission brain (fresh-spawn gate) + repo_root for the
+    // RECLAIM-FIRST disk-health recipe. Cloned up-front for the same
+    // borrow-checker reason. `None` → the deterministic admission floor.
+    let admission = bridges.admission_brain.clone();
+    let admission_repo_root = bridges.repo_root.clone();
+
     // Same pattern for the progress-evidence checker (issue #1967): clone
     // the Arc up-front so it lives across the inner mutable session
     // borrow without colliding with the bridges field-borrow check.
@@ -181,7 +187,21 @@ pub(super) fn dispatch_advance_goal(
         }) = result.action
         {
             let state_mx = std::sync::Mutex::new(&mut *state);
-            return dispatch_spawn_engineer(action, &state_mx, &goal_id, &task, brain.as_ref());
+            let default_admission = crate::ooda_brain::DeterministicAdmissionBrain;
+            let admission_ref: &dyn crate::ooda_brain::OodaAdmissionBrain =
+                match admission.as_deref() {
+                    Some(b) => b,
+                    None => &default_admission,
+                };
+            return dispatch_spawn_engineer(
+                action,
+                &state_mx,
+                &goal_id,
+                &task,
+                brain.as_ref(),
+                admission_ref,
+                &admission_repo_root,
+            );
         }
 
         return result.outcome;

--- a/src/ooda_actions/advance_goal/spawn.rs
+++ b/src/ooda_actions/advance_goal/spawn.rs
@@ -101,6 +101,35 @@ pub fn dispatch_spawn_engineer(
     admission: &dyn OodaAdmissionBrain,
     repo_root: &Path,
 ) -> ActionOutcome {
+    // ── Simard #3125: deterministic read-only spawn rail (L2 defense) ────────
+    //
+    // The single write-bearing chokepoint the Act phase funnels through. When
+    // the active identity's posture is read-only (an OBSERVER identity such as
+    // Crocutus), hard-block BEFORE any assignment re-check, admission gate,
+    // worktree allocation, or subprocess spawn — so no write-bearing engineer
+    // is ever dispatched and no AI credits are burned on work the read_only
+    // guard would block anyway. This is defense-in-depth beneath the
+    // observe-only Act branch (L1): even if control reaches here, the write is
+    // refused. Fail-closed: the posture is read STRAIGHT off the shared state,
+    // and a read-only posture is a benign skip (`success == true`) so the
+    // 3-strikes brain-failure safeguard is never tripped by an observer.
+    {
+        let guard = lock_state(state);
+        if !guard.write_authority.may_dispatch_engineers() {
+            eprintln!(
+                "[simard] spawn_engineer BLOCKED for goal '{goal_id}': identity posture is {} (deny-by-default: only read-write may dispatch engineers) — no write-bearing engineer dispatched (issue #3125)",
+                guard.write_authority
+            );
+            return make_outcome(
+                action,
+                true,
+                format!(
+                    "spawn_engineer skipped: identity posture is read-only (observe-only) for goal '{goal_id}' — no engineer dispatched"
+                ),
+            );
+        }
+    }
+
     // Re-check assignment under a short exclusive state lock to prevent a
     // double-spawn race (two cycles/threads parsing spawn_engineer for the
     // same goal). The per-round claim set in the dispatcher is the primary

--- a/src/ooda_actions/advance_goal/spawn.rs
+++ b/src/ooda_actions/advance_goal/spawn.rs
@@ -7,10 +7,12 @@ use crate::agent_roles::AgentRole;
 use crate::agent_supervisor::{SubordinateConfig, spawn_subordinate};
 use crate::identity_composition::max_subordinate_depth;
 use crate::ooda_brain::{
-    BrainJudgmentRecord, EngineerLifecycleDecision, OodaBrain, apply_decision_to_state,
-    gather_engineer_lifecycle_ctx, push_brain_judgment,
+    AdmissionGate, BrainJudgmentRecord, EngineerLifecycleDecision, OodaAdmissionBrain, OodaBrain,
+    apply_decision_to_state, configured_ceiling_pct, gather_engineer_lifecycle_ctx,
+    gather_resource_admission_ctx, judge_and_resolve, push_brain_judgment,
 };
 use crate::ooda_loop::{ActionOutcome, OodaState, PlannedAction};
+use std::path::Path;
 
 use crate::ooda_actions::make_outcome;
 
@@ -84,12 +86,20 @@ pub(crate) fn lock_state<'g, 'a>(
 ///
 /// Honours `SIMARD_SUBORDINATE_DEPTH` vs. `SIMARD_MAX_SUBORDINATE_DEPTH`
 /// so a recursing supervisor does not spawn forever.
+///
+/// `admission` is the RESOURCE-AWARE admission reasoner consulted on the
+/// fresh-spawn path (after the count cap, before worktree allocation): it
+/// weighs disk / build-cache / load and decides ADMIT / DEFER / RECLAIM-FIRST,
+/// guarded by a deterministic disk hard-rail. `repo_root` locates the
+/// disk-health reclaim recipe invoked on RECLAIM-FIRST.
 pub fn dispatch_spawn_engineer(
     action: &PlannedAction,
     state: &Mutex<&mut OodaState>,
     goal_id: &str,
     task: &str,
     brain: &dyn OodaBrain,
+    admission: &dyn OodaAdmissionBrain,
+    repo_root: &Path,
 ) -> ActionOutcome {
     // Re-check assignment under a short exclusive state lock to prevent a
     // double-spawn race (two cycles/threads parsing spawn_engineer for the
@@ -122,11 +132,16 @@ pub fn dispatch_spawn_engineer(
     // clears the failure counter and makes FAILURE_PENALTY useless), consult
     // the prompt-driven brain. The brain reasons about whether to keep
     // skipping, reclaim, deprioritize, file an issue, or block the goal.
-    let state_root_inflight = engineer_worktree_state_root();
-    if let Some(live) = find_live_engineer_for_goal(&state_root_inflight, goal_id) {
+    // Resolve the engineer-worktree state root ONCE and reuse it for both the
+    // in-flight re-attach check below and the resource-admission gate further
+    // down. `engineer_worktree_state_root()` is a pure env-read + path-join, so
+    // this is a clarity win rather than a hot-path saving, but it removes a
+    // duplicate computation and keeps a single source of truth for the root.
+    let engineer_state_root = engineer_worktree_state_root();
+    if let Some(live) = find_live_engineer_for_goal(&engineer_state_root, goal_id) {
         let ctx = {
             let guard = lock_state(state);
-            gather_engineer_lifecycle_ctx(&guard, &state_root_inflight, goal_id, &live)
+            gather_engineer_lifecycle_ctx(&guard, &engineer_state_root, goal_id, &live)
         };
         // NO FALLBACK: brain.decide_engineer_lifecycle Err must surface as a
         // visible cycle failure (operator constraint, issue #1711, #1748).
@@ -290,6 +305,117 @@ pub fn dispatch_spawn_engineer(
                 "spawn_engineer denied for goal '{goal_id}': subordinate depth {current_depth} >= configured limit {depth_limit}"
             ),
         );
+    }
+
+    // ── RESOURCE-AWARE admission gate (fresh-spawn only) ─────────────────
+    //
+    // The AIMD scaler bounds engineer COUNT; nothing above this point weighs
+    // DISK / build-cache / system load. On a busy host that gap let 40+ cargo
+    // build caches pile up and drove disk to 91% → ENOSPC killed recipes.
+    // Before allocating another worktree, gather the resource picture and ask
+    // the admission brain to reason ADMIT / DEFER / RECLAIM-FIRST — repeated
+    // structured thought at every admission, following the same
+    // gather→reason→apply pattern as the engineer-lifecycle brain above. The
+    // *intelligence* lives in the recipe/prompt; the only deterministic code
+    // here is a THIN disk hard-rail inside `judge_and_resolve` that blocks
+    // admission when disk% is known to be at/over the ceiling, regardless of
+    // what the brain decided (irreversible ENOSPC must never be reachable).
+    //
+    // Placed AFTER the count cap + depth guard and BEFORE worktree allocation
+    // (and before target-repo resolution) so a DEFER grows nothing. Both
+    // dispatch call sites inherit this gate. The live-engineer re-attach branch
+    // above is exempt — it allocates no new resources.
+    {
+        let ceiling = configured_ceiling_pct();
+        let admission_ctx = gather_resource_admission_ctx(&engineer_state_root, ceiling);
+        match judge_and_resolve(admission, &admission_ctx) {
+            Ok(AdmissionGate::Proceed) => {
+                // Admitted — emit an observability record and fall through to
+                // the normal spawn path below.
+                push_brain_judgment(BrainJudgmentRecord::from_admission(
+                    goal_id,
+                    "admit",
+                    "resources healthy; admitting fresh engineer",
+                    "",
+                ));
+            }
+            Ok(AdmissionGate::Defer { reason }) => {
+                // Benign skip: NO worktree, NO failure-count bump (success=true,
+                // see cycle.rs). The goal is simply retried next cycle. A
+                // resource defer is neither progress nor failure.
+                tracing::info!(
+                    target: "simard::ooda_brain",
+                    goal = %goal_id,
+                    reason = %reason,
+                    "resource-aware admission: DEFER (benign skip — no worktree, no failure)",
+                );
+                push_brain_judgment(BrainJudgmentRecord::from_admission(
+                    goal_id, "defer", &reason, "",
+                ));
+                return make_outcome(
+                    action,
+                    true,
+                    format!("deferred: resource pressure: {reason}"),
+                );
+            }
+            Ok(AdmissionGate::Reclaim { reason }) => {
+                // Reclaim disk first (reuse the existing disk-health recipe),
+                // then DEFER this cycle and re-evaluate next cycle. Still a
+                // benign skip (no worktree, no failure-count bump). A reclaim
+                // failure is logged but never turned into a cycle failure — we
+                // defer regardless so a deferred cycle grows nothing.
+                tracing::warn!(
+                    target: "simard::ooda_brain",
+                    goal = %goal_id,
+                    reason = %reason,
+                    "resource-aware admission: RECLAIM-FIRST (running disk-health reclaim, then defer)",
+                );
+                push_brain_judgment(BrainJudgmentRecord::from_admission(
+                    goal_id, "reclaim", &reason, "",
+                ));
+                match crate::disk_health::run_disk_health_check(
+                    repo_root,
+                    &engineer_state_root,
+                    None,
+                ) {
+                    Ok(report) => {
+                        tracing::info!(
+                            target: "simard::ooda_brain",
+                            goal = %goal_id,
+                            "disk-health reclaim completed; deferring this cycle to re-evaluate next cycle: {}",
+                            report.summary(),
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "simard::ooda_brain",
+                            goal = %goal_id,
+                            error = %e,
+                            "disk-health reclaim recipe failed (still deferring this cycle)",
+                        );
+                    }
+                }
+                return make_outcome(action, true, format!("deferred: reclaim-first: {reason}"));
+            }
+            Err(e) => {
+                // NO FALLBACK: a broken admission brain must surface as a
+                // visible cycle failure, never a silent phantom admit that
+                // could fill the disk (mirrors the lifecycle NO-FALLBACK
+                // contract). success=false → cycle.rs bumps the failure count.
+                tracing::error!(
+                    target: "simard::ooda_brain",
+                    goal = %goal_id,
+                    error = %e,
+                    "resource-aware admission brain FAILED — surfacing as cycle failure (NO silent admit)",
+                );
+                eprintln!("[simard] RESOURCE-ADMISSION BRAIN FAILURE goal={goal_id} error={e}");
+                return make_outcome(
+                    action,
+                    false,
+                    format!("resource-admission brain failure: {e}"),
+                );
+            }
+        }
     }
 
     let agent_name = build_engineer_name(goal_id);

--- a/src/ooda_actions/concurrent.rs
+++ b/src/ooda_actions/concurrent.rs
@@ -32,10 +32,11 @@ use crate::base_types::BaseTypeSession;
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::goal_curation::GoalProgress;
 use crate::goal_curation::progress_evidence::ProgressEvidenceChecker;
-use crate::ooda_brain::OodaBrain;
+use crate::ooda_brain::{OodaAdmissionBrain, OodaBrain};
 use crate::ooda_loop::{
     ActionOutcome, OodaBridges, OodaState, OrchestratorSessionFactory, PlannedAction,
 };
+use std::path::Path;
 
 use super::advance_goal::spawn::{dispatch_spawn_engineer, is_brain_failure_marker, lock_state};
 use super::goal_session::{GoalAction, apply_goal_advance_result, build_goal_advance_input};
@@ -98,6 +99,11 @@ struct AdvanceCtx<'a> {
     memory: &'a dyn CognitiveMemoryOps,
     checker: &'a dyn ProgressEvidenceChecker,
     brain: &'a dyn OodaBrain,
+    /// Resource-aware admission reasoner (fresh-spawn gate). Consulted by
+    /// `dispatch_spawn_engineer` before allocating an engineer worktree.
+    admission: &'a dyn OodaAdmissionBrain,
+    /// Repo root for the RECLAIM-FIRST disk-health recipe.
+    repo_root: &'a Path,
     /// Mints a fresh per-goal session so `run_turn` calls run concurrently.
     session_factory: Option<&'a dyn OrchestratorSessionFactory>,
     /// Fallback single session used (under lock, serialized) only when no
@@ -132,6 +138,17 @@ pub(super) fn dispatch_advance_concurrent(
     let session_factory: Option<&dyn OrchestratorSessionFactory> =
         bridges.session_factory.as_deref();
 
+    // Resource-aware admission brain (fresh-spawn gate) + repo_root for the
+    // RECLAIM-FIRST disk-health recipe. `None` → the deterministic admission
+    // floor (still guarded by the deterministic disk hard-rail). The default
+    // is declared here so it outlives the thread scope below.
+    let default_admission = crate::ooda_brain::DeterministicAdmissionBrain;
+    let admission: &dyn OodaAdmissionBrain = match bridges.admission_brain.as_deref() {
+        Some(b) => b,
+        None => &default_admission,
+    };
+    let repo_root: &Path = &bridges.repo_root;
+
     // Take ownership of the shared fallback session for the duration of the
     // round so the per-thread context can lend it out by `Box` (avoids tying a
     // `&mut` into the ctx struct). Restored afterwards so daemon shutdown can
@@ -146,6 +163,8 @@ pub(super) fn dispatch_advance_concurrent(
         memory,
         checker,
         brain,
+        admission,
+        repo_root,
         session_factory,
         shared_session: &shared_session,
         state: &state_mx,
@@ -373,7 +392,15 @@ fn dispatch_advance_goal_concurrent(action: &PlannedAction, ctx: &AdvanceCtx) ->
     // ── Engineer spawn — short state critical sections only (the git
     //    worktree allocation + detached subprocess run with NO lock held). ──
     if let Some(GoalAction::SpawnEngineer { task, .. }) = result.action {
-        return dispatch_spawn_engineer(action, ctx.state, &goal_id, &task, ctx.brain);
+        return dispatch_spawn_engineer(
+            action,
+            ctx.state,
+            &goal_id,
+            &task,
+            ctx.brain,
+            ctx.admission,
+            ctx.repo_root,
+        );
     }
 
     result.outcome

--- a/src/ooda_actions/mod.rs
+++ b/src/ooda_actions/mod.rs
@@ -11,6 +11,10 @@
 pub(crate) mod advance_goal;
 mod concurrent;
 mod goal_session;
+// Simard #3125: OBSERVE-ONLY Act phase for read-only identities. `pub(crate)`
+// so the cognition branch in `crate::ooda_loop::act` and the cross-module
+// tests in `tests_observe_only` can reach it.
+pub(crate) mod observe_only;
 mod session;
 mod simple_actions;
 
@@ -29,6 +33,11 @@ mod tests_dispatch;
 mod tests_dispatch_concurrency;
 #[cfg(test)]
 mod tests_goal_session;
+// Simard #3125: observe-only Act-phase tests. Depend on the (to-be-added)
+// `observe_only` implementation module; registered here so `cargo test`
+// compiles and runs them once that module lands.
+#[cfg(test)]
+mod tests_observe_only;
 
 use crate::error::SimardResult;
 use crate::ooda_loop::{ActionKind, ActionOutcome, OodaBridges, OodaState, PlannedAction};

--- a/src/ooda_actions/observe_only.rs
+++ b/src/ooda_actions/observe_only.rs
@@ -1,0 +1,164 @@
+//! OBSERVE-ONLY Act phase for read-only identities (Simard #3125).
+//!
+//! When the active identity's posture is [`WriteAuthority::ReadOnly`], the Act
+//! phase runs this observe-only branch instead of the engineer-dispatching
+//! one. The branch:
+//!   * consults an agentic [`ObserveOnlyBrain`] over the identity's TARGET repo
+//!     set (what to observe / what goals to propose is a reasoner decision —
+//!     kept agentic, with NO caller-imposed wall-clock timeout),
+//!   * records the returned observations as `[simard]` operator diagnostics, and
+//!   * appends the proposed goals to the board scoped to the identity's targets
+//!     (`repo = Some(target)`), UNASSIGNED — it NEVER calls
+//!     `dispatch_spawn_engineer` and NEVER writes to a target repo.
+//!
+//! Fail-closed contract (no fallbacks / no silent degradation):
+//!   * a failing observe brain surfaces its error — it must NOT fall back to
+//!     the engineer-dispatching Act phase, and
+//!   * a proposal whose repo is absent or outside `targets` is a hard error
+//!     (never silently re-scoped to `rysweet/Simard`); the whole pass is
+//!     validated BEFORE any board mutation, so a rejected proposal leaves the
+//!     board untouched.
+
+use crate::error::{SimardError, SimardResult};
+use crate::goal_curation::{ActiveGoal, GoalProgress};
+use crate::identity::SeedGoal;
+use crate::ooda_loop::{ActionOutcome, OodaState, PlannedAction};
+
+/// The agentic reasoner for the observe-only Act phase.
+///
+/// `observe` decides — over the identity's target repo set — what to observe
+/// and what goals to propose. It is deliberately a trait so the intelligence
+/// can live in a prompt/reasoner; the deterministic rail around it (scope
+/// validation + no engineer dispatch) lives in [`act_observe_only`]. No
+/// caller-imposed wall-clock timeout is applied to `observe`.
+pub trait ObserveOnlyBrain: Send + Sync {
+    fn observe(&self, targets: &[String]) -> SimardResult<ObserveOutcome>;
+}
+
+/// The result of one observe-only reasoning pass.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ObserveOutcome {
+    /// Human-readable observations about the target repos' health.
+    pub observations: Vec<String>,
+    /// Target-scoped goals proposed for the identity's own board.
+    pub proposals: Vec<SeedGoal>,
+}
+
+/// Run one observe-only Act pass and return the number of goals proposed.
+///
+/// See the module docs for the full fail-closed contract. On any error the
+/// board is left untouched.
+pub(crate) fn act_observe_only(
+    brain: &dyn ObserveOnlyBrain,
+    targets: &[String],
+    state: &mut OodaState,
+) -> SimardResult<usize> {
+    // Agentic step (NO fallback): a broken observe brain surfaces as an error
+    // — never a silent fall-through to engineer dispatch.
+    let outcome = brain.observe(targets)?;
+
+    // Validate EVERY proposal before mutating the board so a fail-closed
+    // rejection never leaks a partially-scoped goal (no implicit Simard scope).
+    for proposal in &outcome.proposals {
+        let scoped = proposal
+            .repo
+            .as_deref()
+            .is_some_and(|repo| targets.iter().any(|t| t == repo));
+        if !scoped {
+            return Err(SimardError::InvalidGoalRecord {
+                field: "repo".to_string(),
+                reason: format!(
+                    "observe-only proposal '{}' escapes the identity's target scope {:?} (repo {:?}); refusing to seed (issue #3125)",
+                    proposal.title, targets, proposal.repo
+                ),
+            });
+        }
+    }
+
+    // Record observations as operator diagnostics.
+    for observation in &outcome.observations {
+        eprintln!("[simard] OODA observe-only: {observation}");
+    }
+
+    // Append each proposal UNASSIGNED and target-scoped — no engineer dispatch.
+    let proposed = outcome.proposals.len();
+    for proposal in outcome.proposals {
+        let id = crate::goals::goal_slug(&proposal.title);
+        state.active_goals.active.push(ActiveGoal {
+            parent_goal_id: None,
+            id,
+            description: proposal.description,
+            priority: proposal.priority,
+            status: GoalProgress::NotStarted,
+            assigned_to: None,
+            repo: proposal.repo,
+            current_activity: None,
+            wip_refs: vec![],
+            last_progress_update_at: None,
+        });
+    }
+
+    if proposed > 0 {
+        eprintln!("[simard] OODA observe-only: proposed {proposed} target-scoped goal(s)");
+    }
+    Ok(proposed)
+}
+
+/// Deterministic observe-only floor (Simard #3125).
+///
+/// The non-agentic baseline consulted when no prompt-backed observe brain is
+/// wired: it records that it inspected the identity's targets and proposes no
+/// new goals (the identity's declared seed goals were placed on the board at
+/// boot by `seed_identity_board`). Mirrors the deterministic-floor pattern
+/// used by the lifecycle / admission / decide brains. A prompt-backed
+/// `ObserveOnlyBrain` can replace it without touching the rail.
+pub struct DeterministicObserveBrain;
+
+impl ObserveOnlyBrain for DeterministicObserveBrain {
+    fn observe(&self, targets: &[String]) -> SimardResult<ObserveOutcome> {
+        let observations = if targets.is_empty() {
+            vec!["read-only identity with no target repos configured".to_string()]
+        } else {
+            vec![format!(
+                "observed {} target repo(s) in read-only posture: {}",
+                targets.len(),
+                targets.join(", ")
+            )]
+        };
+        Ok(ObserveOutcome {
+            observations,
+            proposals: Vec::new(),
+        })
+    }
+}
+
+/// Run the OBSERVE-ONLY Act phase for a read-only identity (Simard #3125).
+///
+/// Called by [`crate::ooda_loop::act`] when `state.write_authority` is
+/// read-only. Runs the deterministic observe floor over the identity's targets
+/// (recording observations + proposing target-scoped goals) and returns one
+/// benign observe-only [`ActionOutcome`] per planned action. It NEVER calls
+/// `dispatch_spawn_engineer` — the whole point is that a read-only observer
+/// spends zero AI credits on write-bearing engineer dispatch the guardrail
+/// would block. Fail-closed: an observe-brain error propagates (the cycle
+/// fails loudly rather than silently reverting to engineer dispatch).
+pub(crate) fn run_observe_only_act(
+    actions: &[PlannedAction],
+    state: &mut OodaState,
+) -> SimardResult<Vec<ActionOutcome>> {
+    let targets = state.observer_targets.clone();
+    let brain = DeterministicObserveBrain;
+    let proposed = act_observe_only(&brain, &targets, state)?;
+
+    let outcomes = actions
+        .iter()
+        .map(|action| ActionOutcome {
+            action: action.clone(),
+            success: true,
+            detail: format!(
+                "observe-only: identity posture is read-only; recorded observations, proposed {proposed} target-scoped goal(s), dispatched 0 engineers (issue #3125)"
+            ),
+        })
+        .collect();
+    Ok(outcomes)
+}

--- a/src/ooda_actions/test_helpers.rs
+++ b/src/ooda_actions/test_helpers.rs
@@ -149,6 +149,7 @@ pub(crate) fn test_bridges() -> OodaBridges {
             crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     }
 }
 
@@ -210,5 +211,6 @@ pub(crate) fn bridges_with_session(session: MockSession) -> OodaBridges {
             crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     }
 }

--- a/src/ooda_actions/tests_dispatch.rs
+++ b/src/ooda_actions/tests_dispatch.rs
@@ -8,6 +8,16 @@ use super::make_outcome;
 use super::test_helpers::{board_with_goal, test_bridges};
 use crate::goal_curation::GoalProgress;
 
+// Simard #3125: the deterministic read-only spawn rail. `dispatch_spawn_engineer`
+// is the single write-bearing chokepoint the Act phase funnels through; the
+// rail is the L2 defense-in-depth layer that hard-blocks it when the active
+// identity's posture is read-only.
+use crate::identity::WriteAuthority;
+use crate::ooda_actions::advance_goal::spawn::dispatch_spawn_engineer;
+use crate::ooda_brain::{DeterministicAdmissionBrain, DeterministicLifecycleBrain};
+use std::path::Path;
+use std::sync::Mutex;
+
 // ── make_outcome ────────────────────────────────────────────────
 
 #[test]
@@ -124,4 +134,121 @@ fn dispatch_advance_goal_without_session_fails_gracefully() {
     let outcomes = dispatch_actions(&actions, &mut bridges, &mut state).unwrap();
     assert_eq!(outcomes.len(), 1);
     assert!(!outcomes[0].success);
+}
+
+// ── Simard #3125: deterministic read-only spawn rail (L2) ────────────────────
+//
+// AC3/AC5: when the active identity's posture is read-only,
+// `dispatch_spawn_engineer` MUST hard-block — returning a benign
+// `success == true` skip (so the 3-strikes brain-failure safeguard is not
+// tripped) WITHOUT allocating a worktree, assigning a subordinate, or spawning
+// any process. This is defense-in-depth beneath the observe-only Act branch:
+// even if control reaches the write chokepoint, the rail refuses the write.
+//
+// The rail is expected at the TOP of `dispatch_spawn_engineer` (before the
+// assignment re-check / admission gate), so these tests pass throwaway
+// deterministic brains that must never be consulted on the read-only path.
+
+fn spawn_action(goal_id: &str) -> PlannedAction {
+    PlannedAction {
+        kind: ActionKind::AdvanceGoal,
+        goal_id: Some(goal_id.to_string()),
+        description: format!("advance {goal_id}"),
+    }
+}
+
+#[test]
+fn read_only_posture_blocks_spawn_engineer_without_assigning() {
+    let action = spawn_action("obs-goal");
+    let mut state = OodaState::new(board_with_goal("obs-goal", GoalProgress::NotStarted, None));
+    // Flip the daemon-resolved posture to read-only (the observer case).
+    state.write_authority = WriteAuthority::ReadOnly;
+
+    let state_mx = Mutex::new(&mut state);
+    let brain = DeterministicLifecycleBrain;
+    let admission = DeterministicAdmissionBrain;
+
+    let outcome = dispatch_spawn_engineer(
+        &action,
+        &state_mx,
+        "obs-goal",
+        "do the (blocked) work",
+        &brain,
+        &admission,
+        Path::new("."),
+    );
+
+    // Benign skip: success=true so the failure counter is NOT bumped.
+    assert!(
+        outcome.success,
+        "read-only spawn block must be a benign skip, not a failure: {}",
+        outcome.detail
+    );
+    let detail = outcome.detail.to_lowercase();
+    assert!(
+        detail.contains("read-only") || detail.contains("read only") || detail.contains("observe"),
+        "skip detail must name the read-only / observe-only posture: {}",
+        outcome.detail
+    );
+
+    // Crucially: NO engineer was dispatched — the goal is still unassigned.
+    // End the `state_mx` borrow of `state` before inspecting the board.
+    let state = state_mx.into_inner().expect("state mutex not poisoned");
+    let goal = state
+        .active_goals
+        .active
+        .iter()
+        .find(|g| g.id == "obs-goal")
+        .expect("goal present");
+    assert!(
+        goal.assigned_to.is_none(),
+        "read-only posture must never assign a subordinate engineer"
+    );
+}
+
+#[test]
+fn read_write_posture_does_not_trigger_read_only_rail() {
+    // AC1: Simard herself (read-write) is unaffected by the rail. With an
+    // already-assigned goal, dispatch falls THROUGH the rail to the normal
+    // assignment re-check and reports the ordinary "already assigned" skip —
+    // proving the rail did not short-circuit for read-write. (Using an
+    // already-assigned goal keeps the test from spawning a real subprocess.)
+    let action = spawn_action("rw-goal");
+    let mut state = OodaState::new(board_with_goal(
+        "rw-goal",
+        GoalProgress::InProgress { percent: 30 },
+        Some("subordinate-1"),
+    ));
+    state.write_authority = WriteAuthority::ReadWrite;
+
+    let state_mx = Mutex::new(&mut state);
+    let brain = DeterministicLifecycleBrain;
+    let admission = DeterministicAdmissionBrain;
+
+    let outcome = dispatch_spawn_engineer(
+        &action,
+        &state_mx,
+        "rw-goal",
+        "do the work",
+        &brain,
+        &admission,
+        Path::new("."),
+    );
+
+    assert!(
+        outcome.success,
+        "already-assigned skip is success: {}",
+        outcome.detail
+    );
+    let detail = outcome.detail.to_lowercase();
+    assert!(
+        detail.contains("already assigned"),
+        "read-write dispatch must reach the assignment re-check, not the read-only rail: {}",
+        outcome.detail
+    );
+    assert!(
+        !detail.contains("observe"),
+        "read-write dispatch must NOT emit the observe-only read-only skip: {}",
+        outcome.detail
+    );
 }

--- a/src/ooda_actions/tests_dispatch_concurrency.rs
+++ b/src/ooda_actions/tests_dispatch_concurrency.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 use crate::base_types::{BaseTypeDescriptor, BaseTypeOutcome, BaseTypeSession, BaseTypeTurnInput};
 use crate::error::{SimardError, SimardResult};
 use crate::goal_curation::{GoalBoard, GoalProgress, add_active_goal};
+use crate::identity::WriteAuthority;
 use crate::ooda_actions::dispatch_actions_bounded;
 use crate::ooda_actions::test_helpers::{active_goal, test_bridges};
 use crate::ooda_loop::{ActionKind, OodaState, OrchestratorSessionFactory, PlannedAction};
@@ -265,4 +266,62 @@ fn one_failing_advance_does_not_abort_others() {
     assert_eq!(outcomes[0].action.goal_id.as_deref(), Some("adv-ok-a"));
     assert_eq!(outcomes[1].action.goal_id.as_deref(), Some("adv-fail-b"));
     assert_eq!(outcomes[2].action.goal_id.as_deref(), Some("adv-ok-c"));
+}
+
+// ── Simard #3125: the read-only rail holds on the CONCURRENT spawn path ──────
+//
+// AC3: the concurrent `AdvanceGoal` dispatch reaches `dispatch_spawn_engineer`
+// through a different call site than the serialized path. A read-only posture
+// must hard-block engineer spawns on BOTH sites — a concurrent-path escape
+// would defeat the whole feature. Here every goal's session returns
+// spawn-triggering prose (NOT `NO ACTION`), so absent the rail each would
+// dispatch a real engineer; with `write_authority = ReadOnly` none may.
+
+#[test]
+fn read_only_posture_blocks_concurrent_spawn_path() {
+    let ids = ["obs-a", "obs-b", "obs-c"];
+    let actions: Vec<PlannedAction> = ids.iter().map(|id| advance_action(id)).collect();
+
+    let instr = Arc::new(Instrumentation::default());
+    let mut bridges = test_bridges();
+    bridges.session_factory = Some(Arc::new(FakeFactory {
+        instr: Arc::clone(&instr),
+        sleep: Duration::from_millis(20),
+        // Non-`NO ACTION` prose => parses to GoalAction::SpawnEngineer, which
+        // (absent the rail) would fork a write-bearing engineer subprocess.
+        response: "Fix branch hygiene in the target repo".to_string(),
+        fail_substring: None,
+    }));
+
+    let mut state = OodaState::new(board_with_unassigned_goals(&ids));
+    state.write_authority = WriteAuthority::ReadOnly;
+
+    let outcomes = dispatch_actions_bounded(&actions, &mut bridges, &mut state, ids.len()).unwrap();
+
+    assert_eq!(outcomes.len(), ids.len());
+    for o in &outcomes {
+        assert!(
+            o.success,
+            "read-only spawn block is a benign skip (success): {}",
+            o.detail
+        );
+    }
+    // The rail fired on the concurrent path for every spawn attempt.
+    assert!(
+        outcomes.iter().all(|o| {
+            let d = o.detail.to_lowercase();
+            d.contains("read-only") || d.contains("read only") || d.contains("observe")
+        }),
+        "every concurrent spawn attempt must report the read-only skip: {:?}",
+        outcomes.iter().map(|o| &o.detail).collect::<Vec<_>>()
+    );
+    // No engineer was dispatched: every goal is still unassigned.
+    assert!(
+        state
+            .active_goals
+            .active
+            .iter()
+            .all(|g| g.assigned_to.is_none()),
+        "read-only posture must never assign an engineer on the concurrent path"
+    );
 }

--- a/src/ooda_actions/tests_observe_only.rs
+++ b/src/ooda_actions/tests_observe_only.rs
@@ -1,0 +1,218 @@
+//! Simard #3125 — tests for the OBSERVE-ONLY Act phase (L1 cognition branch).
+//!
+//! When the active identity's posture is read-only, the Act phase must run an
+//! observe-only branch instead of the engineer-dispatching one. That branch:
+//!   * consults an agentic [`ObserveOnlyBrain`] over the identity's TARGET repo
+//!     set (what to observe / what goals to propose is a reasoner decision —
+//!     kept agentic, with NO caller-imposed wall-clock timeout),
+//!   * records the returned observations, and appends the proposed goals to the
+//!     board scoped to the identity's targets (`repo = Some(target)`), and
+//!   * NEVER calls `dispatch_spawn_engineer` and NEVER writes to a target repo
+//!     (zero write-bearing dispatch — don't burn AI credits on work the
+//!     guardrail would block).
+//!
+//! Fail-closed contract (no fallbacks / no silent degradation):
+//!   * a proposal whose repo is absent or outside `targets` is a hard error
+//!     (never silently re-scoped to `rysweet/Simard`), and
+//!   * a failing observe brain surfaces its error — it must NOT fall back to
+//!     the engineer-dispatching Act phase.
+//!
+//! Contract encoded here (implementation must provide, in
+//! `src/ooda_actions/observe_only.rs`):
+//!   pub trait ObserveOnlyBrain: Send + Sync {
+//!       fn observe(&self, targets: &[String]) -> SimardResult<ObserveOutcome>;
+//!   }
+//!   pub struct ObserveOutcome {
+//!       pub observations: Vec<String>,
+//!       pub proposals: Vec<crate::identity::SeedGoal>,
+//!   }
+//!   pub(crate) fn act_observe_only(
+//!       brain: &dyn ObserveOnlyBrain,
+//!       targets: &[String],
+//!       state: &mut OodaState,
+//!   ) -> SimardResult<usize>;   // returns the number of goals proposed
+
+use std::sync::Mutex;
+
+use crate::error::{SimardError, SimardResult};
+use crate::goal_curation::GoalBoard;
+use crate::identity::SeedGoal;
+use crate::ooda_actions::observe_only::{ObserveOnlyBrain, ObserveOutcome, act_observe_only};
+use crate::ooda_loop::OodaState;
+
+/// A configurable observe-only brain that also records the target set it was
+/// asked to reason over, so tests can assert scope (AC4).
+struct MockObserveBrain {
+    result: Mutex<Option<SimardResult<ObserveOutcome>>>,
+    seen_targets: Mutex<Option<Vec<String>>>,
+}
+
+impl MockObserveBrain {
+    fn ok(observations: Vec<&str>, proposals: Vec<SeedGoal>) -> Self {
+        Self {
+            result: Mutex::new(Some(Ok(ObserveOutcome {
+                observations: observations.into_iter().map(String::from).collect(),
+                proposals,
+            }))),
+            seen_targets: Mutex::new(None),
+        }
+    }
+
+    fn err(msg: &str) -> Self {
+        Self {
+            result: Mutex::new(Some(Err(SimardError::BridgeTransportError {
+                bridge: "observe-brain".to_string(),
+                reason: msg.to_string(),
+            }))),
+            seen_targets: Mutex::new(None),
+        }
+    }
+}
+
+impl ObserveOnlyBrain for MockObserveBrain {
+    fn observe(&self, targets: &[String]) -> SimardResult<ObserveOutcome> {
+        *self.seen_targets.lock().unwrap() = Some(targets.to_vec());
+        self.result
+            .lock()
+            .unwrap()
+            .take()
+            .expect("observe called exactly once per test")
+    }
+}
+
+fn seed_goal(priority: u32, title: &str, repo: Option<&str>) -> SeedGoal {
+    SeedGoal {
+        priority,
+        title: title.to_string(),
+        description: format!("OBSERVE ONLY: {title}"),
+        repo: repo.map(str::to_string),
+    }
+}
+
+fn empty_state() -> OodaState {
+    OodaState::new(GoalBoard::new())
+}
+
+// ── AC4: observations + proposals are scoped to the identity's targets ───────
+
+#[test]
+fn observe_only_proposes_target_scoped_goals() {
+    let targets = vec!["hyenas/repo-a".to_string(), "hyenas/repo-b".to_string()];
+    let brain = MockObserveBrain::ok(
+        vec!["repo-a has no CODEOWNERS", "repo-b has stale branches"],
+        vec![
+            seed_goal(80, "Add CODEOWNERS", Some("hyenas/repo-a")),
+            seed_goal(70, "Prune stale branches", Some("hyenas/repo-b")),
+        ],
+    );
+    let mut state = empty_state();
+
+    let proposed = act_observe_only(&brain, &targets, &mut state).unwrap();
+
+    assert_eq!(proposed, 2, "both proposed goals should be recorded");
+    assert_eq!(state.active_goals.active.len(), 2);
+
+    // The brain reasoned over exactly the identity's target set.
+    assert_eq!(
+        brain.seen_targets.lock().unwrap().as_ref().unwrap(),
+        &targets
+    );
+
+    // Every proposed goal is scoped to a target repo — never rysweet/Simard.
+    let repos: Vec<&str> = state
+        .active_goals
+        .active
+        .iter()
+        .filter_map(|g| g.repo.as_deref())
+        .collect();
+    assert!(repos.contains(&"hyenas/repo-a"));
+    assert!(repos.contains(&"hyenas/repo-b"));
+    assert!(
+        state
+            .active_goals
+            .active
+            .iter()
+            .all(|g| g.repo.as_deref() != Some("Simard"))
+    );
+}
+
+// ── AC3: the observe-only branch NEVER dispatches an engineer ────────────────
+
+#[test]
+fn observe_only_never_assigns_an_engineer() {
+    let targets = vec!["hyenas/repo-a".to_string()];
+    let brain = MockObserveBrain::ok(
+        vec!["repo-a missing LICENSE"],
+        vec![seed_goal(90, "Add LICENSE", Some("hyenas/repo-a"))],
+    );
+    let mut state = empty_state();
+
+    act_observe_only(&brain, &targets, &mut state).unwrap();
+
+    // Zero write-bearing dispatch: proposed goals are parked (unassigned),
+    // never handed to a subordinate engineer.
+    assert!(
+        state
+            .active_goals
+            .active
+            .iter()
+            .all(|g| g.assigned_to.is_none()),
+        "observe-only must not assign any goal to an engineer"
+    );
+}
+
+// ── Fail-closed: a proposal escaping the target scope is a hard error ─────────
+
+#[test]
+fn observe_only_fails_closed_on_out_of_targets_proposal() {
+    let targets = vec!["hyenas/repo-a".to_string()];
+    let brain = MockObserveBrain::ok(
+        vec!["observation"],
+        vec![seed_goal(80, "Escapes scope", Some("rysweet/Simard"))],
+    );
+    let mut state = empty_state();
+
+    let result = act_observe_only(&brain, &targets, &mut state);
+    assert!(
+        result.is_err(),
+        "a proposal outside the target set must fail closed"
+    );
+    // Fail-closed leaves the board untouched — no partially-scoped goal leaks in.
+    assert!(
+        state.active_goals.active.is_empty(),
+        "no goal may be seeded when a proposal escapes the target scope"
+    );
+}
+
+#[test]
+fn observe_only_fails_closed_on_unscoped_proposal() {
+    let targets = vec!["hyenas/repo-a".to_string()];
+    let brain = MockObserveBrain::ok(vec!["observation"], vec![seed_goal(80, "No repo", None)]);
+    let mut state = empty_state();
+
+    let result = act_observe_only(&brain, &targets, &mut state);
+    assert!(
+        result.is_err(),
+        "a proposal with repo=None must fail closed (no implicit Simard scope)"
+    );
+    assert!(state.active_goals.active.is_empty());
+}
+
+// ── No fallback: a broken observe brain surfaces, never dispatches ───────────
+
+#[test]
+fn observe_only_surfaces_brain_error_without_fallback() {
+    let targets = vec!["hyenas/repo-a".to_string()];
+    let brain = MockObserveBrain::err("observe brain exploded");
+    let mut state = empty_state();
+
+    let result = act_observe_only(&brain, &targets, &mut state);
+    assert!(
+        result.is_err(),
+        "a failing observe brain must surface as an error (no silent fallback to engineer dispatch)"
+    );
+    assert!(
+        state.active_goals.active.is_empty(),
+        "a failed observe pass must not mutate the board"
+    );
+}

--- a/src/ooda_brain/admission.rs
+++ b/src/ooda_brain/admission.rs
@@ -1,0 +1,255 @@
+//! Types, trait, and the deterministic hard-rail for RESOURCE-AWARE engineer
+//! **admission** — the resource-aware augmentation of the AIMD count cap.
+//!
+//! # Problem
+//! The AIMD controller bounds concurrent engineer *count* but nothing accounts
+//! for DISK / build-cache / system load. Parallel `cargo` builds across 40+
+//! worktrees drove disk to 91% and ENOSPC killed recipes. Count-control is not
+//! resource-admission.
+//!
+//! # Design (mirrors [`super::decide`])
+//! The *intelligence* is agentic: a structured-reasoning brain reasons over the
+//! current resource picture and emits ADMIT / DEFER / RECLAIM-FIRST at every
+//! fresh-spawn admission cycle (repeated structured thought). The LLM-backed
+//! impl drives the `ooda-resource-admission.yaml` recipe. The only deterministic
+//! code in this module is:
+//!
+//!   * [`resolve_admission`] — a THIN safety rail that BLOCKS admission when
+//!     disk% is *known* to be at/above a configurable ceiling, **regardless of
+//!     what the reasoner says**. Irreversible ENOSPC must never be reachable.
+//!   * [`judge_and_resolve`] — the seam core (reason → apply). It surfaces a
+//!     brain error loudly (NO FALLBACK, per the standing operator constraint).
+//!   * [`parse_ceiling`] / [`configured_ceiling_pct`] — read + clamp the single
+//!     configurable threshold.
+//!
+//! No hardcoded admission heuristics live in Rust beyond that single ceiling —
+//! the ADMIT/DEFER/RECLAIM judgement itself lives in the prompt.
+
+use crate::error::SimardResult;
+
+/// Recipe asset that drives the agentic admission reasoner. Read fresh per call
+/// by the recipe-backed brain (hot-reload), mirroring the other OODA-phase
+/// recipes (`ooda-decide.yaml`, `ooda-engineer-lifecycle.yaml`).
+pub const RECIPE_NAME: &str = "ooda-resource-admission.yaml";
+
+/// Env var naming the deterministic disk-admission ceiling (percent full). Read
+/// at the seam, parsed best-effort, and clamped to
+/// [`CEILING_MIN`]..=[`CEILING_MAX`].
+pub const CEILING_ENV: &str = "SIMARD_DISK_ADMISSION_CEILING_PCT";
+
+/// Default disk ceiling (percent full). The incident tripped at 91%; 90 leaves
+/// headroom below ENOSPC without over-throttling.
+pub const DEFAULT_CEILING_PCT: u8 = 90;
+
+/// Lower clamp bound for the configured ceiling (a `0` ceiling would block all
+/// admission forever and deadlock progress).
+pub const CEILING_MIN: u8 = 1;
+
+/// Upper clamp bound for the configured ceiling (a `100` ceiling would let the
+/// rail fire only at true-full, i.e. never usefully — keep headroom).
+pub const CEILING_MAX: u8 = 99;
+
+/// Clamp a raw ceiling into the admissible [`CEILING_MIN`]..=[`CEILING_MAX`]
+/// range.
+pub fn clamp_ceiling(pct: u8) -> u8 {
+    pct.clamp(CEILING_MIN, CEILING_MAX)
+}
+
+/// Parse + clamp a raw env string into a usable ceiling. Best-effort: any
+/// missing / non-numeric / out-of-`u8` value degrades to [`DEFAULT_CEILING_PCT`]
+/// rather than failing (never panic; safe default).
+pub fn parse_ceiling(raw: Option<&str>) -> u8 {
+    raw.and_then(|v| v.trim().parse::<u8>().ok())
+        .map(clamp_ceiling)
+        .unwrap_or(DEFAULT_CEILING_PCT)
+}
+
+/// Read the configured disk-admission ceiling from the environment (see
+/// [`CEILING_ENV`]), applying [`parse_ceiling`].
+pub fn configured_ceiling_pct() -> u8 {
+    parse_ceiling(std::env::var(CEILING_ENV).ok().as_deref())
+}
+
+// ---------------------------------------------------------------------------
+// Context fed to the admission brain (A8)
+// ---------------------------------------------------------------------------
+
+/// Best-effort snapshot of the resource picture the admission brain reasons
+/// over. Every probe degrades to `None` on error (never panic); the `None` is
+/// passed through to the reasoner so it can weigh "unknown" explicitly.
+///
+/// The rail in [`resolve_admission`] only consults [`Self::disk_usage_pct`] and
+/// [`Self::ceiling_pct`]; the other fields exist so the *prompt* can normalize
+/// load-by-cpu and weigh build-cache size / in-flight builds.
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ResourceAdmissionCtx {
+    /// Disk usage of the state/worktree filesystem, 0..=100. `None` when the
+    /// `df` probe failed (rail fails open — see [`resolve_admission`]).
+    pub disk_usage_pct: Option<u8>,
+    /// Total bytes under the engineer-worktrees / build-cache root (`du -sb`).
+    pub worktree_cache_bytes: Option<u64>,
+    /// 1-minute load average (`/proc/loadavg`).
+    pub load_avg_1m: Option<f64>,
+    /// Logical CPU count, so the prompt can normalize load per core.
+    pub cpu_count: Option<usize>,
+    /// Number of live engineer claims already in flight this cycle.
+    pub in_flight_engineers: u32,
+    /// The deterministic hard-rail ceiling in effect for this decision.
+    pub ceiling_pct: u8,
+}
+
+// ---------------------------------------------------------------------------
+// Decision: tagged enum the LLM emits as `{"choice":"...","rationale":"..."}`
+// ---------------------------------------------------------------------------
+
+/// What the admission brain decided. Tagged on `choice` for
+/// forward-compatibility (unknown tags fail to parse → the caller surfaces the
+/// parse error rather than silently admitting).
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "choice", rename_all = "snake_case")]
+pub enum AdmissionDecision {
+    /// Resources are healthy enough — admit one more engineer (still subject to
+    /// the deterministic hard rail in [`resolve_admission`]).
+    Admit { rationale: String },
+    /// Resource pressure — skip this cycle without allocating anything. Benign:
+    /// the goal is retried next cycle and this is NOT a failure.
+    Defer { rationale: String },
+    /// Reclaim disk first (invoke the disk-health recipe), then defer this cycle
+    /// and re-evaluate next cycle.
+    ReclaimFirst { rationale: String },
+}
+
+impl AdmissionDecision {
+    /// The rationale carried by every variant.
+    pub fn rationale(&self) -> &str {
+        match self {
+            Self::Admit { rationale }
+            | Self::Defer { rationale }
+            | Self::ReclaimFirst { rationale } => rationale,
+        }
+    }
+
+    /// Stable snake_case label (matches the serde `choice` tag) for
+    /// observability records / metrics.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Admit { .. } => "admit",
+            Self::Defer { .. } => "defer",
+            Self::ReclaimFirst { .. } => "reclaim_first",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The trait (A1) — single decision site, sync to match the other OODA brains
+// ---------------------------------------------------------------------------
+
+/// Single-decision-site trait for resource-aware admission. Sync on purpose to
+/// match [`super::OodaBrain`] / [`super::OodaDecideBrain`]; the LLM-backed impl
+/// bridges to async internally so callers need no runtime.
+pub trait OodaAdmissionBrain: Send + Sync {
+    fn judge_admission(&self, ctx: &ResourceAdmissionCtx) -> SimardResult<AdmissionDecision>;
+}
+
+// ---------------------------------------------------------------------------
+// Resolved gate — what the seam actually applies (post hard-rail)
+// ---------------------------------------------------------------------------
+
+/// The resolved admission outcome after the deterministic hard rail has had the
+/// final say over the brain's [`AdmissionDecision`]. This is what the spawn seam
+/// applies.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AdmissionGate {
+    /// Admit: proceed with the fresh spawn (allocate worktree, spawn engineer).
+    Proceed,
+    /// Skip this cycle without allocating resources. **Benign** — the caller
+    /// MUST NOT record failure (no `goal_failure_counts` bump, no 3-strike
+    /// safeguard). The goal is retried next cycle.
+    Defer { reason: String },
+    /// Run disk reclamation now (disk-health recipe), then defer this cycle and
+    /// re-evaluate next cycle.
+    Reclaim { reason: String },
+}
+
+impl AdmissionGate {
+    /// `true` only for [`AdmissionGate::Proceed`] — i.e. an actual admission.
+    pub fn is_proceed(&self) -> bool {
+        matches!(self, Self::Proceed)
+    }
+}
+
+/// Apply the THIN deterministic hard rail (FR-5) over the brain's decision, then
+/// map it to an [`AdmissionGate`] (FR-4).
+///
+/// **Safety invariant:** when `ctx.disk_usage_pct` is `Some(pct)` and
+/// `pct >= ctx.ceiling_pct`, the result is NEVER [`AdmissionGate::Proceed`],
+/// regardless of what the brain decided — irreversible ENOSPC must never be
+/// reachable.
+///
+/// **Fail-open:** a `None` `disk_usage_pct` (probe failed) does NOT fire the
+/// rail; the "unknown" was already handed to the reasoner, and a spurious block
+/// on a transient `df` error would deadlock all progress. Layered ENOSPC
+/// protection (emergency cleanup tier) remains the backstop.
+///
+/// The rail only overrides [`AdmissionDecision::Admit`] (the sole `Proceed`
+/// source). `Defer` / `ReclaimFirst` are already non-admitting and pass through
+/// unchanged.
+pub fn resolve_admission(ctx: &ResourceAdmissionCtx, decision: AdmissionDecision) -> AdmissionGate {
+    let rail_blocks = matches!(ctx.disk_usage_pct, Some(pct) if pct >= ctx.ceiling_pct);
+    match decision {
+        AdmissionDecision::Admit { rationale } => {
+            if rail_blocks {
+                let pct = ctx.disk_usage_pct.unwrap_or_default();
+                AdmissionGate::Defer {
+                    reason: format!(
+                        "hard-rail: disk {pct}% >= admission ceiling {}%; ADMIT overridden to \
+                         block (brain rationale: {rationale})",
+                        ctx.ceiling_pct
+                    ),
+                }
+            } else {
+                AdmissionGate::Proceed
+            }
+        }
+        AdmissionDecision::Defer { rationale } => AdmissionGate::Defer { reason: rationale },
+        AdmissionDecision::ReclaimFirst { rationale } => {
+            AdmissionGate::Reclaim { reason: rationale }
+        }
+    }
+}
+
+/// Seam core: reason → apply. Calls the brain for an [`AdmissionDecision`] and
+/// resolves it through the hard rail into an [`AdmissionGate`].
+///
+/// **NO FALLBACK:** a brain error propagates unchanged so the seam can surface
+/// it as a visible cycle failure (mirrors `decide_engineer_lifecycle` — a
+/// broken brain must never look like a silent "admit").
+pub fn judge_and_resolve(
+    brain: &dyn OodaAdmissionBrain,
+    ctx: &ResourceAdmissionCtx,
+) -> SimardResult<AdmissionGate> {
+    let decision = brain.judge_admission(ctx)?;
+    Ok(resolve_admission(ctx, decision))
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic brain — no-LLM floor (NOT the intelligence)
+// ---------------------------------------------------------------------------
+
+/// Deterministic admission floor used when no LLM brain is configured. It
+/// preserves pre-feature behaviour bit-for-bit: always `Admit` (count-cap only).
+/// This is NOT the resource intelligence — that lives in the recipe/prompt. The
+/// deterministic ENOSPC protection is provided by the hard rail in
+/// [`resolve_admission`], which still fires over this brain's `Admit`.
+#[derive(Debug, Default)]
+pub struct DeterministicAdmissionBrain;
+
+impl OodaAdmissionBrain for DeterministicAdmissionBrain {
+    fn judge_admission(&self, _ctx: &ResourceAdmissionCtx) -> SimardResult<AdmissionDecision> {
+        Ok(AdmissionDecision::Admit {
+            rationale: "deterministic-brain: no LLM configured; admit (count-cap only); ENOSPC \
+                        still guarded by the disk hard-rail"
+                .to_string(),
+        })
+    }
+}

--- a/src/ooda_brain/admission_tests.rs
+++ b/src/ooda_brain/admission_tests.rs
@@ -1,0 +1,415 @@
+//! Hermetic tests for RESOURCE-AWARE engineer admission.
+//!
+//! These prove the two things the framing requires of Step-7 tests:
+//!   1. **The seam** — reason → apply: a (stubbed) brain decision flows through
+//!      the hard rail into the resolved [`AdmissionGate`], and a brain *error*
+//!      surfaces (NO FALLBACK).
+//!   2. **The hard rail** — a known disk% at/above the ceiling BLOCKS admission
+//!      regardless of what the brain decided (ENOSPC is never reachable), and
+//!      fails *open* when disk% is unknown.
+//!
+//! The reasoning *quality* (when to ADMIT vs DEFER vs RECLAIM) lives in the
+//! prompt, not here — so the brain is stubbed and only the deterministic seam +
+//! rail are asserted. Everything here is pure and side-effect free.
+
+use super::admission::{
+    AdmissionDecision, AdmissionGate, CEILING_MAX, CEILING_MIN, DEFAULT_CEILING_PCT,
+    DeterministicAdmissionBrain, OodaAdmissionBrain, ResourceAdmissionCtx, clamp_ceiling,
+    configured_ceiling_pct, judge_and_resolve, parse_ceiling, resolve_admission,
+};
+use crate::error::{SimardError, SimardResult};
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+/// A hermetic stub brain returning a preset decision (or error). No IO, no LLM.
+struct StubAdmissionBrain {
+    result: SimardResult<AdmissionDecision>,
+}
+
+impl StubAdmissionBrain {
+    fn admit() -> Self {
+        Self {
+            result: Ok(AdmissionDecision::Admit {
+                rationale: "stub: admit".to_string(),
+            }),
+        }
+    }
+    fn defer() -> Self {
+        Self {
+            result: Ok(AdmissionDecision::Defer {
+                rationale: "stub: defer".to_string(),
+            }),
+        }
+    }
+    fn reclaim() -> Self {
+        Self {
+            result: Ok(AdmissionDecision::ReclaimFirst {
+                rationale: "stub: reclaim".to_string(),
+            }),
+        }
+    }
+    fn failing() -> Self {
+        Self {
+            result: Err(SimardError::AdapterInvocationFailed {
+                base_type: "resource-admission".to_string(),
+                reason: "stub brain intentionally failing".to_string(),
+            }),
+        }
+    }
+}
+
+impl OodaAdmissionBrain for StubAdmissionBrain {
+    fn judge_admission(&self, _ctx: &ResourceAdmissionCtx) -> SimardResult<AdmissionDecision> {
+        // Clone the preset result so the stub can be consulted repeatedly
+        // (repeated structured thought — one call per admission cycle).
+        match &self.result {
+            Ok(d) => Ok(d.clone()),
+            Err(e) => Err(SimardError::AdapterInvocationFailed {
+                base_type: "resource-admission".to_string(),
+                reason: format!("{e}"),
+            }),
+        }
+    }
+}
+
+fn ctx(disk_usage_pct: Option<u8>, ceiling_pct: u8) -> ResourceAdmissionCtx {
+    ResourceAdmissionCtx {
+        disk_usage_pct,
+        worktree_cache_bytes: Some(12_345),
+        load_avg_1m: Some(1.5),
+        cpu_count: Some(8),
+        in_flight_engineers: 2,
+        ceiling_pct,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AdmissionDecision — serde round-trip (matches the LLM JSON schema)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn decision_admit_roundtrips() {
+    let raw = r#"{"choice":"admit","rationale":"disk 40%, load light"}"#;
+    let parsed: AdmissionDecision = serde_json::from_str(raw).expect("parse");
+    assert_eq!(
+        parsed,
+        AdmissionDecision::Admit {
+            rationale: "disk 40%, load light".to_string()
+        }
+    );
+    assert_eq!(parsed.label(), "admit");
+    assert_eq!(parsed.rationale(), "disk 40%, load light");
+}
+
+#[test]
+fn decision_defer_roundtrips() {
+    let raw = r#"{"choice":"defer","rationale":"disk 88%, backing off"}"#;
+    let parsed: AdmissionDecision = serde_json::from_str(raw).expect("parse");
+    assert_eq!(parsed.label(), "defer");
+    assert!(matches!(parsed, AdmissionDecision::Defer { .. }));
+}
+
+#[test]
+fn decision_reclaim_first_roundtrips() {
+    let raw = r#"{"choice":"reclaim_first","rationale":"cache huge, reclaim then retry"}"#;
+    let parsed: AdmissionDecision = serde_json::from_str(raw).expect("parse");
+    assert_eq!(parsed.label(), "reclaim_first");
+    assert!(matches!(parsed, AdmissionDecision::ReclaimFirst { .. }));
+}
+
+#[test]
+fn decision_ignores_extra_fields() {
+    // Forward-compat: the prompt may add fields the enum doesn't model yet.
+    let raw = r#"{"choice":"admit","rationale":"ok","confidence":0.9,"future":42}"#;
+    let parsed: AdmissionDecision = serde_json::from_str(raw).expect("parse");
+    assert!(matches!(parsed, AdmissionDecision::Admit { .. }));
+}
+
+#[test]
+fn decision_unknown_choice_fails_to_parse() {
+    // An unknown tag must NOT silently deserialize to Admit — the caller
+    // surfaces the parse error instead of a phantom admission.
+    let raw = r#"{"choice":"launch_the_missiles","rationale":"nope"}"#;
+    let parsed: Result<AdmissionDecision, _> = serde_json::from_str(raw);
+    assert!(parsed.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// HARD RAIL (FR-5) — the safety-critical deterministic guard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rail_blocks_admit_at_ceiling_boundary() {
+    // disk == ceiling must block (>= comparison, not >).
+    let gate = resolve_admission(
+        &ctx(Some(90), 90),
+        AdmissionDecision::Admit {
+            rationale: "brain wanted to admit".to_string(),
+        },
+    );
+    assert!(
+        !gate.is_proceed(),
+        "disk == ceiling must block admission, got {gate:?}"
+    );
+    assert!(matches!(gate, AdmissionGate::Defer { .. }));
+}
+
+#[test]
+fn rail_blocks_admit_above_ceiling() {
+    let gate = resolve_admission(
+        &ctx(Some(97), 90),
+        AdmissionDecision::Admit {
+            rationale: "brain wanted to admit".to_string(),
+        },
+    );
+    assert!(!gate.is_proceed());
+    if let AdmissionGate::Defer { reason } = gate {
+        assert!(reason.contains("hard-rail"), "reason={reason}");
+        assert!(reason.contains("97"));
+        assert!(reason.contains("90"));
+    } else {
+        panic!("expected Defer, got {gate:?}");
+    }
+}
+
+#[test]
+fn rail_allows_admit_below_ceiling() {
+    let gate = resolve_admission(
+        &ctx(Some(89), 90),
+        AdmissionDecision::Admit {
+            rationale: "healthy".to_string(),
+        },
+    );
+    assert_eq!(gate, AdmissionGate::Proceed);
+}
+
+#[test]
+fn rail_fails_open_when_disk_unknown() {
+    // A failed `df` probe (None) must NOT block — a spurious block would
+    // deadlock all progress. The unknown was already handed to the reasoner.
+    let gate = resolve_admission(
+        &ctx(None, 90),
+        AdmissionDecision::Admit {
+            rationale: "healthy, disk read failed".to_string(),
+        },
+    );
+    assert_eq!(gate, AdmissionGate::Proceed);
+}
+
+#[test]
+fn rail_never_proceeds_when_over_ceiling_for_any_decision() {
+    // The core safety invariant: over-ceiling ⇒ never Proceed, for EVERY
+    // possible brain decision.
+    let over = ctx(Some(95), 90);
+    for decision in [
+        AdmissionDecision::Admit {
+            rationale: "a".to_string(),
+        },
+        AdmissionDecision::Defer {
+            rationale: "d".to_string(),
+        },
+        AdmissionDecision::ReclaimFirst {
+            rationale: "r".to_string(),
+        },
+    ] {
+        let gate = resolve_admission(&over, decision.clone());
+        assert!(
+            !gate.is_proceed(),
+            "decision {decision:?} produced Proceed while disk 95% >= ceiling 90% (ENOSPC reachable!)"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decision mapping (FR-4) under healthy disk
+// ---------------------------------------------------------------------------
+
+#[test]
+fn admit_maps_to_proceed_when_healthy() {
+    let gate = resolve_admission(
+        &ctx(Some(30), 90),
+        AdmissionDecision::Admit {
+            rationale: "plenty of headroom".to_string(),
+        },
+    );
+    assert_eq!(gate, AdmissionGate::Proceed);
+}
+
+#[test]
+fn defer_maps_to_defer_and_preserves_reason() {
+    let gate = resolve_admission(
+        &ctx(Some(30), 90),
+        AdmissionDecision::Defer {
+            rationale: "load spiking, back off one cycle".to_string(),
+        },
+    );
+    assert_eq!(
+        gate,
+        AdmissionGate::Defer {
+            reason: "load spiking, back off one cycle".to_string()
+        }
+    );
+}
+
+#[test]
+fn reclaim_first_maps_to_reclaim_and_preserves_reason() {
+    let gate = resolve_admission(
+        &ctx(Some(30), 90),
+        AdmissionDecision::ReclaimFirst {
+            rationale: "build cache is 200GB, reclaim then retry".to_string(),
+        },
+    );
+    assert_eq!(
+        gate,
+        AdmissionGate::Reclaim {
+            reason: "build cache is 200GB, reclaim then retry".to_string()
+        }
+    );
+}
+
+#[test]
+fn reclaim_first_honored_even_over_ceiling() {
+    // Over the ceiling, a ReclaimFirst is strictly more proactive than a plain
+    // block — it must be honored (still non-admitting).
+    let gate = resolve_admission(
+        &ctx(Some(93), 90),
+        AdmissionDecision::ReclaimFirst {
+            rationale: "over ceiling, reclaim".to_string(),
+        },
+    );
+    assert!(matches!(gate, AdmissionGate::Reclaim { .. }));
+    assert!(!gate.is_proceed());
+}
+
+// ---------------------------------------------------------------------------
+// SEAM (FR-1/FR-2) — reason → apply via a stub brain
+// ---------------------------------------------------------------------------
+
+#[test]
+fn seam_admit_decision_proceeds_when_healthy() {
+    let gate = judge_and_resolve(&StubAdmissionBrain::admit(), &ctx(Some(50), 90)).unwrap();
+    assert_eq!(gate, AdmissionGate::Proceed);
+}
+
+#[test]
+fn seam_defer_decision_defers() {
+    let gate = judge_and_resolve(&StubAdmissionBrain::defer(), &ctx(Some(50), 90)).unwrap();
+    assert!(matches!(gate, AdmissionGate::Defer { .. }));
+}
+
+#[test]
+fn seam_reclaim_decision_reclaims() {
+    let gate = judge_and_resolve(&StubAdmissionBrain::reclaim(), &ctx(Some(50), 90)).unwrap();
+    assert!(matches!(gate, AdmissionGate::Reclaim { .. }));
+}
+
+#[test]
+fn seam_rail_overrides_brain_admit_when_over_ceiling() {
+    // Even when the (stubbed) brain says ADMIT, the seam's hard rail blocks it
+    // if disk is at/over the ceiling. This is the whole point of the feature.
+    let gate = judge_and_resolve(&StubAdmissionBrain::admit(), &ctx(Some(92), 90)).unwrap();
+    assert!(
+        !gate.is_proceed(),
+        "rail must override brain ADMIT, got {gate:?}"
+    );
+    assert!(matches!(gate, AdmissionGate::Defer { .. }));
+}
+
+#[test]
+fn seam_surfaces_brain_error_no_fallback() {
+    // NO FALLBACK: a brain error must propagate, not silently become an admit.
+    let result = judge_and_resolve(&StubAdmissionBrain::failing(), &ctx(Some(10), 90));
+    assert!(
+        result.is_err(),
+        "brain error must surface as an Err, not a phantom admission: {result:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// DeterministicAdmissionBrain — no-LLM floor, still beaten by the rail
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deterministic_brain_admits() {
+    let d = DeterministicAdmissionBrain
+        .judge_admission(&ctx(Some(10), 90))
+        .unwrap();
+    assert!(matches!(d, AdmissionDecision::Admit { .. }));
+}
+
+#[test]
+fn deterministic_brain_admit_proceeds_when_healthy() {
+    let gate = judge_and_resolve(&DeterministicAdmissionBrain, &ctx(Some(10), 90)).unwrap();
+    assert_eq!(gate, AdmissionGate::Proceed);
+}
+
+#[test]
+fn deterministic_brain_still_blocked_by_rail_over_ceiling() {
+    // The no-LLM floor always admits — but the deterministic rail still guards
+    // ENOSPC over the ceiling.
+    let gate = judge_and_resolve(&DeterministicAdmissionBrain, &ctx(Some(99), 90)).unwrap();
+    assert!(
+        !gate.is_proceed(),
+        "rail must protect even the deterministic floor"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Ceiling parse / clamp (A4)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_ceiling_defaults_when_absent_or_garbage() {
+    assert_eq!(parse_ceiling(None), DEFAULT_CEILING_PCT);
+    assert_eq!(parse_ceiling(Some("")), DEFAULT_CEILING_PCT);
+    assert_eq!(parse_ceiling(Some("not-a-number")), DEFAULT_CEILING_PCT);
+    // 300 does not fit in u8, so parse fails → default (not clamped).
+    assert_eq!(parse_ceiling(Some("300")), DEFAULT_CEILING_PCT);
+}
+
+#[test]
+fn parse_ceiling_reads_and_trims_valid_values() {
+    assert_eq!(parse_ceiling(Some("90")), 90);
+    assert_eq!(parse_ceiling(Some("  85 ")), 85);
+}
+
+#[test]
+fn parse_ceiling_clamps_out_of_range() {
+    // 0 would block everything forever; 250 (a valid u8) is too high.
+    assert_eq!(parse_ceiling(Some("0")), CEILING_MIN);
+    assert_eq!(parse_ceiling(Some("250")), CEILING_MAX);
+    assert_eq!(clamp_ceiling(0), CEILING_MIN);
+    assert_eq!(clamp_ceiling(255), CEILING_MAX);
+    assert_eq!(clamp_ceiling(50), 50);
+}
+
+#[test]
+fn configured_ceiling_is_in_range() {
+    // Whatever the ambient env, the configured ceiling is always usable.
+    let c = configured_ceiling_pct();
+    assert!(
+        (CEILING_MIN..=CEILING_MAX).contains(&c),
+        "ceiling {c} out of range"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Context serde (A8) — the recipe reads this as JSON context
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ctx_roundtrips_including_unknown_probes() {
+    let original = ResourceAdmissionCtx {
+        disk_usage_pct: None, // probe failed
+        worktree_cache_bytes: Some(999),
+        load_avg_1m: None,
+        cpu_count: Some(4),
+        in_flight_engineers: 3,
+        ceiling_pct: 90,
+    };
+    let json = serde_json::to_string(&original).expect("serialize");
+    let back: ResourceAdmissionCtx = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(original, back);
+}

--- a/src/ooda_brain/context.rs
+++ b/src/ooda_brain/context.rs
@@ -1,6 +1,7 @@
 //! Pure context gathering — best-effort, never panics, never propagates IO.
 
 use super::EngineerLifecycleCtx;
+use super::admission::ResourceAdmissionCtx;
 use crate::ooda_loop::OodaState;
 use std::path::Path;
 use std::time::SystemTime;
@@ -132,6 +133,58 @@ pub fn count_live_engineer_claims(state_root: &Path) -> u32 {
         }
     }
     count
+}
+
+/// Best-effort byte size of a directory subtree via `du -sb`. Returns `None`
+/// on missing dir / IO failure / parse failure so the caller can pass the
+/// "unknown" through to the admission reasoner (never panic, never 0-as-known).
+fn dir_size_bytes_opt(path: &Path) -> Option<u64> {
+    let out = std::process::Command::new("du")
+        .arg("-sb")
+        .arg(path)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .split_whitespace()
+        .next()?
+        .parse::<u64>()
+        .ok()
+}
+
+/// Read the 1-minute load average from `/proc/loadavg` (first field).
+/// `None` on any platform / read / parse failure.
+fn read_load_avg_1m() -> Option<f64> {
+    std::fs::read_to_string("/proc/loadavg")
+        .ok()?
+        .split_whitespace()
+        .next()?
+        .parse::<f64>()
+        .ok()
+}
+
+/// Assemble the best-effort [`ResourceAdmissionCtx`] the admission brain
+/// reasons over before a FRESH engineer is spawned (resource-aware augmentation
+/// of the AIMD count cap). Every probe degrades to `None` on error — never
+/// panics, never propagates IO — so a transient probe failure hands the
+/// reasoner an explicit "unknown" instead of blocking or crashing.
+///
+/// The disk-usage probe reuses [`crate::disk_health::get_disk_usage_pct`] so
+/// there is one disk-reading implementation, not two. `ceiling_pct` is the
+/// deterministic hard-rail ceiling in effect for this decision (see
+/// [`crate::ooda_brain::admission::resolve_admission`]).
+pub fn gather_resource_admission_ctx(state_root: &Path, ceiling_pct: u8) -> ResourceAdmissionCtx {
+    let worktrees_root = state_root.join(crate::engineer_worktree::WORKTREES_SUBDIR);
+    ResourceAdmissionCtx {
+        disk_usage_pct: crate::disk_health::get_disk_usage_pct(state_root),
+        worktree_cache_bytes: dir_size_bytes_opt(&worktrees_root),
+        load_avg_1m: read_load_avg_1m(),
+        cpu_count: std::thread::available_parallelism().ok().map(|n| n.get()),
+        in_flight_engineers: count_live_engineer_claims(state_root),
+        ceiling_pct,
+    }
 }
 
 /// Minutes since the last safe-update attempt (success or failure), inferred
@@ -349,6 +402,21 @@ fn redact_line(line: &str) -> String {
 #[cfg(test)]
 mod inner_tests {
     use super::*;
+
+    #[test]
+    fn gather_resource_admission_ctx_is_hermetic_and_preserves_ceiling() {
+        // A nonexistent state root must not panic: every probe degrades to
+        // best-effort (None / 0) and the caller-supplied ceiling is preserved
+        // verbatim so the hard rail downstream compares against the right value.
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("no-such-state-root");
+        let ctx = gather_resource_admission_ctx(&missing, 90);
+        assert_eq!(ctx.ceiling_pct, 90);
+        // No engineer worktrees under a missing root → zero in flight.
+        assert_eq!(ctx.in_flight_engineers, 0);
+        // worktree cache probe over a missing dir degrades to None (not 0).
+        assert!(ctx.worktree_cache_bytes.is_none());
+    }
 
     #[test]
     fn tail_file_caps_at_50_lines() {

--- a/src/ooda_brain/judgment_record.rs
+++ b/src/ooda_brain/judgment_record.rs
@@ -41,6 +41,9 @@ pub enum BrainPhase {
     /// Recipe-backed merge-readiness judge (`simard merge-pr`). Serialises as
     /// `"merge_judge"`.
     MergeJudge,
+    /// Recipe-backed RESOURCE-AWARE engineer admission (fresh-spawn gate).
+    /// Serialises as `"resource_admission"`.
+    ResourceAdmission,
 }
 
 impl BrainPhase {
@@ -54,6 +57,7 @@ impl BrainPhase {
             BrainPhase::Decide => "decide",
             BrainPhase::Orient => "orient",
             BrainPhase::MergeJudge => "merge_judge",
+            BrainPhase::ResourceAdmission => "resource_admission",
         }
     }
 }
@@ -234,6 +238,29 @@ impl BrainJudgmentRecord {
             rationale: judgment.rationale.clone(),
             confidence: judgment.confidence as f32,
             fallback,
+            prompt_version: prompt_version.into(),
+            parse_failure: None,
+        }
+    }
+
+    /// Build a ResourceAdmission-phase record from the resolved admission gate.
+    /// Emitted for observability at every fresh-spawn admission cycle so the
+    /// ADMIT / DEFER / RECLAIM-FIRST reasoning is inspectable in cycle reports.
+    /// `label` is the stable snake_case gate label (`admit` / `defer` /
+    /// `reclaim`); `reason` is the brain's (or hard-rail's) rationale.
+    pub fn from_admission(
+        goal_id: &str,
+        label: &str,
+        reason: &str,
+        prompt_version: impl Into<String>,
+    ) -> Self {
+        Self {
+            phase: BrainPhase::ResourceAdmission,
+            context_summary: truncate(&format!("resource-admission goal_id={goal_id}")),
+            decision: label.to_string(),
+            rationale: reason.to_string(),
+            confidence: 1.0,
+            fallback: false,
             prompt_version: prompt_version.into(),
             parse_failure: None,
         }

--- a/src/ooda_brain/mod.rs
+++ b/src/ooda_brain/mod.rs
@@ -51,7 +51,10 @@ pub use confidence::{
     effective_k, is_high_stakes, is_irreversible_lifecycle, lifecycle_conservative_rank,
     self_consistency_vote, should_self_consistency_sample, validate_confidence,
 };
-pub use context::{count_live_engineer_claims, gather_engineer_lifecycle_ctx, redact_secrets};
+pub use context::{
+    count_live_engineer_claims, gather_engineer_lifecycle_ctx, gather_resource_admission_ctx,
+    redact_secrets,
+};
 pub use decide::{
     DecideContext, DecideJudgment, DeterministicDecideBrain, OodaDecideBrain,
     PROMPT_NAME as DECIDE_PROMPT_NAME,
@@ -322,6 +325,26 @@ mod inline_tests_1979 {
             serde_json::to_string(&BrainPhase::Orient).unwrap(),
             "\"orient\""
         );
+        // Resource-aware admission phase (fresh-spawn gate observability).
+        assert_eq!(
+            serde_json::to_string(&BrainPhase::ResourceAdmission).unwrap(),
+            "\"resource_admission\""
+        );
+        assert_eq!(BrainPhase::ResourceAdmission.as_str(), "resource_admission");
+    }
+
+    #[test]
+    fn admission_judgment_record_captures_gate() {
+        let rec =
+            BrainJudgmentRecord::from_admission("goal-x", "defer", "disk 88% near ceiling 90", "");
+        assert_eq!(rec.phase, BrainPhase::ResourceAdmission);
+        assert_eq!(rec.decision, "defer");
+        assert!(rec.rationale.contains("88%"));
+        assert!(!rec.fallback);
+        // Round-trips through the cycle-report JSON like every other record.
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: BrainJudgmentRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(rec, back);
     }
 
     #[test]

--- a/src/ooda_brain/mod.rs
+++ b/src/ooda_brain/mod.rs
@@ -15,6 +15,7 @@ use crate::error::SimardResult;
 use crate::ooda_loop::OodaState;
 use std::path::PathBuf;
 
+mod admission;
 pub mod confidence;
 mod context;
 mod decide;
@@ -28,6 +29,8 @@ mod rustyclawd;
 mod sanitize;
 
 #[cfg(test)]
+mod admission_tests;
+#[cfg(test)]
 mod decide_tests;
 #[cfg(test)]
 mod orient_tests;
@@ -36,6 +39,12 @@ mod prompt_store_tests;
 #[cfg(test)]
 mod tests;
 
+pub use admission::{
+    AdmissionDecision, AdmissionGate, CEILING_ENV, CEILING_MAX, CEILING_MIN, DEFAULT_CEILING_PCT,
+    DeterministicAdmissionBrain, OodaAdmissionBrain, RECIPE_NAME as ADMISSION_RECIPE_NAME,
+    ResourceAdmissionCtx, clamp_ceiling, configured_ceiling_pct, judge_and_resolve, parse_ceiling,
+    resolve_admission,
+};
 pub use confidence::{
     CalibrationWindow, ECE_BINS, ECE_METRIC, ECE_WINDOW, HIGH_STAKES_URGENCY, JudgedDecision,
     JudgedLifecycle, LOW_TRUST_CONFIDENCE, SELF_CONSISTENCY_K, Vote, confidence_or_low_trust,

--- a/src/ooda_brain/recipe_brain.rs
+++ b/src/ooda_brain/recipe_brain.rs
@@ -22,6 +22,7 @@ use std::process::Command;
 
 use serde::Deserialize;
 
+use super::admission::{AdmissionDecision, OodaAdmissionBrain, ResourceAdmissionCtx};
 use super::decide::{DecideContext, DecideJudgment, OodaDecideBrain};
 use super::orient::{
     FAILURE_PENALTY_PER_CONSECUTIVE, OodaOrientBrain, OrientContext, OrientJudgment,
@@ -46,6 +47,13 @@ const MAX_RATIONALE_CHARS: usize = 500;
 /// (issue #2419). `value` is always `1.0`; the `outcome` label in the context
 /// JSON is the numerator/denominator signal.
 const LIFECYCLE_DECISION_METRIC: &str = "brain_lifecycle_decision";
+
+/// Metric emitted once per resource-aware admission decision (fresh-spawn gate)
+/// so the ADMIT / DEFER / RECLAIM-FIRST distribution and the hard-rail block
+/// rate are measurable from `metrics.jsonl`. `value` is always `1.0`; the
+/// context JSON carries `{choice, disk_usage_pct, in_flight_engineers,
+/// ceiling_pct}`. Mirrors [`LIFECYCLE_DECISION_METRIC`].
+const ADMISSION_DECISION_METRIC: &str = "brain_admission_decision";
 
 /// Shared metric emitted once per recipe-backed brain phase invocation
 /// (decide / orient / merge-judge) so the verdict/decision parse-success rate
@@ -848,6 +856,147 @@ impl OodaOrientBrain for RecipeBrain {
             termination,
             attempts,
         )
+    }
+}
+
+impl OodaAdmissionBrain for RecipeBrain {
+    /// RESOURCE-AWARE engineer admission — the agentic augmentation of the AIMD
+    /// count cap. Invoke `recipe-runner-rs --output-format json` on
+    /// `ooda-resource-admission.yaml`, parse the agent's structured
+    /// `{"choice": "...", "rationale": "..."}` decision, and return it.
+    ///
+    /// **NO FALLBACK** (operator zero-fallback contract): a recipe-runner
+    /// failure OR an unparseable decision surfaces as an explicit `Err`. The
+    /// admission seam then treats a broken brain as a visible failure — it must
+    /// never silently become a phantom `admit` that could fill the disk. The
+    /// deterministic hard rail in [`super::admission::resolve_admission`] still
+    /// guards ENOSPC over any `Admit` this brain returns.
+    fn judge_admission(&self, ctx: &ResourceAdmissionCtx) -> SimardResult<AdmissionDecision> {
+        let raw = self.invoke_admission_raw(ctx)?;
+        let decision =
+            parse_admission_decision(&raw).ok_or_else(|| SimardError::AdapterInvocationFailed {
+                base_type: self.adapter_tag.to_string(),
+                reason: format!(
+                    "no parseable admission decision in recipe output (expected \
+                     {{\"choice\":\"admit|defer|reclaim_first\",\"rationale\":\"...\"}}); \
+                     raw={}",
+                    truncate(raw.trim(), MAX_RATIONALE_CHARS)
+                ),
+            })?;
+        record_admission_decision_metric(ctx, &decision);
+        Ok(decision)
+    }
+}
+
+impl RecipeBrain {
+    /// Invoke the admission recipe once, returning the agent's raw decision
+    /// text (the JSON envelope's final step output). Genuine recipe-runner
+    /// failures (spawn / nonzero exit / envelope decode) propagate as `Err`.
+    ///
+    /// The full [`ResourceAdmissionCtx`] is passed as `-c` context vars so the
+    /// prompt can reason over disk %, build-cache size, load-per-core, and
+    /// in-flight builds. `None` probes render as the literal `unknown` so the
+    /// prompt can weigh missing signals explicitly.
+    fn invoke_admission_raw(&self, ctx: &ResourceAdmissionCtx) -> SimardResult<String> {
+        let opt_u8 = |v: Option<u8>| v.map(|n| n.to_string()).unwrap_or_else(|| "unknown".into());
+        let opt_u64 = |v: Option<u64>| v.map(|n| n.to_string()).unwrap_or_else(|| "unknown".into());
+        let opt_f64 = |v: Option<f64>| {
+            v.map(|n| format!("{n:.2}"))
+                .unwrap_or_else(|| "unknown".into())
+        };
+        let opt_usize =
+            |v: Option<usize>| v.map(|n| n.to_string()).unwrap_or_else(|| "unknown".into());
+
+        let output = Command::new("recipe-runner-rs")
+            .arg(self.recipe_path.as_os_str())
+            .arg("--output-format")
+            .arg("json")
+            .env("AMPLIHACK_AGENT_BINARY", self.agent_binary)
+            .arg("-c")
+            .arg(format!("disk_usage_pct={}", opt_u8(ctx.disk_usage_pct)))
+            .arg("-c")
+            .arg(format!(
+                "worktree_cache_bytes={}",
+                opt_u64(ctx.worktree_cache_bytes)
+            ))
+            .arg("-c")
+            .arg(format!("load_avg_1m={}", opt_f64(ctx.load_avg_1m)))
+            .arg("-c")
+            .arg(format!("cpu_count={}", opt_usize(ctx.cpu_count)))
+            .arg("-c")
+            .arg(format!("in_flight_engineers={}", ctx.in_flight_engineers))
+            .arg("-c")
+            .arg(format!("ceiling_pct={}", ctx.ceiling_pct))
+            .output()
+            .map_err(|e| SimardError::AdapterInvocationFailed {
+                base_type: self.adapter_tag.to_string(),
+                reason: format!("recipe-runner-rs spawn failed: {e}"),
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(SimardError::AdapterInvocationFailed {
+                base_type: self.adapter_tag.to_string(),
+                reason: format!(
+                    "recipe exited with {}: {}",
+                    output.status,
+                    truncate(&stderr, MAX_RATIONALE_CHARS)
+                ),
+            });
+        }
+
+        extract_recipe_decision_output(&output.stdout, self.adapter_tag)
+    }
+}
+
+/// Parse the admission reasoner's raw output into an [`AdmissionDecision`].
+///
+/// Routes through the shared #2484 sanitizing chokepoint
+/// ([`crate::recipe_output::extract_json_payload`]) so a banner/log-polluted
+/// `{"choice": "...", "rationale": "..."}` object still parses, then
+/// deserializes it directly into the tagged [`AdmissionDecision`] enum. Returns
+/// `None` when no well-formed decision object is present — the caller surfaces
+/// that as an explicit `Err` (NO silent default admission).
+fn parse_admission_decision(text: &str) -> Option<AdmissionDecision> {
+    let payload = crate::recipe_output::extract_json_payload(text)?;
+    serde_json::from_str::<AdmissionDecision>(&payload).ok()
+}
+
+/// Build the JSON `context` payload for the `brain_admission_decision` metric.
+/// Separated from I/O so the payload shape can be unit-tested without touching
+/// the real `metrics.jsonl`.
+fn build_admission_metric_context(
+    ctx: &ResourceAdmissionCtx,
+    decision: &AdmissionDecision,
+) -> String {
+    serde_json::json!({
+        "choice": decision.label(),
+        "disk_usage_pct": ctx.disk_usage_pct,
+        "worktree_cache_bytes": ctx.worktree_cache_bytes,
+        "load_avg_1m": ctx.load_avg_1m,
+        "cpu_count": ctx.cpu_count,
+        "in_flight_engineers": ctx.in_flight_engineers,
+        "ceiling_pct": ctx.ceiling_pct,
+    })
+    .to_string()
+}
+
+/// Record one `brain_admission_decision` metric event (value `1.0`) per
+/// admission decision. Best-effort: a metrics-write failure is logged, never
+/// propagated. No-op under `cfg!(test)` so unit tests never append to the
+/// operator's real `metrics.jsonl`.
+fn record_admission_decision_metric(ctx: &ResourceAdmissionCtx, decision: &AdmissionDecision) {
+    if cfg!(test) {
+        return;
+    }
+    let context = build_admission_metric_context(ctx, decision);
+    if let Err(e) = crate::self_metrics::record_metric(ADMISSION_DECISION_METRIC, 1.0, &context) {
+        tracing::warn!(
+            target: "simard::ooda_brain",
+            error = %e,
+            choice = decision.label(),
+            "failed to record brain_admission_decision metric (decision unaffected)",
+        );
     }
 }
 
@@ -2088,6 +2237,94 @@ mod tests {
             msg.contains("recipe-decide-brain"),
             "error should contain the adapter tag; got: {msg}"
         );
+    }
+
+    // ===================================================================
+    // Resource-aware admission — parse seam + metric payload + NO FALLBACK
+    // ===================================================================
+
+    fn admission_ctx() -> ResourceAdmissionCtx {
+        ResourceAdmissionCtx {
+            disk_usage_pct: Some(42),
+            worktree_cache_bytes: Some(1_024),
+            load_avg_1m: Some(3.1),
+            cpu_count: Some(16),
+            in_flight_engineers: 2,
+            ceiling_pct: 90,
+        }
+    }
+
+    #[test]
+    fn parse_admission_decision_reads_all_three_choices() {
+        let admit = parse_admission_decision(r#"{"choice":"admit","rationale":"headroom"}"#)
+            .expect("admit parses");
+        assert!(matches!(admit, AdmissionDecision::Admit { .. }));
+
+        let defer = parse_admission_decision(r#"{"choice":"defer","rationale":"tight"}"#)
+            .expect("defer parses");
+        assert!(matches!(defer, AdmissionDecision::Defer { .. }));
+
+        let reclaim =
+            parse_admission_decision(r#"{"choice":"reclaim_first","rationale":"stale cache"}"#)
+                .expect("reclaim parses");
+        assert!(matches!(reclaim, AdmissionDecision::ReclaimFirst { .. }));
+    }
+
+    #[test]
+    fn parse_admission_decision_recovers_from_banner_and_fence() {
+        // The agent step output routinely wraps the JSON in a ```json fence and
+        // a runner banner; the shared #2484 chokepoint must still recover it.
+        let raw = "Recipe: ooda-resource-admission SUCCESS\n```json\n{\"choice\": \"defer\", \"rationale\": \"load 2.1/core\"}\n```\n";
+        let d = parse_admission_decision(raw).expect("banner-wrapped JSON must parse");
+        assert_eq!(d.label(), "defer");
+    }
+
+    #[test]
+    fn parse_admission_decision_none_for_unparseable() {
+        // No default admission: garbage / unknown tag / empty must be None so
+        // the caller surfaces an explicit Err (never a phantom admit).
+        assert!(parse_admission_decision("").is_none());
+        assert!(parse_admission_decision("not json at all").is_none());
+        assert!(
+            parse_admission_decision(r#"{"choice":"launch_the_missiles","rationale":"x"}"#)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn judge_admission_surfaces_error_no_fallback() {
+        // A recipe-runner failure (nonexistent recipe) must surface as Err,
+        // NEVER a silent Admit that could fill the disk.
+        let brain = RecipeBrain {
+            recipe_path: PathBuf::from("/nonexistent/recipe.yaml"),
+            agent_binary: "copilot",
+            adapter_tag: "recipe-resource-admission-brain",
+        };
+        let result = brain.judge_admission(&admission_ctx());
+        assert!(
+            result.is_err(),
+            "broken admission brain must Err, not phantom-admit: {result:?}"
+        );
+        assert!(
+            format!("{}", result.unwrap_err()).contains("recipe-resource-admission-brain"),
+            "error should name the adapter tag"
+        );
+    }
+
+    #[test]
+    fn admission_metric_context_carries_choice_and_numbers() {
+        let ctx = admission_ctx();
+        let json = build_admission_metric_context(
+            &ctx,
+            &AdmissionDecision::Defer {
+                rationale: "tight".to_string(),
+            },
+        );
+        let v: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(v["choice"], "defer");
+        assert_eq!(v["disk_usage_pct"], 42);
+        assert_eq!(v["in_flight_engineers"], 2);
+        assert_eq!(v["ceiling_pct"], 90);
     }
 
     #[test]

--- a/src/ooda_loop/bridge_factory.rs
+++ b/src/ooda_loop/bridge_factory.rs
@@ -107,6 +107,7 @@ pub fn bridges_from_state_root(state_root: &Path) -> SimardResult<OodaBridges> {
             crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     })
 }
 

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -128,10 +128,25 @@ fn run_ooda_cycle_inner(
     // to avoid false-positive clearing in non-tmux environments.
     sweep_stale_assignments(&mut state.active_goals);
 
-    // Seed with default goals if the board is still empty.
-    let seeded = crate::goal_curation::seed_default_board(&mut state.active_goals);
-    if seeded > 0 {
-        eprintln!("[simard] OODA start: seeded {seeded} default goal(s)");
+    // Seed with default goals if the board is still empty. Simard #3125: when
+    // the active identity declared its own seed goals they OVERRIDE Simard's
+    // baked-in DEFAULT_SEED_GOALS and are seeded target-scoped + unassigned;
+    // Simard herself (no identity seeds) keeps her exact 5 defaults unchanged.
+    if state.identity_seed_goals.is_empty() {
+        let n = crate::goal_curation::seed_default_board(&mut state.active_goals);
+        if n > 0 {
+            eprintln!("[simard] OODA start: seeded {n} default goal(s)");
+        }
+    } else {
+        let n = crate::goal_curation::seed_identity_board(
+            &mut state.active_goals,
+            &state.identity_seed_goals,
+        );
+        if n > 0 {
+            eprintln!(
+                "[simard] OODA start: seeded {n} identity goal(s) — overriding defaults, target-scoped observe-only (issue #3125)"
+            );
+        }
     }
 
     // Ingest meeting handoff decisions as new goals.

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -90,6 +90,19 @@ pub fn act(
     state: &mut OodaState,
     max_concurrency: usize,
 ) -> SimardResult<Vec<ActionOutcome>> {
+    // Simard #3125: read-only identity ⇒ OBSERVE-ONLY Act phase (L1 cognition
+    // branch). Records observations + proposes target-scoped goals and returns
+    // benign outcomes WITHOUT ever reaching the engineer-dispatching path, so
+    // an OBSERVER identity burns no AI credits on doomed, guardrail-blocked
+    // engineer dispatch. The deterministic spawn rail inside
+    // `dispatch_spawn_engineer` is the independent L2 backstop that also
+    // hard-blocks writes if control ever reaches the chokepoint.
+    if state.write_authority.is_read_only() {
+        eprintln!(
+            "[simard] OODA Act: identity posture is read-only — running observe-only branch (no engineer dispatch, issue #3125)"
+        );
+        return crate::ooda_actions::observe_only::run_observe_only_act(actions, state);
+    }
     crate::ooda_actions::dispatch_actions_bounded(actions, bridges, state, max_concurrency)
 }
 

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -479,6 +479,14 @@ pub struct OodaBridges {
     /// non-daemon callers. Bounded by the AIMD `cap` (`scaler.current_max()`)
     /// so concurrency stays resource-aware.
     pub session_factory: Option<std::sync::Arc<dyn OrchestratorSessionFactory>>,
+    /// Resource-aware admission brain (fresh-spawn gate). When `Some`, the
+    /// spawn seam consults it — gathering the resource picture (disk %,
+    /// build-cache size, load, in-flight engineers) and reasoning ADMIT /
+    /// DEFER / RECLAIM-FIRST — before allocating an engineer worktree. When
+    /// `None`, the seam uses the [`crate::ooda_brain::DeterministicAdmissionBrain`]
+    /// floor (always admit). The deterministic disk hard-rail
+    /// ([`crate::ooda_brain::resolve_admission`]) blocks ENOSPC either way.
+    pub admission_brain: Option<std::sync::Arc<dyn crate::ooda_brain::OodaAdmissionBrain>>,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -80,6 +80,23 @@ pub struct OodaState {
     /// done-gate ladder (mark done / drop / escalate). See
     /// `docs/concepts/steerable-ooda-daemon.md` ("The no-progress breaker (Fix 3)").
     pub no_progress_tracker: crate::goal_curation::NoProgressTracker,
+    /// Active identity's write posture (Simard #3125). Set once at daemon boot
+    /// from the resolved identity; [`WriteAuthority::ReadWrite`] by default so
+    /// Simard — and any read-write identity — is behaviorally unchanged. When
+    /// [`WriteAuthority::ReadOnly`] the Act phase runs an observe-only branch
+    /// and the deterministic spawn rail in
+    /// [`crate::ooda_actions::advance_goal::spawn::dispatch_spawn_engineer`]
+    /// hard-blocks every engineer dispatch (defense in depth).
+    pub write_authority: crate::identity::WriteAuthority,
+    /// Target repo slugs the active identity is scoped to (Simard #3125). Empty
+    /// for Simard herself; populated at boot for a scoped observer identity so
+    /// the observe-only Act branch reasons over the identity's repos, never
+    /// `rysweet/Simard`.
+    pub observer_targets: Vec<String>,
+    /// Identity-declared seed goals (Simard #3125). Empty for Simard (keeps her
+    /// baked-in `DEFAULT_SEED_GOALS`); when non-empty the cycle seeds the board
+    /// from these — OVERRIDING the defaults — via `seed_identity_board`.
+    pub identity_seed_goals: Vec<crate::identity::SeedGoal>,
 }
 
 impl OodaState {
@@ -98,6 +115,9 @@ impl OodaState {
             engineer_worktrees: HashMap::new(),
             last_distill_cycle: 0,
             no_progress_tracker: crate::goal_curation::NoProgressTracker::new(),
+            write_authority: crate::identity::WriteAuthority::ReadWrite,
+            observer_targets: Vec::new(),
+            identity_seed_goals: Vec::new(),
         }
     }
 

--- a/src/operator_commands_ooda/daemon/brains.rs
+++ b/src/operator_commands_ooda/daemon/brains.rs
@@ -161,6 +161,39 @@ pub(super) fn build_orient_brain(
     }
 }
 
+/// Construct the RESOURCE-AWARE admission brain (fresh-spawn gate). Always
+/// returns an `Arc` — falls back to
+/// [`crate::ooda_brain::DeterministicAdmissionBrain`] (the no-LLM floor, which
+/// always `Admit`s and is still guarded by the deterministic disk hard-rail)
+/// when the recipe/runner is unavailable, loudly per [`record_fallback`].
+///
+/// Unlike `build_decide_brain` / `build_orient_brain`, admission always yields
+/// a concrete brain rather than `None`: the seam must always have a reasoner to
+/// consult, and the deterministic floor + hard-rail preserve safe behaviour
+/// even with no LLM.
+pub(super) fn build_admission_brain(
+    state_root: &Path,
+    repo_root: &Path,
+) -> Arc<dyn crate::ooda_brain::OodaAdmissionBrain> {
+    if let Some(b) = crate::ooda_brain::RecipeBrain::new(
+        repo_root,
+        crate::ooda_brain::ADMISSION_RECIPE_NAME,
+        "recipe-resource-admission-brain",
+    ) {
+        daemon_log(
+            state_root,
+            "[simard] OODA daemon: admission_brain = RecipeBrain (recipe-runner-rs backed, resource-admission)",
+        );
+        return Arc::new(b);
+    }
+    record_fallback(
+        state_root,
+        "admission",
+        "recipe-runner-rs or ooda-resource-admission.yaml not available",
+    );
+    Arc::new(crate::ooda_brain::DeterministicAdmissionBrain)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -240,5 +273,78 @@ mod tests {
             log.contains(unique_reason),
             "the LlmProvider::resolve() error must be in the dashboard log verbatim; got: {log}"
         );
+    }
+
+    /// RAII guard that points `$HOME` at an empty directory for the duration of
+    /// a test and restores the prior value on drop. `resolve_recipe_path`
+    /// consults `~/.simard/prompt_assets/simard/recipes/…` *before* `repo_root`,
+    /// so a nonexistent repo alone does NOT make `RecipeBrain::new` return
+    /// `None` on a provisioned host where the ambient hot-reload recipe exists.
+    /// Neutralizing `$HOME` closes that non-hermetic hole. Safe because the
+    /// caller holds [`lock()`], which serializes all env-var mutation in this
+    /// module.
+    struct HomeGuard {
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl HomeGuard {
+        fn empty(dir: &Path) -> Self {
+            let prev = std::env::var_os("HOME");
+            // SAFETY: env mutation is serialized via `lock()`; restored on drop.
+            unsafe {
+                std::env::set_var("HOME", dir);
+            }
+            Self { prev }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: env mutation is serialized via `lock()`.
+            unsafe {
+                match self.prev.take() {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
+    }
+
+    /// `build_admission_brain` ALWAYS yields a working brain (never `None`):
+    /// with an unresolvable recipe, it falls back — loudly — to the
+    /// deterministic admission floor, which admits so the deterministic disk
+    /// hard-rail (not this brain) remains the ENOSPC guard.
+    #[test]
+    fn build_admission_brain_falls_back_to_deterministic_floor() {
+        use crate::ooda_brain::ResourceAdmissionCtx;
+        let _g = lock();
+        reset_fallback_brain_count_for_test();
+        let tmp = TempDir::new().expect("tempdir");
+
+        // Point HOME at a fresh empty dir so the hot-reload lookup
+        // (`~/.simard/prompt_assets/…`) finds nothing, THEN pass a nonexistent
+        // repo so the in-tree lookup also misses → resolve_recipe_path returns
+        // None → RecipeBrain::new returns None regardless of recipe-runner
+        // availability → deterministic floor. Hermetic against the ambient
+        // ~/.simard/prompt_assets directory on provisioned hosts.
+        let fake_home = TempDir::new().expect("fake home tempdir");
+        let _home = HomeGuard::empty(fake_home.path());
+        let brain = build_admission_brain(tmp.path(), Path::new("/nonexistent-repo-root"));
+        assert!(
+            fallback_brain_count() >= 1,
+            "fallback to the deterministic floor must be recorded loudly"
+        );
+        // The floor admits (count-cap only); the deterministic disk hard-rail
+        // downstream is what guards ENOSPC.
+        let ctx = ResourceAdmissionCtx {
+            disk_usage_pct: Some(10),
+            worktree_cache_bytes: None,
+            load_avg_1m: None,
+            cpu_count: Some(8),
+            in_flight_engineers: 0,
+            ceiling_pct: 90,
+        };
+        let decision = brain.judge_admission(&ctx).expect("floor never errors");
+        assert_eq!(decision.label(), "admit");
     }
 }

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -214,8 +214,9 @@ pub fn run_ooda_daemon(
     let brain = brains::build_act_brain(&state_root, &repo_root);
     let decide_brain = brains::build_decide_brain(&state_root, &repo_root);
     let orient_brain = brains::build_orient_brain(&state_root, &repo_root);
+    let admission_brain = brains::build_admission_brain(&state_root, &repo_root);
 
-    // After all three brains are constructed, surface the cumulative
+    // After all four brains are constructed, surface the cumulative
     // fallback count in the dashboard. Nonzero == daemon is running in
     // degraded mode (see issues #1711, #1748). Future health endpoints
     // should refuse "healthy" when this is nonzero.
@@ -224,13 +225,13 @@ pub fn run_ooda_daemon(
         daemon_log(
             &state_root,
             &format!(
-                "[simard] OODA daemon: DEGRADED MODE — {degraded}/3 brains fell back to deterministic (see issues #1711, #1748)"
+                "[simard] OODA daemon: DEGRADED MODE — {degraded}/4 brains fell back to deterministic (see issues #1711, #1748)"
             ),
         );
     } else {
         daemon_log(
             &state_root,
-            "[simard] OODA daemon: all 3 brains LLM-backed (no fallback in use)",
+            "[simard] OODA daemon: all 4 brains LLM-backed (no fallback in use)",
         );
     }
 
@@ -344,6 +345,7 @@ pub fn run_ooda_daemon(
         repo_root,
         progress_evidence,
         completion_evidence,
+        admission_brain: Some(admission_brain),
     };
 
     // Issue #1: the authoritative goal board lives in
@@ -1536,6 +1538,7 @@ mod tests {
                 crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
             ),
             completion_evidence: None,
+            admission_brain: None,
         }
     }
 

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -367,6 +367,32 @@ pub fn run_ooda_daemon(
     let board = crate::goal_board_store::heal_stale_no_progress_blocks(board);
     let mut state = OodaState::new(board);
     state.no_progress_tracker = persistent.no_progress;
+
+    // Simard #3125: resolve the active identity's write posture at boot and
+    // thread it into the OODA state. `SIMARD_IDENTITY_PATH` unset ⇒ no identity
+    // ⇒ Simard's read-write default (unchanged). A read-only observer identity
+    // (e.g. Crocutus watching the hyenas repos) runs an observe-only Act phase
+    // and its declared seed goals OVERRIDE Simard's baked-in defaults, scoped to
+    // the identity's target repos — never rysweet/Simard. An identity that is
+    // present but cannot be resolved fails CLOSED to read-only.
+    let posture = crate::bootstrap::assembly::resolve_boot_posture();
+    state.write_authority = posture.write_authority();
+    state.observer_targets = posture.targets().to_vec();
+    state.identity_seed_goals = posture.seed_goals().to_vec();
+    daemon_log(
+        &state_root,
+        &format!(
+            "[simard] OODA daemon: identity write posture = {} (targets: {}; identity seed goals: {}) (issue #3125)",
+            state.write_authority,
+            if state.observer_targets.is_empty() {
+                "none".to_string()
+            } else {
+                state.observer_targets.join(", ")
+            },
+            state.identity_seed_goals.len(),
+        ),
+    );
+
     let config = OodaConfig::default();
 
     // Issue #1197: sweep orphaned engineer worktrees from prior crashed

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -1265,7 +1265,8 @@ pub fn run_ooda_daemon(
                             &format!(
                                 "[simard] overseer tick: problems={} issues_filed={} \
                                  recipes_launched={} prs_merged={} deploys={} escalations={} \
-                                 held={} errors={} panicked={} ({}ms)",
+                                 held={} goals_unblocked={} goals_escalated={} errors={} \
+                                 panicked={} ({}ms)",
                                 report.problems,
                                 report.issues_filed,
                                 report.recipes_launched,
@@ -1273,6 +1274,8 @@ pub fn run_ooda_daemon(
                                 report.deploys,
                                 report.escalations,
                                 report.held,
+                                report.goals_unblocked,
+                                report.goals_escalated,
                                 report.errors,
                                 report.panicked,
                                 report.duration_ms,

--- a/src/overseer/activity.rs
+++ b/src/overseer/activity.rs
@@ -55,6 +55,10 @@ pub struct OverseerTotals {
     pub prs_merged: u64,
     pub deploys: u64,
     pub escalations: u64,
+    /// False-parked perpetual goals self-healed (auto-unblocked + reactivated).
+    pub goals_unblocked: u64,
+    /// Genuinely-blocked "needs human review" goals escalated to the operator.
+    pub goals_escalated: u64,
     pub held: u64,
     pub errors: u64,
 }
@@ -216,6 +220,8 @@ impl OverseerActivity {
             t.prs_merged += rep.prs_merged as u64;
             t.deploys += rep.deploys as u64;
             t.escalations += rep.escalations as u64;
+            t.goals_unblocked += rep.goals_unblocked as u64;
+            t.goals_escalated += rep.goals_escalated as u64;
             t.held += rep.held as u64;
             t.errors += rep.errors as u64;
         }
@@ -223,11 +229,18 @@ impl OverseerActivity {
     }
 
     /// Count of *actions taken* over the retained window (issues filed, fix
-    /// workstreams launched, PRs merged, deploys, escalations). `held` is
-    /// deliberately excluded: holding is observing-and-waiting, not an action.
+    /// workstreams launched, PRs merged, deploys, escalations, goal-board
+    /// self-heals + escalations). `held` is deliberately excluded: holding is
+    /// observing-and-waiting, not an action.
     pub fn interventions(&self) -> u64 {
         let t = &self.totals;
-        t.issues_filed + t.recipes_launched + t.prs_merged + t.deploys + t.escalations
+        t.issues_filed
+            + t.recipes_launched
+            + t.prs_merged
+            + t.deploys
+            + t.escalations
+            + t.goals_unblocked
+            + t.goals_escalated
     }
 
     /// The honest one-line status summary rendered on every surface.
@@ -397,6 +410,20 @@ pub fn humanize_tick(r: &OverseerTickReport) -> String {
     }
     if r.escalations > 0 {
         did.push(format!("escalated {} to the operator", r.escalations));
+    }
+    if r.goals_unblocked > 0 {
+        did.push(format!(
+            "self-healed {} blocked goal{}",
+            r.goals_unblocked,
+            plural(r.goals_unblocked)
+        ));
+    }
+    if r.goals_escalated > 0 {
+        did.push(format!(
+            "escalated {} blocked goal{} for human review",
+            r.goals_escalated,
+            plural(r.goals_escalated)
+        ));
     }
 
     let saw = format!("saw {} problem{}", r.problems, plural(r.problems));

--- a/src/overseer/capabilities.rs
+++ b/src/overseer/capabilities.rs
@@ -349,6 +349,20 @@ pub trait GoalCurator {
         Ok(Vec::new())
     }
 
+    /// Project BOTH the goal-board *health* (blocked goals) and the in-flight
+    /// dedup set from ONE board read, so the acting Observe pass reads the board
+    /// once per cycle instead of twice. This halves the per-tick board load
+    /// (`search_facts` + snapshot deserialize) AND guarantees both projections
+    /// come from the SAME snapshot — no intra-cycle drift where the board mutates
+    /// between the two reads.
+    ///
+    /// The default composes the two existing methods (two loads), preserving
+    /// fakes that model neither or only one; the real board-backed adapter
+    /// overrides this to load once.
+    fn observe_board(&self) -> Result<(Vec<BlockedGoal>, Vec<InFlightItem>), OverseerError> {
+        Ok((self.blocked_goals()?, self.in_flight()?))
+    }
+
     /// Auto-unblock + reactivate a false-parked goal — the exact operation
     /// `simard goal unblock` performs: restore a `Blocked` goal to `NotStarted`
     /// so the next OODA cycle re-enters the spawn path.

--- a/src/overseer/capabilities.rs
+++ b/src/overseer/capabilities.rs
@@ -86,6 +86,12 @@ pub struct ObservedState {
     pub ready_prs: Vec<PrRef>,
     /// CI-failure clusters observed across recent runs.
     pub ci_failures: Vec<CiFailure>,
+    /// Blocked goals observed on Simard's goal board this Observe pass — the
+    /// goal-board *health* signal. Populated by the sensor from the durable
+    /// board markers (`BLOCKED`, the `🔒 [OODA-SAFEGUARD] … needs human review`
+    /// no-progress marker, and the brain-failure marker). Empty when the board
+    /// is clean or unreadable (degrade-to-empty, never a panic).
+    pub blocked_goals: Vec<BlockedGoal>,
     /// Consecutive OODA cycles the active goal has produced no action / no
     /// progress. Mirrors the OODA no-progress tracker; drives the loop-whisper.
     /// `None` when unknown (e.g. no active goal).
@@ -110,6 +116,33 @@ pub struct PrRef {
 pub struct CiFailure {
     pub repo: String,
     pub failing: u32,
+}
+
+/// One blocked goal observed on Simard's goal board — the unit of goal-board
+/// *health* the Overseer observes and (in the acting loop) acts on.
+///
+/// Derived from a `GoalProgress::Blocked(reason)` on the live board by the
+/// sensor's pure projection (`sensor::blocked_goals_from_board`). It reuses the
+/// EXISTING standing/perpetual detection (`ActiveGoal::is_perpetual`, #2589/#2609)
+/// and the EXISTING safeguard-marker predicates
+/// (`goal_curation::no_progress_breaker::is_no_progress_marker`,
+/// `ooda_actions::advance_goal::is_brain_failure_marker`) — it never invents a
+/// second notion of either.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlockedGoal {
+    /// The blocked goal's id on the active board.
+    pub id: String,
+    /// The verbatim `GoalProgress::Blocked` reason string (carries the marker).
+    pub reason: String,
+    /// True when the goal is standing/perpetual (`ActiveGoal::is_perpetual`).
+    pub perpetual: bool,
+    /// True when the block carries a "needs human review" safeguard marker
+    /// (the no-progress OODA-SAFEGUARD marker or the brain-failure marker) —
+    /// the signal that a human must be reached.
+    pub needs_review: bool,
+    /// Consecutive no-action / no-progress cycles parsed from the safeguard
+    /// marker, or `0` when the block is not a counted safeguard marker.
+    pub consecutive_no_action: u32,
 }
 
 // ─────────────────────────── Capability briefs ─────────────────────────────
@@ -304,6 +337,29 @@ pub trait IssueFiler {
 pub trait GoalCurator {
     fn propose(&self, goal: &GoalBrief) -> Result<(), OverseerError>;
     fn in_flight(&self) -> Result<Vec<InFlightItem>, OverseerError>;
+
+    /// Read the goal-board *health* — the goals currently `Blocked` — so the
+    /// Observe pass can surface them into [`ObservedState::blocked_goals`].
+    ///
+    /// **Reuse:** `crate::goal_curation::load_goal_board` projected by
+    /// `crate::overseer::sensor::blocked_goals_from_board`. Read-only; a board
+    /// read failure degrades to an empty list, never a panic. The default
+    /// returns an empty list for fakes that do not model a board.
+    fn blocked_goals(&self) -> Result<Vec<BlockedGoal>, OverseerError> {
+        Ok(Vec::new())
+    }
+
+    /// Auto-unblock + reactivate a false-parked goal — the exact operation
+    /// `simard goal unblock` performs: restore a `Blocked` goal to `NotStarted`
+    /// so the next OODA cycle re-enters the spawn path.
+    ///
+    /// **Reuse:** the `simard goal unblock` board mutation
+    /// (`src/operator_cli/goal.rs`) via `load_goal_board` → set status
+    /// `NotStarted` → `save_goal_board`. The default is a no-op for fakes that
+    /// do not model a board (real adapters override it).
+    fn unblock(&self, _goal_id: &str) -> Result<(), OverseerError> {
+        Ok(())
+    }
 }
 
 /// Run a quality-audit loop (crusty-old-engineer-gated).

--- a/src/overseer/config.rs
+++ b/src/overseer/config.rs
@@ -35,6 +35,12 @@ pub const OVERSEER_INTERVAL_ENV: &str = "SIMARD_OVERSEER_INTERVAL_SECS";
 /// whisperer off regardless of this flag.
 pub const SIMARD_OVERSEER_WHISPER_ENV: &str = "SIMARD_OVERSEER_WHISPER";
 
+/// Opt-out flag for **goal-board health handling** (the self-heal + escalate
+/// paths). ON by default whenever the acting Overseer runs; an explicit falsey
+/// value (`0`/`false`/`no`/`off`) disables it. Goal-board health only makes
+/// sense while the Overseer runs, so a disabled Overseer forces it off.
+pub const SIMARD_OVERSEER_GOAL_HEALTH_ENV: &str = "SIMARD_OVERSEER_GOAL_HEALTH";
+
 /// GitHub login the acting Overseer authors its own workstreams under. Sourced
 /// here so the daemon and the merge/recursion path agree on ONE stable, DISTINCT
 /// identity (never the human operator's login). Defaults to
@@ -115,6 +121,29 @@ pub fn whisper_enabled_from(lookup: impl Fn(&str) -> Option<String>) -> bool {
 /// Production entry point: read the real process environment.
 pub fn whisper_enabled() -> bool {
     whisper_enabled_from(|k| std::env::var(k).ok())
+}
+
+/// Resolve whether **goal-board health handling** (self-heal false-parked
+/// perpetual goals + escalate genuine "needs human review" blocks) is enabled,
+/// with **default ON** opt-out semantics consistent with the acting Overseer.
+/// Enabled UNLESS [`SIMARD_OVERSEER_GOAL_HEALTH_ENV`] is an explicit falsey
+/// value — AND only while the acting Overseer itself is enabled (an
+/// explicitly-disabled Overseer forces goal-board health off).
+pub fn goal_health_enabled_from(lookup: impl Fn(&str) -> Option<String>) -> bool {
+    // No Overseer ⇒ no goal-board health handling.
+    if !overseer_acting_enabled_from(&lookup) {
+        return false;
+    }
+    // Opt-out: enabled unless an explicit falsey value is set.
+    !matches!(
+        lookup(SIMARD_OVERSEER_GOAL_HEALTH_ENV).as_deref().map(str::trim),
+        Some(v) if is_falsey(v)
+    )
+}
+
+/// Production entry point: read the real process environment.
+pub fn goal_health_enabled() -> bool {
+    goal_health_enabled_from(|k| std::env::var(k).ok())
 }
 
 /// Resolve the Overseer's DISTINCT author login. Falls back to

--- a/src/overseer/guardrails.rs
+++ b/src/overseer/guardrails.rs
@@ -46,6 +46,13 @@ pub fn classify(iv: &Intervention) -> RiskClass {
         // is advisory context only. Routine; its own dedup/identity gates
         // ([`WhisperGate`] / [`RecursionGuard`]) apply in the act path.
         Intervention::Whisper { .. } => RiskClass::Routine,
+        // Goal-board self-heal and escalation are routine stewardship: unblocking
+        // a false-parked perpetual goal restores the shipped `simard goal unblock`
+        // state, and escalation is a notification. Both are deduped and
+        // identity-gated (fail-closed) in the act path, and spend no LLM budget.
+        Intervention::UnblockGoal { .. } | Intervention::EscalateBlockedGoal { .. } => {
+            RiskClass::Routine
+        }
         _ => RiskClass::Routine,
     }
 }

--- a/src/overseer/intervention.rs
+++ b/src/overseer/intervention.rs
@@ -46,6 +46,18 @@ pub enum Intervention {
         note: String,
         urgency: WhisperUrgency,
     },
+    /// SELF-HEAL a false-parked standing/perpetual goal: auto-unblock + reactivate
+    /// it — the exact operation `simard goal unblock` performs — so a perpetual
+    /// goal wrongly hard-blocked by the no-progress safeguard re-enters the OODA
+    /// spawn path. Deduped so it never fights itself; optionally followed by an
+    /// advisory whisper steering Simard to carve a bounded shippable sub-goal.
+    /// Capability: `GoalCurator::unblock` (+ optional `whisper_ops::WhisperSink`).
+    UnblockGoal { goal_id: String, reason: String },
+    /// ESCALATE a genuinely-blocked goal carrying a "needs human review" marker to
+    /// the operator (email + Signal) with the goal id + reason, so the marker
+    /// actually reaches a human — closing the silent-failure gap.
+    /// Capability: `notify::OperatorNotifier`.
+    EscalateBlockedGoal { goal_id: String, reason: String },
 }
 
 impl Intervention {
@@ -62,6 +74,8 @@ impl Intervention {
             Self::RunAudit { .. } => "run_audit",
             Self::Escalate { .. } => "escalate",
             Self::Whisper { .. } => "whisper",
+            Self::UnblockGoal { .. } => "unblock_goal",
+            Self::EscalateBlockedGoal { .. } => "escalate_blocked_goal",
         }
     }
 }

--- a/src/overseer/mod.rs
+++ b/src/overseer/mod.rs
@@ -66,6 +66,8 @@ pub mod whisper_ops;
 pub mod wiring;
 
 #[cfg(test)]
+mod tests_goal_health;
+#[cfg(test)]
 mod tests_m1;
 #[cfg(test)]
 mod tests_m2;
@@ -73,11 +75,12 @@ mod tests_m2;
 mod tests_whisper;
 
 pub use capabilities::{
-    Auditor, Deployer, GoalCurator, IssueFiler, MeetingHost, ObservedState, OrchestratorRunBrief,
-    OverseerError, PrOps, RecipeBrief, RecipeLauncher, StatusReader,
+    Auditor, BlockedGoal, Deployer, GoalCurator, IssueFiler, MeetingHost, ObservedState,
+    OrchestratorRunBrief, OverseerError, PrOps, RecipeBrief, RecipeLauncher, StatusReader,
 };
 pub use config::{
-    daily_budget_usd, overseer_acting_enabled, overseer_author_login, overseer_enabled,
+    daily_budget_usd, goal_health_enabled, overseer_acting_enabled, overseer_author_login,
+    overseer_enabled,
 };
 pub use guardrails::{
     AutonomyGate, BudgetGate, ConflictSequencer, RecursionGuard, RiskClass, Subject,
@@ -87,7 +90,7 @@ pub use intervention::{Intervention, PlannedIntervention};
 pub use observer::{StewardshipIssueFiler, decide_read_only, is_m1_permitted};
 pub use sensor::{
     ObserverReport, OverseerSensorThread, SnapshotSource, SnapshotStatusReader,
-    in_flight_from_board, observed_from_snapshot, run_observer_cycle,
+    blocked_goals_from_board, in_flight_from_board, observed_from_snapshot, run_observer_cycle,
 };
 pub use signal::{Priority, Problem, ProblemKind, Signal, signals_from};
 pub use whisper_ops::{
@@ -100,7 +103,10 @@ pub use wiring::{
     run_overseer_tick_isolated,
 };
 
-use crate::goal_curation::no_progress_breaker::NO_PROGRESS_BREAKER_THRESHOLD;
+use crate::goal_curation::no_progress_breaker::{
+    NO_PROGRESS_BREAKER_THRESHOLD, is_no_progress_marker,
+};
+use crate::overseer::notify::{OperatorNotification, OperatorNotifier};
 use capabilities::{DeployReport, GoalBrief, InFlightItem, IssueOutcome, WorkstreamHandle};
 use std::path::PathBuf;
 
@@ -137,6 +143,16 @@ pub struct Overseer {
     /// Whether the whisperer is enabled (config opt-out). When off, whispers are
     /// held (never delivered) even if the observed condition holds.
     whisper_enabled: bool,
+    /// The operator-notification seam (email + Signal) the ESCALATE-blocked-goal
+    /// path fires through so a "needs human review" marker reaches a human.
+    /// `None` until wired; escalation requires it.
+    notifier: Option<Box<dyn OperatorNotifier>>,
+    /// Dedup + rate-limit gate for goal-board self-heal / escalation actions, so
+    /// the same blocked goal is not re-unblocked or re-escalated every tick.
+    blocked_goal_gate: WhisperGate,
+    /// Whether goal-board health handling (self-heal + escalate) is enabled
+    /// (config opt-out). When off, both actions are held (never taken).
+    goal_health_enabled: bool,
 }
 
 /// The result of one meta-OODA turn. Side-effect free: it reports what was
@@ -172,6 +188,21 @@ pub enum ActOutcome {
     WhisperSuppressed {
         reason: &'static str,
     },
+    /// A false-parked standing/perpetual goal was auto-unblocked + reactivated
+    /// (the `simard goal unblock` operation) by the self-heal path.
+    GoalUnblocked {
+        goal_id: String,
+    },
+    /// A genuinely-blocked "needs human review" goal was escalated to the
+    /// operator on both channels (email + Signal).
+    GoalEscalated {
+        goal_id: String,
+    },
+    /// A goal-board self-heal / escalation was suppressed by the dedup gate
+    /// (duplicate within the window, or the per-hour cap was reached).
+    GoalHealthSuppressed {
+        reason: &'static str,
+    },
 }
 
 impl Overseer {
@@ -188,12 +219,32 @@ impl Overseer {
             // 15-minute dedup window; at most 5 whispers per rolling hour.
             whisper_gate: WhisperGate::new(900, 5),
             whisper_enabled: false,
+            notifier: None,
+            // 15-minute dedup window so a persistent blocked goal is self-healed
+            // / escalated once per window (never in a per-tick loop); a generous
+            // per-hour cap covers many distinct goals without flooding.
+            blocked_goal_gate: WhisperGate::new(900, 20),
+            goal_health_enabled: false,
         }
     }
 
     /// Wire the Simard Whisperer's delivery seam (advisory steering notes).
     pub fn with_whisper_sink(mut self, sink: Box<dyn WhisperSink>) -> Self {
         self.whisper_sink = Some(sink);
+        self
+    }
+
+    /// Wire the operator-notification seam (email + Signal) used by the
+    /// ESCALATE-blocked-goal path. `None` until wired; escalation requires it.
+    pub fn with_operator_notifier(mut self, notifier: Box<dyn OperatorNotifier>) -> Self {
+        self.notifier = Some(notifier);
+        self
+    }
+
+    /// Enable/disable goal-board health handling (self-heal + escalate). Off by
+    /// default; the daemon sets this from [`config::goal_health_enabled`].
+    pub fn with_goal_health_enabled(mut self, enabled: bool) -> Self {
+        self.goal_health_enabled = enabled;
         self
     }
 
@@ -229,7 +280,11 @@ impl Overseer {
     /// execute side effects; returns the plan for M2+ Act to run.
     pub fn run_cycle(&mut self) -> Result<CycleReport, OverseerError> {
         // Observe.
-        let observed = self.caps.status.snapshot()?;
+        let mut observed = self.caps.status.snapshot()?;
+        // Enrich with goal-board health: the goals currently BLOCKED on Simard's
+        // board (false-parks + genuine "needs human review" blocks). Read-only;
+        // a board-read failure degrades to "no blocked goals", never aborts.
+        observed.blocked_goals = self.caps.goals.blocked_goals().unwrap_or_default();
         let signals = signals_from(&observed);
 
         // Orient (dedup against Simard's in-flight work; failure to read the
@@ -269,6 +324,20 @@ impl Overseer {
                 intervention: iv.clone(),
                 admitted: false,
                 note: "held: whisper disabled (SIMARD_OVERSEER_WHISPER)".to_string(),
+            };
+        }
+
+        // Goal-board health opt-out: when disabled, hold the self-heal /
+        // escalation (no action taken) even though a blocked goal was observed.
+        if matches!(
+            iv,
+            Intervention::UnblockGoal { .. } | Intervention::EscalateBlockedGoal { .. }
+        ) && !self.goal_health_enabled
+        {
+            return PlannedIntervention {
+                intervention: iv.clone(),
+                admitted: false,
+                note: "held: goal-board health disabled (SIMARD_OVERSEER_GOAL_HEALTH)".to_string(),
             };
         }
 
@@ -357,6 +426,10 @@ impl Overseer {
             }
             Intervention::Escalate { .. } => Ok(ActOutcome::Escalated),
             Intervention::Whisper { note, urgency } => self.act_whisper(note, *urgency),
+            Intervention::UnblockGoal { goal_id, reason } => self.act_unblock_goal(goal_id, reason),
+            Intervention::EscalateBlockedGoal { goal_id, reason } => {
+                self.act_escalate_blocked_goal(goal_id, reason)
+            }
         }
     }
 
@@ -445,6 +518,158 @@ impl Overseer {
                 })
             }
         }
+    }
+
+    /// SELF-HEAL a false-parked standing/perpetual goal: auto-unblock +
+    /// reactivate it (the exact `simard goal unblock` operation), deduped so it
+    /// never re-fires in a tight loop, then OPTIONALLY whisper Simard to carve a
+    /// bounded shippable sub-goal. Fails CLOSED without a DISTINCT steward
+    /// identity (anti-recursion — the Overseer must never self-heal a goal
+    /// without a configured distinct identity, which also prevents a self-heal
+    /// loop). The whisper is best-effort: a whisper failure never fails the
+    /// unblock.
+    fn act_unblock_goal(
+        &mut self,
+        goal_id: &str,
+        reason: &str,
+    ) -> Result<ActOutcome, OverseerError> {
+        if !self.recursion.is_configured() {
+            return Err(OverseerError::Recursion {
+                subject: format!("unblock goal (unconfigured steward identity): {goal_id}"),
+            });
+        }
+        let signature = format!("unblock:{goal_id}");
+        let now = now_secs();
+        match self.blocked_goal_gate.peek(&signature, now) {
+            WhisperDecision::Deliver => {
+                self.caps.goals.unblock(goal_id)?;
+                // Consume the dedup slot only after a successful unblock.
+                self.blocked_goal_gate.commit(&signature, now);
+                tracing::info!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    reason,
+                    action = "unblock",
+                    "overseer self-healed a false-parked perpetual goal: auto-unblocked + reactivated"
+                );
+                // Optional advisory whisper: steer Simard to carve a bounded,
+                // shippable sub-goal instead of re-attempting the whole standing
+                // goal at once. Best-effort and reuses the whisper gate/identity.
+                self.try_whisper_carve_subgoal(goal_id);
+                Ok(ActOutcome::GoalUnblocked {
+                    goal_id: goal_id.to_string(),
+                })
+            }
+            WhisperDecision::SuppressDuplicate => {
+                tracing::debug!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    action = "unblock",
+                    reason = "duplicate",
+                    "overseer suppressed a duplicate self-heal within the dedup window"
+                );
+                Ok(ActOutcome::GoalHealthSuppressed {
+                    reason: "duplicate",
+                })
+            }
+            WhisperDecision::SuppressCapReached => {
+                tracing::debug!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    action = "unblock",
+                    reason = "cap_reached",
+                    "overseer suppressed a self-heal: per-hour cap reached"
+                );
+                Ok(ActOutcome::GoalHealthSuppressed {
+                    reason: "cap_reached",
+                })
+            }
+        }
+    }
+
+    /// ESCALATE a genuinely-blocked "needs human review" goal to the operator on
+    /// BOTH channels (email + Signal) with the goal id + reason, so the marker
+    /// actually reaches a human. Deduped so it never re-fires in a loop; fails
+    /// CLOSED without a DISTINCT steward identity (anti-recursion).
+    fn act_escalate_blocked_goal(
+        &mut self,
+        goal_id: &str,
+        reason: &str,
+    ) -> Result<ActOutcome, OverseerError> {
+        if !self.recursion.is_configured() {
+            return Err(OverseerError::Recursion {
+                subject: format!(
+                    "escalate blocked goal (unconfigured steward identity): {goal_id}"
+                ),
+            });
+        }
+        let signature = format!("escalate:{goal_id}");
+        let now = now_secs();
+        match self.blocked_goal_gate.peek(&signature, now) {
+            WhisperDecision::Deliver => {
+                let notifier = self.notifier.as_ref().ok_or(OverseerError::Capability {
+                    what: "notify.operator",
+                    detail: "no operator notifier configured".to_string(),
+                })?;
+                let notification = OperatorNotification::goal_blocked(goal_id, reason);
+                let report = notifier.notify(&notification);
+                // Consume the dedup slot only after a dispatch attempt (the
+                // notifier itself never drops — it queues/logs on failure).
+                self.blocked_goal_gate.commit(&signature, now);
+                tracing::info!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    reason,
+                    action = "escalate",
+                    dispatched = report.dispatched(),
+                    all_sent = report.all_sent(),
+                    "overseer escalated a genuinely-blocked needs-human-review goal to the operator"
+                );
+                Ok(ActOutcome::GoalEscalated {
+                    goal_id: goal_id.to_string(),
+                })
+            }
+            WhisperDecision::SuppressDuplicate => {
+                tracing::debug!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    action = "escalate",
+                    reason = "duplicate",
+                    "overseer suppressed a duplicate escalation within the dedup window"
+                );
+                Ok(ActOutcome::GoalHealthSuppressed {
+                    reason: "duplicate",
+                })
+            }
+            WhisperDecision::SuppressCapReached => {
+                tracing::debug!(
+                    target: "overseer::goal_health",
+                    goal_id,
+                    action = "escalate",
+                    reason = "cap_reached",
+                    "overseer suppressed an escalation: per-hour cap reached"
+                );
+                Ok(ActOutcome::GoalHealthSuppressed {
+                    reason: "cap_reached",
+                })
+            }
+        }
+    }
+
+    /// Best-effort advisory whisper steering Simard to carve ONE bounded,
+    /// shippable sub-goal from a just-unblocked standing goal. Silently skipped
+    /// when the whisperer is disabled/unwired; a delivery error or suppression is
+    /// ignored (the self-heal already succeeded).
+    fn try_whisper_carve_subgoal(&mut self, goal_id: &str) {
+        if !self.whisper_enabled || self.whisper_sink.is_none() {
+            return;
+        }
+        let note = format!(
+            "Overseer steering note for goal {goal_id}: this standing goal was auto-unblocked \
+             after a no-progress false-park. Carve ONE bounded, shippable sub-goal from it and \
+             ship that next, rather than re-attempting the whole standing goal at once."
+        );
+        let _ = self.act_whisper(&note, WhisperUrgency::Normal);
     }
 }
 
@@ -584,6 +809,28 @@ fn classify_signal(s: &Signal) -> (ProblemKind, Priority, String, String) {
             format!("drift:{goal_id}"),
             format!("goal {goal_id} drifting from intent: {detail}"),
         ),
+        Signal::GoalBlocked {
+            goal_id,
+            needs_review,
+            consecutive_no_action,
+            ..
+        } => (
+            ProblemKind::GoalHygiene,
+            if *needs_review {
+                Priority::High
+            } else {
+                Priority::Normal
+            },
+            format!("goal:blocked:{goal_id}"),
+            format!(
+                "goal {goal_id} blocked{} ({consecutive_no_action} no-action cycle(s))",
+                if *needs_review {
+                    " — needs human review"
+                } else {
+                    ""
+                }
+            ),
+        ),
     }
 }
 
@@ -637,14 +884,35 @@ pub fn decide(problem: &Problem) -> Intervention {
         ProblemKind::ResourcePressure => Intervention::Escalate {
             reason: problem.summary.clone(),
         },
-        ProblemKind::GoalHygiene => Intervention::TransferGoal {
-            goal: GoalBrief {
-                title: problem.summary.clone(),
-                rationale: "stale / re-litigated goal — transfer to Simard for closure".to_string(),
-                priority: 3,
-                target_repo: "rysweet/Simard".to_string(),
-            },
-        },
+        ProblemKind::GoalHygiene => {
+            // Goal-board health takes precedence when the evidence is a blocked
+            // goal: self-heal a false-parked perpetual goal, or escalate a
+            // genuine "needs human review" block. A stale/re-litigated goal
+            // (no `GoalBlocked` evidence) still transfers to Simard for closure.
+            if let Some((goal_id, reason, perpetual, needs_review)) =
+                problem.evidence.iter().find_map(|s| match s {
+                    Signal::GoalBlocked {
+                        goal_id,
+                        reason,
+                        perpetual,
+                        needs_review,
+                        ..
+                    } => Some((goal_id.clone(), reason.clone(), *perpetual, *needs_review)),
+                    _ => None,
+                })
+            {
+                return decide_blocked_goal(goal_id, reason, perpetual, needs_review);
+            }
+            Intervention::TransferGoal {
+                goal: GoalBrief {
+                    title: problem.summary.clone(),
+                    rationale: "stale / re-litigated goal — transfer to Simard for closure"
+                        .to_string(),
+                    priority: 3,
+                    target_repo: "rysweet/Simard".to_string(),
+                },
+            }
+        }
         // A looping goal is steered with a LIGHTWEIGHT whisper by default. Only
         // once the loop reaches Simard's no-progress breaker threshold (the
         // whisper was insufficient) does the Overseer escalate to a full meeting
@@ -684,6 +952,36 @@ pub fn decide(problem: &Problem) -> Intervention {
             urgency: WhisperUrgency::Normal,
         },
     }
+}
+
+/// Route a blocked goal to the right stewardship action (defense-in-depth for
+/// #2609):
+///
+/// - a PERPETUAL/standing goal false-parked by the **no-progress** safeguard is
+///   SELF-HEALED — auto-unblocked + reactivated (never escalated: it is a false
+///   park, not a genuine block);
+/// - ANY OTHER goal carrying a "needs human review" marker (a normal no-progress
+///   block, or any brain-failure block) is ESCALATED to the operator so the
+///   marker reaches a human;
+/// - a plain operator-set / dependency block is surfaced in the periodic Report
+///   and left untouched (respect the deliberate block).
+///
+/// Reuses the EXISTING no-progress marker predicate ([`is_no_progress_marker`])
+/// and the perpetual flag derived from #2589/#2609 — it invents no new notion of
+/// either.
+fn decide_blocked_goal(
+    goal_id: String,
+    reason: String,
+    perpetual: bool,
+    needs_review: bool,
+) -> Intervention {
+    if perpetual && is_no_progress_marker(&reason) {
+        return Intervention::UnblockGoal { goal_id, reason };
+    }
+    if needs_review {
+        return Intervention::EscalateBlockedGoal { goal_id, reason };
+    }
+    Intervention::Report
 }
 
 #[cfg(test)]

--- a/src/overseer/mod.rs
+++ b/src/overseer/mod.rs
@@ -281,15 +281,17 @@ impl Overseer {
     pub fn run_cycle(&mut self) -> Result<CycleReport, OverseerError> {
         // Observe.
         let mut observed = self.caps.status.snapshot()?;
-        // Enrich with goal-board health: the goals currently BLOCKED on Simard's
-        // board (false-parks + genuine "needs human review" blocks). Read-only;
-        // a board-read failure degrades to "no blocked goals", never aborts.
-        observed.blocked_goals = self.caps.goals.blocked_goals().unwrap_or_default();
+        // Enrich with goal-board health + in-flight dedup from ONE board read:
+        // the goals currently BLOCKED on Simard's board (false-parks + genuine
+        // "needs human review" blocks) plus Simard's in-flight work, both
+        // projected from the SAME snapshot. Read-only; a board-read failure
+        // degrades both to empty ("no blocked goals" + "no dedup"), never aborts.
+        let (blocked_goals, in_flight) = self.caps.goals.observe_board().unwrap_or_default();
+        observed.blocked_goals = blocked_goals;
         let signals = signals_from(&observed);
 
-        // Orient (dedup against Simard's in-flight work; failure to read the
-        // board degrades to "no dedup", never aborts the cycle).
-        let in_flight = self.caps.goals.in_flight().unwrap_or_default();
+        // Orient (dedup against Simard's in-flight work, read above from the same
+        // board snapshot as the goal-board health above).
         let problems = orient(&signals, &in_flight);
 
         // Decide + gate.

--- a/src/overseer/notify.rs
+++ b/src/overseer/notify.rs
@@ -415,6 +415,35 @@ impl EmailSender for TcpSmtpSender {
     }
 }
 
+/// Fold any CR/LF out of an SMTP header value or envelope address (replace with
+/// a space). Prevents **SMTP header / command injection**: an embedded newline
+/// in a subject, From/To display value, or envelope address could otherwise
+/// inject extra headers (e.g. `Bcc:`) or raw SMTP commands into the stream.
+/// Notification subjects/addresses now carry board-derived, potentially
+/// LLM-influenced goal text, so this is enforced at the transport sink for every
+/// notification kind.
+fn sanitize_smtp_field(value: &str) -> String {
+    value.replace(['\r', '\n'], " ")
+}
+
+/// Apply SMTP dot-stuffing (RFC 5321 §4.5.2) to an already CRLF-normalized body:
+/// any line beginning with `.` gets an extra leading `.`. Without this, a body
+/// line consisting of a lone `.` would terminate the DATA section early and let
+/// following body content be interpreted as SMTP commands — the message body now
+/// carries attacker-influenceable `reason` text, so it must be escaped.
+fn dot_stuff_body(body: &str) -> String {
+    body.split("\r\n")
+        .map(|line| {
+            if line.starts_with('.') {
+                format!(".{line}")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\r\n")
+}
+
 /// Minimal plaintext SMTP conversation. Kept small and defensive.
 fn smtp_send_plaintext(host: &str, port: u16, msg: &EmailMessage) -> Result<(), String> {
     use std::io::{BufRead, BufReader, Write};
@@ -447,10 +476,11 @@ fn smtp_send_plaintext(host: &str, port: u16, msg: &EmailMessage) -> Result<(), 
     expect(&mut reader, 2)?; // greeting 220
     writeln!(writer, "EHLO simard-overseer").map_err(|e| e.to_string())?;
     expect(&mut reader, 2)?;
-    writeln!(writer, "MAIL FROM:<{}>", msg.from).map_err(|e| e.to_string())?;
+    writeln!(writer, "MAIL FROM:<{}>", sanitize_smtp_field(&msg.from))
+        .map_err(|e| e.to_string())?;
     expect(&mut reader, 2)?;
     for rcpt in &msg.to {
-        writeln!(writer, "RCPT TO:<{rcpt}>").map_err(|e| e.to_string())?;
+        writeln!(writer, "RCPT TO:<{}>", sanitize_smtp_field(rcpt)).map_err(|e| e.to_string())?;
         expect(&mut reader, 2)?;
     }
     writeln!(writer, "DATA").map_err(|e| e.to_string())?;
@@ -458,10 +488,10 @@ fn smtp_send_plaintext(host: &str, port: u16, msg: &EmailMessage) -> Result<(), 
     write!(
         writer,
         "From: {}\r\nTo: {}\r\nSubject: {}\r\n\r\n{}\r\n.\r\n",
-        msg.from,
-        msg.to.join(", "),
-        msg.subject,
-        msg.body.replace("\r\n", "\n").replace('\n', "\r\n"),
+        sanitize_smtp_field(&msg.from),
+        sanitize_smtp_field(&msg.to.join(", ")),
+        sanitize_smtp_field(&msg.subject),
+        dot_stuff_body(&msg.body.replace("\r\n", "\n").replace('\n', "\r\n")),
     )
     .map_err(|e| e.to_string())?;
     expect(&mut reader, 2)?; // 250 accepted
@@ -600,6 +630,28 @@ mod tests {
         assert!(body.contains("abcdef1234567890"));
         assert!(body.contains("0011223344556677"));
         assert!(body.contains("canary green"));
+    }
+
+    // ── SMTP wire-format hardening (injection defenses) ───────────────────────
+
+    #[test]
+    fn sanitize_smtp_field_folds_crlf_to_space() {
+        // A CRLF-bearing subject must not be able to inject a second header.
+        let injected = "needs review\r\nBcc: attacker@evil.test";
+        let safe = super::sanitize_smtp_field(injected);
+        assert!(!safe.contains('\r') && !safe.contains('\n'));
+        assert_eq!(safe, "needs review  Bcc: attacker@evil.test");
+    }
+
+    #[test]
+    fn dot_stuff_body_escapes_leading_dot_lines() {
+        // A lone "." line (or any leading-dot line) must be escaped so it cannot
+        // terminate the DATA section early and smuggle SMTP commands.
+        let body = "line one\r\n.\r\n.MAIL FROM:<x>\r\nnormal";
+        let stuffed = super::dot_stuff_body(body);
+        assert_eq!(stuffed, "line one\r\n..\r\n..MAIL FROM:<x>\r\nnormal");
+        // A body that does not begin lines with '.' is left byte-for-byte intact.
+        assert_eq!(super::dot_stuff_body("a\r\nb\r\nc"), "a\r\nb\r\nc");
     }
 
     // ── fakes ────────────────────────────────────────────────────────────────

--- a/src/overseer/notify.rs
+++ b/src/overseer/notify.rs
@@ -141,6 +141,24 @@ impl OperatorNotification {
             autonomous: true,
         }
     }
+
+    /// Build a blocked-goal escalation: a goal carrying a "needs human review"
+    /// safeguard marker that a human must resolve. Sent on BOTH channels (email
+    /// and Signal) with the goal id and reason so the marker actually reaches a
+    /// person — closing the silent-failure gap where a "needs human review"
+    /// marker reached no human.
+    pub fn goal_blocked(goal_id: &str, reason: &str) -> Self {
+        Self {
+            kind: "goal-blocked",
+            headline: format!("goal {goal_id} needs human review"),
+            problem: format!(
+                "Goal `{goal_id}` is blocked and needs human review.\n  Reason: {reason}"
+            ),
+            link: None,
+            repo: "rysweet/Simard".to_string(),
+            autonomous: true,
+        }
+    }
 }
 
 fn short_commit(commit: &str) -> &str {
@@ -204,6 +222,21 @@ pub trait NotifyChannel: Send + Sync {
 /// Constructed with an email channel and a Signal channel so both fire.
 pub struct DualChannelNotifier {
     channels: Vec<Box<dyn NotifyChannel>>,
+}
+
+/// Object-safe seam the acting Overseer notifies the operator through. Lets the
+/// Overseer hold the mandatory [`DualChannelNotifier`] (email + Signal) in
+/// production while tests inject a fake that records the notification — reusing
+/// the ONE "notify on both channels, never drop" guarantee rather than adding a
+/// second notification path.
+pub trait OperatorNotifier: Send + Sync {
+    fn notify(&self, notification: &OperatorNotification) -> NotifyReport;
+}
+
+impl OperatorNotifier for DualChannelNotifier {
+    fn notify(&self, notification: &OperatorNotification) -> NotifyReport {
+        DualChannelNotifier::notify(self, notification)
+    }
 }
 
 impl DualChannelNotifier {

--- a/src/overseer/observer.rs
+++ b/src/overseer/observer.rs
@@ -233,6 +233,7 @@ fn signal_kind_label(s: &Signal) -> &'static str {
         Signal::Anomaly { .. } => "Anomaly",
         Signal::LoopDetected { .. } => "LoopDetected",
         Signal::DriftCorrection { .. } => "DriftCorrection",
+        Signal::GoalBlocked { .. } => "GoalBlocked",
     }
 }
 

--- a/src/overseer/sensor.rs
+++ b/src/overseer/sensor.rs
@@ -27,12 +27,18 @@ use crate::cognitive_threads::{
     CognitiveThread, Priority, SchedulePolicy, ThreadContext, ThreadHealth, ThreadKind,
     ThreadOutcome,
 };
-use crate::goal_curation::{GoalBoard, load_goal_board};
+use crate::goal_curation::no_progress_breaker::{
+    NO_PROGRESS_BLOCKED_PREFIX, is_no_progress_marker,
+};
+use crate::goal_curation::{ActiveGoal, GoalBoard, GoalProgress, load_goal_board};
+use crate::ooda_actions::advance_goal::spawn::{
+    BRAIN_FAILURE_BLOCKED_PREFIX, is_brain_failure_marker,
+};
 use crate::status::{AssembleOptions, StatusSnapshot, assemble};
 use crate::stewardship::RealGhClient;
 
 use crate::overseer::capabilities::{
-    InFlightItem, IssueFiler, IssueOutcome, ObservedState, OverseerError, StatusReader,
+    BlockedGoal, InFlightItem, IssueFiler, IssueOutcome, ObservedState, OverseerError, StatusReader,
 };
 use crate::overseer::config;
 use crate::overseer::intervention::Intervention;
@@ -121,6 +127,11 @@ pub fn observed_from_snapshot(snap: &StatusSnapshot) -> ObservedState {
         anomalies: telemetry.map(|t| t.anomalies.clone()).unwrap_or_default(),
         ready_prs: Vec::new(),
         ci_failures: Vec::new(),
+        // Goal-board health (blocked goals) is projected from the live board by
+        // the acting Overseer's Observe pass via the goal curator, not from the
+        // read-only status snapshot; left empty here so this projection stays
+        // additive and side-effect free.
+        blocked_goals: Vec::new(),
         // Loop/drift are surfaced from the OODA no-progress tracker, which the
         // read-only status snapshot does not yet expose. Left `None` here so the
         // adapter stays additive; a follow-up enriches this from the goal board's
@@ -160,6 +171,49 @@ pub fn in_flight_from_board(board: &GoalBoard) -> Vec<InFlightItem> {
         });
     }
     items
+}
+
+/// Project the goal board's *health* onto the Overseer's [`BlockedGoal`]s: one
+/// per active goal in a [`GoalProgress::Blocked`] state. Read-only and pure.
+///
+/// Reuses the EXISTING notions rather than inventing new ones:
+/// - `perpetual` ← [`ActiveGoal::is_perpetual`] (the standing/perpetual marker
+///   from #2589/#2609);
+/// - `needs_review` ← the two EXISTING "needs human review" safeguard-marker
+///   predicates ([`is_no_progress_marker`] and [`is_brain_failure_marker`]);
+/// - `consecutive_no_action` ← parsed from the safeguard marker's `{prefix}{n}`
+///   shape (`0` for a non-safeguard block, e.g. an operator-set one).
+///
+/// [`GoalProgress::Blocked`]: crate::goal_curation::GoalProgress::Blocked
+pub fn blocked_goals_from_board(board: &GoalBoard) -> Vec<BlockedGoal> {
+    board.active.iter().filter_map(blocked_goal_of).collect()
+}
+
+/// Project one active goal onto a [`BlockedGoal`] when it is `Blocked`.
+fn blocked_goal_of(goal: &ActiveGoal) -> Option<BlockedGoal> {
+    let GoalProgress::Blocked(reason) = &goal.status else {
+        return None;
+    };
+    let needs_review = is_no_progress_marker(reason) || is_brain_failure_marker(reason);
+    Some(BlockedGoal {
+        id: goal.id.clone(),
+        reason: reason.clone(),
+        perpetual: goal.is_perpetual(),
+        needs_review,
+        consecutive_no_action: safeguard_marker_count(reason).unwrap_or(0),
+    })
+}
+
+/// Parse the leading no-action/no-progress count from a safeguard-marker reason.
+/// Both markers share the `{prefix}{count}{suffix}` shape, so stripping whichever
+/// prefix matches and reading the leading digits yields the count. Returns `None`
+/// for a non-safeguard block.
+fn safeguard_marker_count(reason: &str) -> Option<u32> {
+    let rest = reason
+        .strip_prefix(NO_PROGRESS_BLOCKED_PREFIX)
+        .or_else(|| reason.strip_prefix(BRAIN_FAILURE_BLOCKED_PREFIX))?;
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse::<u32>().ok()
 }
 
 // ─────────────────────────── Read-only cycle ───────────────────────────────

--- a/src/overseer/signal.rs
+++ b/src/overseer/signal.rs
@@ -43,6 +43,19 @@ pub enum Signal {
     /// Active work appears to be drifting from a goal's stated intent. From
     /// `ObservedState.{drift_detail, active_goal_id}`.
     DriftCorrection { goal_id: String, detail: String },
+    /// A goal is `Blocked` on Simard's goal board — the goal-board *health*
+    /// signal. From `ObservedState.blocked_goals`. `perpetual` reuses the
+    /// standing/perpetual detection (#2589/#2609); `needs_review` is true when
+    /// the block carries a "needs human review" safeguard marker. Routed to
+    /// [`ProblemKind::GoalHygiene`]: a false-parked perpetual goal is
+    /// self-healed, a genuine "needs human review" block is escalated.
+    GoalBlocked {
+        goal_id: String,
+        reason: String,
+        perpetual: bool,
+        needs_review: bool,
+        consecutive_no_action: u32,
+    },
 }
 
 /// Coarse relative importance. `Ord` sorts ascending so `Critical` comes first,
@@ -176,6 +189,17 @@ pub fn signals_from(state: &ObservedState) -> Vec<Signal> {
         out.push(Signal::DriftCorrection {
             goal_id: goal_id.clone(),
             detail: detail.clone(),
+        });
+    }
+
+    // Goal-board health: one signal per blocked goal observed on the board.
+    for bg in &state.blocked_goals {
+        out.push(Signal::GoalBlocked {
+            goal_id: bg.id.clone(),
+            reason: bg.reason.clone(),
+            perpetual: bg.perpetual,
+            needs_review: bg.needs_review,
+            consecutive_no_action: bg.consecutive_no_action,
         });
     }
 

--- a/src/overseer/tests_goal_health.rs
+++ b/src/overseer/tests_goal_health.rs
@@ -1,0 +1,695 @@
+//! Tests for the Overseer's **goal-board health** OBSERVE→ACT surface — the
+//! defense-in-depth complement to #2609 (which exempts perpetual goals from the
+//! no-progress hard-block). These pin the contract that:
+//!
+//! - the sensor projection surfaces `Blocked` goals into
+//!   [`ObservedState::blocked_goals`] from the REAL board markers, reusing the
+//!   EXISTING perpetual detection (#2589/#2609) and the safeguard-marker
+//!   predicates — never a second notion;
+//! - a `Signal::GoalBlocked` maps to a [`ProblemKind::GoalHygiene`] problem;
+//! - a PERPETUAL goal false-parked by the no-progress safeguard is
+//!   auto-unblocked + reactivated EXACTLY ONCE (dedup prevents a loop) and is
+//!   NOT escalated;
+//! - ANY goal carrying a "needs human review" marker fires `NotifyOperator` on
+//!   BOTH channels (email + Signal) with the goal id + reason;
+//! - the recursion guard / distinct identity fails CLOSED (no self-heal /
+//!   self-whisper without a configured DISTINCT identity);
+//! - the enable flag holds both actions when off;
+//! - a single blocked-goal handling failure is isolated (the tick survives).
+//!
+//! Everything is exercised with injected fakes (goal store, notifier, clock via
+//! the dedup gate, identity) — no network, no `~/.simard`.
+
+use std::sync::{Arc, Mutex};
+
+use crate::goal_curation::no_progress_breaker::no_progress_blocked_reason;
+use crate::goal_curation::{ActiveGoal, GoalBoard, GoalProgress};
+use crate::ooda_actions::advance_goal::spawn::{
+    BRAIN_FAILURE_BLOCKED_PREFIX, BRAIN_FAILURE_BLOCKED_SUFFIX,
+};
+
+use crate::overseer::capabilities::{
+    AuditReport, AuditScope, Auditor, BlockedGoal, DeployReport, Deployer, GoalBrief, GoalCurator,
+    InFlightItem, IssueOutcome, MeetingHost, ObservedState, OrchestratorRunBrief, OverseerError,
+    PrOps, RecipeBrief, RecipeLauncher, StatusReader, VerifyReport, WorkstreamHandle,
+    WorkstreamStatus,
+};
+use crate::overseer::config::{SIMARD_OVERSEER_GOAL_HEALTH_ENV, goal_health_enabled_from};
+use crate::overseer::guardrails::{AutonomyGate, RiskClass, classify};
+use crate::overseer::intervention::Intervention;
+use crate::overseer::notify::{
+    ChannelDelivery, DualChannelNotifier, NotifyChannel, OperatorNotification,
+};
+use crate::overseer::sensor::blocked_goals_from_board;
+use crate::overseer::signal::{Problem, ProblemKind, Signal, signals_from};
+use crate::overseer::wiring::{overseer_identity, overseer_tick, run_overseer_tick_isolated};
+use crate::overseer::{Capabilities, Overseer, decide, orient};
+
+// ─────────────────────────── marker helpers ────────────────────────────────
+
+/// The brain-failure safeguard `Blocked` reason for `n` cycles (mirrors the
+/// deterministic marker `dispatch_spawn_engineer` writes).
+fn brain_failure_reason(n: u32) -> String {
+    format!("{BRAIN_FAILURE_BLOCKED_PREFIX}{n}{BRAIN_FAILURE_BLOCKED_SUFFIX}")
+}
+
+// ─────────────────────────── capability fakes ──────────────────────────────
+
+struct FakeStatus(ObservedState);
+impl StatusReader for FakeStatus {
+    fn snapshot(&self) -> Result<ObservedState, OverseerError> {
+        Ok(self.0.clone())
+    }
+}
+
+struct FakeRecipes;
+impl RecipeLauncher for FakeRecipes {
+    fn launch(&self, _b: &RecipeBrief) -> Result<WorkstreamHandle, OverseerError> {
+        Ok(WorkstreamHandle {
+            id: "ws-1".to_string(),
+        })
+    }
+    fn poll(&self, _h: &WorkstreamHandle) -> Result<WorkstreamStatus, OverseerError> {
+        Ok(WorkstreamStatus::Running)
+    }
+}
+
+struct FakePrs;
+impl PrOps for FakePrs {
+    fn verify(&self, _r: &str, _p: u32) -> Result<VerifyReport, OverseerError> {
+        Ok(VerifyReport {
+            ready: false,
+            checks: vec![],
+        })
+    }
+    fn merge(&self, _r: &str, _p: u32) -> Result<(), OverseerError> {
+        Ok(())
+    }
+    fn resolve_conflict(&self, _r: &str, _p: u32) -> Result<(), OverseerError> {
+        Ok(())
+    }
+}
+
+struct FakeDeployer;
+impl Deployer for FakeDeployer {
+    fn deploy(&self, commit: &str) -> Result<DeployReport, OverseerError> {
+        Ok(DeployReport {
+            deployed_commit: commit.to_string(),
+            gates_passed: true,
+        })
+    }
+    fn deployed_commit(&self) -> Result<String, OverseerError> {
+        Ok("deadbeef".to_string())
+    }
+}
+
+struct FakeIssues;
+impl crate::overseer::capabilities::IssueFiler for FakeIssues {
+    fn file(&self, _run: &OrchestratorRunBrief) -> Result<IssueOutcome, OverseerError> {
+        Ok(IssueOutcome::FiledNew {
+            url: "https://example/issues/1".to_string(),
+        })
+    }
+}
+
+struct FakeMeetings;
+impl MeetingHost for FakeMeetings {
+    fn transfer_goal(&self, _g: &GoalBrief) -> Result<(), OverseerError> {
+        Ok(())
+    }
+}
+
+struct FakeAuditor;
+impl Auditor for FakeAuditor {
+    fn run_audit(&self, scope: &AuditScope) -> Result<AuditReport, OverseerError> {
+        Ok(AuditReport {
+            scope: scope.clone(),
+            passed: true,
+            findings: vec![],
+        })
+    }
+}
+
+/// A goal-store fake: serves a fixed set of blocked goals and records every
+/// `unblock` call so the self-heal path is observable without a real board.
+/// `fail_unblock` makes `unblock` return an error so failure isolation can be
+/// proven.
+struct FakeGoalStore {
+    blocked: Vec<BlockedGoal>,
+    unblocked: Arc<Mutex<Vec<String>>>,
+    fail_unblock: bool,
+}
+impl FakeGoalStore {
+    fn new(blocked: Vec<BlockedGoal>) -> (Self, Arc<Mutex<Vec<String>>>) {
+        let unblocked = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                blocked,
+                unblocked: unblocked.clone(),
+                fail_unblock: false,
+            },
+            unblocked,
+        )
+    }
+    fn failing(blocked: Vec<BlockedGoal>) -> Self {
+        Self {
+            blocked,
+            unblocked: Arc::new(Mutex::new(Vec::new())),
+            fail_unblock: true,
+        }
+    }
+}
+impl GoalCurator for FakeGoalStore {
+    fn propose(&self, _g: &GoalBrief) -> Result<(), OverseerError> {
+        Ok(())
+    }
+    fn in_flight(&self) -> Result<Vec<InFlightItem>, OverseerError> {
+        Ok(vec![])
+    }
+    fn blocked_goals(&self) -> Result<Vec<BlockedGoal>, OverseerError> {
+        Ok(self.blocked.clone())
+    }
+    fn unblock(&self, goal_id: &str) -> Result<(), OverseerError> {
+        if self.fail_unblock {
+            return Err(OverseerError::Capability {
+                what: "goal_board.unblock",
+                detail: "board write failed".to_string(),
+            });
+        }
+        self.unblocked.lock().unwrap().push(goal_id.to_string());
+        Ok(())
+    }
+}
+
+/// A notify channel that records every notification and always reports `Sent`.
+struct RecordingChannel {
+    name: String,
+    seen: Arc<Mutex<Vec<OperatorNotification>>>,
+}
+impl RecordingChannel {
+    fn new(name: &str) -> (Self, Arc<Mutex<Vec<OperatorNotification>>>) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                name: name.to_string(),
+                seen: seen.clone(),
+            },
+            seen,
+        )
+    }
+}
+impl NotifyChannel for RecordingChannel {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn deliver(&self, n: &OperatorNotification) -> ChannelDelivery {
+        self.seen.lock().unwrap().push(n.clone());
+        ChannelDelivery::Sent
+    }
+}
+
+/// Build the Overseer's capabilities around a goal store; everything else is a
+/// canned fake (the status reader yields an otherwise-clean snapshot so the only
+/// signals are the goal-board ones).
+fn caps_with_goals(goals: Box<dyn GoalCurator>) -> Capabilities {
+    Capabilities {
+        status: Box::new(FakeStatus(ObservedState::default())),
+        recipes: Box::new(FakeRecipes),
+        prs: Box::new(FakePrs),
+        deployer: Box::new(FakeDeployer),
+        meetings: Box::new(FakeMeetings),
+        issues: Box::new(FakeIssues),
+        goals,
+        auditor: Box::new(FakeAuditor),
+    }
+}
+
+/// A `DualChannelNotifier` (the SAME mandatory notifier the merge path uses)
+/// wired with two recording channels so a test can prove BOTH email + Signal
+/// fired. Returns the notifier plus the two capture logs.
+type NotifierAndLogs = (
+    DualChannelNotifier,
+    Arc<Mutex<Vec<OperatorNotification>>>,
+    Arc<Mutex<Vec<OperatorNotification>>>,
+);
+fn dual_recording_notifier() -> NotifierAndLogs {
+    let (email, email_log) = RecordingChannel::new("email");
+    let (signal, signal_log) = RecordingChannel::new("signal");
+    let notifier = DualChannelNotifier::new(vec![Box::new(email), Box::new(signal)]);
+    (notifier, email_log, signal_log)
+}
+
+// ─────────────────── 1. Sensor: project the board → ObservedState ───────────
+
+#[test]
+fn blocked_goals_projection_surfaces_perpetual_and_needs_review_goals() {
+    let mut board = GoalBoard::new();
+    // A standing/perpetual research goal, false-parked by the no-progress
+    // safeguard (perpetual + needs_review, count parsed from the marker).
+    let mut research = ActiveGoal::new(
+        "research",
+        "Continuously research the frontier. Standing goal.",
+        1,
+    );
+    research.status = GoalProgress::Blocked(no_progress_blocked_reason(4));
+    // A NORMAL feature goal, genuinely blocked by the brain-failure safeguard
+    // (needs_review, not perpetual).
+    let mut feature = ActiveGoal::new("feature-x", "Ship feature X", 2);
+    feature.status = GoalProgress::Blocked(brain_failure_reason(3));
+    // A NORMAL goal blocked by an operator-set reason (no safeguard marker):
+    // surfaced, but neither perpetual nor needs_review.
+    let mut opsblock = ActiveGoal::new("ops", "Wait on infra", 3);
+    opsblock.status = GoalProgress::Blocked("waiting on the operator".to_string());
+    // A healthy in-progress goal: never surfaced.
+    let mut healthy = ActiveGoal::new("healthy", "Make progress", 4);
+    healthy.status = GoalProgress::InProgress { percent: 40 };
+    board.active = vec![research, feature, opsblock, healthy];
+
+    let blocked = blocked_goals_from_board(&board);
+    assert_eq!(
+        blocked.len(),
+        3,
+        "only the three Blocked goals are surfaced"
+    );
+
+    let research = blocked.iter().find(|b| b.id == "research").unwrap();
+    assert!(
+        research.perpetual,
+        "standing goal is perpetual (#2589/#2609)"
+    );
+    assert!(
+        research.needs_review,
+        "no-progress marker needs human review"
+    );
+    assert_eq!(
+        research.consecutive_no_action, 4,
+        "count parsed from marker"
+    );
+
+    let feature = blocked.iter().find(|b| b.id == "feature-x").unwrap();
+    assert!(!feature.perpetual);
+    assert!(
+        feature.needs_review,
+        "brain-failure marker needs human review"
+    );
+    assert_eq!(feature.consecutive_no_action, 3);
+
+    let ops = blocked.iter().find(|b| b.id == "ops").unwrap();
+    assert!(!ops.perpetual);
+    assert!(
+        !ops.needs_review,
+        "an operator-set block is not a review marker"
+    );
+    assert_eq!(ops.consecutive_no_action, 0);
+}
+
+#[test]
+fn run_cycle_populates_observed_blocked_goals_and_emits_signals() {
+    let blocked = vec![
+        BlockedGoal {
+            id: "research".to_string(),
+            reason: no_progress_blocked_reason(4),
+            perpetual: true,
+            needs_review: true,
+            consecutive_no_action: 4,
+        },
+        BlockedGoal {
+            id: "feature-x".to_string(),
+            reason: brain_failure_reason(3),
+            perpetual: false,
+            needs_review: true,
+            consecutive_no_action: 3,
+        },
+    ];
+    let (store, _log) = FakeGoalStore::new(blocked);
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_identity(overseer_identity())
+        .with_goal_health_enabled(true);
+
+    let cycle = ov.run_cycle().expect("cycle");
+    assert_eq!(
+        cycle.observed.blocked_goals.len(),
+        2,
+        "the Observe pass surfaces the board's blocked goals into ObservedState"
+    );
+    let goal_blocked: Vec<_> = cycle
+        .signals
+        .iter()
+        .filter(|s| matches!(s, Signal::GoalBlocked { .. }))
+        .collect();
+    assert_eq!(
+        goal_blocked.len(),
+        2,
+        "one GoalBlocked signal per blocked goal"
+    );
+}
+
+// ─────────────────── 2. Signal → GoalHygiene problem ────────────────────────
+
+#[test]
+fn goal_blocked_signal_maps_to_a_goal_hygiene_problem() {
+    let observed = ObservedState {
+        blocked_goals: vec![BlockedGoal {
+            id: "research".to_string(),
+            reason: no_progress_blocked_reason(4),
+            perpetual: true,
+            needs_review: true,
+            consecutive_no_action: 4,
+        }],
+        ..ObservedState::default()
+    };
+    let signals = signals_from(&observed);
+    assert!(
+        signals
+            .iter()
+            .any(|s| matches!(s, Signal::GoalBlocked { .. })),
+        "a blocked goal produces a GoalBlocked signal"
+    );
+    let problems = orient(&signals, &[]);
+    let problem = problems
+        .iter()
+        .find(|p| p.kind == ProblemKind::GoalHygiene)
+        .expect("GoalBlocked classifies to GoalHygiene");
+    assert_eq!(problem.dedup_key, "goal:blocked:research");
+}
+
+// ─────────────────── 3. Self-heal: unblock once, never escalate ─────────────
+
+#[test]
+fn perpetual_no_progress_goal_is_unblocked_once_and_not_escalated() {
+    let blocked = vec![BlockedGoal {
+        id: "research".to_string(),
+        reason: no_progress_blocked_reason(4),
+        perpetual: true,
+        needs_review: true,
+        consecutive_no_action: 4,
+    }];
+    let (store, unblocked) = FakeGoalStore::new(blocked);
+    let (notifier, email_log, signal_log) = dual_recording_notifier();
+
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_identity(overseer_identity())
+        .with_goal_health_enabled(true)
+        .with_operator_notifier(Box::new(notifier));
+
+    let first = overseer_tick(&mut ov);
+    assert_eq!(first.goals_unblocked, 1, "the false-park is self-healed");
+    assert_eq!(first.goals_escalated, 0, "a false-park is NOT escalated");
+    assert_eq!(first.errors, 0);
+    assert!(!first.panicked);
+
+    // The SAME blocked goal is still served next tick (the fake store does not
+    // reflect the unblock). Dedup must prevent a re-unblock loop.
+    let second = overseer_tick(&mut ov);
+    assert_eq!(
+        second.goals_unblocked, 0,
+        "dedup prevents a re-unblock loop"
+    );
+    assert_eq!(
+        second.goals_health_suppressed, 1,
+        "the duplicate is counted"
+    );
+
+    assert_eq!(
+        &*unblocked.lock().unwrap(),
+        &vec!["research".to_string()],
+        "the goal store's unblock was called EXACTLY ONCE across two ticks"
+    );
+    assert!(
+        email_log.lock().unwrap().is_empty() && signal_log.lock().unwrap().is_empty(),
+        "a self-healed false-park never notifies the operator"
+    );
+}
+
+// ─────────────────── 4. Escalate: NotifyOperator on both channels ───────────
+
+#[test]
+fn needs_review_goal_escalates_to_operator_on_both_channels() {
+    let reason = brain_failure_reason(3);
+    let blocked = vec![BlockedGoal {
+        id: "feature-x".to_string(),
+        reason: reason.clone(),
+        perpetual: false,
+        needs_review: true,
+        consecutive_no_action: 3,
+    }];
+    let (store, unblocked) = FakeGoalStore::new(blocked);
+    let (notifier, email_log, signal_log) = dual_recording_notifier();
+
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_identity(overseer_identity())
+        .with_goal_health_enabled(true)
+        .with_operator_notifier(Box::new(notifier));
+
+    let report = overseer_tick(&mut ov);
+    assert_eq!(report.goals_escalated, 1, "the genuine block is escalated");
+    assert_eq!(
+        report.goals_unblocked, 0,
+        "a normal goal is not self-healed"
+    );
+    assert!(
+        unblocked.lock().unwrap().is_empty(),
+        "escalation never unblocks the goal"
+    );
+
+    for (chan, log) in [("email", &email_log), ("signal", &signal_log)] {
+        let seen = log.lock().unwrap();
+        assert_eq!(seen.len(), 1, "the {chan} channel received the escalation");
+        let n = &seen[0];
+        assert!(
+            n.headline.contains("feature-x"),
+            "the {chan} notification names the goal id: {n:?}"
+        );
+        assert!(
+            n.problem.contains(&reason) || n.problem.contains("needs human review"),
+            "the {chan} notification carries the block reason: {n:?}"
+        );
+    }
+}
+
+// ─────────────────── 5. Anti-recursion: fail closed on no identity ──────────
+
+#[test]
+fn self_heal_and_escalate_fail_closed_without_a_distinct_identity() {
+    // No `.with_identity(...)` ⇒ the default RecursionGuard is unconfigured, so
+    // both goal-health actions must be REFUSED (fail closed) — the Overseer can
+    // never self-heal / escalate (nor self-whisper) without a DISTINCT identity.
+    let (store, unblocked) = FakeGoalStore::new(vec![]);
+    let (notifier, email_log, signal_log) = dual_recording_notifier();
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_goal_health_enabled(true)
+        .with_operator_notifier(Box::new(notifier));
+
+    let unblock = ov.act(&Intervention::UnblockGoal {
+        goal_id: "research".to_string(),
+        reason: no_progress_blocked_reason(4),
+    });
+    assert!(
+        matches!(unblock, Err(OverseerError::Recursion { .. })),
+        "unconfigured identity refuses the self-heal (fail closed): {unblock:?}"
+    );
+
+    let escalate = ov.act(&Intervention::EscalateBlockedGoal {
+        goal_id: "feature-x".to_string(),
+        reason: brain_failure_reason(3),
+    });
+    assert!(
+        matches!(escalate, Err(OverseerError::Recursion { .. })),
+        "unconfigured identity refuses the escalation (fail closed): {escalate:?}"
+    );
+
+    assert!(
+        unblocked.lock().unwrap().is_empty(),
+        "no unblock reached the store"
+    );
+    assert!(
+        email_log.lock().unwrap().is_empty() && signal_log.lock().unwrap().is_empty(),
+        "no notification reached the operator"
+    );
+}
+
+// ─────────────────── 6. Enable flag: disabled ⇒ no action ───────────────────
+
+#[test]
+fn disabled_goal_health_holds_both_actions() {
+    let blocked = vec![
+        BlockedGoal {
+            id: "research".to_string(),
+            reason: no_progress_blocked_reason(4),
+            perpetual: true,
+            needs_review: true,
+            consecutive_no_action: 4,
+        },
+        BlockedGoal {
+            id: "feature-x".to_string(),
+            reason: brain_failure_reason(3),
+            perpetual: false,
+            needs_review: true,
+            consecutive_no_action: 3,
+        },
+    ];
+    let (store, unblocked) = FakeGoalStore::new(blocked);
+    let (notifier, email_log, signal_log) = dual_recording_notifier();
+
+    // Identity configured, notifier wired — only the enable flag is OFF.
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_identity(overseer_identity())
+        .with_goal_health_enabled(false)
+        .with_operator_notifier(Box::new(notifier));
+
+    let report = overseer_tick(&mut ov);
+    assert_eq!(report.goals_unblocked, 0);
+    assert_eq!(report.goals_escalated, 0);
+    assert!(
+        report.held >= 2,
+        "both goal-health interventions are held: {report:?}"
+    );
+    assert!(
+        unblocked.lock().unwrap().is_empty(),
+        "disabled ⇒ no unblock is performed"
+    );
+    assert!(
+        email_log.lock().unwrap().is_empty() && signal_log.lock().unwrap().is_empty(),
+        "disabled ⇒ no escalation is dispatched"
+    );
+}
+
+#[test]
+fn goal_health_enable_flag_is_opt_out_and_off_when_overseer_off() {
+    use crate::overseer::config::OVERSEER_ENABLED_ENV;
+    let env = |pairs: &[(&str, &str)]| {
+        let owned: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        move |k: &str| owned.iter().find(|(ek, _)| ek == k).map(|(_, v)| v.clone())
+    };
+    // Default (unset): ON, because the acting Overseer is opt-out ON.
+    assert!(goal_health_enabled_from(env(&[])));
+    // Explicit falsey on the goal-health flag: OFF.
+    assert!(!goal_health_enabled_from(env(&[(
+        SIMARD_OVERSEER_GOAL_HEALTH_ENV,
+        "off"
+    )])));
+    // A disabled Overseer forces goal-health OFF regardless of the flag.
+    assert!(!goal_health_enabled_from(env(&[
+        (OVERSEER_ENABLED_ENV, "false"),
+        (SIMARD_OVERSEER_GOAL_HEALTH_ENV, "on"),
+    ])));
+}
+
+// ─────────────────── 7. Failure isolation: the tick survives ────────────────
+
+#[test]
+fn a_failing_unblock_is_isolated_and_the_tick_survives() {
+    let blocked = vec![BlockedGoal {
+        id: "research".to_string(),
+        reason: no_progress_blocked_reason(4),
+        perpetual: true,
+        needs_review: true,
+        consecutive_no_action: 4,
+    }];
+    // The goal store errors on unblock — a capability failure, not a panic.
+    let store = FakeGoalStore::failing(blocked);
+    let mut ov = Overseer::new(caps_with_goals(Box::new(store)))
+        .with_identity(overseer_identity())
+        .with_goal_health_enabled(true);
+
+    let report = run_overseer_tick_isolated(&mut ov);
+    assert_eq!(
+        report.goals_unblocked, 0,
+        "the failed self-heal took no effect"
+    );
+    assert_eq!(report.errors, 1, "the failure is counted, isolated");
+    assert!(!report.panicked, "a capability error never panics the tick");
+    assert!(report.duration_ms < 60_000);
+}
+
+// ─────────────────── decide/classify unit routing ──────────────────────────
+
+#[test]
+fn decide_routes_a_blocked_goal_by_shape() {
+    // Perpetual + no-progress marker ⇒ self-heal (unblock), never escalate.
+    let self_heal = decide(&Problem {
+        kind: ProblemKind::GoalHygiene,
+        priority: crate::overseer::signal::Priority::High,
+        dedup_key: "goal:blocked:research".to_string(),
+        summary: "blocked".to_string(),
+        evidence: vec![Signal::GoalBlocked {
+            goal_id: "research".to_string(),
+            reason: no_progress_blocked_reason(4),
+            perpetual: true,
+            needs_review: true,
+            consecutive_no_action: 4,
+        }],
+    });
+    assert!(matches!(self_heal, Intervention::UnblockGoal { .. }));
+
+    // Normal + needs_review ⇒ escalate.
+    let escalate = decide(&Problem {
+        kind: ProblemKind::GoalHygiene,
+        priority: crate::overseer::signal::Priority::High,
+        dedup_key: "goal:blocked:feature-x".to_string(),
+        summary: "blocked".to_string(),
+        evidence: vec![Signal::GoalBlocked {
+            goal_id: "feature-x".to_string(),
+            reason: brain_failure_reason(3),
+            perpetual: false,
+            needs_review: true,
+            consecutive_no_action: 3,
+        }],
+    });
+    assert!(matches!(escalate, Intervention::EscalateBlockedGoal { .. }));
+
+    // A plain operator-set block (no marker) ⇒ Report only, no autonomous action.
+    let report = decide(&Problem {
+        kind: ProblemKind::GoalHygiene,
+        priority: crate::overseer::signal::Priority::Normal,
+        dedup_key: "goal:blocked:ops".to_string(),
+        summary: "blocked".to_string(),
+        evidence: vec![Signal::GoalBlocked {
+            goal_id: "ops".to_string(),
+            reason: "waiting on the operator".to_string(),
+            perpetual: false,
+            needs_review: false,
+            consecutive_no_action: 0,
+        }],
+    });
+    assert!(matches!(report, Intervention::Report));
+}
+
+#[test]
+fn goal_health_interventions_are_routine_and_admitted_by_default_gate() {
+    for iv in [
+        Intervention::UnblockGoal {
+            goal_id: "g".to_string(),
+            reason: "r".to_string(),
+        },
+        Intervention::EscalateBlockedGoal {
+            goal_id: "g".to_string(),
+            reason: "r".to_string(),
+        },
+    ] {
+        assert_eq!(classify(&iv), RiskClass::Routine);
+        assert!(
+            AutonomyGate::default().admit(&iv).is_ok(),
+            "routine goal-health actions are admitted; their own dedup/identity gates apply in act"
+        );
+    }
+    assert_eq!(
+        Intervention::UnblockGoal {
+            goal_id: "g".to_string(),
+            reason: "r".to_string()
+        }
+        .label(),
+        "unblock_goal"
+    );
+    assert_eq!(
+        Intervention::EscalateBlockedGoal {
+            goal_id: "g".to_string(),
+            reason: "r".to_string()
+        }
+        .label(),
+        "escalate_blocked_goal"
+    );
+}

--- a/src/overseer/wiring.rs
+++ b/src/overseer/wiring.rs
@@ -331,6 +331,17 @@ impl GoalCurator for BoardGoalCurator {
         Ok(blocked_goals_from_board(&self.load()?))
     }
 
+    fn observe_board(&self) -> Result<(Vec<BlockedGoal>, Vec<InFlightItem>), OverseerError> {
+        // One board read per Observe pass: load the snapshot once, then project
+        // both the goal-board health and the in-flight dedup set from it, instead
+        // of loading (search_facts + deserialize) twice per tick.
+        let board = self.load()?;
+        Ok((
+            blocked_goals_from_board(&board),
+            in_flight_from_board(&board),
+        ))
+    }
+
     fn unblock(&self, goal_id: &str) -> Result<(), OverseerError> {
         // The exact `simard goal unblock` mutation: restore the blocked goal to
         // `NotStarted` so the next OODA cycle re-enters the spawn path. Reuses

--- a/src/overseer/wiring.rs
+++ b/src/overseer/wiring.rs
@@ -32,23 +32,28 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 
 use crate::cognitive_memory::CognitiveMemoryOps;
-use crate::goal_curation::{BacklogItem, GoalBoard};
+use crate::goal_curation::{BacklogItem, GoalBoard, GoalProgress};
 use crate::goal_curation::{
     DEFAULT_STEWARD_SCORE, add_backlog_item, load_goal_board, save_goal_board,
 };
 
 use crate::overseer::audit::SelfQualityAuditor;
 use crate::overseer::capabilities::{
-    DeployReport, Deployer, GoalBrief, GoalCurator, InFlightItem, OverseerError,
+    BlockedGoal, DeployReport, Deployer, GoalBrief, GoalCurator, InFlightItem, OverseerError,
 };
-use crate::overseer::config::{overseer_author_login, overseer_interval_secs, whisper_enabled};
+use crate::overseer::config::{
+    goal_health_enabled, overseer_author_login, overseer_interval_secs, whisper_enabled,
+};
 use crate::overseer::deploy::GuardedDeployer;
 use crate::overseer::guardrails::RecursionGuard;
 use crate::overseer::launch::SmartOrchestratorLauncher;
 use crate::overseer::meeting_ops::MeetingGoalTransfer;
 use crate::overseer::merge_ops::MergePrOps;
+use crate::overseer::notify::DualChannelNotifier;
 use crate::overseer::observer::StewardshipIssueFiler;
-use crate::overseer::sensor::{SnapshotStatusReader, in_flight_from_board};
+use crate::overseer::sensor::{
+    SnapshotStatusReader, blocked_goals_from_board, in_flight_from_board,
+};
 use crate::overseer::{ActOutcome, Capabilities, Overseer};
 
 // ─────────────────────────── cadence scheduler ─────────────────────────────
@@ -123,6 +128,15 @@ pub struct OverseerTickReport {
     pub whispers: usize,
     /// Whispers suppressed by the dedup window / per-hour cap this tick.
     pub whispers_suppressed: usize,
+    /// False-parked standing/perpetual goals auto-unblocked + reactivated this
+    /// tick (the self-heal path).
+    pub goals_unblocked: usize,
+    /// Genuinely-blocked "needs human review" goals escalated to the operator
+    /// (email + Signal) this tick.
+    pub goals_escalated: usize,
+    /// Goal-board self-heal / escalation actions suppressed by the dedup gate
+    /// this tick.
+    pub goals_health_suppressed: usize,
     /// Capability errors encountered while acting (isolated, never fatal).
     pub errors: usize,
     /// Set when the tick itself panicked and was isolated by
@@ -189,6 +203,9 @@ pub fn overseer_tick(overseer: &mut Overseer) -> OverseerTickReport {
         held = report.held,
         whispers = report.whispers,
         whispers_suppressed = report.whispers_suppressed,
+        goals_unblocked = report.goals_unblocked,
+        goals_escalated = report.goals_escalated,
+        goals_health_suppressed = report.goals_health_suppressed,
         errors = report.errors,
         duration_ms = report.duration_ms,
         "overseer tick complete"
@@ -229,6 +246,9 @@ fn tally_outcome(report: &mut OverseerTickReport, outcome: &ActOutcome) {
         ActOutcome::Escalated => report.escalations += 1,
         ActOutcome::Whispered { .. } => report.whispers += 1,
         ActOutcome::WhisperSuppressed { .. } => report.whispers_suppressed += 1,
+        ActOutcome::GoalUnblocked { .. } => report.goals_unblocked += 1,
+        ActOutcome::GoalEscalated { .. } => report.goals_escalated += 1,
+        ActOutcome::GoalHealthSuppressed { .. } => report.goals_health_suppressed += 1,
         ActOutcome::ConflictResolved
         | ActOutcome::GoalTransferred
         | ActOutcome::Reported
@@ -305,6 +325,31 @@ impl GoalCurator for BoardGoalCurator {
 
     fn in_flight(&self) -> Result<Vec<InFlightItem>, OverseerError> {
         Ok(in_flight_from_board(&self.load()?))
+    }
+
+    fn blocked_goals(&self) -> Result<Vec<BlockedGoal>, OverseerError> {
+        Ok(blocked_goals_from_board(&self.load()?))
+    }
+
+    fn unblock(&self, goal_id: &str) -> Result<(), OverseerError> {
+        // The exact `simard goal unblock` mutation: restore the blocked goal to
+        // `NotStarted` so the next OODA cycle re-enters the spawn path. Reuses
+        // the shipped `load_goal_board` / `save_goal_board` under the flock
+        // write-lock (`save_goal_board` acquires `BoardWriteLock`).
+        let mut board = self.load()?;
+        let goal = board
+            .active
+            .iter_mut()
+            .find(|g| g.id == goal_id)
+            .ok_or_else(|| OverseerError::Capability {
+                what: "goal_board.unblock",
+                detail: format!("goal '{goal_id}' not found on the active board"),
+            })?;
+        goal.status = GoalProgress::NotStarted;
+        save_goal_board(&board, self.mem.as_ref()).map_err(|e| OverseerError::Capability {
+            what: "goal_board.save",
+            detail: e.to_string(),
+        })
     }
 }
 
@@ -403,6 +448,12 @@ pub fn build_overseer(
                 crate::meeting_facilitator::default_handoff_dir(),
             ),
         ))
+        // Goal-board health: self-heal false-parked perpetual goals and escalate
+        // genuine "needs human review" blocks to the operator on BOTH channels
+        // (email + Signal) via the SAME mandatory notifier the merge path uses.
+        // Enabled by default (opt-out via SIMARD_OVERSEER_GOAL_HEALTH).
+        .with_goal_health_enabled(goal_health_enabled())
+        .with_operator_notifier(Box::new(DualChannelNotifier::from_env()))
 }
 
 /// Resolve the acting Overseer's tick cadence (seconds), clamped to the config

--- a/tests/identity_posture.rs
+++ b/tests/identity_posture.rs
@@ -1,0 +1,568 @@
+//! Integration tests for Simard #3125 — identity as a first-class *write
+//! posture* so a read-only OBSERVER identity (e.g. Crocutus observing the
+//! hyenas AzDO repos) is enforced at the COGNITION level, not only at the
+//! write-primitive chokepoint.
+//!
+//! These tests are written FIRST (TDD) and define the public contract the
+//! implementation must satisfy. They exercise the crate's public boundary:
+//!   * `simard::identity::{WriteAuthority, SeedGoal, IdentityPosture, ResolvedPosture}`
+//!   * `simard::identity::{IdentityManifest, FileIdentityLoader, BuiltinIdentityLoader}`
+//!   * `simard::{GoalBoard, seed_default_board, seed_identity_board, DEFAULT_SEED_GOALS}`
+//!
+//! Acceptance criteria mapped:
+//!   AC1  no-identity / read-write identity ⇒ Simard's 5 named default goals,
+//!        read-write authority (no behavior change for Simard herself).
+//!   AC2  a read-only identity's seed goals OVERRIDE the baked-in defaults.
+//!   AC4  seed goals / observations are scoped to the identity's target repo
+//!        set, never `rysweet/Simard`.
+//!   AC5  an undetermined posture fails CLOSED (read-only / no spawn).
+//!   AC6  an absent `write_authority` parses to `ReadWrite`.
+//!
+//! NOTE for the implementer: the new identity types must be re-exported from
+//! `src/identity/mod.rs` (alongside `MemoryPolicy`/`OperatingMode`) and
+//! `seed_identity_board` re-exported at the crate root (alongside
+//! `seed_default_board`). If a path below does not resolve, add the missing
+//! re-export — do not weaken the test.
+
+use std::collections::BTreeSet;
+use std::fs;
+
+use tempfile::TempDir;
+
+use simard::identity::{
+    BuiltinIdentityLoader, FileIdentityLoader, IdentityLoadRequest, IdentityLoader,
+    IdentityManifest, IdentityPosture, ManifestContract, OperatingMode, ResolvedPosture, SeedGoal,
+    WriteAuthority,
+};
+use simard::metadata::{Freshness, Provenance};
+use simard::{BaseTypeId, DEFAULT_SEED_GOALS, GoalBoard};
+
+// ── shared helpers ──────────────────────────────────────────────────────────
+
+fn test_contract() -> ManifestContract {
+    ManifestContract::new(
+        "test::entrypoint",
+        "a -> b",
+        vec!["key:value".to_string()],
+        Provenance::new("test-source", "test-locator"),
+        Freshness::now().unwrap(),
+    )
+    .unwrap()
+}
+
+fn base_manifest(name: &str, mode: OperatingMode) -> IdentityManifest {
+    IdentityManifest::new(
+        name,
+        "0.1.0",
+        vec![],
+        vec![BaseTypeId::new("local-harness")],
+        BTreeSet::new(),
+        mode,
+        simard::identity::MemoryPolicy::default(),
+        test_contract(),
+    )
+    .unwrap()
+}
+
+fn seed_goal(priority: u32, title: &str, repo: Option<&str>) -> SeedGoal {
+    SeedGoal {
+        priority,
+        title: title.to_string(),
+        description: format!("OBSERVE ONLY: {title}"),
+        repo: repo.map(str::to_string),
+    }
+}
+
+fn write_identity_toml(dir: &std::path::Path, content: &str) {
+    fs::write(dir.join("identity.toml"), content).unwrap();
+}
+
+fn builtin(name: &str) -> IdentityManifest {
+    BuiltinIdentityLoader
+        .load(&IdentityLoadRequest::new(name, "0.1.0", test_contract()))
+        .unwrap()
+}
+
+// ── WriteAuthority: default + serde (kebab-case) ─────────────────────────────
+
+#[test]
+fn write_authority_defaults_to_read_write() {
+    // Simard herself is unchanged: the default posture authorizes writes.
+    assert_eq!(WriteAuthority::default(), WriteAuthority::ReadWrite);
+}
+
+#[test]
+fn write_authority_serializes_kebab_case() {
+    assert_eq!(
+        serde_json::to_string(&WriteAuthority::ReadOnly).unwrap(),
+        "\"read-only\""
+    );
+    assert_eq!(
+        serde_json::to_string(&WriteAuthority::ReadWrite).unwrap(),
+        "\"read-write\""
+    );
+}
+
+#[test]
+fn write_authority_deserializes_kebab_case() {
+    let ro: WriteAuthority = serde_json::from_str("\"read-only\"").unwrap();
+    let rw: WriteAuthority = serde_json::from_str("\"read-write\"").unwrap();
+    assert_eq!(ro, WriteAuthority::ReadOnly);
+    assert_eq!(rw, WriteAuthority::ReadWrite);
+}
+
+// ── ResolvedPosture: boot-time fail-closed resolution (AC1 + AC5) ────────────
+
+#[test]
+fn resolved_posture_no_identity_is_read_write() {
+    // AC1: no identity present is a DETERMINED state ⇒ Simard default.
+    assert_eq!(
+        ResolvedPosture::None.write_authority(),
+        WriteAuthority::ReadWrite
+    );
+}
+
+#[test]
+fn resolved_posture_undetermined_fails_closed_to_read_only() {
+    // AC5: an identity IS present but its posture cannot be resolved
+    // (load/parse/threading gap) ⇒ fail CLOSED (read-only / no spawn).
+    assert_eq!(
+        ResolvedPosture::Undetermined.write_authority(),
+        WriteAuthority::ReadOnly
+    );
+}
+
+#[test]
+fn resolved_posture_identity_uses_declared_authority() {
+    let ro = IdentityPosture {
+        write_authority: WriteAuthority::ReadOnly,
+        targets: vec!["hyenas/repo-a".to_string()],
+        seed_goals: vec![],
+    };
+    assert_eq!(
+        ResolvedPosture::Identity(ro).write_authority(),
+        WriteAuthority::ReadOnly
+    );
+
+    let rw = IdentityPosture {
+        write_authority: WriteAuthority::ReadWrite,
+        targets: vec![],
+        seed_goals: vec![],
+    };
+    assert_eq!(
+        ResolvedPosture::Identity(rw).write_authority(),
+        WriteAuthority::ReadWrite
+    );
+}
+
+// ── IdentityManifest posture fields + with_posture builder ───────────────────
+
+#[test]
+fn manifest_new_defaults_to_read_write_and_empty_scope() {
+    // AC1: constructing a manifest the old way yields the Simard-unchanged
+    // posture — read-write, no targets, no seed goals.
+    let m = base_manifest("plain", OperatingMode::Engineer);
+    assert_eq!(m.write_authority, WriteAuthority::ReadWrite);
+    assert!(m.targets.is_empty());
+    assert!(m.seed_goals.is_empty());
+}
+
+#[test]
+fn with_posture_sets_read_only_scope_and_seed_goals() {
+    let m = base_manifest("crocutus-observer", OperatingMode::Curator)
+        .with_posture(
+            WriteAuthority::ReadOnly,
+            vec!["hyenas/repo-a".to_string(), "hyenas/repo-b".to_string()],
+            vec![
+                seed_goal(80, "Observe branch hygiene", Some("hyenas/repo-a")),
+                seed_goal(70, "Observe CODEOWNERS", Some("hyenas/repo-b")),
+            ],
+        )
+        .unwrap();
+    assert_eq!(m.write_authority, WriteAuthority::ReadOnly);
+    assert_eq!(m.targets.len(), 2);
+    assert_eq!(m.seed_goals.len(), 2);
+    assert!(m.seed_goals.iter().all(|g| {
+        g.repo
+            .as_deref()
+            .map(|r| m.targets.iter().any(|t| t == r))
+            .unwrap_or(false)
+    }));
+}
+
+#[test]
+fn with_posture_read_only_rejects_seed_goal_outside_targets() {
+    // Fail-closed: a read-only identity must NOT be able to seed a goal that
+    // escapes its declared target set (never silently scoped to Simard).
+    let result = base_manifest("crocutus-observer", OperatingMode::Curator).with_posture(
+        WriteAuthority::ReadOnly,
+        vec!["hyenas/repo-a".to_string()],
+        vec![seed_goal(80, "Escapes scope", Some("someone-else/repo"))],
+    );
+    assert!(
+        result.is_err(),
+        "read-only seed goal with an out-of-targets repo must fail closed"
+    );
+}
+
+#[test]
+fn with_posture_read_only_rejects_unscoped_seed_goal() {
+    // A read-only seed goal with no repo would default to Simard's own repo —
+    // exactly the bug #3125 fixes. It must fail closed instead.
+    let result = base_manifest("crocutus-observer", OperatingMode::Curator).with_posture(
+        WriteAuthority::ReadOnly,
+        vec!["hyenas/repo-a".to_string()],
+        vec![seed_goal(80, "Unscoped", None)],
+    );
+    assert!(
+        result.is_err(),
+        "read-only seed goal with repo=None must fail closed (no implicit Simard scope)"
+    );
+}
+
+// ── IdentityPosture::from_manifest ───────────────────────────────────────────
+
+#[test]
+fn identity_posture_from_manifest_reads_all_fields() {
+    let m = base_manifest("crocutus-observer", OperatingMode::Curator)
+        .with_posture(
+            WriteAuthority::ReadOnly,
+            vec!["hyenas/repo-a".to_string()],
+            vec![seed_goal(90, "Observe LICENSE", Some("hyenas/repo-a"))],
+        )
+        .unwrap();
+    let posture = IdentityPosture::from_manifest(&m);
+    assert_eq!(posture.write_authority, WriteAuthority::ReadOnly);
+    assert_eq!(posture.targets, vec!["hyenas/repo-a".to_string()]);
+    assert_eq!(posture.seed_goals.len(), 1);
+    assert_eq!(posture.seed_goals[0].repo.as_deref(), Some("hyenas/repo-a"));
+}
+
+// ── Builtin identities are unchanged (AC1) ───────────────────────────────────
+
+#[test]
+fn builtin_identities_are_read_write_with_empty_scope() {
+    for name in [
+        "simard-engineer",
+        "simard-meeting",
+        "simard-gym",
+        "simard-goal-curator",
+        "simard-improvement-curator",
+    ] {
+        let m = builtin(name);
+        assert_eq!(
+            m.write_authority,
+            WriteAuthority::ReadWrite,
+            "{name} must remain read-write"
+        );
+        assert!(m.targets.is_empty(), "{name} must have no target scope");
+        assert!(
+            m.seed_goals.is_empty(),
+            "{name} must not declare identity seed goals"
+        );
+    }
+}
+
+// ── Composition: most-restrictive authority, union targets, concat seeds ─────
+
+#[test]
+fn compose_takes_most_restrictive_authority_and_unions_scope() {
+    let rw = base_manifest("comp-rw", OperatingMode::Engineer)
+        .with_posture(
+            WriteAuthority::ReadWrite,
+            vec!["owner/rw".to_string()],
+            vec![seed_goal(10, "rw goal", Some("owner/rw"))],
+        )
+        .unwrap();
+    let ro = base_manifest("comp-ro", OperatingMode::Curator)
+        .with_posture(
+            WriteAuthority::ReadOnly,
+            vec!["owner/ro".to_string()],
+            vec![seed_goal(20, "ro goal", Some("owner/ro"))],
+        )
+        .unwrap();
+
+    let composed = IdentityManifest::compose(
+        "composite",
+        "1.0",
+        vec![rw, ro],
+        OperatingMode::Engineer,
+        test_contract(),
+    )
+    .unwrap();
+
+    // Most restrictive wins: one read-only component makes the whole identity
+    // read-only (defense in depth — a composed identity can never be more
+    // permissive than its least-trusted part).
+    assert_eq!(composed.write_authority, WriteAuthority::ReadOnly);
+    // Targets are the union.
+    assert!(composed.targets.iter().any(|t| t == "owner/rw"));
+    assert!(composed.targets.iter().any(|t| t == "owner/ro"));
+    // Seed goals are concatenated.
+    assert_eq!(composed.seed_goals.len(), 2);
+}
+
+// ── File loader: read-only observer identity from identity.toml ──────────────
+
+const OBSERVER_TOML: &str = r#"
+[package]
+name = "crocutus"
+version = "0.1.0"
+
+[[identities]]
+name = "crocutus-observer"
+default_mode = "curator"
+supported_base_types = ["local-harness"]
+required_capabilities = ["prompt-assets", "memory"]
+write_authority = "read-only"
+targets = ["hyenas/repo-a", "hyenas/repo-b"]
+
+[[identities.seed_goals]]
+priority = 80
+title = "Observe branch hygiene"
+description = "OBSERVE ONLY: branch hygiene / CODEOWNERS / LICENSE / dependabot / large blobs"
+repo = "hyenas/repo-a"
+
+[[identities.seed_goals]]
+priority = 70
+title = "Observe repo hygiene"
+description = "OBSERVE ONLY: CODEOWNERS, LICENSE, dependabot"
+repo = "hyenas/repo-b"
+"#;
+
+#[test]
+fn file_loader_parses_read_only_observer_posture() {
+    let prompt_root = TempDir::new().unwrap();
+    let identity_dir = prompt_root.path().join("crocutus");
+    fs::create_dir_all(&identity_dir).unwrap();
+    write_identity_toml(&identity_dir, OBSERVER_TOML);
+
+    let loader = FileIdentityLoader::new(&identity_dir, prompt_root.path());
+    let m = loader
+        .load(&IdentityLoadRequest::new(
+            "crocutus-observer",
+            "0.1.0",
+            test_contract(),
+        ))
+        .unwrap();
+
+    assert_eq!(m.write_authority, WriteAuthority::ReadOnly);
+    assert_eq!(
+        m.targets,
+        vec!["hyenas/repo-a".to_string(), "hyenas/repo-b".to_string()]
+    );
+    assert_eq!(m.seed_goals.len(), 2);
+    // AC4: every seed goal is scoped to a target repo, never rysweet/Simard.
+    assert!(m.seed_goals.iter().all(|g| {
+        g.repo
+            .as_deref()
+            .map(|r| m.targets.iter().any(|t| t == r))
+            .unwrap_or(false)
+    }));
+    assert!(
+        m.seed_goals
+            .iter()
+            .all(|g| g.repo.as_deref() != Some("Simard"))
+    );
+}
+
+const OBSERVER_TOML_ESCAPED_SCOPE: &str = r#"
+[package]
+name = "crocutus"
+version = "0.1.0"
+
+[[identities]]
+name = "crocutus-observer"
+default_mode = "curator"
+supported_base_types = ["local-harness"]
+required_capabilities = ["prompt-assets", "memory"]
+write_authority = "read-only"
+targets = ["hyenas/repo-a"]
+
+[[identities.seed_goals]]
+priority = 80
+title = "Escapes scope"
+description = "OBSERVE ONLY"
+repo = "rysweet/Simard"
+"#;
+
+#[test]
+fn file_loader_read_only_seed_goal_outside_targets_fails_closed() {
+    // The core bug #3125 guards against: a read-only observer must never seed
+    // a goal against rysweet/Simard (or any repo outside its targets).
+    let prompt_root = TempDir::new().unwrap();
+    let identity_dir = prompt_root.path().join("crocutus");
+    fs::create_dir_all(&identity_dir).unwrap();
+    write_identity_toml(&identity_dir, OBSERVER_TOML_ESCAPED_SCOPE);
+
+    let loader = FileIdentityLoader::new(&identity_dir, prompt_root.path());
+    let err = loader
+        .load(&IdentityLoadRequest::new(
+            "crocutus-observer",
+            "0.1.0",
+            test_contract(),
+        ))
+        .unwrap_err();
+    assert!(
+        matches!(err, simard::SimardError::IdentityTomlParseError { .. }),
+        "out-of-targets read-only seed goal must be a hard parse error, got: {err:?}"
+    );
+}
+
+const RW_TOML_NO_AUTHORITY: &str = r#"
+[package]
+name = "plain"
+version = "0.1.0"
+
+[[identities]]
+name = "plain-engineer"
+default_mode = "engineer"
+supported_base_types = ["local-harness"]
+required_capabilities = ["prompt-assets", "memory"]
+"#;
+
+#[test]
+fn file_loader_absent_write_authority_defaults_to_read_write() {
+    // AC6: an identity.toml with no `write_authority` parses to ReadWrite and
+    // carries no target scope / seed goals (behaviorally identical to today).
+    let prompt_root = TempDir::new().unwrap();
+    let identity_dir = prompt_root.path().join("plain");
+    fs::create_dir_all(&identity_dir).unwrap();
+    write_identity_toml(&identity_dir, RW_TOML_NO_AUTHORITY);
+
+    let loader = FileIdentityLoader::new(&identity_dir, prompt_root.path());
+    let m = loader
+        .load(&IdentityLoadRequest::new(
+            "plain-engineer",
+            "0.1.0",
+            test_contract(),
+        ))
+        .unwrap();
+    assert_eq!(m.write_authority, WriteAuthority::ReadWrite);
+    assert!(m.targets.is_empty());
+    assert!(m.seed_goals.is_empty());
+}
+
+const TOML_UNKNOWN_FIELD: &str = r#"
+[package]
+name = "plain"
+version = "0.1.0"
+
+[[identities]]
+name = "plain-engineer"
+default_mode = "engineer"
+write_authority = "read-write"
+bogus_new_field = true
+"#;
+
+#[test]
+fn file_loader_still_rejects_unknown_identity_fields() {
+    // AC8: the new fields are additive `#[serde(default)]`; `deny_unknown_fields`
+    // must stay intact so typos remain hard errors.
+    let prompt_root = TempDir::new().unwrap();
+    let identity_dir = prompt_root.path().join("plain");
+    fs::create_dir_all(&identity_dir).unwrap();
+    write_identity_toml(&identity_dir, TOML_UNKNOWN_FIELD);
+
+    let loader = FileIdentityLoader::new(&identity_dir, prompt_root.path());
+    let err = loader
+        .load(&IdentityLoadRequest::new(
+            "plain-engineer",
+            "0.1.0",
+            test_contract(),
+        ))
+        .unwrap_err();
+    assert!(
+        matches!(err, simard::SimardError::IdentityTomlParseError { .. }),
+        "unknown identity field must remain a parse error, got: {err:?}"
+    );
+}
+
+// ── Seeding: identity seeds override defaults; defaults unchanged (AC1/AC2) ───
+
+#[test]
+fn seed_default_board_still_produces_the_five_named_defaults() {
+    // AC1: Simard with no identity keeps her exact 5 baked-in seed goals.
+    let mut board = GoalBoard::new();
+    let n = simard::seed_default_board(&mut board);
+    assert_eq!(n, 5);
+    assert_eq!(board.active.len(), 5);
+
+    let descriptions: Vec<&str> = board
+        .active
+        .iter()
+        .map(|g| g.description.as_str())
+        .collect();
+    for (_priority, _title, description, _repo) in DEFAULT_SEED_GOALS {
+        assert!(
+            descriptions.contains(&description),
+            "default board must include the seeded description: {description}"
+        );
+    }
+    // None of Simard's defaults are scoped to a hyenas observer target.
+    assert!(
+        board
+            .active
+            .iter()
+            .all(|g| g.repo.as_deref() != Some("hyenas/repo-a"))
+    );
+}
+
+#[test]
+fn seed_identity_board_scopes_goals_to_targets_not_simard() {
+    // AC2 + AC4: a read-only identity seeds ITS OWN goals, scoped to its
+    // target repos — replacing Simard's defaults, never touching rysweet/Simard.
+    let seeds = vec![
+        seed_goal(80, "Observe branch hygiene", Some("hyenas/repo-a")),
+        seed_goal(70, "Observe CODEOWNERS", Some("hyenas/repo-b")),
+    ];
+    let mut board = GoalBoard::new();
+    let n = simard::seed_identity_board(&mut board, &seeds);
+
+    assert_eq!(n, 2);
+    assert_eq!(board.active.len(), 2);
+
+    // Every seeded goal is scoped to one of the identity's targets.
+    let repos: Vec<&str> = board
+        .active
+        .iter()
+        .filter_map(|g| g.repo.as_deref())
+        .collect();
+    assert!(repos.contains(&"hyenas/repo-a"));
+    assert!(repos.contains(&"hyenas/repo-b"));
+    assert!(
+        board
+            .active
+            .iter()
+            .all(|g| g.repo.as_deref() != Some("Simard"))
+    );
+    // Observe-only: proposed/seeded goals are unassigned (no engineer dispatch).
+    assert!(board.active.iter().all(|g| g.assigned_to.is_none()));
+
+    // The seeded goals are the identity's, NOT Simard's defaults.
+    let descriptions: Vec<&str> = board
+        .active
+        .iter()
+        .map(|g| g.description.as_str())
+        .collect();
+    for (_priority, _title, default_desc, _repo) in DEFAULT_SEED_GOALS {
+        assert!(
+            !descriptions.contains(&default_desc),
+            "identity-seeded board must NOT contain Simard's default: {default_desc}"
+        );
+    }
+}
+
+#[test]
+fn seed_identity_board_is_noop_on_non_empty_board() {
+    // Mirrors seed_default_board: never clobber an already-populated board.
+    let mut board = GoalBoard::new();
+    let _ =
+        simard::seed_identity_board(&mut board, &[seed_goal(80, "first", Some("hyenas/repo-a"))]);
+    let n = simard::seed_identity_board(
+        &mut board,
+        &[seed_goal(70, "second", Some("hyenas/repo-b"))],
+    );
+    assert_eq!(n, 0, "seeding a non-empty board must be a no-op");
+    assert_eq!(board.active.len(), 1);
+}

--- a/tests/memory_consolidation_lifecycle.rs
+++ b/tests/memory_consolidation_lifecycle.rs
@@ -187,6 +187,7 @@ fn ooda_cycle_runs_with_consolidation_wired_in() {
             simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     };
 
     let mut board = GoalBoard::new();
@@ -344,6 +345,7 @@ fn multiple_ooda_cycles_accumulate_consolidation() {
             simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     };
 
     let mut board = GoalBoard::new();

--- a/tests/ooda.rs
+++ b/tests/ooda.rs
@@ -88,6 +88,7 @@ fn test_bridges() -> OodaBridges {
             simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     }
 }
 
@@ -261,6 +262,7 @@ fn feral_gym_bridge_down() {
             simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     };
     let mut state = OodaState::new(board_with_goals());
     let report = run_ooda_cycle(&mut state, &mut bridges, &OodaConfig::default()).unwrap();
@@ -478,6 +480,7 @@ fn successful_outcome_stores_procedural_memory() {
             simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     };
 
     let mut state = OodaState::new(board_with_goals());

--- a/tests/ooda_daemon.rs
+++ b/tests/ooda_daemon.rs
@@ -103,6 +103,7 @@ fn test_bridges() -> OodaBridges {
             simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
         ),
         completion_evidence: None,
+        admission_brain: None,
     }
 }
 

--- a/tests/overseer_activity.rs
+++ b/tests/overseer_activity.rs
@@ -62,12 +62,9 @@ fn report(
         issues_filed,
         recipes_launched,
         prs_merged,
-        deploys: 0,
-        escalations: 0,
         held,
-        errors: 0,
-        panicked: false,
         duration_ms: 42,
+        ..OverseerTickReport::default()
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #3125. Makes **write authority a first-class property of IDENTITY** so a read-only OBSERVER identity (e.g. **Crocutus** observing the hyenas AzDO repos) is enforced at the **cognition** level — *which goals get seeded* and *whether the Act phase may dispatch engineers at all* — not only at the write-primitive chokepoint.

**Simard's own behavior is unchanged by default** (no identity, or a read-write identity ⇒ same 5 `DEFAULT_SEED_GOALS`, same engineer-dispatching Act phase). Proven by test.

Surface is kept small: identity config + an agentic Act-phase branch behind a thin deterministic rail — no new imperative subsystem, no new "Bridge".

## What changed

**Identity (config surface — depend-not-fork)**
- `WriteAuthority { ReadOnly, ReadWrite }` — kebab serde, `#[default] ReadWrite`, deny-by-default helpers `may_dispatch_engineers()` / `is_read_only()`.
- `SeedGoal`; `IdentityPosture` + `ResolvedPosture` (`None`⇒read-write, `Undetermined`⇒read-only **fail-closed**, `Identity`⇒declared).
- `IdentityManifest` gains `write_authority`/`targets`/`seed_goals` + `with_posture`, which **fail-closes** a read-only seed goal whose `repo` is absent or outside `targets` (never silently scoped to `rysweet/Simard`). `compose()` takes the **most-restrictive** authority, unions targets, concatenates seed goals.
- `identity.toml`: additive `#[serde(default)]` `write_authority`/`targets`/`seed_goals` (`deny_unknown_fields` preserved); loader maps posture-validation failures to `IdentityTomlParseError`.

**Seeding** — `seed_identity_board()` seeds an identity's own goals (unassigned, target-scoped), **overriding** `DEFAULT_SEED_GOALS`; the cycle picks the source by `state.identity_seed_goals`. `seed_default_board` / `DEFAULT_SEED_GOALS` untouched.

**Observe-only Act phase (L1 cognition branch)** — when posture is read-only, `act()` runs the `ObserveOnlyBrain` seam via `act_observe_only` (deterministic floor `DeterministicObserveBrain`): records observations, proposes target-scoped goals, **never** dispatches an engineer. Fail-closed: a brain error surfaces (no fallback); an out-of-targets/unscoped proposal is a hard error leaving the board untouched.

**Deterministic spawn rail (L2 defense-in-depth)** — `dispatch_spawn_engineer` hard-blocks at its top when `!write_authority.may_dispatch_engineers()`, guarding **both** the serialized and concurrent call sites with a benign success-skip (never trips the 3-strikes safeguard).

**Daemon boot** — `resolve_boot_posture()` resolves the identity via the existing `SIMARD_IDENTITY_PATH`/`load_identity` plumbing (unset ⇒ Simard default; unresolvable ⇒ read-only fail-closed) and threads posture into `OodaState`. `[simard]` eprintln operator diagnostics throughout. No wall-clock timeouts; no silent degradation.

## Constraints honored
- ✅ Simard unchanged when no identity / read-write identity (test-proven).
- ✅ Crocutus consumes via `identity.toml` + prompts only — no forked logic.
- ✅ Read-only posture fails **closed** (undetermined ⇒ no spawn). No fallbacks. Nothing named "Bridge".
- ✅ Additive. All CI gates green: `cargo fmt`, `clippy -D warnings`, `cargo test` (8133 pass), `cargo-deny`.
- ✅ `[simard]` eprintln operator-diagnostic convention.

## Deps
Bumped transitive `crossbeam-epoch 0.9.18 → 0.9.20` to clear the newly-published **RUSTSEC-2026-0204**, keeping `cargo-deny` green (lockfile-only).

## Tests
- `tests/identity_posture.rs` — WriteAuthority/ResolvedPosture, manifest posture + `with_posture` fail-closed scoping, compose merge, `FileIdentityLoader`, `seed_default_board` (5 defaults unchanged) vs `seed_identity_board`.
- `src/ooda_actions/tests_observe_only.rs` — observe-only Act: target-scoped proposals, never assigns, fail-closed on out-of-scope/unscoped/brain-error.
- `src/ooda_actions/tests_dispatch{,_concurrency}.rs` — read-only rail blocks spawn on **both** paths; read-write unaffected.

## Docs
Concept (`identity-write-authority.md`), how-to (`configure-observer-identity.md`), and API reference (`identity-posture-observer.md`), cross-linked and added to mkdocs nav.

## Follow-up (separate, Crocutus repo)
Crocutus's `identity.toml` sets `write_authority = "read-only"`, lists the hyenas repos in `targets`, and declares repo-hygiene `seed_goals` — the exact schema is documented in the how-to. That config change lands in the Crocutus repo; **this Simard PR is the framework deliverable**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>