### PR TITLE
feat(identity): identity-scoped cognition — seed goals, observe-only Act, target scope (#3125)

### DIFF
--- a/docs/concepts/identity-scoped-cognition.md
+++ b/docs/concepts/identity-scoped-cognition.md
@@ -1,0 +1,243 @@
+---
+title: Identity-scoped cognition — seed goals, observe-only Act, and target scope
+description: How an identity shapes Simard's COGNITION, not just her write primitives. A first-class identity declares its own seed goals (overriding the baked-in defaults), scopes goals and observations to its own target repos, and — when its write-authority posture is read-only — runs an observe-only Act phase that proposes goals but never dispatches a write-bearing engineer. This closes the abstraction gap where a read-only observer inherited Simard's default goals and burned credits on doomed, guardrail-blocked engineer dispatch.
+last_updated: 2026-07-08
+owner: simard
+doc_type: concept
+related:
+  - ./write-authority-posture.md
+  - ./pluggable-identity.md
+  - ./multi-identity-host-isolation.md
+  - ../reference/identity-scoped-cognition-api.md
+  - ../reference/write-authority-posture-api.md
+  - ../tutorials/deploy-crocutus-read-only-observer.md
+---
+
+# Identity-scoped cognition — seed goals, observe-only Act, and target scope
+
+!!! warning "Implementation status — the write chokepoint ships today; identity-scoped cognition is the target design (tracking #3125)"
+    **Shipped today (issue #1, PR [#3071](https://github.com/rysweet/Simard/pull/3071)):**
+    the read-only *write* floor. `SIMARD_OBSERVE_ONLY=1` activates the fail-closed
+    `read_only_guard` classifier, wired into `git_guardrails::check_git_safety` and
+    into `ooda_actions::advance_goal::spawn::dispatch_spawn_engineer` (via
+    `observe_only_dispatch_refusal`), so a read-only identity dispatches **0** write
+    actions. **Planned (this page, NOT yet implemented, tracking
+    [#3125](https://github.com/rysweet/Simard/issues/3125)):** the *cognition-level*
+    identity fields — identity-declared **seed goals** that override
+    `DEFAULT_SEED_GOALS`, a **target-repo scope**, and the **observe-only Act phase**
+    that proposes goals without ever *entering* engineer dispatch. Treat the field
+    and function names below as the target design; they are grounded in the real
+    seeding and dispatch code they extend. The runnable read-only proof lives in the
+    `rysweet/Crocutus` repo (`scripts/prove-guardrail.sh`).
+
+## The problem: the guardrail held, but the cognition was still Simard's
+
+The [write-authority posture](./write-authority-posture.md) and the shipped
+`SIMARD_OBSERVE_ONLY` floor make a second identity *structurally unable to
+write*. That is necessary but **not sufficient** for a real observer.
+
+Running the `crocutus` read-only identity live on host `dev` — its own
+`SIMARD_STATE_ROOT`, `SIMARD_IDENTITY=crocutus`, `SIMARD_OBSERVE_ONLY=1`, working
+directory a read-only clone of an external Azure DevOps repo — exposed the gap
+([#3125](https://github.com/rysweet/Simard/issues/3125)). A full OODA cycle ran,
+and **the identity did not shape cognition**:
+
+- It **seeded Simard's five `DEFAULT_SEED_GOALS`**
+  (`self-serve-dashboard-improvement`, `improve-amplihack-test-coverage`,
+  `fix-broken-features`, `improve-cognitive-memory-persistence`,
+  `enhance-simard-meeting-experience`) — *not* hyenas-observation goals.
+- In the Act phase it **decided to spawn write-bearing engineers** against
+  `rysweet/Simard` — i.e. it tried to *change software*, not *observe* its target.
+
+The `read_only_guard` did its job: the target clone had 0 local changes, 0
+unpushed commits, 0 engineer worktrees. Fail-closed worked. **But the reasoning
+was wasted** — the DECIDE/ACT cognition ran on Simard's goals and chose engineer
+dispatch that the guardrail was always going to block, spending AI credits on
+doomed work. A read-only observer should not merely be *blocked from writing*;
+its **cognition** should be scoped to observing its target and articulating
+goals, and its Act phase should be **observe-only** in the first place.
+
+## The abstraction gap
+
+Before this feature, an identity parameterized state root, prompts, the
+write guardrail, port, and systemd unit — but **not** the three things that make
+an observer an observer:
+
+| Parameterized before #3125 | **Not** parameterized (the gap) |
+|---|---|
+| State root / isolation ([host isolation](./multi-identity-host-isolation.md)) | **Seed goals** — the observer inherited Simard's baked-in defaults |
+| Prompt assets / persona ([pluggable identity](./pluggable-identity.md)) | **Act-phase posture** — read-only still *entered* engineer dispatch |
+| Write guardrail ([`SIMARD_OBSERVE_ONLY`](./write-authority-posture.md)) | **Target scope** — goals pointed at `rysweet/Simard`, not the target |
+
+Identity-scoped cognition adds exactly those three, and nothing more. It is
+**config plus one agentic Act branch behind a thin deterministic rail**, not a
+new subsystem.
+
+## Two enforcement levels: write chokepoint vs. cognition
+
+The read-only mandate now stacks at two distinct levels. The lower level already
+ships; this feature adds the upper one.
+
+```mermaid
+flowchart TD
+    subgraph COG["COGNITION level (this feature, #3125)"]
+        SEED["Seed: identity seed goals<br/>override DEFAULT_SEED_GOALS"]
+        POSTURE{"identity write-authority<br/>posture read-only?"}
+        OBSERVE["Act: observe-only branch<br/>record observations +<br/>propose goals to own board"]
+        DISPATCH["Act: dispatch_spawn_engineer"]
+    end
+    subgraph WRITE["WRITE-PRIMITIVE level (shipped, #3071)"]
+        FLOOR["observe_only_dispatch_refusal<br/>+ read_only_guard (git seam)"]
+    end
+    SEED --> POSTURE
+    POSTURE -->|yes| OBSERVE
+    POSTURE -->|"no / full"| DISPATCH
+    OBSERVE -.->|never reaches| DISPATCH
+    DISPATCH --> FLOOR
+    FLOOR -->|read-only| REFUSE["refuse, fail-closed"]
+    FLOOR -->|full| RUN["spawn engineer"]
+```
+
+- **Write-primitive chokepoint (shipped).** `observe_only_dispatch_refusal`
+  short-circuits `dispatch_spawn_engineer` *if* it is ever reached under a
+  read-only posture, and `read_only_guard` blocks the git write seam. This is the
+  last-line, defense-in-depth floor and it stays.
+- **Cognition level (this feature).** A read-only identity should never *reach*
+  the chokepoint for a write-bearing action, because its Act phase takes the
+  observe-only branch. That saves the credits the chokepoint would otherwise let
+  the brain burn deciding to spawn.
+
+The two are **defense in depth**: the cognition branch prevents the doomed
+decision; the write chokepoint remains as the structural guarantee if anything
+slips past.
+
+## The solution — three first-class identity fields
+
+### 1. Seed goals from the identity (override, not append)
+
+An identity may declare its own initial goals. When present, they **replace**
+Simard's baked-in `DEFAULT_SEED_GOALS` at the OODA cold-start seeding site in
+`ooda_loop::cycle`; when absent, `DEFAULT_SEED_GOALS` is used unchanged. Each
+seed goal carries a target-repo slug, exactly like the existing
+`DEFAULT_SEED_GOALS` tuple `(priority, title, description, Option<repo>)` and
+`ActiveGoal.repo`, so seeding stays a single shape.
+
+```toml
+[[identities]]
+name = "crocutus"
+default_mode = "engineer"
+
+# Identity seed goals OVERRIDE Simard's DEFAULT_SEED_GOALS when present.
+[[identities.seed_goals]]
+priority = 1
+title = "Observe hyenas repo health"
+description = "Read the hyenas Azure DevOps repos and assess branch hygiene, CODEOWNERS, LICENSE, dependabot coverage, and large blobs. OBSERVE ONLY — record findings and propose repo-hygiene goals; do not change anything."
+repo = "hyenas"
+
+[[identities.seed_goals]]
+priority = 2
+title = "Articulate repo-hygiene backlog"
+description = "Turn the observations into prioritized, target-scoped repo-hygiene goals on this identity's own board."
+repo = "hyenas"
+```
+
+Simard herself sets **no** `identity.toml` (or a `full` identity with no
+`seed_goals`), so she keeps her exact five defaults — **no behavior change**.
+
+### 2. Observe-only Act phase when the posture is read-only
+
+The [write-authority posture](./write-authority-posture.md) `read-only` value is
+the switch. When the resolved identity is read-only, the Act phase runs an
+**observe-only branch** instead of the engineer-dispatching branch:
+
+- **Agentic where it belongs.** A reasoner/prompt decides *what to observe* and
+  *what goals to propose* — this is cognition, not a hard-coded checklist. There
+  are **no wall-clock timeouts** on that agentic step.
+- **Thin deterministic rail.** A pure predicate (`posture_permits_spawn`) hard
+  blocks the dispatch branch when the posture is read-only, so the observe-only
+  path can never call `dispatch_spawn_engineer`. This mirrors the existing
+  pattern in `dispatch_spawn_engineer`, which already pairs an **agentic brain
+  decision** (`decide_engineer_lifecycle`) with a **deterministic 3-strikes
+  safeguard**.
+- **Fail-closed.** If the posture cannot be determined, the rail denies spawn —
+  it does **not** fall back to dispatching. "No identity" resolves deterministically
+  to `full` (Simard's default), which *is* a determinable state, so Simard is
+  unaffected; an *unresolved* posture under an identity denies. There is **no
+  silent degradation**.
+
+The observe-only branch records its observations and proposes goals **to the
+identity's own board** — the positive behavior the issue asks for, replacing the
+"decide to spawn, then get refused" waste.
+
+### 3. Target scope
+
+Goals and observations are scoped to the identity's **target repo set**, not
+`rysweet/Simard`. The target set is the identity's `target_repos` (or, when
+omitted, the union of the `repo` slugs on its `seed_goals`). Resolution reuses
+the existing goal-to-repo mapping, so a `crocutus` observation about branch
+hygiene is filed against `hyenas`, never against the daemon's own repo.
+
+```toml
+[[identities]]
+name = "crocutus"
+default_mode = "engineer"
+target_repos = ["hyenas"]     # observations/goals scoped here, not rysweet/Simard
+
+[identities.authority]
+posture = "read-only"          # the switch for the observe-only Act phase
+```
+
+## Why this is depend-not-fork
+
+`crocutus` gains all of this **through configuration**, not a code fork. The
+seed goals, target scope, and read-only posture live in the Crocutus identity's
+`identity.toml` and prompt assets in the `rysweet/Crocutus` repo, which
+*depends on* Simard. Simard owns the mechanism; the identity owns the values.
+Duplicating any of this logic into Crocutus would be the exact abstraction
+failure the [Crocutus tutorial](../tutorials/deploy-crocutus-read-only-observer.md#abstraction-gap-note)
+warns against.
+
+## Simard is unchanged by default
+
+The feature is strictly additive and gated on an identity being present *and*
+read-only:
+
+- **No identity**, or a **`full` / read-write identity with no `seed_goals`**:
+  the five `DEFAULT_SEED_GOALS` seed exactly as before, and the Act phase
+  dispatches engineers exactly as before. This invariant is an acceptance test,
+  not a hope.
+- The observe-only branch and the seed-goal override activate **only** when the
+  resolved identity declares them.
+
+Operator visibility follows the repo's `[simard]` eprintln convention — the
+seeding site logs whether it seeded identity goals or the defaults, and the Act
+phase logs when it takes the observe-only branch and how many goals it proposed.
+
+## What this is not
+
+- **Not a second guardrail system.** It reuses the existing
+  [write-authority posture](./write-authority-posture.md) as the read-only
+  switch and keeps `observe_only_dispatch_refusal` / `read_only_guard` as the
+  write-primitive floor. Cognition scoping is *above* those, not a replacement.
+- **Not a per-cycle toggle.** Seed goals, target scope, and posture are
+  identity-level, resolved once at load time. A running session cannot grant
+  itself Simard's default goals or raise its own posture.
+- **Not a sandbox.** It governs Simard's own seeding and Act cognition. A
+  read-only identity must still hold no write credential (see the
+  [four-layer defense in depth](./write-authority-posture.md#defense-in-depth-for-a-read-only-identity)).
+- **Not a fork.** Crocutus consumes it via `identity.toml` + prompts only.
+
+## See also
+
+- [Write-authority posture](./write-authority-posture.md) — the read-only *write*
+  posture this cognition layer sits on top of, and its four-layer defense in depth.
+- [Identity-scoped cognition API reference](../reference/identity-scoped-cognition-api.md)
+  — the `[[identities.seed_goals]]` / `target_repos` TOML surface and the seeding
+  and Act-phase function contracts.
+- [Pluggable identity](./pluggable-identity.md) — the `identity.toml` loader that
+  carries these fields.
+- [Multi-identity host isolation](./multi-identity-host-isolation.md) — the
+  per-instance isolation that keeps a read-only identity's board and credentials
+  separate.
+- [Deploy Crocutus as a read-only observer](../tutorials/deploy-crocutus-read-only-observer.md)
+  — the worked example this feature makes "mostly configuration".

--- a/docs/concepts/multi-identity-host-isolation.md
+++ b/docs/concepts/multi-identity-host-isolation.md
@@ -7,6 +7,7 @@ doc_type: concept
 related:
   - ./pluggable-identity.md
   - ./write-authority-posture.md
+  - ./identity-scoped-cognition.md
   - ../reference/agent-instance-isolation.md
   - ../howto/run-a-second-agent-identity.md
   - ../tutorials/deploy-crocutus-read-only-observer.md
@@ -174,6 +175,10 @@ isolation before starting the second daemon.
 - [Write-authority posture](./write-authority-posture.md) — the read-only /
   scoped-write / full contract that makes a second identity a *bounded*
   observer rather than a second full-write actor.
+- [Identity-scoped cognition](./identity-scoped-cognition.md) — the cognition
+  layer above isolation: identity seed goals, target scope, and the observe-only
+  Act phase that keep a read-only identity's *reasoning* on its own target, not
+  just its writes.
 - [Agent instance-isolation reference](../reference/agent-instance-isolation.md)
   — `SIMARD_HOME`, `instance_home()`, the env matrix, and unit templating.
 - [How to run a second agent identity](../howto/run-a-second-agent-identity.md)

--- a/docs/concepts/pluggable-identity.md
+++ b/docs/concepts/pluggable-identity.md
@@ -11,6 +11,7 @@ related:
   - ../architecture/agent-composition.md
   - ./multi-identity-host-isolation.md
   - ./write-authority-posture.md
+  - ./identity-scoped-cognition.md
 ---
 
 # Pluggable identity — TOML-driven agent personas

--- a/docs/concepts/write-authority-posture.md
+++ b/docs/concepts/write-authority-posture.md
@@ -7,6 +7,7 @@ doc_type: concept
 related:
   - ./pluggable-identity.md
   - ./multi-identity-host-isolation.md
+  - ./identity-scoped-cognition.md
   - ../reference/write-authority-posture-api.md
   - ../reference/ado-acl-self-escalation-guard.md
   - ../tutorials/deploy-crocutus-read-only-observer.md
@@ -141,6 +142,13 @@ reports `dispatched 0 actions (read-only), 0 writes` (see the
 Delivering that guarantee is an implementation acceptance criterion, not an
 emergent property of the guardrail functions alone.
 
+Posture is the *write-primitive* half of a read-only identity. The *cognition*
+half — seeding the identity's own goals and taking an observe-only Act branch so
+the loop never even *decides* to dispatch a write-bearing engineer — is
+[identity-scoped cognition](./identity-scoped-cognition.md). The two compose as
+defense in depth: cognition prevents the doomed decision, this posture guarantees
+no write if anything slips past.
+
 ## Why a contract, not just an env var
 
 Posture must be enforced *inside the code* at the guardrail layer, so it has
@@ -197,6 +205,9 @@ refuses + a dry-run check) is a required acceptance step, documented in the
 - [Multi-identity host isolation](./multi-identity-host-isolation.md) — the
   per-instance isolation that keeps a read-only identity away from the
   primary's credentials and state.
+- [Identity-scoped cognition](./identity-scoped-cognition.md) — the cognition
+  half: identity seed goals, target scope, and the observe-only Act phase that
+  sits on top of this posture.
 - [Azure DevOps ACL self-escalation guard](../reference/ado-acl-self-escalation-guard.md)
   — the pre-existing fail-closed guard that posture extends.
 - [Deploy Crocutus as a read-only observer](../tutorials/deploy-crocutus-read-only-observer.md)

--- a/docs/reference/identity-scoped-cognition-api.md
+++ b/docs/reference/identity-scoped-cognition-api.md
@@ -1,0 +1,271 @@
+---
+title: Identity-scoped cognition API reference
+description: TOML and Rust reference for identity-scoped cognition (#3125) — the [[identities.seed_goals]] and target_repos identity.toml surface, the seed-goal override at the OODA seeding site (seed_default_board / seed_default_goals / DEFAULT_SEED_GOALS), the read-only observe-only Act phase (posture_permits_spawn deterministic rail + agentic observe-and-propose branch, layered above observe_only_dispatch_refusal), target-scope resolution, fail-closed error behavior, and operator diagnostics.
+last_updated: 2026-07-08
+owner: simard
+doc_type: reference
+related:
+  - ../concepts/identity-scoped-cognition.md
+  - ../concepts/write-authority-posture.md
+  - ./write-authority-posture-api.md
+  - ./pluggable-identity-api.md
+---
+
+# Identity-scoped cognition API reference
+
+!!! warning "Implementation status — this page describes the PLANNED cognition surface (tracking #3125)"
+    The `[[identities.seed_goals]]` / `target_repos` TOML fields, the identity
+    seed-goal override at the OODA seeding site, and the read-only observe-only Act
+    phase are **not yet implemented**; they are the target design tracked in
+    [#3125](https://github.com/rysweet/Simard/issues/3125). **What ships today** is
+    the env-driven write floor documented under
+    [write-authority posture](./write-authority-posture-api.md): `SIMARD_OBSERVE_ONLY=1`
+    → `read_only_guard` → `observe_only_dispatch_refusal` inside
+    `dispatch_spawn_engineer`. The **shipped** seeding primitives this page extends —
+    `DEFAULT_SEED_GOALS`, `seed_default_board`, `seed_default_goals`, the
+    `.reseed_goals` marker — exist today and are named exactly as below. Because every
+    pluggable-identity TOML struct uses `deny_unknown_fields`, a `[[identities.seed_goals]]`
+    or `target_repos` key is a hard parse error against the **current** schema until
+    this lands.
+
+Modules: `simard::identity::toml_types`, `simard::identity::manifest`,
+`simard::goal_curation`, `simard::goals::seed`, `simard::ooda_loop::cycle`,
+`simard::ooda_actions::advance_goal::spawn`
+
+For the rationale and the two-level (write chokepoint vs. cognition) model, see
+[Identity-scoped cognition](../concepts/identity-scoped-cognition.md).
+
+---
+
+## `identity.toml` surface
+
+```toml
+[[identities]]
+name = "crocutus"
+default_mode = "engineer"
+
+# Target repos for goals/observations (scope). Optional: defaults to the union
+# of the `repo` slugs declared on `seed_goals` below.
+target_repos = ["hyenas"]
+
+# Identity seed goals. When present they OVERRIDE Simard's DEFAULT_SEED_GOALS.
+[[identities.seed_goals]]
+priority = 1
+title = "Observe hyenas repo health"
+description = "Read the hyenas Azure DevOps repos and assess branch hygiene, CODEOWNERS, LICENSE, dependabot coverage, and large blobs. OBSERVE ONLY."
+repo = "hyenas"
+
+# The read-only switch for the observe-only Act phase (write-authority posture).
+[identities.authority]
+posture = "read-only"          # "read-only" | "scoped-write" | "full"
+```
+
+Both new structs are deserialized with `deny_unknown_fields`, matching every
+other [pluggable-identity TOML type](./pluggable-identity-api.md); an unexpected
+key is a hard `IdentityTomlParseError`.
+
+### `[[identities.seed_goals]]` — `TomlSeedGoal`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `priority` | int (`u32`) | *required* | Seed priority, mirroring the `DEFAULT_SEED_GOALS` tuple's first element. |
+| `title` | string | *required* | Goal title (the `id_source` for `goal_slug`). |
+| `description` | string | *required* | Goal description shown on the board. |
+| `repo` | string | *optional* | Target-repo slug. `None`/omitted means the identity's own repo; a slug scopes the goal to an ecosystem/target repo, exactly like `ActiveGoal.repo`. |
+
+### `target_repos`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `target_repos` | `[string]` | union of `seed_goals[].repo` | The identity's target repo set. Goals and observations are scoped here, never to `rysweet/Simard`. |
+
+!!! note "Relationship to `[identities.authority]`"
+    The read-only *switch* is the existing (planned, #3067)
+    [`[identities.authority] posture`](./write-authority-posture-api.md#identitytoml-surface)
+    field, **not** a new one. The task framing `write_authority = "read-only" | "read-write"`
+    maps onto `posture`: `read-write` = `full` (the default, Simard unchanged),
+    `read-only` = `read-only`. Reusing `posture` keeps one authority concept rather
+    than two parallel fields.
+
+---
+
+## Domain types
+
+Module: `simard::identity::manifest`
+
+```rust
+/// One identity-declared seed goal. Mirrors the DEFAULT_SEED_GOALS tuple shape
+/// (priority, title, description, Option<repo>) so seeding stays one shape.
+pub struct SeedGoal {
+    pub priority: u32,
+    pub title: String,
+    pub description: String,
+    pub repo: Option<String>,
+}
+```
+
+`IdentityManifest` gains two fields, both defaulting empty so built-in and
+`full` identities are unchanged:
+
+```rust
+pub struct IdentityManifest {
+    // ... existing fields (name, version, prompt_assets, components,
+    // supported_base_types, required_capabilities, default_mode,
+    // memory_policy, contract) ...
+    pub seed_goals: Vec<SeedGoal>,   // empty => use DEFAULT_SEED_GOALS
+    pub target_repos: Vec<String>,   // empty => union of seed_goals[].repo
+}
+```
+
+An empty `seed_goals` is the backward-compatible default: seeding falls through
+to `DEFAULT_SEED_GOALS`, so Simard's five defaults are untouched.
+
+---
+
+## Seed-goal override
+
+Module: `simard::goal_curation` / `simard::goals::seed`
+
+The single source of truth for Simard's defaults is unchanged:
+
+```rust
+// simard::goal_curation — SHIPPED, unchanged by this feature.
+pub const DEFAULT_SEED_GOALS: [(u32, &str, &str, Option<&str>); 5] = [ /* ... */ ];
+
+pub fn seed_default_board(board: &mut GoalBoard) -> usize;              // GoalBoard
+pub fn seed_default_goals(store: &dyn GoalStore) -> SimardResult<Vec<GoalRecord>>; // GoalStore
+```
+
+The override is a **resolver at the seeding site**, not a rewrite of the seeding
+functions. The OODA cold-start seeding block in `simard::ooda_loop::cycle`
+consults the resolved identity first:
+
+```rust
+// Planned (#3125): identity seed goals override the baked-in defaults.
+let seeds: Vec<SeedGoal> = if !identity.seed_goals.is_empty() {
+    identity.seed_goals.clone()                 // identity-scoped override
+} else {
+    default_seed_goals()                        // DEFAULT_SEED_GOALS, unchanged
+};
+```
+
+Precedence at the seeding site (in order):
+
+1. **`.reseed_goals` marker** — forces a fresh seed, ignoring the cognitive-memory
+   board (shipped behavior, unchanged).
+2. **Non-empty loaded board** from cognitive memory — kept (shipped behavior).
+3. **Seed** — identity `seed_goals` if present, else `DEFAULT_SEED_GOALS`.
+
+Seeding only fires when the board is empty, so the override never disturbs an
+identity that already has a live board.
+
+---
+
+## Read-only observe-only Act phase
+
+Module: `simard::ooda_actions::advance_goal::spawn`
+
+### Deterministic rail — `posture_permits_spawn`
+
+A pure, default-DENY predicate gates the dispatch branch. It is the thin
+deterministic rail that the agentic Act cognition runs behind:
+
+```rust
+/// Returns true only for a definitively writing posture (`full` / `scoped-write`).
+/// read-only => false. An UNRESOLVED posture under an identity => false
+/// (fail-closed). No identity resolves deterministically to `full` => true,
+/// so Simard is unaffected.
+pub fn posture_permits_spawn(authority: Option<&IdentityAuthority>) -> bool;
+```
+
+When `posture_permits_spawn` is false, the Act phase takes the **observe-only
+branch** and never calls `dispatch_spawn_engineer`. There are **no wall-clock
+timeouts** on the agentic observe/propose step, and **no fallback** to
+dispatching if resolution is uncertain.
+
+### Agentic branch — observe and propose
+
+The observe-only branch is agentic: a reasoner/prompt decides what to observe on
+the identity's `target_repos` and what goals to propose, then records
+observations and writes the proposed goals **to the identity's own board**. This
+follows the existing `dispatch_spawn_engineer` pattern of an agentic brain
+decision (`OodaBrain::decide_engineer_lifecycle`) paired with a deterministic
+safeguard — here the safeguard is `posture_permits_spawn` rather than the
+3-strikes counter.
+
+### Layering with the shipped write floor
+
+`observe_only_dispatch_refusal` (shipped, #3071) remains **inside**
+`dispatch_spawn_engineer` as the last-line write-primitive floor:
+
+```rust
+// SHIPPED — write-primitive chokepoint, kept as defense-in-depth.
+fn observe_only_dispatch_refusal(action: &PlannedAction, goal_id: &str) -> Option<ActionOutcome>;
+// returns Some(success=true refusal) when read_only_guard::observe_only_enabled().
+```
+
+The cognition-level `posture_permits_spawn` rail means a correctly configured
+read-only identity **never reaches** that refusal for a write-bearing action —
+the two compose as defense in depth (cognition prevents the doomed decision; the
+chokepoint guarantees no write if anything slips past).
+
+---
+
+## Target-scope resolution
+
+Observations and proposed goals are scoped to the identity's target set:
+
+- **Explicit** `target_repos` when present.
+- Otherwise the **union** of `repo` slugs on `seed_goals`.
+- Repo resolution reuses the existing goal-to-repo mapping (the same path used
+  by `ActiveGoal.repo` and `DEFAULT_SEED_GOALS`' `Option<repo>` slug), so a
+  scoped goal is filed against the target repo, never `rysweet/Simard`.
+
+A read-only identity with an empty target set proposes nothing and dispatches
+nothing (fail-closed): it does not fall back to the daemon's own repo.
+
+---
+
+## Error and fail-closed behavior
+
+| Condition | Behavior |
+|-----------|----------|
+| Unknown field in `[[identities.seed_goals]]` or `target_repos` | `IdentityTomlParseError` (`deny_unknown_fields`) |
+| `seed_goals` present | **Override** — replaces `DEFAULT_SEED_GOALS` at seeding (no merge) |
+| `seed_goals` empty / absent | `DEFAULT_SEED_GOALS` used unchanged (Simard default) |
+| Posture read-only | Act takes observe-only branch; `dispatch_spawn_engineer` **not called** |
+| Posture `full` / no identity | Engineer-dispatching Act phase, unchanged |
+| Posture **unresolved** under an identity | `posture_permits_spawn` = false → **no spawn** (fail-closed) |
+| Read-only identity reaches `dispatch_spawn_engineer` anyway | `observe_only_dispatch_refusal` refuses, fail-closed (shipped floor) |
+
+No branch degrades to a silent no-op or a silent fallback; read-only always
+fails **closed**.
+
+---
+
+## Operator diagnostics
+
+Following the repo's `[simard]` eprintln operator-diagnostic convention, the
+seeding site and Act phase surface which path they took, e.g.:
+
+```
+[simard] OODA start: seeded 2 identity seed goal(s) (crocutus) — overriding defaults
+[simard] OODA start: seeded 5 default goal(s)
+[simard] Act: read-only posture (crocutus) — observe-only branch, proposed 3 goal(s), dispatched 0 engineer(s)
+```
+
+The default (no identity) line is the existing
+`[simard] OODA start: seeded {n} default goal(s)` message — unchanged.
+
+---
+
+## See also
+
+- [Identity-scoped cognition](../concepts/identity-scoped-cognition.md) — the
+  design rationale and the write-chokepoint-vs-cognition model.
+- [Write-authority posture API reference](./write-authority-posture-api.md) — the
+  `[identities.authority] posture` field this feature reuses as the read-only switch.
+- [Pluggable identity API reference](./pluggable-identity-api.md) — the
+  `identity.toml` loader and TOML types these fields extend.
+- [Deploy Crocutus as a read-only observer](../tutorials/deploy-crocutus-read-only-observer.md)
+  — the end-to-end worked example.

--- a/docs/reference/write-authority-posture-api.md
+++ b/docs/reference/write-authority-posture-api.md
@@ -6,6 +6,8 @@ owner: simard
 doc_type: reference
 related:
   - ../concepts/write-authority-posture.md
+  - ../concepts/identity-scoped-cognition.md
+  - ../reference/identity-scoped-cognition-api.md
   - ../reference/pluggable-identity-api.md
   - ../reference/ado-acl-self-escalation-guard.md
   - ../reference/agent-instance-isolation.md
@@ -316,3 +318,6 @@ can gate CI/acceptance.
   — the pre-existing fail-closed guard that posture generalizes.
 - [Agent instance-isolation reference](./agent-instance-isolation.md) — the
   per-instance isolation that pairs with posture.
+- [Identity-scoped cognition API reference](./identity-scoped-cognition-api.md)
+  — the cognition-level `seed_goals` / `target_repos` surface and the observe-only
+  Act phase that reuses this posture's `read-only` value as its switch.

--- a/docs/tutorials/deploy-crocutus-read-only-observer.md
+++ b/docs/tutorials/deploy-crocutus-read-only-observer.md
@@ -7,6 +7,7 @@ doc_type: tutorial
 related:
   - ../concepts/multi-identity-host-isolation.md
   - ../concepts/write-authority-posture.md
+  - ../concepts/identity-scoped-cognition.md
   - ../reference/agent-instance-isolation.md
   - ../reference/write-authority-posture-api.md
   - ../howto/run-a-second-agent-identity.md
@@ -336,12 +337,17 @@ than the two small parameterizations
 [write-authority posture](../concepts/write-authority-posture.md)), that is an
 abstraction gap. Record it as a Simard issue and fix the abstraction upstream —
 do not fork. A correctly abstracted Simard makes a second identity *mostly
-configuration*, which is exactly what this tutorial demonstrates.
+configuration*, which is exactly what this tutorial demonstrates. The cognition
+half of that abstraction — seeding Crocutus's own hyenas-observation goals and
+running an [observe-only Act phase](../concepts/identity-scoped-cognition.md)
+instead of inheriting Simard's defaults and dispatching engineers — is
+[identity-scoped cognition](../concepts/identity-scoped-cognition.md).
 
 ## See also
 
 - [Multi-identity host isolation](../concepts/multi-identity-host-isolation.md)
 - [Write-authority posture](../concepts/write-authority-posture.md)
+- [Identity-scoped cognition](../concepts/identity-scoped-cognition.md) — seed goals, target scope, and the observe-only Act phase
 - [How to run a second agent identity](../howto/run-a-second-agent-identity.md)
 - [How to configure pluggable identities](../howto/configure-pluggable-identity.md)
 - [Write-authority posture API reference](../reference/write-authority-posture-api.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
     - Pluggable Identity: concepts/pluggable-identity.md
     - Multi-Identity Host Isolation: concepts/multi-identity-host-isolation.md
     - Write-Authority Posture: concepts/write-authority-posture.md
+    - Identity-Scoped Cognition (Seed Goals, Observe-Only Act): concepts/identity-scoped-cognition.md
     - OODA Loop Self-Detection: concepts/ooda-loop-self-detection.md
     - Unified RecipeBrain: concepts/unified-recipe-brain.md
     - Prompt-Driven OODA Brain: concepts/prompt-driven-ooda-brain.md
@@ -377,6 +378,7 @@ nav:
     - Pluggable Identity API: reference/pluggable-identity-api.md
     - Agent Instance Isolation: reference/agent-instance-isolation.md
     - Write-Authority Posture API: reference/write-authority-posture-api.md
+    - Identity-Scoped Cognition API: reference/identity-scoped-cognition-api.md
     - Adaptive Scaling API: reference/adaptive-scaling-api.md
     - Brain Introspection API: reference/brain-introspection-api.md
     - Self-Quality-Audit API: reference/self-quality-audit-api.md

--- a/src/goal_curation/mod.rs
+++ b/src/goal_curation/mod.rs
@@ -28,9 +28,10 @@ pub use operations::CarryoverVerification;
 pub use operations::{
     BoardPlacement, DEFAULT_SEED_GOALS, DEFAULT_STEWARD_SCORE, active_goals_as_records,
     add_active_goal, add_backlog_item, archive_completed, board_snapshot_hash,
-    clear_goal_assignment, enqueue_stewardship_issue, load_goal_board, overwrite_memory_cache,
-    persist_board, promote_to_active, read_latest_carryover, record_as_active_goal,
-    rollup_parent_progress, save_goal_board, save_goal_board_with_removals, seed_default_board,
+    clear_goal_assignment, default_seed_goals, enqueue_stewardship_issue, load_goal_board,
+    overwrite_memory_cache, persist_board, promote_to_active, read_latest_carryover,
+    record_as_active_goal, resolve_seed_goals, rollup_parent_progress, save_goal_board,
+    save_goal_board_with_removals, seed_board_from_seed_goals, seed_default_board,
     simard_state_root, update_goal_progress, update_goal_progress_with_evidence,
     verify_goal_carryover, write_goal_carryover,
 };

--- a/src/goal_curation/operations.rs
+++ b/src/goal_curation/operations.rs
@@ -1358,6 +1358,76 @@ pub fn seed_default_board(board: &mut GoalBoard) -> usize {
     DEFAULT_SEED_GOALS.len()
 }
 
+/// `DEFAULT_SEED_GOALS` projected as owned [`crate::identity::SeedGoal`] values.
+///
+/// This is the single shape shared by Simard's baked-in defaults and an
+/// identity's declared seed goals (#3125), so the seeding site can treat both
+/// uniformly. `title` is the tuple's `id_source` (the slug source).
+pub fn default_seed_goals() -> Vec<crate::identity::SeedGoal> {
+    DEFAULT_SEED_GOALS
+        .iter()
+        .map(|(priority, title, description, repo)| {
+            crate::identity::SeedGoal::new(
+                *priority,
+                *title,
+                *description,
+                repo.map(str::to_string),
+            )
+        })
+        .collect()
+}
+
+/// Resolve which seed goals to use at the OODA cold-start seeding site (#3125).
+///
+/// When the identity declares a non-empty `seed_goals` list it **overrides**
+/// Simard's baked-in `DEFAULT_SEED_GOALS` (no merge); an empty list falls
+/// through to [`default_seed_goals`], so Simard herself is unchanged.
+pub fn resolve_seed_goals(
+    identity_seed_goals: &[crate::identity::SeedGoal],
+) -> Vec<crate::identity::SeedGoal> {
+    if identity_seed_goals.is_empty() {
+        default_seed_goals()
+    } else {
+        identity_seed_goals.to_vec()
+    }
+}
+
+/// Seed the board from an explicit list of [`crate::identity::SeedGoal`] if it
+/// has no active goals. Returns the number of goals added. Mirrors
+/// [`seed_default_board`] exactly (same `SOURCE_SEED` label, same empty-board
+/// guard), differing only in that the goals come from the resolved identity /
+/// default list rather than the baked-in `DEFAULT_SEED_GOALS` tuple. A goal's
+/// `repo` slug scopes it to the identity's target repo (#3125), never to
+/// `rysweet/Simard`.
+pub fn seed_board_from_seed_goals(
+    board: &mut GoalBoard,
+    goals: &[crate::identity::SeedGoal],
+) -> usize {
+    if !board.active.is_empty() {
+        return 0;
+    }
+
+    for goal in goals {
+        let id = crate::goals::goal_slug(&goal.title);
+        board.active.push(ActiveGoal {
+            parent_goal_id: None,
+            priority_explicit: false,
+            id,
+            description: goal.description.clone(),
+            priority: goal.priority,
+            status: GoalProgress::NotStarted,
+            assigned_to: None,
+            repo: goal.repo.clone(),
+            current_activity: None,
+            wip_refs: vec![],
+            last_progress_update_at: None,
+            labels: vec![crate::goal_curation::labels::SOURCE_SEED.to_string()],
+        });
+    }
+
+    goals.len()
+}
+
 // ---------------------------------------------------------------------------
 // GoalBoard -> Vec<GoalRecord> adapter
 // ---------------------------------------------------------------------------

--- a/src/identity/compose.rs
+++ b/src/identity/compose.rs
@@ -68,6 +68,20 @@ impl IdentityManifest {
             });
         }
 
+        // Write-authority posture composes like memory_policy: all components
+        // must agree on `posture`, so a read-only component cannot be diluted by
+        // composing it with a `full` one (#3125 / #3067, defense in depth).
+        let authority = components[0].authority.clone();
+        if components
+            .iter()
+            .any(|component| component.authority.posture != authority.posture)
+        {
+            return Err(SimardError::InvalidIdentityComposition {
+                identity: name.clone(),
+                reason: "component identities must agree on write-authority posture".to_string(),
+            });
+        }
+
         IdentityManifest::new(
             name,
             version,
@@ -78,6 +92,7 @@ impl IdentityManifest {
             memory_policy,
             contract,
         )?
+        .with_authority(authority)
         .with_components(component_names)
     }
 }

--- a/src/identity/file_loader.rs
+++ b/src/identity/file_loader.rs
@@ -13,8 +13,11 @@ use std::path::{Component, Path, PathBuf};
 use tracing::warn;
 
 use super::loader::BuiltinIdentityLoader;
-use super::toml_types::{TomlIdentity, TomlIdentityFile};
-use super::{IdentityLoadRequest, IdentityLoader, IdentityManifest, MemoryPolicy, OperatingMode};
+use super::toml_types::{TomlAuthority, TomlIdentity, TomlIdentityFile};
+use super::{
+    IdentityAuthority, IdentityLoadRequest, IdentityLoader, IdentityManifest, MemoryPolicy,
+    OperatingMode, SeedGoal, WritePosture,
+};
 use crate::base_types::{BaseTypeCapability, BaseTypeId};
 use crate::error::{SimardError, SimardResult};
 use crate::memory::MemoryScope;
@@ -65,6 +68,27 @@ impl FileIdentityLoader {
             }
         })?;
 
+        // #3125: identity-scoped cognition fields (seed goals, target scope,
+        // write-authority posture). Computed once and applied to whichever
+        // manifest is built (leaf or composite).
+        let seed_goals: Vec<SeedGoal> = identity
+            .seed_goals
+            .iter()
+            .map(|g| {
+                SeedGoal::new(
+                    g.priority,
+                    g.title.clone(),
+                    g.description.clone(),
+                    g.repo.clone(),
+                )
+            })
+            .collect();
+        let target_repos = identity.target_repos.clone();
+        let declared_authority: Option<IdentityAuthority> = match &identity.authority {
+            Some(a) => Some(toml_authority_to_domain(a, &identity.name, toml_path)?),
+            None => None,
+        };
+
         if !identity.components.is_empty() {
             if depth >= MAX_COMPOSITION_DEPTH {
                 return Err(SimardError::IdentityTomlParseError {
@@ -110,13 +134,32 @@ impl FileIdentityLoader {
             // the same node (diamond pattern).
             visited.remove(&identity.name);
 
-            return IdentityManifest::compose(
+            let composed = IdentityManifest::compose(
                 &identity.name,
                 &request.package_version,
                 components,
                 default_mode,
                 request.contract.clone(),
-            );
+            )?;
+            // A composite may not DILUTE its components' posture: if it declares
+            // its own `[identities.authority]`, it must agree with the posture
+            // `compose` derived from the components (defense in depth, #3125).
+            if let Some(declared) = &declared_authority
+                && declared.posture != composed.authority.posture
+            {
+                return Err(SimardError::IdentityTomlParseError {
+                    path: toml_path.to_path_buf(),
+                    reason: format!(
+                        "composite identity '{}' declares authority.posture = \"{}\" but its \
+                         components resolve to \"{}\"; a composite cannot dilute its components' \
+                         write-authority posture",
+                        identity.name, declared.posture, composed.authority.posture
+                    ),
+                });
+            }
+            return Ok(composed
+                .with_seed_goals(seed_goals)
+                .with_target_repos(target_repos));
         }
 
         let supported_base_types = identity
@@ -237,7 +280,75 @@ impl FileIdentityLoader {
             memory_policy,
             request.contract.clone(),
         )
+        .map(|m| {
+            m.with_seed_goals(seed_goals)
+                .with_target_repos(target_repos)
+                .with_authority(declared_authority.unwrap_or_default())
+        })
     }
+}
+
+/// Convert a `[identities.authority]` TOML block into a validated
+/// [`IdentityAuthority`] (#3125 / #3067), failing closed on contradictions.
+///
+/// Rules (see docs/reference/write-authority-posture-api.md):
+/// - `posture` must be one of `read-only | scoped-write | full`.
+/// - Under `read-only`, any `allow_*_writes = true` is a hard contradiction.
+/// - `allowed_write_repos` must be empty unless `posture = "scoped-write"`.
+/// - `allow_*` default is posture-dependent: `false` under `read-only`,
+///   `true` otherwise.
+fn toml_authority_to_domain(
+    authority: &TomlAuthority,
+    identity_name: &str,
+    toml_path: &Path,
+) -> SimardResult<IdentityAuthority> {
+    let posture: WritePosture =
+        authority
+            .posture
+            .parse()
+            .map_err(|e: String| SimardError::IdentityTomlParseError {
+                path: toml_path.to_path_buf(),
+                reason: format!(
+                    "invalid authority.posture '{}' for identity '{identity_name}': {e}",
+                    authority.posture
+                ),
+            })?;
+    let read_only = posture == WritePosture::ReadOnly;
+
+    for (field, value) in [
+        ("allow_git_push", authority.allow_git_push),
+        ("allow_ado_writes", authority.allow_ado_writes),
+        ("allow_github_writes", authority.allow_github_writes),
+    ] {
+        if read_only && value == Some(true) {
+            return Err(SimardError::IdentityTomlParseError {
+                path: toml_path.to_path_buf(),
+                reason: format!(
+                    "authority.{field} = true contradicts posture = \"read-only\" for identity \
+                     '{identity_name}' (a read-only identity may not enable any write path)"
+                ),
+            });
+        }
+    }
+
+    if !authority.allowed_write_repos.is_empty() && posture != WritePosture::ScopedWrite {
+        return Err(SimardError::IdentityTomlParseError {
+            path: toml_path.to_path_buf(),
+            reason: format!(
+                "authority.allowed_write_repos is non-empty but posture is \"{posture}\" for \
+                 identity '{identity_name}' (only scoped-write may list writable repos)"
+            ),
+        });
+    }
+
+    let default_allow = !read_only;
+    Ok(IdentityAuthority {
+        posture,
+        allowed_write_repos: authority.allowed_write_repos.clone(),
+        allow_git_push: authority.allow_git_push.unwrap_or(default_allow),
+        allow_ado_writes: authority.allow_ado_writes.unwrap_or(default_allow),
+        allow_github_writes: authority.allow_github_writes.unwrap_or(default_allow),
+    })
 }
 
 fn validate_identity_name(name: &str, toml_path: &Path) -> SimardResult<()> {
@@ -1000,5 +1111,220 @@ path = "prompts/evil.md"
             msg.contains("escapes identity directory"),
             "error should mention directory escape, got: {msg}"
         );
+    }
+
+    // ── #3125: identity-scoped cognition (seed goals, target scope, posture) ──
+
+    const CROCUTUS_TOML: &str = r#"
+[package]
+name = "crocutus"
+version = "0.1.0"
+
+[[identities]]
+name = "crocutus"
+default_mode = "engineer"
+target_repos = ["hyenas"]
+
+[[identities.seed_goals]]
+priority = 1
+title = "Observe hyenas repo health"
+description = "Read the hyenas repos and assess branch hygiene, CODEOWNERS, LICENSE, dependabot, large blobs. OBSERVE ONLY."
+repo = "hyenas"
+
+[[identities.seed_goals]]
+priority = 2
+title = "Articulate repo-hygiene backlog"
+description = "Turn observations into prioritized, target-scoped repo-hygiene goals on this identity's own board."
+repo = "hyenas"
+
+[identities.authority]
+posture = "read-only"
+"#;
+
+    fn load_crocutus(toml: &str) -> SimardResult<IdentityManifest> {
+        let prompt_root = TempDir::new().unwrap();
+        let identity_dir = prompt_root.path().join("crocutus");
+        fs::create_dir_all(&identity_dir).unwrap();
+        write_identity_toml(&identity_dir, toml);
+        let loader = FileIdentityLoader::new(&identity_dir, prompt_root.path());
+        loader.load(&test_request("crocutus"))
+    }
+
+    #[test]
+    fn file_loader_reads_read_only_identity_seed_goals_and_target_scope() {
+        let manifest = load_crocutus(CROCUTUS_TOML).expect("crocutus identity must load");
+        // (b) A read-only identity seeds its OWN goals, scoped to its target.
+        assert_eq!(manifest.seed_goals.len(), 2);
+        assert_eq!(manifest.seed_goals[0].priority, 1);
+        assert_eq!(manifest.seed_goals[0].title, "Observe hyenas repo health");
+        assert_eq!(manifest.seed_goals[0].repo.as_deref(), Some("hyenas"));
+        assert_eq!(manifest.target_repos, vec!["hyenas".to_string()]);
+        assert_eq!(manifest.resolved_target_repos(), vec!["hyenas".to_string()]);
+        // Read-only posture with every write path denied (defaults under read-only).
+        assert_eq!(manifest.authority.posture, WritePosture::ReadOnly);
+        assert!(!manifest.authority.allow_git_push);
+        assert!(!manifest.authority.allow_ado_writes);
+        assert!(!manifest.authority.allow_github_writes);
+        assert!(!manifest.authority.permits_spawn());
+    }
+
+    #[test]
+    fn file_loader_target_repos_defaults_to_union_of_seed_goal_repos() {
+        let toml = r#"
+[package]
+name = "crocutus"
+version = "0.1.0"
+
+[[identities]]
+name = "crocutus"
+default_mode = "engineer"
+
+[[identities.seed_goals]]
+priority = 1
+title = "Observe hyenas repo health"
+description = "OBSERVE ONLY"
+repo = "hyenas"
+
+[identities.authority]
+posture = "read-only"
+"#;
+        let manifest = load_crocutus(toml).expect("identity must load");
+        // target_repos omitted => union of seed-goal repos.
+        assert!(manifest.target_repos.is_empty());
+        assert_eq!(manifest.resolved_target_repos(), vec!["hyenas".to_string()]);
+    }
+
+    #[test]
+    fn file_loader_identity_without_authority_is_full_and_unchanged() {
+        // (a) An identity that omits [identities.authority] and declares no seed
+        // goals resolves to `full` with no override — Simard-equivalent.
+        let toml = r#"
+[package]
+name = "plain"
+version = "0.1.0"
+
+[[identities]]
+name = "plain"
+default_mode = "engineer"
+supported_base_types = ["local-harness"]
+"#;
+        let prompt_root = TempDir::new().unwrap();
+        let identity_dir = prompt_root.path().join("plain");
+        fs::create_dir_all(&identity_dir).unwrap();
+        write_identity_toml(&identity_dir, toml);
+        let loader = FileIdentityLoader::new(&identity_dir, prompt_root.path());
+        let manifest = loader.load(&test_request("plain")).unwrap();
+        assert!(manifest.seed_goals.is_empty());
+        assert!(manifest.target_repos.is_empty());
+        assert_eq!(manifest.authority, IdentityAuthority::default());
+        assert!(manifest.authority.permits_spawn());
+    }
+
+    #[test]
+    fn file_loader_rejects_read_only_write_contradiction() {
+        let toml = r#"
+[package]
+name = "crocutus"
+version = "0.1.0"
+
+[[identities]]
+name = "crocutus"
+default_mode = "engineer"
+
+[identities.authority]
+posture = "read-only"
+allow_git_push = true
+"#;
+        let err =
+            load_crocutus(toml).expect_err("read-only + allow_git_push=true must be rejected");
+        let msg = err.to_string();
+        assert!(
+            matches!(err, SimardError::IdentityTomlParseError { .. }),
+            "contradiction must be an IdentityTomlParseError, got: {err:?}"
+        );
+        assert!(
+            msg.contains("contradicts posture") && msg.contains("read-only"),
+            "error should explain the contradiction, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn file_loader_rejects_allowlist_without_scoped_write() {
+        let toml = r#"
+[package]
+name = "crocutus"
+version = "0.1.0"
+
+[[identities]]
+name = "crocutus"
+default_mode = "engineer"
+
+[identities.authority]
+posture = "full"
+allowed_write_repos = ["some-repo"]
+"#;
+        let err = load_crocutus(toml).expect_err("allowed_write_repos under full must be rejected");
+        assert!(
+            matches!(err, SimardError::IdentityTomlParseError { .. }),
+            "must be an IdentityTomlParseError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn file_loader_rejects_invalid_posture_value() {
+        let toml = r#"
+[package]
+name = "crocutus"
+version = "0.1.0"
+
+[[identities]]
+name = "crocutus"
+default_mode = "engineer"
+
+[identities.authority]
+posture = "read-write"
+"#;
+        let err = load_crocutus(toml).expect_err("unknown posture must be rejected");
+        assert!(matches!(err, SimardError::IdentityTomlParseError { .. }));
+    }
+
+    #[test]
+    fn file_loader_rejects_unknown_seed_goal_field() {
+        let toml = r#"
+[package]
+name = "crocutus"
+version = "0.1.0"
+
+[[identities]]
+name = "crocutus"
+default_mode = "engineer"
+
+[[identities.seed_goals]]
+priority = 1
+title = "g"
+description = "d"
+bogus = "x"
+"#;
+        let err = load_crocutus(toml).expect_err("unknown seed_goal field must be rejected");
+        assert!(matches!(err, SimardError::IdentityTomlParseError { .. }));
+    }
+
+    #[test]
+    fn file_loader_rejects_unknown_authority_field() {
+        let toml = r#"
+[package]
+name = "crocutus"
+version = "0.1.0"
+
+[[identities]]
+name = "crocutus"
+default_mode = "engineer"
+
+[identities.authority]
+posture = "read-only"
+encryption = "aes"
+"#;
+        let err = load_crocutus(toml).expect_err("unknown authority field must be rejected");
+        assert!(matches!(err, SimardError::IdentityTomlParseError { .. }));
     }
 }

--- a/src/identity/manifest.rs
+++ b/src/identity/manifest.rs
@@ -1,10 +1,143 @@
 use std::collections::BTreeSet;
+use std::fmt::{self, Display, Formatter};
+use std::str::FromStr;
 
 use crate::base_types::{BaseTypeCapability, BaseTypeId};
 use crate::error::{SimardError, SimardResult};
 use crate::prompt_assets::PromptAssetRef;
 
 use super::{ManifestContract, MemoryPolicy, OperatingMode};
+
+/// One identity-declared seed goal. Mirrors the shape of a
+/// [`crate::goal_curation::DEFAULT_SEED_GOALS`] tuple
+/// `(priority, title, description, Option<repo>)` so identity seeding and
+/// default seeding stay a single shape (#3125).
+///
+/// When an identity declares a non-empty `seed_goals` list it OVERRIDES
+/// Simard's baked-in `DEFAULT_SEED_GOALS` at the OODA cold-start seeding site;
+/// an empty list falls through to the defaults, so Simard herself is unchanged.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SeedGoal {
+    pub priority: u32,
+    pub title: String,
+    pub description: String,
+    /// Target-repo slug. `None` means the identity's own repo; a slug scopes the
+    /// goal to an ecosystem/target repo, exactly like `ActiveGoal.repo`.
+    pub repo: Option<String>,
+}
+
+impl SeedGoal {
+    pub fn new(
+        priority: u32,
+        title: impl Into<String>,
+        description: impl Into<String>,
+        repo: Option<String>,
+    ) -> Self {
+        Self {
+            priority,
+            title: title.into(),
+            description: description.into(),
+            repo,
+        }
+    }
+}
+
+/// The write-authority posture of an identity — the read-only switch that the
+/// observe-only Act phase keys off (#3125, reusing the #3067 posture concept).
+///
+/// `Full` is the historical, default behaviour so Simard and any identity that
+/// omits `[identities.authority]` are unchanged.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum WritePosture {
+    /// Bounded observer: reads and reasons, never writes anywhere.
+    ReadOnly,
+    /// Writes only to an explicit allowlist of repos.
+    ScopedWrite,
+    /// Historical behaviour — no posture restriction beyond the existing guards.
+    #[default]
+    Full,
+}
+
+impl WritePosture {
+    /// Whether this posture is a definitively *writing* posture. `Full` and
+    /// `ScopedWrite` write; `ReadOnly` does not. This is the pure kernel of the
+    /// deterministic spawn rail — see
+    /// [`crate::ooda_actions::advance_goal::spawn::posture_permits_spawn`].
+    pub fn permits_writes(self) -> bool {
+        matches!(self, Self::Full | Self::ScopedWrite)
+    }
+}
+
+impl Display for WritePosture {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::ReadOnly => "read-only",
+            Self::ScopedWrite => "scoped-write",
+            Self::Full => "full",
+        };
+        f.write_str(label)
+    }
+}
+
+impl FromStr for WritePosture {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "read-only" => Ok(Self::ReadOnly),
+            "scoped-write" => Ok(Self::ScopedWrite),
+            "full" => Ok(Self::Full),
+            other => Err(format!(
+                "unknown write posture: '{other}' (expected read-only | scoped-write | full)"
+            )),
+        }
+    }
+}
+
+/// The typed write-authority contract on an identity. `Default` is `Full` with
+/// every `allow_*` true, so built-in identities and TOML identities that omit
+/// `[identities.authority]` behave exactly as before this feature.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IdentityAuthority {
+    pub posture: WritePosture,
+    pub allowed_write_repos: Vec<String>,
+    pub allow_git_push: bool,
+    pub allow_ado_writes: bool,
+    pub allow_github_writes: bool,
+}
+
+impl Default for IdentityAuthority {
+    fn default() -> Self {
+        Self {
+            posture: WritePosture::Full,
+            allowed_write_repos: Vec::new(),
+            allow_git_push: true,
+            allow_ado_writes: true,
+            allow_github_writes: true,
+        }
+    }
+}
+
+impl IdentityAuthority {
+    /// A `read-only` authority with every write path denied. The canonical
+    /// bounded-observer posture; also the fail-closed value the daemon installs
+    /// when an identity is named but its posture cannot be resolved.
+    pub fn read_only() -> Self {
+        Self {
+            posture: WritePosture::ReadOnly,
+            allowed_write_repos: Vec::new(),
+            allow_git_push: false,
+            allow_ado_writes: false,
+            allow_github_writes: false,
+        }
+    }
+
+    /// Whether this authority permits dispatching a write-bearing engineer.
+    /// `ReadOnly` never does; `Full`/`ScopedWrite` do.
+    pub fn permits_spawn(&self) -> bool {
+        self.posture.permits_writes()
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IdentityManifest {
@@ -17,6 +150,13 @@ pub struct IdentityManifest {
     pub default_mode: OperatingMode,
     pub memory_policy: MemoryPolicy,
     pub contract: ManifestContract,
+    /// Identity-declared seed goals. Empty => use `DEFAULT_SEED_GOALS` (#3125).
+    pub seed_goals: Vec<SeedGoal>,
+    /// Target repo set for goals/observations. Empty => union of
+    /// `seed_goals[].repo` (#3125). Never scopes to `rysweet/Simard`.
+    pub target_repos: Vec<String>,
+    /// Write-authority posture (the read-only switch). Default `Full`.
+    pub authority: IdentityAuthority,
 }
 
 impl IdentityManifest {
@@ -46,7 +186,54 @@ impl IdentityManifest {
             default_mode,
             memory_policy,
             contract,
+            seed_goals: Vec::new(),
+            target_repos: Vec::new(),
+            authority: IdentityAuthority::default(),
         })
+    }
+
+    /// Attach identity-declared seed goals (override for `DEFAULT_SEED_GOALS`).
+    /// Additive builder: the default is an empty list (Simard's defaults).
+    #[must_use]
+    pub fn with_seed_goals(mut self, seed_goals: Vec<SeedGoal>) -> Self {
+        self.seed_goals = seed_goals;
+        self
+    }
+
+    /// Attach an explicit target-repo scope. Additive builder; the default is
+    /// empty (resolved as the union of `seed_goals[].repo`).
+    #[must_use]
+    pub fn with_target_repos(mut self, target_repos: Vec<String>) -> Self {
+        self.target_repos = target_repos;
+        self
+    }
+
+    /// Attach a write-authority posture. Additive builder; the default is
+    /// [`IdentityAuthority::default`] (`Full`), so Simard is unchanged.
+    #[must_use]
+    pub fn with_authority(mut self, authority: IdentityAuthority) -> Self {
+        self.authority = authority;
+        self
+    }
+
+    /// The resolved target-repo set: the explicit `target_repos` when present,
+    /// otherwise the de-duplicated union of the `repo` slugs on `seed_goals`.
+    /// A read-only identity with an empty resolved set scopes to nothing and
+    /// (fail-closed) never falls back to the daemon's own repo (#3125).
+    pub fn resolved_target_repos(&self) -> Vec<String> {
+        if !self.target_repos.is_empty() {
+            return self.target_repos.clone();
+        }
+        let mut seen = BTreeSet::new();
+        let mut union = Vec::new();
+        for goal in &self.seed_goals {
+            if let Some(repo) = &goal.repo
+                && seen.insert(repo.clone())
+            {
+                union.push(repo.clone());
+            }
+        }
+        union
     }
 
     pub fn with_components(
@@ -253,5 +440,130 @@ mod tests {
         assert!(manifest.supports_base_type(&BaseTypeId::new("local-harness")));
         assert!(manifest.supports_base_type(&BaseTypeId::new("rusty-clawd")));
         assert!(!manifest.supports_base_type(&BaseTypeId::new("nonexistent")));
+    }
+
+    // --- #3125: identity-scoped cognition fields ---
+
+    fn base_manifest() -> IdentityManifest {
+        IdentityManifest::new(
+            "test-identity",
+            "0.1.0",
+            vec![],
+            vec![BaseTypeId::new("local-harness")],
+            capability_set([]),
+            OperatingMode::Engineer,
+            MemoryPolicy::default(),
+            test_contract(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn manifest_defaults_leave_simard_unchanged() {
+        // A manifest built via `new` (as every built-in loader does) must have
+        // NO identity seed goals, NO explicit target scope, and a `Full`
+        // posture — this is the invariant that keeps Simard herself unchanged.
+        let manifest = base_manifest();
+        assert!(manifest.seed_goals.is_empty());
+        assert!(manifest.target_repos.is_empty());
+        assert_eq!(manifest.authority, IdentityAuthority::default());
+        assert_eq!(manifest.authority.posture, WritePosture::Full);
+        assert!(manifest.authority.permits_spawn());
+        assert!(manifest.resolved_target_repos().is_empty());
+    }
+
+    #[test]
+    fn write_posture_default_is_full() {
+        assert_eq!(WritePosture::default(), WritePosture::Full);
+    }
+
+    #[test]
+    fn write_posture_permits_writes_matrix() {
+        assert!(WritePosture::Full.permits_writes());
+        assert!(WritePosture::ScopedWrite.permits_writes());
+        assert!(!WritePosture::ReadOnly.permits_writes());
+    }
+
+    #[test]
+    fn write_posture_parses_and_displays_kebab_case() {
+        assert_eq!(
+            "read-only".parse::<WritePosture>().unwrap(),
+            WritePosture::ReadOnly
+        );
+        assert_eq!(
+            "scoped-write".parse::<WritePosture>().unwrap(),
+            WritePosture::ScopedWrite
+        );
+        assert_eq!("full".parse::<WritePosture>().unwrap(), WritePosture::Full);
+        assert!("read_write".parse::<WritePosture>().is_err());
+        assert_eq!(WritePosture::ReadOnly.to_string(), "read-only");
+        assert_eq!(WritePosture::ScopedWrite.to_string(), "scoped-write");
+        assert_eq!(WritePosture::Full.to_string(), "full");
+    }
+
+    #[test]
+    fn identity_authority_default_is_full_all_allowed() {
+        let a = IdentityAuthority::default();
+        assert_eq!(a.posture, WritePosture::Full);
+        assert!(a.allow_git_push);
+        assert!(a.allow_ado_writes);
+        assert!(a.allow_github_writes);
+        assert!(a.allowed_write_repos.is_empty());
+        assert!(a.permits_spawn());
+    }
+
+    #[test]
+    fn identity_authority_read_only_denies_all() {
+        let a = IdentityAuthority::read_only();
+        assert_eq!(a.posture, WritePosture::ReadOnly);
+        assert!(!a.allow_git_push);
+        assert!(!a.allow_ado_writes);
+        assert!(!a.allow_github_writes);
+        assert!(!a.permits_spawn());
+    }
+
+    #[test]
+    fn with_seed_goals_and_authority_are_additive() {
+        let manifest = base_manifest()
+            .with_seed_goals(vec![
+                SeedGoal::new(
+                    1,
+                    "Observe hyenas repo health",
+                    "OBSERVE ONLY",
+                    Some("hyenas".into()),
+                ),
+                SeedGoal::new(
+                    2,
+                    "Articulate repo-hygiene backlog",
+                    "propose goals",
+                    Some("hyenas".into()),
+                ),
+            ])
+            .with_authority(IdentityAuthority::read_only());
+        assert_eq!(manifest.seed_goals.len(), 2);
+        assert_eq!(manifest.authority.posture, WritePosture::ReadOnly);
+        // target scope falls back to the union of the seed goals' repos.
+        assert_eq!(manifest.resolved_target_repos(), vec!["hyenas".to_string()]);
+    }
+
+    #[test]
+    fn resolved_target_repos_prefers_explicit_over_union() {
+        let manifest = base_manifest()
+            .with_seed_goals(vec![SeedGoal::new(1, "g", "d", Some("hyenas".into()))])
+            .with_target_repos(vec!["explicit-target".into()]);
+        assert_eq!(
+            manifest.resolved_target_repos(),
+            vec!["explicit-target".to_string()]
+        );
+    }
+
+    #[test]
+    fn resolved_target_repos_dedups_union() {
+        let manifest = base_manifest().with_seed_goals(vec![
+            SeedGoal::new(1, "a", "d", Some("hyenas".into())),
+            SeedGoal::new(2, "b", "d", Some("hyenas".into())),
+            SeedGoal::new(3, "c", "d", None),
+        ]);
+        assert_eq!(manifest.resolved_target_repos(), vec!["hyenas".to_string()]);
     }
 }

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -14,7 +14,9 @@ mod coverage_tests;
 pub use contract::ManifestContract;
 pub use file_loader::FileIdentityLoader;
 pub use loader::{BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader};
-pub use manifest::{IdentityManifest, compose_with_precedence};
+pub use manifest::{
+    IdentityAuthority, IdentityManifest, SeedGoal, WritePosture, compose_with_precedence,
+};
 pub use types::{MemoryPolicy, OperatingMode};
 
 #[cfg(test)]

--- a/src/identity/toml_types.rs
+++ b/src/identity/toml_types.rs
@@ -43,6 +43,53 @@ pub(crate) struct TomlIdentity {
     pub components: Vec<String>,
     #[serde(default)]
     pub memory_policy: Option<TomlMemoryPolicy>,
+    /// Identity seed goals (#3125). When non-empty they OVERRIDE
+    /// `DEFAULT_SEED_GOALS` at the OODA cold-start seeding site.
+    #[serde(default)]
+    pub seed_goals: Vec<TomlSeedGoal>,
+    /// Target repo set for goals/observations (#3125). Empty => union of
+    /// `seed_goals[].repo`.
+    #[serde(default)]
+    pub target_repos: Vec<String>,
+    /// Write-authority posture (#3125 / #3067). Absent => `full` (default).
+    #[serde(default)]
+    pub authority: Option<TomlAuthority>,
+}
+
+/// A `[[identities.seed_goals]]` entry (#3125). Mirrors the shape of a
+/// `DEFAULT_SEED_GOALS` tuple `(priority, title, description, Option<repo>)`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlSeedGoal {
+    pub priority: u32,
+    pub title: String,
+    pub description: String,
+    #[serde(default)]
+    pub repo: Option<String>,
+}
+
+/// An optional `[identities.authority]` table (#3125 / #3067). The read-only
+/// switch for the observe-only Act phase. `allow_*` are `Option<bool>` so an
+/// explicit `true` under `posture = "read-only"` can be rejected as a
+/// contradiction (rather than silently coerced) while an omitted field takes a
+/// posture-dependent default.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlAuthority {
+    #[serde(default = "default_posture")]
+    pub posture: String,
+    #[serde(default)]
+    pub allowed_write_repos: Vec<String>,
+    #[serde(default)]
+    pub allow_git_push: Option<bool>,
+    #[serde(default)]
+    pub allow_ado_writes: Option<bool>,
+    #[serde(default)]
+    pub allow_github_writes: Option<bool>,
+}
+
+fn default_posture() -> String {
+    "full".to_string()
 }
 
 /// A `[[identities.prompt_assets]]` entry.
@@ -391,5 +438,116 @@ path = "b.md"
         assert_eq!(file.identities[0].prompt_assets.len(), 2);
         assert_eq!(file.identities[0].prompt_assets[0].id, "system-a");
         assert_eq!(file.identities[0].prompt_assets[1].id, "system-b");
+    }
+
+    // --- #3125: seed_goals / target_repos / authority ---
+
+    #[test]
+    fn parse_identity_scoped_cognition_fields() {
+        let toml_str = r#"
+[package]
+name = "crocutus"
+version = "0.1.0"
+
+[[identities]]
+name = "crocutus"
+default_mode = "engineer"
+target_repos = ["hyenas"]
+
+[[identities.seed_goals]]
+priority = 1
+title = "Observe hyenas repo health"
+description = "OBSERVE ONLY"
+repo = "hyenas"
+
+[identities.authority]
+posture = "read-only"
+"#;
+        let file: TomlIdentityFile = toml::from_str(toml_str).unwrap();
+        let identity = &file.identities[0];
+        assert_eq!(identity.target_repos, vec!["hyenas".to_string()]);
+        assert_eq!(identity.seed_goals.len(), 1);
+        assert_eq!(identity.seed_goals[0].priority, 1);
+        assert_eq!(identity.seed_goals[0].title, "Observe hyenas repo health");
+        assert_eq!(identity.seed_goals[0].repo.as_deref(), Some("hyenas"));
+        let authority = identity.authority.as_ref().unwrap();
+        assert_eq!(authority.posture, "read-only");
+        assert!(authority.allowed_write_repos.is_empty());
+        assert_eq!(authority.allow_git_push, None);
+    }
+
+    #[test]
+    fn cognition_fields_default_empty_and_absent() {
+        // Simard-equivalent identity: no seed goals, no targets, no authority.
+        let file: TomlIdentityFile = toml::from_str(MINIMAL_TOML).unwrap();
+        assert!(file.identities[0].seed_goals.is_empty());
+        assert!(file.identities[0].target_repos.is_empty());
+        assert!(file.identities[0].authority.is_none());
+    }
+
+    #[test]
+    fn authority_posture_defaults_to_full_when_block_present() {
+        let toml_str = r#"
+[package]
+name = "test"
+version = "0.1.0"
+
+[[identities]]
+name = "test"
+default_mode = "engineer"
+
+[identities.authority]
+"#;
+        let file: TomlIdentityFile = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            file.identities[0].authority.as_ref().unwrap().posture,
+            "full"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_unknown_seed_goal_field() {
+        let toml_str = r#"
+[package]
+name = "test"
+version = "0.1.0"
+
+[[identities]]
+name = "test"
+default_mode = "engineer"
+
+[[identities.seed_goals]]
+priority = 1
+title = "g"
+description = "d"
+weight = 5
+"#;
+        let result: Result<TomlIdentityFile, _> = toml::from_str(toml_str);
+        assert!(
+            result.is_err(),
+            "unknown field in seed_goals should be rejected by deny_unknown_fields"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_unknown_authority_field() {
+        let toml_str = r#"
+[package]
+name = "test"
+version = "0.1.0"
+
+[[identities]]
+name = "test"
+default_mode = "engineer"
+
+[identities.authority]
+posture = "full"
+mystery = true
+"#;
+        let result: Result<TomlIdentityFile, _> = toml::from_str(toml_str);
+        assert!(
+            result.is_err(),
+            "unknown field in authority should be rejected by deny_unknown_fields"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,8 +300,8 @@ pub use handoff::{
     RuntimeHandoffStore,
 };
 pub use identity::{
-    BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, IdentityManifest, ManifestContract,
-    MemoryPolicy, OperatingMode,
+    BuiltinIdentityLoader, IdentityAuthority, IdentityLoadRequest, IdentityLoader,
+    IdentityManifest, ManifestContract, MemoryPolicy, OperatingMode, SeedGoal, WritePosture,
 };
 pub use identity_auth::{
     AuthIdentity, DualIdentityConfig, env_for_identity, identity_for_operation,

--- a/src/ooda_actions/advance_goal/spawn.rs
+++ b/src/ooda_actions/advance_goal/spawn.rs
@@ -101,6 +101,65 @@ fn observe_only_dispatch_refusal(action: &PlannedAction, goal_id: &str) -> Optio
     ))
 }
 
+/// Deterministic spawn rail (#3125) — the thin, pure, default-DENY predicate the
+/// agentic Act cognition runs behind.
+///
+/// Returns `true` only for a definitively *writing* posture (`Full` /
+/// `ScopedWrite`). Semantics:
+///
+/// - `None` — no identity is resolved. This deterministically resolves to
+///   `Full` (Simard's own default), so Simard is unaffected and spawns proceed.
+/// - `Some(Full | ScopedWrite)` — a writing identity: spawn permitted.
+/// - `Some(ReadOnly)` — a bounded observer: spawn denied.
+///
+/// An *unresolved* posture under a named identity must be encoded by the caller
+/// as `Some(IdentityAuthority::read_only())` so it too denies — the rail never
+/// spawns when authority is uncertain (fail-closed). There is no wall-clock
+/// timeout and no fallback-to-dispatch anywhere on this path.
+///
+/// This mirrors the existing `dispatch_spawn_engineer` pattern of an agentic
+/// brain decision paired with a deterministic safeguard: here the safeguard is
+/// this predicate rather than the 3-strikes counter.
+pub fn posture_permits_spawn(authority: Option<&crate::identity::IdentityAuthority>) -> bool {
+    match authority {
+        None => true,
+        Some(a) => a.permits_spawn(),
+    }
+}
+
+/// Cognition-level observe-only refusal (#3125). Returns `Some(outcome)` when the
+/// resolved identity's write-authority posture forbids dispatching a
+/// write-bearing engineer, so the Act phase takes the observe-only branch
+/// *before* ever reaching the shipped `observe_only_dispatch_refusal` floor.
+///
+/// The outcome is `success = true`: for a read-only observer, *declining to
+/// dispatch* is the correct behaviour — it must not bump goal-failure counters
+/// or trip the no-progress breaker. Records which identity/posture refused.
+fn posture_observe_only_refusal(
+    action: &PlannedAction,
+    goal_id: &str,
+    authority: Option<&crate::identity::IdentityAuthority>,
+    identity_name: Option<&str>,
+) -> Option<ActionOutcome> {
+    if posture_permits_spawn(authority) {
+        return None;
+    }
+    let who = identity_name.unwrap_or("identity");
+    let posture = authority
+        .map(|a| a.posture.to_string())
+        .unwrap_or_else(|| "read-only".to_string());
+    Some(make_outcome(
+        action,
+        true,
+        format!(
+            "observe-only (cognition): {who} write-authority posture is '{posture}', so goal \
+             '{goal_id}' takes the observe-only branch — proposes/observes on its own \
+             target-scoped board and dispatches 0 engineer(s). No write-bearing engineer is \
+             spawned. Rail: posture_permits_spawn."
+        ),
+    ))
+}
+
 /// Spawn a subordinate engineer for a goal that the LLM picked
 /// `spawn_engineer` for, then mutate the active board to record the
 /// assignment.
@@ -126,6 +185,38 @@ pub fn dispatch_spawn_engineer(
     brain: &dyn OodaBrain,
     repo_root: &Path,
 ) -> ActionOutcome {
+    // ── Cognition-level observe-only rail (#3125) ───────────────────────────
+    // Defense in depth ABOVE the shipped write-primitive floor below. If the
+    // resolved identity's write-authority posture does not permit a
+    // write-bearing engineer (posture = read-only, or an unresolved posture
+    // under a named identity, encoded fail-closed), take the observe-only branch
+    // BEFORE any brain decision, worktree, or subprocess: the identity observes
+    // and proposes on its own target-scoped board and dispatches 0 engineers.
+    // A read-only identity therefore never even *reaches* the env floor for a
+    // write-bearing action, saving the credits the brain would burn deciding to
+    // spawn. No identity (None) resolves to `full`, so Simard is unaffected.
+    {
+        let (authority, identity_name) = {
+            let guard = lock_state(state);
+            (
+                guard.identity_cognition.authority.clone(),
+                guard.identity_cognition.identity_name.clone(),
+            )
+        };
+        if let Some(refusal) = posture_observe_only_refusal(
+            action,
+            goal_id,
+            authority.as_ref(),
+            identity_name.as_deref(),
+        ) {
+            eprintln!(
+                "[simard] Act: observe-only posture ({}) — refusing engineer dispatch for goal '{goal_id}', dispatched 0 engineer(s)",
+                identity_name.as_deref().unwrap_or("identity")
+            );
+            return refusal;
+        }
+    }
+
     // ── Observe-only floor (issue #1, Crocutus) ─────────────────────────────
     // A read-only identity (SIMARD_OBSERVE_ONLY=1) is a bounded OBSERVER: it may
     // reason about goals but must never dispatch a write-bearing engineer, which
@@ -1069,6 +1160,164 @@ mod tests {
         assert!(
             observe_only_dispatch_refusal(&action, "ship-feature").is_none(),
             "engineer identity (env unset) must not be short-circuited"
+        );
+    }
+
+    // ── #3125: cognition-level observe-only rail (posture_permits_spawn) ──────
+    // Pure-function coverage plus an end-to-end proof that dispatch_spawn_engineer
+    // takes the observe-only branch under a read-only posture WITHOUT ever
+    // consulting the brain or spawning a worktree. These are hermetic (no env, no
+    // subprocess) — the read-only rail returns before any of that.
+
+    use crate::identity::{IdentityAuthority, WritePosture};
+
+    fn authority(posture: WritePosture) -> IdentityAuthority {
+        IdentityAuthority {
+            posture,
+            ..IdentityAuthority::default()
+        }
+    }
+
+    #[test]
+    fn posture_permits_spawn_default_deny_matrix() {
+        // No identity resolves deterministically to `full` => Simard spawns.
+        assert!(posture_permits_spawn(None));
+        // A writing posture permits spawn.
+        assert!(posture_permits_spawn(Some(&authority(WritePosture::Full))));
+        assert!(posture_permits_spawn(Some(&authority(
+            WritePosture::ScopedWrite
+        ))));
+        // A read-only posture NEVER permits spawn (fail-closed cognition rail).
+        assert!(!posture_permits_spawn(
+            Some(&IdentityAuthority::read_only())
+        ));
+        assert!(!posture_permits_spawn(Some(&authority(
+            WritePosture::ReadOnly
+        ))));
+    }
+
+    #[test]
+    fn posture_observe_only_refusal_none_for_writing_postures() {
+        let action = advance_action("observe-hyenas");
+        assert!(
+            posture_observe_only_refusal(&action, "observe-hyenas", None, None).is_none(),
+            "no identity (full) must not take the observe-only branch"
+        );
+        assert!(
+            posture_observe_only_refusal(
+                &action,
+                "observe-hyenas",
+                Some(&authority(WritePosture::Full)),
+                Some("simard-engineer"),
+            )
+            .is_none(),
+            "a full identity must not take the observe-only branch"
+        );
+    }
+
+    #[test]
+    fn posture_observe_only_refusal_records_read_only_branch() {
+        let action = advance_action("observe-hyenas");
+        let outcome = posture_observe_only_refusal(
+            &action,
+            "observe-hyenas",
+            Some(&IdentityAuthority::read_only()),
+            Some("crocutus"),
+        )
+        .expect("read-only posture must take the observe-only branch");
+        // Declining to dispatch is correct behaviour, not a failure.
+        assert!(
+            outcome.success,
+            "observer refusal must not count as failure"
+        );
+        assert!(
+            outcome.detail.contains("observe-only (cognition)")
+                && outcome.detail.contains("crocutus")
+                && outcome.detail.contains("read-only")
+                && outcome.detail.contains("0 engineer")
+                && outcome.detail.contains("posture_permits_spawn"),
+            "refusal detail must name the identity, posture, and rail; got: {}",
+            outcome.detail
+        );
+    }
+
+    /// A brain that panics on any decision — proves the read-only rail
+    /// short-circuits BEFORE any (credit-spending) brain reasoning.
+    struct PanicBrain;
+
+    impl crate::ooda_brain::OodaBrain for PanicBrain {
+        fn decide_engineer_lifecycle(
+            &self,
+            _ctx: &crate::ooda_brain::EngineerLifecycleCtx,
+        ) -> crate::error::SimardResult<crate::ooda_brain::EngineerLifecycleDecision> {
+            panic!("read-only cognition rail must not consult the brain");
+        }
+    }
+
+    #[test]
+    fn dispatch_spawn_engineer_read_only_cognition_never_spawns_or_reasons() {
+        let cognition = crate::ooda_loop::IdentityCognition {
+            identity_name: Some("crocutus".to_string()),
+            seed_goals: Vec::new(),
+            target_repos: vec!["hyenas".to_string()],
+            authority: Some(IdentityAuthority::read_only()),
+        };
+        let mut state = OodaState::new(crate::goal_curation::GoalBoard::new())
+            .with_identity_cognition(cognition);
+        let state_mx = std::sync::Mutex::new(&mut state);
+        let action = advance_action("observe-hyenas-branch-hygiene");
+        let repo_root = tempfile::tempdir().unwrap();
+
+        // If the cognition rail works, PanicBrain is never called and no
+        // worktree/subprocess is launched.
+        let outcome = dispatch_spawn_engineer(
+            &action,
+            &state_mx,
+            "observe-hyenas-branch-hygiene",
+            "propose repo-hygiene goals for hyenas",
+            &PanicBrain,
+            repo_root.path(),
+        );
+
+        assert!(
+            outcome.success,
+            "observe-only dispatch must be a success outcome, got: {}",
+            outcome.detail
+        );
+        assert!(
+            outcome.detail.contains("observe-only (cognition)")
+                && outcome.detail.contains("0 engineer"),
+            "read-only identity must take the observe-only branch; got: {}",
+            outcome.detail
+        );
+        // No engineer was assigned or worktree registered.
+        assert!(state.engineer_worktrees.is_empty());
+        assert!(
+            state
+                .active_goals
+                .active
+                .iter()
+                .all(|g| g.assigned_to.is_none())
+        );
+    }
+
+    #[test]
+    fn identity_cognition_default_permits_spawn_simard_unchanged() {
+        // The default carrier (no identity) must permit spawn so Simard's Act
+        // phase is byte-for-byte unchanged.
+        let cognition = crate::ooda_loop::IdentityCognition::default();
+        assert!(cognition.permits_spawn());
+        assert!(cognition.authority.is_none());
+        let action = advance_action("ship-feature");
+        assert!(
+            posture_observe_only_refusal(
+                &action,
+                "ship-feature",
+                cognition.authority.as_ref(),
+                cognition.identity_name.as_deref(),
+            )
+            .is_none(),
+            "Simard (no identity) must never take the observe-only branch"
         );
     }
 }

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -128,10 +128,32 @@ fn run_ooda_cycle_inner(
     // to avoid false-positive clearing in non-tmux environments.
     sweep_stale_assignments(&mut state.active_goals);
 
-    // Seed with default goals if the board is still empty.
-    let seeded = crate::goal_curation::seed_default_board(&mut state.active_goals);
-    if seeded > 0 {
-        eprintln!("[simard] OODA start: seeded {seeded} default goal(s)");
+    // Seed with the identity's seed goals (override) or the defaults if the
+    // board is still empty (#3125). When the resolved identity declares its own
+    // `seed_goals` they REPLACE Simard's baked-in DEFAULT_SEED_GOALS at this
+    // cold-start seeding site; with no identity (or a `full` identity that
+    // declares none) the five defaults seed exactly as before — Simard herself
+    // is unchanged. Goals carry the identity's target-repo slug, so they are
+    // scoped to its targets, never to rysweet/Simard.
+    let identity_seed_goals = &state.identity_cognition.seed_goals;
+    if !identity_seed_goals.is_empty() {
+        let goals = crate::goal_curation::resolve_seed_goals(identity_seed_goals);
+        let n = crate::goal_curation::seed_board_from_seed_goals(&mut state.active_goals, &goals);
+        if n > 0 {
+            let who = state
+                .identity_cognition
+                .identity_name
+                .as_deref()
+                .unwrap_or("identity");
+            eprintln!(
+                "[simard] OODA start: seeded {n} identity seed goal(s) ({who}) — overriding defaults"
+            );
+        }
+    } else {
+        let n = crate::goal_curation::seed_default_board(&mut state.active_goals);
+        if n > 0 {
+            eprintln!("[simard] OODA start: seeded {n} default goal(s)");
+        }
     }
 
     // Ingest meeting handoff decisions as new goals.

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -82,9 +82,9 @@ pub use priority_kind::{SyntheticPriorityKind, is_synthetic_id};
 pub use review::review_outcomes;
 pub use summary::summarize_cycle_report;
 pub use types::{
-    ActionKind, ActionOutcome, CycleReport, EnvironmentSnapshot, GoalSnapshot, Observation,
-    OodaClients, OodaConfig, OodaPhase, OodaState, OodaStateSnapshot, OrchestratorSessionFactory,
-    PlannedAction, Priority,
+    ActionKind, ActionOutcome, CycleReport, EnvironmentSnapshot, GoalSnapshot, IdentityCognition,
+    Observation, OodaClients, OodaConfig, OodaPhase, OodaState, OodaStateSnapshot,
+    OrchestratorSessionFactory, PlannedAction, Priority,
 };
 
 use crate::error::SimardResult;

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -35,6 +35,52 @@ impl Display for OodaPhase {
     }
 }
 
+/// Resolved identity-scoped cognition threaded into the OODA loop (#3125).
+///
+/// This is the small, OODA-facing projection of an [`IdentityManifest`]'s three
+/// cognition fields — identity seed goals, target-repo scope, and write-authority
+/// posture — carried on [`OodaState`] so the cold-start seeding site and the Act
+/// dispatch rail can consult them without threading the whole manifest.
+///
+/// [`IdentityCognition::default`] represents **Simard herself** (no identity): no
+/// seed-goal override, no explicit target scope, and `authority: None` — which
+/// [`crate::ooda_actions::advance_goal::spawn::posture_permits_spawn`] resolves
+/// to `Full`, so the default is byte-for-byte the pre-#3125 behaviour.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct IdentityCognition {
+    /// The resolved identity's name, when one is set (for operator diagnostics).
+    pub identity_name: Option<String>,
+    /// Identity-declared seed goals. Empty => use `DEFAULT_SEED_GOALS`.
+    pub seed_goals: Vec<crate::identity::SeedGoal>,
+    /// Resolved target-repo scope (explicit or the union of seed-goal repos).
+    pub target_repos: Vec<String>,
+    /// Write-authority posture. `None` => no identity => `Full` (Simard). A named
+    /// identity whose posture cannot be resolved must be encoded as
+    /// `Some(IdentityAuthority::read_only())` (fail-closed).
+    pub authority: Option<crate::identity::IdentityAuthority>,
+}
+
+impl IdentityCognition {
+    /// Project the cognition-relevant fields out of a resolved identity manifest.
+    /// A named identity always yields `Some(authority)` so the deterministic
+    /// spawn rail treats it as an identity (never as "no identity").
+    pub fn from_manifest(manifest: &crate::identity::IdentityManifest) -> Self {
+        Self {
+            identity_name: Some(manifest.name.clone()),
+            seed_goals: manifest.seed_goals.clone(),
+            target_repos: manifest.resolved_target_repos(),
+            authority: Some(manifest.authority.clone()),
+        }
+    }
+
+    /// Whether this identity's posture permits dispatching a write-bearing
+    /// engineer. Delegates to the deterministic rail's semantics: no identity
+    /// (`None`) and `Full`/`ScopedWrite` permit; `ReadOnly` does not.
+    pub fn permits_spawn(&self) -> bool {
+        crate::ooda_actions::advance_goal::spawn::posture_permits_spawn(self.authority.as_ref())
+    }
+}
+
 /// Mutable state carried across OODA cycles.
 pub struct OodaState {
     pub current_phase: OodaPhase,
@@ -80,6 +126,9 @@ pub struct OodaState {
     /// done-gate ladder (mark done / drop / escalate). See
     /// `docs/concepts/steerable-ooda-daemon.md` ("The no-progress breaker (Fix 3)").
     pub no_progress_tracker: crate::goal_curation::NoProgressTracker,
+    /// Resolved identity-scoped cognition (#3125). `Default` (no identity) keeps
+    /// Simard unchanged: default seed goals + engineer-dispatching Act phase.
+    pub identity_cognition: IdentityCognition,
 }
 
 impl OodaState {
@@ -98,7 +147,16 @@ impl OodaState {
             engineer_worktrees: HashMap::new(),
             last_distill_cycle: 0,
             no_progress_tracker: crate::goal_curation::NoProgressTracker::new(),
+            identity_cognition: IdentityCognition::default(),
         }
+    }
+
+    /// Attach resolved identity-scoped cognition (#3125). Additive builder; the
+    /// default is [`IdentityCognition::default`] (no identity => Simard).
+    #[must_use]
+    pub fn with_identity_cognition(mut self, cognition: IdentityCognition) -> Self {
+        self.identity_cognition = cognition;
+        self
     }
 
     /// Remove `goal_failure_counts` entries for goal IDs that are no longer

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -57,6 +57,101 @@ fn seed_cycle_count(persistent_cycle_count: u32, state_root: &std::path::Path) -
     }
 }
 
+/// Resolve the identity-scoped cognition (#3125) for the daemon from the
+/// environment, **fail-closed**.
+///
+/// - `SIMARD_IDENTITY` unset/blank → no identity → [`crate::ooda_loop::IdentityCognition::default`]
+///   (Simard herself: default seed goals + engineer-dispatching Act phase — unchanged).
+/// - `SIMARD_IDENTITY` set and the manifest resolves → project its seed goals,
+///   target scope, and write-authority posture via
+///   [`crate::ooda_loop::IdentityCognition::from_manifest`].
+/// - `SIMARD_IDENTITY` set but the manifest CANNOT be resolved → fail-closed:
+///   install a `read-only` posture so the observe-only rail denies every engineer
+///   dispatch. A named identity whose posture is uncertain never spawns (operator
+///   constraint #3125). There is no wall-clock timeout and no fallback-to-dispatch.
+fn resolve_daemon_identity_cognition() -> crate::ooda_loop::IdentityCognition {
+    use crate::ooda_loop::IdentityCognition;
+
+    let identity_name = match std::env::var("SIMARD_IDENTITY") {
+        Ok(name) if !name.trim().is_empty() => name,
+        _ => return IdentityCognition::default(),
+    };
+
+    let prompt_root = std::env::var_os("SIMARD_PROMPT_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets"));
+    let identity_path = std::env::var_os("SIMARD_IDENTITY_PATH").map(PathBuf::from);
+
+    let freshness = match crate::Freshness::now() {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!(
+                "[simard] OODA daemon: identity cognition FAIL-CLOSED for '{identity_name}': \
+                 freshness error: {e}; installing read-only posture (0 engineer dispatch)"
+            );
+            return fail_closed_identity_cognition(&identity_name);
+        }
+    };
+    let contract = match crate::ManifestContract::new(
+        concat!(module_path!(), "::resolve_daemon_identity_cognition"),
+        "ooda-daemon -> identity-loader -> identity-cognition",
+        vec![format!("identity:{identity_name}")],
+        crate::Provenance::runtime(format!("ooda-daemon/identity-cognition/{identity_name}")),
+        freshness,
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "[simard] OODA daemon: identity cognition FAIL-CLOSED for '{identity_name}': \
+                 contract error: {e}; installing read-only posture (0 engineer dispatch)"
+            );
+            return fail_closed_identity_cognition(&identity_name);
+        }
+    };
+
+    match crate::bootstrap::assembly::load_identity(
+        identity_path.as_ref(),
+        &prompt_root,
+        &crate::IdentityLoadRequest::new(
+            identity_name.clone(),
+            env!("CARGO_PKG_VERSION"),
+            contract,
+        ),
+    ) {
+        Ok(manifest) => {
+            let cognition = IdentityCognition::from_manifest(&manifest);
+            eprintln!(
+                "[simard] OODA daemon: resolved identity cognition for '{}' — posture={}, \
+                 {} seed goal(s), targets={:?}",
+                manifest.name,
+                manifest.authority.posture,
+                cognition.seed_goals.len(),
+                cognition.target_repos,
+            );
+            cognition
+        }
+        Err(e) => {
+            eprintln!(
+                "[simard] OODA daemon: identity cognition FAIL-CLOSED for '{identity_name}': \
+                 manifest load error: {e}; installing read-only posture (0 engineer dispatch)"
+            );
+            fail_closed_identity_cognition(&identity_name)
+        }
+    }
+}
+
+/// The fail-closed identity cognition: a named identity with a `read-only`
+/// posture and no seed-goal override, so the observe-only rail denies every
+/// engineer dispatch while leaving Simard's default seeding in place.
+fn fail_closed_identity_cognition(identity_name: &str) -> crate::ooda_loop::IdentityCognition {
+    crate::ooda_loop::IdentityCognition {
+        identity_name: Some(identity_name.to_string()),
+        seed_goals: Vec::new(),
+        target_repos: Vec::new(),
+        authority: Some(crate::identity::IdentityAuthority::read_only()),
+    }
+}
+
 /// Run one or more OODA cycles as a daemon-style loop.
 ///
 /// Launches all memories, opens a RustyClawd session via [`SessionBuilder`]
@@ -442,6 +537,11 @@ pub fn run_ooda_daemon(
     let board = crate::goal_board_store::heal_stale_no_progress_blocks(board);
     let mut state = OodaState::new(board);
     state.no_progress_tracker = persistent.no_progress;
+    // #3125: resolve identity-scoped cognition (seed goals / target scope /
+    // write-authority posture) once at boot, fail-closed. No identity => Simard
+    // unchanged; a read-only identity seeds its own goals and takes the
+    // observe-only Act branch.
+    state.identity_cognition = resolve_daemon_identity_cognition();
     // Seed the OODA cycle counter from durable brain memory so the cycle number
     // reflects the brain's total lived cognition and CONTINUES across restarts,
     // instead of resetting to 1 on every daemon restart / deploy (issue #1).

--- a/tests/issue_3125_identity_scoped_cognition.rs
+++ b/tests/issue_3125_identity_scoped_cognition.rs
@@ -1,0 +1,244 @@
+//! Integration tests for #3125 — identity-scoped cognition.
+//!
+//! These prove the two acceptance criteria at the public API level:
+//!
+//! (a) **Simard is unchanged by default.** With no identity (or a `full`
+//!     identity that declares no seed goals) the five `DEFAULT_SEED_GOALS` seed
+//!     exactly as before and the deterministic spawn rail permits engineer
+//!     dispatch.
+//!
+//! (b) **A read-only identity shapes cognition.** It seeds its OWN goals
+//!     (overriding the defaults), scopes them to its target repos (never
+//!     `rysweet/Simard`), and its write-authority posture makes the observe-only
+//!     rail deny engineer dispatch (fail-closed).
+//!
+//! The Act-phase dispatch rail itself (`dispatch_spawn_engineer` taking the
+//! observe-only branch without ever consulting the brain) is proven by the
+//! in-crate unit tests in `src/ooda_actions/advance_goal/spawn.rs`; that
+//! function is `pub(crate)` and cannot be reached from an integration test.
+
+use simard::goal_curation::{
+    DEFAULT_SEED_GOALS, GoalBoard, default_seed_goals, resolve_seed_goals,
+    seed_board_from_seed_goals, seed_default_board,
+};
+use simard::ooda_loop::IdentityCognition;
+use simard::{
+    BuiltinIdentityLoader, Freshness, IdentityAuthority, IdentityLoadRequest, IdentityLoader,
+    IdentityManifest, ManifestContract, Provenance, SeedGoal, WritePosture,
+};
+
+fn test_contract() -> ManifestContract {
+    ManifestContract::new(
+        "test::entrypoint",
+        "a -> b",
+        vec!["key:value".to_string()],
+        Provenance::new("test-source", "test-locator"),
+        Freshness::now().unwrap(),
+    )
+    .unwrap()
+}
+
+/// A read-only observer identity (Crocutus-shaped) built through the public
+/// builder API — the same surface `FileIdentityLoader` produces from
+/// `identity.toml`.
+fn crocutus_manifest() -> IdentityManifest {
+    IdentityManifest::new(
+        "crocutus",
+        "0.1.0",
+        vec![],
+        vec![],
+        std::collections::BTreeSet::new(),
+        simard::OperatingMode::Engineer,
+        simard::MemoryPolicy::default(),
+        test_contract(),
+    )
+    .unwrap()
+    .with_seed_goals(vec![
+        SeedGoal::new(
+            1,
+            "Observe hyenas repo health",
+            "Assess branch hygiene, CODEOWNERS, LICENSE, dependabot, large blobs. OBSERVE ONLY.",
+            Some("hyenas".to_string()),
+        ),
+        SeedGoal::new(
+            2,
+            "Articulate repo-hygiene backlog",
+            "Turn observations into prioritized, target-scoped repo-hygiene goals.",
+            Some("hyenas".to_string()),
+        ),
+    ])
+    .with_authority(IdentityAuthority::read_only())
+}
+
+// ─────────────────────────── (a) Simard unchanged ───────────────────────────
+
+#[test]
+fn default_seed_goals_mirror_the_baked_in_defaults() {
+    let goals = default_seed_goals();
+    assert_eq!(goals.len(), 5, "Simard keeps her five defaults");
+    assert_eq!(goals.len(), DEFAULT_SEED_GOALS.len());
+    for (goal, (priority, title, description, repo)) in goals.iter().zip(DEFAULT_SEED_GOALS.iter())
+    {
+        assert_eq!(goal.priority, *priority);
+        assert_eq!(goal.title, *title);
+        assert_eq!(goal.description, *description);
+        assert_eq!(goal.repo.as_deref(), *repo);
+    }
+}
+
+#[test]
+fn resolve_seed_goals_falls_through_to_defaults_when_identity_declares_none() {
+    // Empty identity seed goals => Simard's defaults, unchanged.
+    assert_eq!(resolve_seed_goals(&[]), default_seed_goals());
+}
+
+#[test]
+fn identity_seeding_from_defaults_matches_seed_default_board() {
+    // The identity-shaped seeding path, when fed the defaults, is byte-for-byte
+    // the historical `seed_default_board` result: same ids, priorities, repos.
+    let mut baseline = GoalBoard::new();
+    let n_baseline = seed_default_board(&mut baseline);
+
+    let mut via_identity = GoalBoard::new();
+    let n_identity = seed_board_from_seed_goals(&mut via_identity, &resolve_seed_goals(&[]));
+
+    assert_eq!(n_baseline, 5);
+    assert_eq!(n_identity, 5);
+    assert_eq!(via_identity.active.len(), baseline.active.len());
+    for (a, b) in via_identity.active.iter().zip(baseline.active.iter()) {
+        assert_eq!(a.id, b.id);
+        assert_eq!(a.priority, b.priority);
+        assert_eq!(a.description, b.description);
+        assert_eq!(a.repo, b.repo);
+    }
+}
+
+#[test]
+fn no_identity_cognition_permits_spawn() {
+    let cognition = IdentityCognition::default();
+    assert!(cognition.authority.is_none());
+    assert!(cognition.seed_goals.is_empty());
+    assert!(cognition.target_repos.is_empty());
+    // No identity => `full` => the deterministic rail permits engineer dispatch.
+    assert!(cognition.permits_spawn());
+}
+
+#[test]
+fn builtin_simard_engineer_identity_is_full_and_declares_no_seed_goals() {
+    let loader = BuiltinIdentityLoader;
+    let manifest = loader
+        .load(&IdentityLoadRequest::new(
+            "simard-engineer",
+            "0.1.0",
+            test_contract(),
+        ))
+        .unwrap();
+    assert_eq!(manifest.authority.posture, WritePosture::Full);
+    assert!(manifest.authority.permits_spawn());
+    assert!(
+        manifest.seed_goals.is_empty(),
+        "Simard's built-in identity declares no seed-goal override"
+    );
+    assert!(manifest.target_repos.is_empty());
+
+    let cognition = IdentityCognition::from_manifest(&manifest);
+    assert!(
+        cognition.permits_spawn(),
+        "a full built-in identity must still dispatch engineers"
+    );
+    // With no seed-goal override, cold-start seeding uses the five defaults.
+    assert_eq!(
+        resolve_seed_goals(&cognition.seed_goals),
+        default_seed_goals()
+    );
+}
+
+// ────────────────────── (b) read-only identity shapes cognition ─────────────
+
+#[test]
+fn read_only_identity_seeds_its_own_target_scoped_goals() {
+    let crocutus = crocutus_manifest();
+    let cognition = IdentityCognition::from_manifest(&crocutus);
+
+    // Its own goals OVERRIDE Simard's defaults (no merge).
+    let resolved = resolve_seed_goals(&cognition.seed_goals);
+    assert_eq!(resolved.len(), 2, "override replaces the 5 defaults with 2");
+    assert_eq!(resolved[0].title, "Observe hyenas repo health");
+
+    // The override is distinct from Simard's defaults.
+    let default_titles: Vec<&str> = DEFAULT_SEED_GOALS.iter().map(|(_, t, _, _)| *t).collect();
+    for goal in &resolved {
+        assert!(
+            !default_titles.contains(&goal.title.as_str()),
+            "observer goal '{}' must not be one of Simard's defaults",
+            goal.title
+        );
+    }
+
+    // Seeding a fresh board yields ONLY the hyenas-scoped observer goals.
+    let mut board = GoalBoard::new();
+    let n = seed_board_from_seed_goals(&mut board, &resolved);
+    assert_eq!(n, 2);
+    assert_eq!(board.active.len(), 2);
+    for goal in &board.active {
+        assert_eq!(
+            goal.repo.as_deref(),
+            Some("hyenas"),
+            "every observer goal is scoped to the target repo, never rysweet/Simard"
+        );
+    }
+}
+
+#[test]
+fn read_only_identity_target_scope_resolves_to_targets_not_simard() {
+    let crocutus = crocutus_manifest();
+    let cognition = IdentityCognition::from_manifest(&crocutus);
+    assert_eq!(cognition.target_repos, vec!["hyenas".to_string()]);
+    assert!(
+        !cognition.target_repos.iter().any(|r| r.contains("Simard")),
+        "target scope must never point at rysweet/Simard"
+    );
+}
+
+#[test]
+fn read_only_posture_denies_engineer_dispatch_fail_closed() {
+    let crocutus = crocutus_manifest();
+    assert_eq!(crocutus.authority.posture, WritePosture::ReadOnly);
+    assert!(!crocutus.authority.permits_spawn());
+
+    let cognition = IdentityCognition::from_manifest(&crocutus);
+    assert_eq!(cognition.identity_name.as_deref(), Some("crocutus"));
+    // The Act-phase cognition rail denies dispatch for this identity.
+    assert!(
+        !cognition.permits_spawn(),
+        "a read-only identity must never dispatch a write-bearing engineer"
+    );
+}
+
+#[test]
+fn simard_and_read_only_identity_seed_divergent_boards() {
+    // Same cold-start seeding site, two identities, two different boards —
+    // the crux of #3125: identity shapes cognition.
+    let mut simard_board = GoalBoard::new();
+    seed_board_from_seed_goals(&mut simard_board, &resolve_seed_goals(&[]));
+
+    let crocutus = crocutus_manifest();
+    let mut crocutus_board = GoalBoard::new();
+    seed_board_from_seed_goals(
+        &mut crocutus_board,
+        &resolve_seed_goals(&crocutus.seed_goals),
+    );
+
+    assert_eq!(simard_board.active.len(), 5);
+    assert_eq!(crocutus_board.active.len(), 2);
+    let simard_ids: Vec<&str> = simard_board.active.iter().map(|g| g.id.as_str()).collect();
+    let crocutus_ids: Vec<&str> = crocutus_board
+        .active
+        .iter()
+        .map(|g| g.id.as_str())
+        .collect();
+    assert!(
+        crocutus_ids.iter().all(|id| !simard_ids.contains(id)),
+        "the observer's goals are disjoint from Simard's defaults"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #3125. Makes **IDENTITY shape COGNITION**, not just write primitives. A read-only
OBSERVER identity (e.g. **Crocutus** observing the hyenas AzDO repos) is now enforced at the
**cognition** level — *which goals get seeded* and *whether the Act phase may dispatch engineers
at all* — layered above the shipped write-primitive chokepoint (`read_only_guard` /
`SIMARD_OBSERVE_ONLY`, PR #3071). This closes the gap where a read-only identity inherited
Simard's `DEFAULT_SEED_GOALS` and burned AI credits deciding to spawn write-bearing engineers the
guardrail would always block.

**Simard's own behavior is unchanged by default** (no identity, or a `full`/read-write identity ⇒
same five `DEFAULT_SEED_GOALS`, same engineer-dispatching Act phase). Proven by tests.

Surface is kept small: identity config + one agentic Act-phase branch behind a thin deterministic
rail — no new imperative subsystem, nothing named "Bridge".

> Supersedes the closed #3196, which was built off a ~94-commits-stale checkout. This PR is the
> clean relaunch from a fresh `origin/main` base (0 behind, additive).

## Three first-class identity fields

1. **Seed goals from identity (override).** `IdentityManifest.seed_goals`; when non-empty they
   OVERRIDE `DEFAULT_SEED_GOALS` at the OODA cold-start seeding site (`ooda_loop::cycle`).
   `goal_curation` gains `default_seed_goals` / `resolve_seed_goals` / `seed_board_from_seed_goals`
   — one shape for both default and identity seeding. Simard with no identity keeps her five
   defaults.
2. **Observe-only Act phase.** `IdentityAuthority` / `WritePosture` (`ReadOnly | ScopedWrite |
   Full`, `#[default] Full`). The deterministic rail `posture_permits_spawn` (default-DENY) gates
   `dispatch_spawn_engineer`: a read-only posture takes the observe-only branch and **never
   consults the brain or spawns an engineer** — layered above the shipped
   `observe_only_dispatch_refusal` floor (defense in depth). No wall-clock timeouts; fails CLOSED
   (unresolved posture under a named identity ⇒ no spawn).
3. **Target scope.** `IdentityManifest.target_repos` (or the union of `seed_goals[].repo`) scopes
   goals/observations to the identity's targets, **never** `rysweet/Simard`.

## Wiring

- `IdentityCognition` carrier on `OodaState`; the daemon resolves it once at boot
  (`resolve_daemon_identity_cognition`), **fail-closed** — a named identity whose posture cannot be
  resolved installs a `read-only` authority so the rail denies every dispatch.
- TOML surface: `[[identities.seed_goals]]`, `target_repos`, `[identities.authority] posture` with
  `deny_unknown_fields` + read-only contradiction validation, mapped by `FileIdentityLoader`.
- Composition cannot **dilute** a read-only component's posture (`compose` takes the agreed posture;
  a composite declaring a weaker posture is a hard `IdentityTomlParseError`).
- `[simard]` eprintln operator-diagnostic convention throughout. No fallbacks / silent degradation.

## Constraints honored

- ✅ Simard unchanged with no identity / a `full` identity — same five seed goals, same
  engineer-dispatching Act phase (test-proven).
- ✅ Crocutus consumes this via `identity.toml` + `targets` + prompts only — no forked logic
  (depend-not-fork).
- ✅ Read-only posture fails **CLOSED** (undetermined ⇒ no spawn). No wall-clock timeouts. Nothing
  named "Bridge".
- ✅ Additive. All CI gates green: `cargo fmt --check`, `clippy --all-targets -D warnings`,
  `cargo test` (lib 8297 + `issue_3125` integration 9), `cargo deny check`, `mkdocs build --strict`.

## Tests

- `src/identity/manifest.rs` — `WritePosture`/`IdentityAuthority`, `SeedGoal`, `resolved_target_repos`.
- `src/ooda_actions/advance_goal/spawn.rs` — `posture_permits_spawn` default-DENY matrix; the
  observe-only branch proven to never consult a `PanicBrain`.
- `src/identity/toml_types.rs` + `file_loader.rs` — TOML parse, `deny_unknown_fields`, posture
  contradiction validation.
- `tests/issue_3125_identity_scoped_cognition.rs` — (a) Simard unchanged by default; (b) a
  read-only identity seeds its own target-scoped goals and never spawns.

## Docs

- `docs/concepts/identity-scoped-cognition.md`, `docs/reference/identity-scoped-cognition-api.md`
  (linked in `mkdocs.yml`), backlinks from write-authority-posture / pluggable-identity /
  multi-identity-host-isolation.

## Follow-up (separate repo)

The **Crocutus** identity config (`rysweet/Crocutus`) is updated separately to declare its
`[identities.authority] posture = "read-only"`, `target_repos`, and observe-only `seed_goals` so it
observes the hyenas repos via config + prompts only. The Simard framework change is the deliverable
here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
