### PR TITLE
fix(ci): resolve lbug version from Cargo.lock when lbug is a git dep (#3119 coverage regression)

### DIFF
--- a/scripts/provision-lbug-prebuilt.sh
+++ b/scripts/provision-lbug-prebuilt.sh
@@ -38,8 +38,19 @@ static_lib_name="liblbug.a"
 # unauthenticated `releases/latest` API call and no version skew with the crate
 # we actually compile against.
 lbug_version() {
-  sed -nE 's/^lbug[[:space:]]*=[[:space:]]*"=?([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' \
-    "$REPO_ROOT/Cargo.toml" | head -n1
+  # Direct crates.io version-pin form: `lbug = "=0.17.1"`.
+  local v
+  v="$(sed -nE 's/^lbug[[:space:]]*=[[:space:]]*"=?([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' \
+    "$REPO_ROOT/Cargo.toml" | head -n1)"
+  # Git-dep form (`lbug = { git = ..., rev = ... }`, issue #3119): the version is
+  # not on the manifest line, so resolve it from the lockfile's `[[package]]`
+  # entry instead. Cargo.lock lists `name = "lbug"` immediately followed by
+  # `version = "X.Y.Z"`, so advance one line and extract it.
+  if [ -z "$v" ] && [ -f "$REPO_ROOT/Cargo.lock" ]; then
+    v="$(sed -nE '/^name = "lbug"$/{n; s/^version = "([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p;}' \
+      "$REPO_ROOT/Cargo.lock" | head -n1)"
+  fi
+  printf '%s\n' "$v"
 }
 
 # Name of the prebuilt static archive for this OS/arch, mirroring lbug's own
@@ -93,7 +104,7 @@ download_prebuilt() {
   # build/coverage jobs consume.
   local version asset repo url
   version="$(lbug_version || true)"
-  [ -n "$version" ] || die "could not determine lbug version from Cargo.toml"
+  [ -n "$version" ] || die "could not determine lbug version from Cargo.toml or Cargo.lock"
   asset="$(prebuilt_asset_name || true)"
   [ -n "$asset" ] || die "unsupported OS/arch for prebuilt liblbug ($(uname -sm))"
   repo="${LBUG_GITHUB_REPOSITORY:-LadybugDB/ladybug}"


### PR DESCRIPTION
## Problem
The lbug portability fix (#3171) changed the direct `lbug` dependency from a crates.io version pin (`lbug = "=0.17.1"`) to a **git dependency** on `rysweet/ladybug-rust`. That broke `scripts/provision-lbug-prebuilt.sh`'s `lbug_version()`, which only parsed a `lbug = "=X.Y.Z"` manifest line. It now returns empty, so the **coverage CI job dies** with `could not determine lbug version from Cargo.toml` on **every PR off current main** (observed on #3217 and #3223).

## Fix
Fall back to the resolved version in `Cargo.lock` (`[[package]] name = "lbug"` → `version = "0.17.0"`) when the manifest line carries no version. The version-pin path is unchanged, so nothing regresses if lbug ever goes back to a crates.io pin.

## Verification
- Patched `lbug_version()` resolves `0.17.0` from the current git-dep manifest (via Cargo.lock).
- `bash -n` syntax clean.

Unblocks the coverage gate for all PRs off main (incl. #3217, #3223).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>