### PR TITLE
fix(ooda): convert observe-only spawn requests to no-action

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -26,8 +26,8 @@ A terminal-native engineering agent who drives and curates agentic coding system
 
 ### Technology Stack
 
-- **Language**: JavaScript/TypeScript
 - **Language**: Python
+- **Language**: JavaScript/TypeScript
 - **Language**: Rust
 - **Framework**: [Main framework if applicable]
 - **Database**: [Database system if applicable]

--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: issue-2323-eliminate-the-private-gymeval-fork-in-simard-by-ad
+## Project: observe-only-no-spawn
 
 ## Overview
 
@@ -26,7 +26,6 @@ A terminal-native engineering agent who drives and curates agentic coding system
 
 ### Technology Stack
 
-- **Language**: Python
 - **Language**: JavaScript/TypeScript
 - **Language**: Rust
 - **Framework**: [Main framework if applicable]

--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: observe-only-no-spawn
+## Project: issue-2323-eliminate-the-private-gymeval-fork-in-simard-by-ad
 
 ## Overview
 
@@ -27,6 +27,7 @@ A terminal-native engineering agent who drives and curates agentic coding system
 ### Technology Stack
 
 - **Language**: JavaScript/TypeScript
+- **Language**: Python
 - **Language**: Rust
 - **Framework**: [Main framework if applicable]
 - **Database**: [Database system if applicable]

--- a/prompt_assets/simard/progress_assessment_reviewer.md
+++ b/prompt_assets/simard/progress_assessment_reviewer.md
@@ -40,6 +40,12 @@ Accept when the claimed percent is *coherent with the plan*:
   100% — that is fine).
 - The plan field is empty but the WIP summary lists concrete artifacts
   (an open PR, a real engineer branch) and the delta is modest.
+- For an **observe-only / read-only audit goal**, concrete read-only evidence in
+  the plan is itself progress. Accept modest positive claims (roughly 5–25%)
+  when the plan records specific observed facts, files, branches, CI paths, or
+  proposals, even though no target write, PR, or shipped artifact exists. Do
+  not require a write artifact for a goal whose mandate explicitly forbids
+  writes.
 
 Reject when the claimed percent looks hallucinated:
 - A large delta with no matching plan or WIP (e.g. prior 5% → claimed 88%

--- a/prompt_assets/simard/recipes/progress-assessment.yaml
+++ b/prompt_assets/simard/recipes/progress-assessment.yaml
@@ -54,6 +54,12 @@ steps:
         percent matches.
       - The plan field is empty but the WIP summary lists concrete artifacts
         and the delta is modest.
+      - For an observe-only / read-only audit goal, concrete read-only evidence
+        in the plan is itself progress. Accept modest positive claims (roughly
+        5-25%) when the plan records specific observed facts, files, branches,
+        CI paths, or proposals, even though no target write, PR, or shipped
+        artifact exists. Do not require a write artifact for a goal whose
+        mandate explicitly forbids writes.
 
       Reject when the claimed percent looks hallucinated:
       - A large delta with no matching plan or WIP.

--- a/src/goal_curation/progress_reviewer.rs
+++ b/src/goal_curation/progress_reviewer.rs
@@ -244,15 +244,21 @@ fn parse_action_verdict_response(s: &str) -> Option<ReviewerResponse> {
     let mut rationale = None;
     for line in s.lines() {
         let trimmed = line.trim();
-        let rest = trimmed
+        let Some(rest) = trimmed
             .strip_prefix("ACTION:")
             .or_else(|| trimmed.strip_prefix("Action:"))
-            .or_else(|| trimmed.strip_prefix("action:"))?
-            .trim();
-        let (field, value) = rest
+            .or_else(|| trimmed.strip_prefix("action:"))
+            .map(str::trim)
+        else {
+            continue;
+        };
+        let Some((field, value)) = rest
             .split_once('—')
             .or_else(|| rest.split_once('-'))
-            .or_else(|| rest.split_once(':'))?;
+            .or_else(|| rest.split_once(':'))
+        else {
+            continue;
+        };
         let field = field.trim().to_ascii_lowercase();
         let value = value.trim();
         match field.as_str() {
@@ -550,6 +556,14 @@ mod tests {
             parsed.rationale,
             "Read-only audit produced concrete evidence."
         );
+    }
+
+    #[test]
+    fn parser_handles_action_verdict_response_with_extra_lines() {
+        let raw = "ACTION: verdict — accept\nACTION: rationale — Read-only audit produced concrete evidence.\nEXPLANATION: this line is not part of the schema";
+        let parsed = parse_reviewer_response(raw).expect("parse ok");
+        assert_eq!(parsed.verdict, "accept");
+        assert!(parsed.rationale.contains("Read-only audit"));
     }
 
     #[test]

--- a/src/goal_curation/progress_reviewer.rs
+++ b/src/goal_curation/progress_reviewer.rs
@@ -230,10 +230,41 @@ pub fn parse_reviewer_response(raw: &str) -> Result<ReviewerResponse, String> {
     {
         return Ok(parsed);
     }
+    if let Some(parsed) = parse_action_verdict_response(stripped) {
+        return Ok(parsed);
+    }
     Err(format!(
         "{ADAPTER_TAG} response had no parseable JSON object; raw={:?}",
         truncate_for_err(raw)
     ))
+}
+
+fn parse_action_verdict_response(s: &str) -> Option<ReviewerResponse> {
+    let mut verdict = None;
+    let mut rationale = None;
+    for line in s.lines() {
+        let trimmed = line.trim();
+        let rest = trimmed
+            .strip_prefix("ACTION:")
+            .or_else(|| trimmed.strip_prefix("Action:"))
+            .or_else(|| trimmed.strip_prefix("action:"))?
+            .trim();
+        let (field, value) = rest
+            .split_once('—')
+            .or_else(|| rest.split_once('-'))
+            .or_else(|| rest.split_once(':'))?;
+        let field = field.trim().to_ascii_lowercase();
+        let value = value.trim();
+        match field.as_str() {
+            "verdict" => verdict = Some(value.to_string()),
+            "rationale" => rationale = Some(value.to_string()),
+            _ => {}
+        }
+    }
+    verdict.map(|verdict| ReviewerResponse {
+        verdict,
+        rationale: rationale.unwrap_or_default(),
+    })
 }
 
 fn extract_fenced_blocks(s: &str) -> Vec<&str> {
@@ -508,6 +539,17 @@ mod tests {
         let raw = "Brain says: {\"verdict\":\"accept\",\"rationale\":\"ok\"} and that's that.";
         let parsed = parse_reviewer_response(raw).expect("parse ok");
         assert_eq!(parsed.verdict, "accept");
+    }
+
+    #[test]
+    fn parser_handles_action_verdict_response() {
+        let raw = "ACTION: verdict — accept\nACTION: rationale — Read-only audit produced concrete evidence.";
+        let parsed = parse_reviewer_response(raw).expect("parse ok");
+        assert_eq!(parsed.verdict, "accept");
+        assert_eq!(
+            parsed.rationale,
+            "Read-only audit produced concrete evidence."
+        );
     }
 
     #[test]

--- a/src/ooda_actions/concurrent.rs
+++ b/src/ooda_actions/concurrent.rs
@@ -111,6 +111,7 @@ struct AdvanceCtx<'a> {
     /// The daemon's own repository root (for the resource-admission gate's
     /// `reclaim_first` disk-health recipe lookup — issue #2706).
     repo_root: &'a Path,
+    observe_only: bool,
 }
 
 /// Dispatch the spawn-path `AdvanceGoal` actions at `indices` concurrently,
@@ -137,6 +138,8 @@ pub(super) fn dispatch_advance_concurrent(
         memories.session_factory.as_deref();
     // Daemon repo root for the resource-admission reclaim path (issue #2706).
     let repo_root: &Path = &memories.repo_root;
+    let observe_only =
+        crate::read_only_guard::observe_only_enabled() || !state.identity_cognition.permits_spawn();
 
     // Take ownership of the shared fallback session for the duration of the
     // round so the per-thread context can lend it out by `Box` (avoids tying a
@@ -158,6 +161,7 @@ pub(super) fn dispatch_advance_concurrent(
         claims: &claims,
         sem: &sem,
         repo_root,
+        observe_only,
     };
     let ctx_ref = &ctx;
 
@@ -318,7 +322,12 @@ fn dispatch_advance_goal_concurrent(action: &PlannedAction, ctx: &AdvanceCtx) ->
     let run_result = match ctx.session_factory {
         Some(factory) => match factory.open_session() {
             Ok(mut session) => {
-                let input = build_goal_advance_input(ctx.memory, prepared_context.as_ref(), &goal);
+                let input = build_goal_advance_input(
+                    ctx.memory,
+                    prepared_context.as_ref(),
+                    &goal,
+                    ctx.observe_only,
+                );
                 let result = session.run_turn(input);
                 // Best-effort close; failure to close never masks the turn.
                 if let Err(e) = session.close() {
@@ -347,8 +356,12 @@ fn dispatch_advance_goal_concurrent(action: &PlannedAction, ctx: &AdvanceCtx) ->
             let mut sess_guard = ctx.shared_session.lock().unwrap_or_else(|p| p.into_inner());
             match sess_guard.as_deref_mut() {
                 Some(session) => {
-                    let input =
-                        build_goal_advance_input(ctx.memory, prepared_context.as_ref(), &goal);
+                    let input = build_goal_advance_input(
+                        ctx.memory,
+                        prepared_context.as_ref(),
+                        &goal,
+                        ctx.observe_only,
+                    );
                     session.run_turn(input)
                 }
                 None => {
@@ -374,6 +387,7 @@ fn dispatch_advance_goal_concurrent(action: &PlannedAction, ctx: &AdvanceCtx) ->
             &mut guard.active_goals,
             &goal,
             run_result,
+            ctx.observe_only,
         )
     };
 

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -329,6 +329,25 @@ pub(crate) fn apply_goal_advance_result(
                     ref files,
                     issue,
                 } => {
+                    if crate::read_only_guard::observe_only_enabled() {
+                        let reason = format!(
+                            "observe-only posture converted spawn request to no-action: {task}"
+                        );
+                        let outcome = assess_only_outcome(
+                            action,
+                            memory,
+                            checker,
+                            board,
+                            &goal.id,
+                            &reason,
+                            progress_pct,
+                        );
+                        return GoalSessionResult {
+                            outcome,
+                            action: Some(GoalAction::NoAction { reason }),
+                        };
+                    }
+
                     // Apply the optional progress marker BEFORE spawning,
                     // so even if the engineer subprocess crashes the
                     // orchestrator's progress assessment is recorded.

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -233,9 +233,10 @@ pub(crate) fn build_goal_advance_input(
              plan, or dispatch an engineer. Perform the allowed read-only inspection \
              in this session using only read commands, then respond with a line \
              containing exactly NO ACTION, a conservative PROGRESS: NN marker when \
-             you have concrete evidence, and EVIDENCE/PROPOSALS bullets. If you \
-             cannot gather new evidence, respond NO ACTION with PROGRESS: 0 and \
-             state why.",
+             you have concrete evidence, and EVIDENCE/PROPOSALS bullets. Read-only \
+             means no writes, not no progress: if you gathered concrete evidence, \
+             use a modest positive progress value such as 5-25. If you cannot gather \
+             new evidence, respond NO ACTION with PROGRESS: 0 and state why.",
         );
     }
 

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -64,6 +64,11 @@ pub(crate) fn assess_only_outcome(
         }
     };
 
+    let previous_activity = board
+        .active
+        .iter()
+        .find(|goal| goal.id == goal_id)
+        .and_then(|goal| goal.current_activity.clone());
     if let Some(goal) = board.active.iter_mut().find(|goal| goal.id == goal_id) {
         goal.current_activity = Some(format!("no-action evidence: {reason}"));
     }
@@ -88,6 +93,9 @@ pub(crate) fn assess_only_outcome(
             make_outcome(action, true, detail)
         }
         Ok(EvidenceDecision::Reject { reason: rej }) => {
+            if let Some(goal) = board.active.iter_mut().find(|goal| goal.id == goal_id) {
+                goal.current_activity = previous_activity;
+            }
             eprintln!(
                 "[simard] OODA goal-action no-action REJECTED progress for '{}': {} (proposed={}%, reason={})",
                 goal_id, reason_short, pct, rej,
@@ -99,6 +107,9 @@ pub(crate) fn assess_only_outcome(
             make_outcome(action, true, detail)
         }
         Err(e) => {
+            if let Some(goal) = board.active.iter_mut().find(|goal| goal.id == goal_id) {
+                goal.current_activity = previous_activity;
+            }
             eprintln!(
                 "[simard] OODA goal-action no-action FAILED to update progress for '{}': {} (reason='{}', progress={}%)",
                 goal_id, e, reason_short, pct,

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -495,7 +495,8 @@ pub(crate) fn outcome_made_no_progress(outcome: &ActionOutcome) -> bool {
     outcome.success
         && outcome.action.goal_id.is_some()
         && outcome.detail.starts_with("no-action:")
-        && (!outcome.detail.contains("(progress=") || outcome.detail.contains("no-progress"))
+        && (!outcome.detail.contains("(progress=")
+            || outcome.detail.contains("(progress=0%, no-progress, goal "))
 }
 
 #[cfg(test)]
@@ -585,6 +586,27 @@ mod tests_no_progress_classifier {
         assert!(
             !outcome_made_no_progress(&outcome),
             "an accepted progress advance must NOT count as no progress: {}",
+            outcome.detail
+        );
+    }
+
+    #[test]
+    fn accepted_positive_progress_can_mention_no_progress_without_counting() {
+        let action = advance_goal_action("g");
+        let mut board = board_with("g");
+        let outcome = assess_only_outcome(
+            &action,
+            &*mem(),
+            &NoopProgressEvidenceChecker,
+            &mut board,
+            "g",
+            "fixed the prior no-progress loop",
+            Some(20),
+        );
+        assert!(outcome.success);
+        assert!(
+            !outcome_made_no_progress(&outcome),
+            "positive progress mentioning no-progress must stay progress: {}",
             outcome.detail
         );
     }

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -54,10 +54,20 @@ pub(crate) fn assess_only_outcome(
         return make_outcome(action, true, detail);
     };
 
+    if pct == 0 {
+        eprintln!(
+            "[simard] OODA goal-action no-action for '{}': {} (progress=0%, no-progress)",
+            goal_id, reason_short,
+        );
+        let detail = format!(
+            "no-action: {} (progress=0%, no-progress, goal '{}')",
+            reason_short, goal_id,
+        );
+        return make_outcome(action, true, detail);
+    }
+
     let new_progress = if pct >= 100 {
         GoalProgress::Completed
-    } else if pct == 0 {
-        GoalProgress::NotStarted
     } else {
         GoalProgress::InProgress {
             percent: pct as u32,
@@ -615,6 +625,9 @@ mod tests_no_progress_classifier {
     fn accepted_zero_progress_marker_is_still_no_progress() {
         let action = advance_goal_action("g");
         let mut board = board_with("g");
+        if let Some(goal) = board.active.iter_mut().find(|goal| goal.id == "g") {
+            goal.status = crate::goal_curation::GoalProgress::InProgress { percent: 20 };
+        }
         let outcome = assess_only_outcome(
             &action,
             &*mem(),
@@ -629,6 +642,19 @@ mod tests_no_progress_classifier {
             outcome_made_no_progress(&outcome),
             "accepted PROGRESS: 0 must not reset no-progress tracking: {}",
             outcome.detail
+        );
+        let status = board
+            .active
+            .iter()
+            .find(|goal| goal.id == "g")
+            .map(|goal| &goal.status)
+            .expect("goal remains");
+        assert!(
+            matches!(
+                status,
+                crate::goal_curation::GoalProgress::InProgress { percent: 20 }
+            ),
+            "PROGRESS: 0 must not reset prior progress, got {status:?}"
         );
     }
 

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -64,6 +64,10 @@ pub(crate) fn assess_only_outcome(
         }
     };
 
+    if let Some(goal) = board.active.iter_mut().find(|goal| goal.id == goal_id) {
+        goal.current_activity = Some(format!("no-action evidence: {reason}"));
+    }
+
     match update_goal_progress_with_evidence(
         board,
         goal_id,

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -502,11 +502,20 @@ pub(crate) fn apply_goal_advance_result(
 /// already counted by the brain-failure safeguard's `goal_failure_counts`, so
 /// this predicate excludes it to avoid double-counting.
 pub(crate) fn outcome_made_no_progress(outcome: &ActionOutcome) -> bool {
+    let Some(goal_id) = outcome.action.goal_id.as_deref() else {
+        return false;
+    };
+    let progress_suffix = outcome
+        .detail
+        .rfind(" (progress=")
+        .map(|idx| &outcome.detail[idx..]);
+    let authored_progress =
+        progress_suffix.is_some_and(|suffix| suffix.ends_with(&format!(", goal '{goal_id}')")));
+    let authored_zero_progress = progress_suffix
+        .is_some_and(|suffix| suffix.ends_with(&format!(", no-progress, goal '{goal_id}')")));
     outcome.success
-        && outcome.action.goal_id.is_some()
         && outcome.detail.starts_with("no-action:")
-        && (!outcome.detail.contains("(progress=")
-            || outcome.detail.contains("(progress=0%, no-progress, goal "))
+        && (!authored_progress || authored_zero_progress)
 }
 
 #[cfg(test)]
@@ -568,7 +577,7 @@ mod tests_no_progress_classifier {
             &NoopProgressEvidenceChecker,
             &mut board,
             "g",
-            "I'll verify concretely next cycle",
+            "I'll verify concretely next cycle; prior detail said (progress=20%, goal 'g')",
             None,
         );
         assert!(outcome.success);

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -130,7 +130,10 @@ pub(crate) fn advance_goal_with_session(
     state: &mut OodaState,
     goal: &crate::goal_curation::ActiveGoal,
 ) -> GoalSessionResult {
-    let input = build_goal_advance_input(memory, state.prepared_context.as_ref(), goal);
+    let observe_only =
+        crate::read_only_guard::observe_only_enabled() || !state.identity_cognition.permits_spawn();
+    let input =
+        build_goal_advance_input(memory, state.prepared_context.as_ref(), goal, observe_only);
     let run_result = session.run_turn(input);
     apply_goal_advance_result(
         action,
@@ -139,6 +142,7 @@ pub(crate) fn advance_goal_with_session(
         &mut state.active_goals,
         goal,
         run_result,
+        observe_only,
     )
 }
 
@@ -151,6 +155,7 @@ pub(crate) fn build_goal_advance_input(
     memory: &dyn crate::cognitive_memory::CognitiveMemoryOps,
     prepared_context: Option<&crate::memory_consolidation::PreparedContext>,
     goal: &crate::goal_curation::ActiveGoal,
+    observe_only: bool,
 ) -> crate::base_types::BaseTypeTurnInput {
     use crate::base_types::BaseTypeTurnInput;
     use std::fmt::Write;
@@ -210,7 +215,7 @@ pub(crate) fn build_goal_advance_input(
         }
     }
 
-    if crate::read_only_guard::observe_only_enabled() {
+    if observe_only {
         objective.push_str(
             "\n\n## Read-only observer contract\n\
              This identity is running with SIMARD_OBSERVE_ONLY=1. Do not ask for, \
@@ -297,6 +302,7 @@ pub(crate) fn apply_goal_advance_result(
     board: &mut GoalBoard,
     goal: &crate::goal_curation::ActiveGoal,
     run_result: crate::error::SimardResult<crate::base_types::BaseTypeOutcome>,
+    observe_only: bool,
 ) -> GoalSessionResult {
     match run_result {
         Ok(outcome) => {
@@ -346,7 +352,7 @@ pub(crate) fn apply_goal_advance_result(
                     ref files,
                     issue,
                 } => {
-                    if crate::read_only_guard::observe_only_enabled() {
+                    if observe_only {
                         let reason = format!(
                             "observe-only posture converted spawn request to no-action: {task}"
                         );

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -206,6 +206,19 @@ pub(crate) fn build_goal_advance_input(
         }
     }
 
+    if crate::read_only_guard::observe_only_enabled() {
+        objective.push_str(
+            "\n\n## Read-only observer contract\n\
+             This identity is running with SIMARD_OBSERVE_ONLY=1. Do not ask for, \
+             plan, or dispatch an engineer. Perform the allowed read-only inspection \
+             in this session using only read commands, then respond with a line \
+             containing exactly NO ACTION, a conservative PROGRESS: NN marker when \
+             you have concrete evidence, and EVIDENCE/PROPOSALS bullets. If you \
+             cannot gather new evidence, respond NO ACTION with PROGRESS: 0 and \
+             state why.",
+        );
+    }
+
     // Append recalled memory context (facts, prospectives, procedures) when available.
     if let Some(ctx) = prepared_context {
         if !ctx.relevant_facts.is_empty() {

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -86,10 +86,17 @@ pub(crate) fn assess_only_outcome(
                 "[simard] OODA goal-action no-action for '{}': {} (progress={}%)",
                 goal_id, reason_short, pct,
             );
-            let detail = format!(
-                "no-action: {} (progress={}%, goal '{}')",
-                reason_short, pct, goal_id,
-            );
+            let detail = if pct == 0 {
+                format!(
+                    "no-action: {} (progress=0%, no-progress, goal '{}')",
+                    reason_short, goal_id,
+                )
+            } else {
+                format!(
+                    "no-action: {} (progress={}%, goal '{}')",
+                    reason_short, pct, goal_id,
+                )
+            };
             make_outcome(action, true, detail)
         }
         Ok(EvidenceDecision::Reject { reason: rej }) => {
@@ -475,19 +482,20 @@ pub(crate) fn apply_goal_advance_result(
 ///
 /// - pure no-action: `"no-action: {reason} (goal '{id}')"`               → no progress
 /// - accepted bump:  `"no-action: {reason} (progress={pct}%, goal '{id}')"` → progress
+/// - accepted 0%:    `"no-action: {reason} (progress=0%, no-progress, goal '{id}')"` → no progress
 /// - rejected bump:  `"no-action: progress claim rejected (reviewer): … (goal '{id}', proposed={pct}%)"` → no progress
 ///
-/// The accepted-bump branch is the only one that emits the deterministic
-/// `"(progress="` token, so the predicate keys on that token rather than the
-/// free-form reviewer/orchestrator prose. A `success=false` outcome (empty
-/// response, run error, or a failed progress update) is *not* a no-progress
-/// no-op — it is already counted by the brain-failure safeguard's
-/// `goal_failure_counts`, so this predicate excludes it to avoid double-counting.
+/// Positive accepted bumps emit `"(progress="` without the `no-progress` marker;
+/// accepted 0% explicitly keeps the no-progress marker so a stuck observer cannot
+/// reset the breaker forever. A `success=false` outcome (empty response, run
+/// error, or a failed progress update) is *not* a no-progress no-op — it is
+/// already counted by the brain-failure safeguard's `goal_failure_counts`, so
+/// this predicate excludes it to avoid double-counting.
 pub(crate) fn outcome_made_no_progress(outcome: &ActionOutcome) -> bool {
     outcome.success
         && outcome.action.goal_id.is_some()
         && outcome.detail.starts_with("no-action:")
-        && !outcome.detail.contains("(progress=")
+        && (!outcome.detail.contains("(progress=") || outcome.detail.contains("no-progress"))
 }
 
 #[cfg(test)]
@@ -577,6 +585,27 @@ mod tests_no_progress_classifier {
         assert!(
             !outcome_made_no_progress(&outcome),
             "an accepted progress advance must NOT count as no progress: {}",
+            outcome.detail
+        );
+    }
+
+    #[test]
+    fn accepted_zero_progress_marker_is_still_no_progress() {
+        let action = advance_goal_action("g");
+        let mut board = board_with("g");
+        let outcome = assess_only_outcome(
+            &action,
+            &*mem(),
+            &NoopProgressEvidenceChecker,
+            &mut board,
+            "g",
+            "no evidence gathered this cycle",
+            Some(0),
+        );
+        assert!(outcome.success);
+        assert!(
+            outcome_made_no_progress(&outcome),
+            "accepted PROGRESS: 0 must not reset no-progress tracking: {}",
             outcome.detail
         );
     }

--- a/src/ooda_actions/tests_goal_session.rs
+++ b/src/ooda_actions/tests_goal_session.rs
@@ -6,6 +6,7 @@ use crate::goal_curation::{GoalBoard, GoalProgress};
 use crate::ooda_actions::goal_session::{GoalAction, advance_goal_with_session};
 use crate::ooda_actions::test_helpers::*;
 use crate::ooda_loop::{ActionKind, OodaState, PlannedAction};
+use std::sync::{Mutex, OnceLock};
 
 fn planned_action(goal_id: &str) -> PlannedAction {
     PlannedAction {
@@ -28,6 +29,11 @@ fn live_goal(state: &OodaState, goal_id: &str) -> crate::goal_curation::ActiveGo
         .find(|g| g.id == goal_id)
         .cloned()
         .expect("seeded goal must exist")
+}
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
 }
 
 #[test]
@@ -94,6 +100,55 @@ fn prose_response_routes_to_spawn_engineer() {
             assert_eq!(task, task_text);
         }
         other => panic!("expected SpawnEngineer, got {other:?}"),
+    }
+}
+
+#[test]
+fn observe_only_prose_response_records_no_action_without_spawn() {
+    let _guard = env_lock().lock().unwrap();
+    let old_observe = std::env::var_os("SIMARD_OBSERVE_ONLY");
+    unsafe {
+        std::env::set_var("SIMARD_OBSERVE_ONLY", "1");
+    }
+
+    let goal_id = "test-goal";
+    let mut state = state_with_goal(goal_id);
+    let goal = live_goal(&state, goal_id);
+    let action = planned_action(goal_id);
+
+    let task_text = "Spawn engineer to inspect the repository read-only.";
+    let (mut session, _captured) = MockSession::new_ok(task_text, vec![]);
+
+    let mem_box = mock_memory();
+    let checker = crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker;
+    let result = advance_goal_with_session(
+        &action,
+        &*mem_box,
+        &checker,
+        &mut session,
+        &mut state,
+        &goal,
+    );
+
+    assert!(result.outcome.success);
+    assert!(result.outcome.detail.contains("no-action"));
+    assert!(
+        !result.outcome.detail.contains("spawn_engineer"),
+        "observe-only prose must not surface as a spawn outcome"
+    );
+    match result.action {
+        Some(GoalAction::NoAction { reason }) => {
+            assert!(reason.contains("converted spawn request"));
+            assert!(reason.contains(task_text));
+        }
+        other => panic!("expected NoAction, got {other:?}"),
+    }
+
+    unsafe {
+        match old_observe {
+            Some(value) => std::env::set_var("SIMARD_OBSERVE_ONLY", value),
+            None => std::env::remove_var("SIMARD_OBSERVE_ONLY"),
+        }
     }
 }
 

--- a/src/ooda_actions/tests_goal_session.rs
+++ b/src/ooda_actions/tests_goal_session.rs
@@ -168,6 +168,55 @@ fn observe_only_prose_response_records_no_action_without_spawn() {
 }
 
 #[test]
+fn read_only_identity_prose_response_records_no_action_without_env_floor() {
+    let _guard = env_lock().lock().unwrap();
+    let old_observe = std::env::var_os("SIMARD_OBSERVE_ONLY");
+    unsafe {
+        std::env::remove_var("SIMARD_OBSERVE_ONLY");
+    }
+
+    let goal_id = "test-goal";
+    let mut state = state_with_goal(goal_id);
+    state.identity_cognition.authority = Some(crate::identity::IdentityAuthority::read_only());
+    let goal = live_goal(&state, goal_id);
+    let action = planned_action(goal_id);
+
+    let task_text = "Spawn engineer to inspect the repository read-only.";
+    let (mut session, captured) = MockSession::new_ok(task_text, vec![]);
+
+    let mem_box = mock_memory();
+    let checker = crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker;
+    let result = advance_goal_with_session(
+        &action,
+        &*mem_box,
+        &checker,
+        &mut session,
+        &mut state,
+        &goal,
+    );
+
+    assert!(result.outcome.success);
+    assert!(result.outcome.detail.contains("no-action"));
+    match result.action {
+        Some(GoalAction::NoAction { reason }) => {
+            assert!(reason.contains("converted spawn request"));
+            assert!(reason.contains(task_text));
+        }
+        other => panic!("expected NoAction, got {other:?}"),
+    }
+    let captured = captured.borrow();
+    let input = captured.as_ref().expect("session must be invoked once");
+    assert!(input.objective.contains("Read-only observer contract"));
+
+    unsafe {
+        match old_observe {
+            Some(value) => std::env::set_var("SIMARD_OBSERVE_ONLY", value),
+            None => std::env::remove_var("SIMARD_OBSERVE_ONLY"),
+        }
+    }
+}
+
+#[test]
 fn progress_marker_in_prose_updates_goal_progress_before_spawn() {
     let _guard = env_lock().lock().unwrap();
     let old_observe = std::env::var_os("SIMARD_OBSERVE_ONLY");

--- a/src/ooda_actions/tests_goal_session.rs
+++ b/src/ooda_actions/tests_goal_session.rs
@@ -2,10 +2,12 @@
 //! dispatch contract: NO ACTION marker, SpawnEngineer prose, PROGRESS
 //! marker, and empty-response failure.
 
+use crate::goal_curation::progress_evidence::{EvidenceDecision, ProgressEvidenceChecker};
 use crate::goal_curation::{GoalBoard, GoalProgress};
 use crate::ooda_actions::goal_session::{GoalAction, advance_goal_with_session};
 use crate::ooda_actions::test_helpers::*;
 use crate::ooda_loop::{ActionKind, OodaState, PlannedAction};
+use chrono::{DateTime, Utc};
 use std::sync::{Mutex, OnceLock};
 
 fn planned_action(goal_id: &str) -> PlannedAction {
@@ -233,6 +235,64 @@ fn progress_marker_in_no_action_updates_goal_progress() {
     match updated.status {
         GoalProgress::InProgress { percent } => assert_eq!(percent, 95),
         other => panic!("expected InProgress(95), got {other:?}"),
+    }
+}
+
+struct RequiresCurrentEvidence;
+
+impl ProgressEvidenceChecker for RequiresCurrentEvidence {
+    fn check(
+        &self,
+        goal: &crate::goal_curation::ActiveGoal,
+        _old_percent: u32,
+        _new_percent: u32,
+        _since: DateTime<Utc>,
+    ) -> EvidenceDecision {
+        let activity = goal.current_activity.as_deref().unwrap_or("");
+        if activity.contains("EVIDENCE:") {
+            EvidenceDecision::Accept {
+                reason: "current no-action evidence was visible".to_string(),
+            }
+        } else {
+            EvidenceDecision::Reject {
+                reason: format!("missing current no-action evidence; activity={activity:?}"),
+            }
+        }
+    }
+}
+
+#[test]
+fn no_action_progress_review_sees_current_cycle_evidence() {
+    let goal_id = "test-goal";
+    let mut state = state_with_goal(goal_id);
+    let goal = live_goal(&state, goal_id);
+    let action = planned_action(goal_id);
+
+    let (mut session, _captured) = MockSession::new_ok(
+        "NO ACTION\nPROGRESS: 5\nEVIDENCE:\n- observed CODEOWNERS is missing",
+        vec![],
+    );
+
+    let mem_box = mock_memory();
+    let result = advance_goal_with_session(
+        &action,
+        &*mem_box,
+        &RequiresCurrentEvidence,
+        &mut session,
+        &mut state,
+        &goal,
+    );
+
+    assert!(result.outcome.success);
+    assert!(
+        result.outcome.detail.contains("progress=5%"),
+        "expected accepted progress detail, got: {}",
+        result.outcome.detail
+    );
+    let updated = live_goal(&state, goal_id);
+    match updated.status {
+        GoalProgress::InProgress { percent } => assert_eq!(percent, 5),
+        other => panic!("expected InProgress(5), got {other:?}"),
     }
 }
 

--- a/src/ooda_actions/tests_goal_session.rs
+++ b/src/ooda_actions/tests_goal_session.rs
@@ -75,6 +75,7 @@ fn no_action_response_records_no_action_outcome_without_spawning() {
 }
 
 #[test]
+#[serial_test::serial(cognitive_memory)]
 fn prose_response_routes_to_spawn_engineer() {
     let _guard = env_lock().lock().unwrap();
     let old_observe = std::env::var_os("SIMARD_OBSERVE_ONLY");
@@ -119,6 +120,7 @@ fn prose_response_routes_to_spawn_engineer() {
 }
 
 #[test]
+#[serial_test::serial(cognitive_memory)]
 fn observe_only_prose_response_records_no_action_without_spawn() {
     let _guard = env_lock().lock().unwrap();
     let old_observe = std::env::var_os("SIMARD_OBSERVE_ONLY");
@@ -168,6 +170,7 @@ fn observe_only_prose_response_records_no_action_without_spawn() {
 }
 
 #[test]
+#[serial_test::serial(cognitive_memory)]
 fn read_only_identity_prose_response_records_no_action_without_env_floor() {
     let _guard = env_lock().lock().unwrap();
     let old_observe = std::env::var_os("SIMARD_OBSERVE_ONLY");
@@ -217,6 +220,7 @@ fn read_only_identity_prose_response_records_no_action_without_env_floor() {
 }
 
 #[test]
+#[serial_test::serial(cognitive_memory)]
 fn progress_marker_in_prose_updates_goal_progress_before_spawn() {
     let _guard = env_lock().lock().unwrap();
     let old_observe = std::env::var_os("SIMARD_OBSERVE_ONLY");
@@ -425,6 +429,7 @@ fn objective_includes_goal_metadata_and_environment() {
 }
 
 #[test]
+#[serial_test::serial(cognitive_memory)]
 fn observe_only_objective_forbids_engineer_dispatch_and_requires_evidence_protocol() {
     let _guard = env_lock().lock().unwrap();
     let old_observe = std::env::var_os("SIMARD_OBSERVE_ONLY");

--- a/src/ooda_actions/tests_goal_session.rs
+++ b/src/ooda_actions/tests_goal_session.rs
@@ -457,6 +457,12 @@ fn observe_only_objective_forbids_engineer_dispatch_and_requires_evidence_protoc
     assert!(input.objective.contains("dispatch an engineer"));
     assert!(input.objective.contains("NO ACTION"));
     assert!(input.objective.contains("EVIDENCE/PROPOSALS"));
+    assert!(
+        input
+            .objective
+            .contains("Read-only means no writes, not no progress")
+    );
+    assert!(input.objective.contains("modest positive progress"));
 
     unsafe {
         match old_observe {

--- a/src/ooda_actions/tests_goal_session.rs
+++ b/src/ooda_actions/tests_goal_session.rs
@@ -74,6 +74,12 @@ fn no_action_response_records_no_action_outcome_without_spawning() {
 
 #[test]
 fn prose_response_routes_to_spawn_engineer() {
+    let _guard = env_lock().lock().unwrap();
+    let old_observe = std::env::var_os("SIMARD_OBSERVE_ONLY");
+    unsafe {
+        std::env::remove_var("SIMARD_OBSERVE_ONLY");
+    }
+
     let goal_id = "test-goal";
     let mut state = state_with_goal(goal_id);
     let goal = live_goal(&state, goal_id);
@@ -100,6 +106,13 @@ fn prose_response_routes_to_spawn_engineer() {
             assert_eq!(task, task_text);
         }
         other => panic!("expected SpawnEngineer, got {other:?}"),
+    }
+
+    unsafe {
+        match old_observe {
+            Some(value) => std::env::set_var("SIMARD_OBSERVE_ONLY", value),
+            None => std::env::remove_var("SIMARD_OBSERVE_ONLY"),
+        }
     }
 }
 
@@ -154,6 +167,12 @@ fn observe_only_prose_response_records_no_action_without_spawn() {
 
 #[test]
 fn progress_marker_in_prose_updates_goal_progress_before_spawn() {
+    let _guard = env_lock().lock().unwrap();
+    let old_observe = std::env::var_os("SIMARD_OBSERVE_ONLY");
+    unsafe {
+        std::env::remove_var("SIMARD_OBSERVE_ONLY");
+    }
+
     let goal_id = "test-goal";
     let mut state = state_with_goal(goal_id);
     let goal = live_goal(&state, goal_id);
@@ -179,6 +198,13 @@ fn progress_marker_in_prose_updates_goal_progress_before_spawn() {
     match updated.status {
         GoalProgress::InProgress { percent } => assert_eq!(percent, 70),
         other => panic!("expected InProgress(70), got {other:?}"),
+    }
+
+    unsafe {
+        match old_observe {
+            Some(value) => std::env::set_var("SIMARD_OBSERVE_ONLY", value),
+            None => std::env::remove_var("SIMARD_OBSERVE_ONLY"),
+        }
     }
 }
 
@@ -287,4 +313,46 @@ fn objective_includes_goal_metadata_and_environment() {
     assert!(input.objective.contains(goal_id));
     assert!(input.objective.contains(&format!("Goal {goal_id}")));
     assert!(input.objective.contains("Environment context"));
+}
+
+#[test]
+fn observe_only_objective_forbids_engineer_dispatch_and_requires_evidence_protocol() {
+    let _guard = env_lock().lock().unwrap();
+    let old_observe = std::env::var_os("SIMARD_OBSERVE_ONLY");
+    unsafe {
+        std::env::set_var("SIMARD_OBSERVE_ONLY", "1");
+    }
+
+    let goal_id = "test-goal";
+    let mut state = state_with_goal(goal_id);
+    let goal = live_goal(&state, goal_id);
+    let action = planned_action(goal_id);
+
+    let (mut session, captured) = MockSession::new_ok("NO ACTION\nPROGRESS: 0", vec![]);
+
+    let mem_box = mock_memory();
+    let checker = crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker;
+    let _ = advance_goal_with_session(
+        &action,
+        &*mem_box,
+        &checker,
+        &mut session,
+        &mut state,
+        &goal,
+    );
+
+    let captured = captured.borrow();
+    let input = captured.as_ref().expect("session must be invoked once");
+    assert!(input.objective.contains("Read-only observer contract"));
+    assert!(input.objective.contains("Do not ask for"));
+    assert!(input.objective.contains("dispatch an engineer"));
+    assert!(input.objective.contains("NO ACTION"));
+    assert!(input.objective.contains("EVIDENCE/PROPOSALS"));
+
+    unsafe {
+        match old_observe {
+            Some(value) => std::env::set_var("SIMARD_OBSERVE_ONLY", value),
+            None => std::env::remove_var("SIMARD_OBSERVE_ONLY"),
+        }
+    }
 }

--- a/src/ooda_brain/prompt_store_tests.rs
+++ b/src/ooda_brain/prompt_store_tests.rs
@@ -1025,6 +1025,32 @@ fn progress_assessment_recipe_mirrors_done_gate() {
     );
 }
 
+#[test]
+fn progress_reviewer_accepts_observe_only_evidence_progress() {
+    let content = embedded_fallback("progress_assessment_reviewer.md")
+        .expect("progress_assessment_reviewer.md must be registered");
+    let norm = normalize_ws(content).to_lowercase();
+    assert!(
+        norm.contains("observe-only / read-only audit goal"),
+        "progress reviewer must treat read-only audit evidence as progress"
+    );
+    assert!(
+        norm.contains("do not require a write artifact"),
+        "observe-only progress must not require forbidden target writes"
+    );
+
+    let recipe = include_str!("../../prompt_assets/simard/recipes/progress-assessment.yaml");
+    let recipe_norm = normalize_ws(recipe).to_lowercase();
+    assert!(
+        recipe_norm.contains("observe-only / read-only audit goal"),
+        "progress-assessment.yaml must mirror the observe-only evidence rule"
+    );
+    assert!(
+        recipe_norm.contains("do not require a write artifact"),
+        "recipe mirror must not require forbidden target writes"
+    );
+}
+
 // ── PR-finalization review pipeline (#2410 follow-on) ───────────────────────
 //
 // These tests pin the prompt-content contract for the new, bounded, ordered

--- a/src/ooda_brain/tests.rs
+++ b/src/ooda_brain/tests.rs
@@ -1037,7 +1037,7 @@ fn t14_large_input_truncated_in_error_message() {
             || msg.contains("...")
             || msg.contains("bytes"),
         "truncated error should signal that truncation occurred, got first 200 bytes: {}",
-        &msg.chars().take(200).collect::<String>()
+        msg.chars().take(200).collect::<String>()
     );
 }
 

--- a/src/operator_commands_dashboard/memory.rs
+++ b/src/operator_commands_dashboard/memory.rs
@@ -1286,12 +1286,12 @@ mod tests_memory_graph {
             text.contains(fact_marker),
             "the live semantic fact {fact_marker:?} must appear in the graph nodes \
              (LIVE data, not a placeholder). Nodes: {}",
-            &v["nodes"]
+            v["nodes"]
         );
         assert!(
             text.contains(ep_marker),
             "the live episode {ep_marker:?} must appear in the graph nodes. Nodes: {}",
-            &v["nodes"]
+            v["nodes"]
         );
         let types = node_types(v);
         assert!(
@@ -1324,13 +1324,13 @@ mod tests_memory_graph {
         assert!(
             text.contains(proc_marker),
             "the live procedure {proc_marker:?} must appear in the graph nodes; nodes: {}",
-            &v["nodes"]
+            v["nodes"]
         );
         assert!(
             text.contains(prosp_marker),
             "the live prospective memory {prosp_marker:?} must appear in the graph \
              nodes; nodes: {}",
-            &v["nodes"]
+            v["nodes"]
         );
     }
 
@@ -1527,7 +1527,7 @@ mod tests_memory_graph {
                 hubs.contains(t),
                 "an in-build failure must keep the six type hubs (legend/filters stay \
                  meaningful); missing hub {t:?}. Nodes: {}",
-                &v["nodes"]
+                v["nodes"]
             );
         }
     }

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -386,10 +386,17 @@ pub fn run_ooda_daemon(
     //   2. Direct LLM (LlmReviewerProgressChecker)
     //   3. NoopProgressEvidenceChecker (fallback)
     //
-    // Honors `SIMARD_PROGRESS_EVIDENCE=off` as a kill switch.
-    let kill_switch = std::env::var("SIMARD_PROGRESS_EVIDENCE")
-        .ok()
+    // Honors `SIMARD_PROGRESS_EVIDENCE=off` as a kill switch, and
+    // `SIMARD_PROGRESS_EVIDENCE=direct` as an explicit request to use the
+    // direct LLM reviewer instead of the recipe-runner-backed checker.
+    let progress_mode = std::env::var("SIMARD_PROGRESS_EVIDENCE").ok();
+    let kill_switch = progress_mode
+        .as_deref()
         .map(|v| v.eq_ignore_ascii_case("off"))
+        .unwrap_or(false);
+    let force_direct = progress_mode
+        .as_deref()
+        .map(|v| v.eq_ignore_ascii_case("direct"))
         .unwrap_or(false);
     let progress_evidence: std::sync::Arc<
         dyn crate::goal_curation::progress_evidence::ProgressEvidenceChecker,
@@ -399,8 +406,9 @@ pub fn run_ooda_daemon(
             "[simard] progress-evidence: DISABLED (NoopProgressEvidenceChecker -- SIMARD_PROGRESS_EVIDENCE=off)",
         );
         std::sync::Arc::new(crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker)
-    } else if let Some(recipe_checker) =
-        crate::goal_curation::recipe_progress_checker::RecipeProgressChecker::new(&repo_root)
+    } else if !force_direct
+        && let Some(recipe_checker) =
+            crate::goal_curation::recipe_progress_checker::RecipeProgressChecker::new(&repo_root)
     {
         daemon_log(
             &state_root,
@@ -412,7 +420,11 @@ pub fn run_ooda_daemon(
             Ok(reviewer_provider) => {
                 daemon_log(
                     &state_root,
-                    "[simard] progress-evidence: enabled (LlmReviewerProgressChecker -- direct LLM fallback)",
+                    if force_direct {
+                        "[simard] progress-evidence: enabled (LlmReviewerProgressChecker -- SIMARD_PROGRESS_EVIDENCE=direct)"
+                    } else {
+                        "[simard] progress-evidence: enabled (LlmReviewerProgressChecker -- direct LLM fallback)"
+                    },
                 );
                 let reviewer_submitter =
                     crate::ooda_brain::SessionLlmSubmitter::new(reviewer_provider);

--- a/src/recipe_output/extract.rs
+++ b/src/recipe_output/extract.rs
@@ -210,6 +210,46 @@ fn is_noise_line(line: &str) -> bool {
         || t.starts_with("[running]")
 }
 
+/// Strip recipe-runner's per-agent line prefix:
+/// `  [08:25:09] [amplihack:copilot:123] <payload>`.
+///
+/// The prefix is logging metadata, not payload. Removing it lets downstream
+/// extractors see a real verdict when the agent answered, and lets launcher-only
+/// lines collapse to ordinary launcher noise. Non-matching lines are returned
+/// unchanged on the borrowed path.
+fn strip_recipe_agent_prefix(line: &str) -> Cow<'_, str> {
+    let leading = line.len() - line.trim_start().len();
+    let t = &line[leading..];
+    let b = t.as_bytes();
+    if b.len() < "[00:00:00] [amplihack:x:0] ".len() {
+        return Cow::Borrowed(line);
+    }
+    if b.first() != Some(&b'[') {
+        return Cow::Borrowed(line);
+    }
+    let time_ok = b.get(1..9).is_some_and(|time| {
+        time[0].is_ascii_digit()
+            && time[1].is_ascii_digit()
+            && time[2] == b':'
+            && time[3].is_ascii_digit()
+            && time[4].is_ascii_digit()
+            && time[5] == b':'
+            && time[6].is_ascii_digit()
+            && time[7].is_ascii_digit()
+    });
+    if !time_ok || b.get(9) != Some(&b']') || b.get(10) != Some(&b' ') {
+        return Cow::Borrowed(line);
+    }
+    let rest = &t[11..];
+    let Some(after_agent) = rest.strip_prefix("[amplihack:") else {
+        return Cow::Borrowed(line);
+    };
+    let Some(end) = after_agent.find("] ") else {
+        return Cow::Borrowed(line);
+    };
+    Cow::Owned(after_agent[end + 2..].to_string())
+}
+
 /// Strip ANSI escapes **and** drop whole tracing/env_logger log lines,
 /// recipe-runner summary-banner lines, and Copilot CLI launch-log preamble
 /// lines (all via [`is_noise_line`]).
@@ -218,12 +258,26 @@ fn is_noise_line(line: &str) -> bool {
 /// no droppable line), preserving today's behaviour and allocations.
 pub fn strip_recipe_noise(raw: &str) -> Cow<'_, str> {
     let de_ansi = strip_ansi(raw);
-    if !de_ansi.lines().any(is_noise_line) {
+    if !de_ansi
+        .lines()
+        .any(|line| is_noise_line(line) || matches!(strip_recipe_agent_prefix(line), Cow::Owned(_)))
+    {
         // No droppable lines: pass through the ANSI-strip result as-is
         // (`Borrowed` stays `Borrowed` on the fully-clean path).
         return de_ansi;
     }
-    let kept: Vec<&str> = de_ansi.lines().filter(|l| !is_noise_line(l)).collect();
+    let kept: Vec<String> = de_ansi
+        .lines()
+        .filter_map(|line| {
+            let stripped = strip_recipe_agent_prefix(line);
+            let payload = stripped.as_ref();
+            if is_noise_line(payload) {
+                None
+            } else {
+                Some(payload.to_string())
+            }
+        })
+        .collect();
     Cow::Owned(kept.join("\n"))
 }
 
@@ -569,6 +623,37 @@ mod tests {
         assert_eq!(
             strip_recipe_noise(raw),
             "Sure, here is the result:\n{\"facts\":[]}\nThat's all."
+        );
+    }
+
+    #[test]
+    fn strip_recipe_noise_removes_prefixed_launcher_line() {
+        let raw = "Recipe: progress-assessment (v1.0.0)\n\
+                   Steps: 1\n\
+                     [08:26:10] [amplihack:copilot:460198] ℹ NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: /home/u/.amplihack/config\n\
+                   Recipe 'progress-assessment': SUCCESS (6.0s)\n\
+                     [completed] assess-progress (6.0s)";
+        assert_eq!(
+            strip_recipe_noise(raw),
+            "Recipe 'progress-assessment': SUCCESS (6.0s)"
+        );
+    }
+
+    #[test]
+    fn strip_recipe_noise_preserves_prefixed_payload() {
+        let raw = "Recipe: progress-assessment (v1.0.0)\n\
+                   Steps: 1\n\
+                     [08:25:09] [amplihack:copilot:1635817] {\"verdict\":\"accept\",\"rationale\":\"evidence-backed\"}\n\
+                   Recipe 'progress-assessment': SUCCESS (14.0s)\n\
+                     [completed] assess-progress (14.0s)";
+        let cleaned = strip_recipe_noise(raw);
+        assert!(
+            cleaned.contains("{\"verdict\":\"accept\""),
+            "payload must survive: {cleaned}"
+        );
+        assert!(
+            !cleaned.contains("amplihack:copilot"),
+            "agent log prefix must be removed: {cleaned}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Convert observe-only goal-session spawn-shaped prose into no-action outcomes before a `SpawnEngineer` action is returned.
- Derive observe-only behavior from both `SIMARD_OBSERVE_ONLY` and identity cognition posture, including concurrent advance paths.
- Add an observe-only goal-session contract so read-only identities inspect/report in-session instead of asking for engineer delegation.
- Make current `NO ACTION` evidence visible to progress review before applying progress, while restoring prior activity if review rejects.
- Add `SIMARD_PROGRESS_EVIDENCE=direct`, harden recipe-output cleaning for recipe-runner agent prefixes, and parse explicit `ACTION: verdict` / `ACTION: rationale` reviewer responses even with explanatory prose.
- Keep accepted `PROGRESS: 0` classified as no-progress without resetting prior progress; classification uses the authored progress suffix only.
- Teach progress review that concrete read-only audit evidence is valid modest progress for observe-only goals.

## Scope / files changed
- `src/ooda_actions/goal_session/advance.rs`: observe-only decision/result semantics, current-evidence review, zero-progress no-progress classification.
- `src/ooda_actions/concurrent.rs`: threads observe-only posture into concurrent goal advancement.
- `src/operator_commands_ooda/daemon/mod.rs`: `SIMARD_PROGRESS_EVIDENCE=direct` selection.
- `src/goal_curation/progress_reviewer.rs`: action-style verdict parsing for direct reviewer output.
- `src/recipe_output/extract.rs`: recipe-runner agent-prefix cleanup.
- `prompt_assets/simard/progress_assessment_reviewer.md` and `prompt_assets/simard/recipes/progress-assessment.yaml`: observe-only audit evidence rule.
- Tests only in `src/ooda_actions/tests_goal_session.rs`, `src/ooda_brain/prompt_store_tests.rs`, `src/goal_curation/progress_reviewer.rs`, and clippy-only test formatting fixes.

No unrelated workflow/context files are included in the PR diff.

## Documentation
No durable user-facing docs are changed in Simard. This PR changes internal OODA runtime semantics and prompt assets covered by tests; the durable operator/install documentation lives in linked Crocutus PR #30.

## Validation / QA evidence
- Goal-session unit QA: `cargo test --quiet tests_goal_session` — passed.
- Progress reviewer prompt/parser QA: `cargo test --quiet progress_reviewer` and `cargo test --quiet progress_assessment_recipe` — passed.
- Recipe-output parser QA: `cargo test --quiet recipe_output` — passed.
- Env-race guard QA: `cargo test --quiet every_env_mutating_test_is_serialized` — passed.
- Compile/lint QA: `cargo check --quiet --lib`, `cargo clippy --all-targets --all-features --locked -- -D warnings`, and commit/pre-push hooks — passed.
- Live integration QA through Crocutus PR #30 on dev:
  - installed current Crocutus head pinned to this Simard head through canonical installer;
  - prompt assets synced from pinned Simard checkout;
  - direct progress mode active;
  - first OODA cycle completed 2/2 actions;
  - no engineer dispatch/refusal loop;
  - accepted positive no-action progress 15% and 20%;
  - target checkout clean and `unpushed=0`;
  - no-progress counts empty.

## Quality-audit / review cycles
1. SEEK: crusty review found env-only observe semantics, stale prompt asset sync, and upgrade asset gaps. FIX: identity posture now drives goal-session observe-only behavior, pinned Simard prompt assets win, and upgrade syncs/rematerializes assets. VALIDATE: targeted tests + live dev install.
2. SEEK: crusty review found upgrade rollback/guardrail gaps and seed protocol proof weakness. FIX: upgrade now checks operations, proves guardrails, daemon-reloads, has backup/restore path; seed proof rejects protocol markers across title/description case-insensitively. VALIDATE: installer contracts + guardrail proof.
3. SEEK: live cycles and crusty review exposed progress-review/parser/no-progress holes. FIX: current evidence is reviewed, observe-only evidence is acceptable modest progress, `PROGRESS: 0` remains no-progress and does not reset status, and action-style verdicts parse. VALIDATE: prompt/parser tests, serial guard, clippy, and final live dev cycle.

## CI evidence
All required GitHub checks on head `3e4df5507c2a396047aeb643cbf1bb210f698781` are green:

```text
coverage	COMPLETED	SUCCESS	https://github.com/rysweet/Simard/actions/runs/29098238970/job/86380153786
pre-commit	COMPLETED	SUCCESS	https://github.com/rysweet/Simard/actions/runs/29098239003/job/86380153771
pre-commit	COMPLETED	SUCCESS	https://github.com/rysweet/Simard/actions/runs/29098236229/job/86380143987
cargo-audit	COMPLETED	SUCCESS	https://github.com/rysweet/Simard/actions/runs/29098239003/job/86380153709
cargo-audit	COMPLETED	SUCCESS	https://github.com/rysweet/Simard/actions/runs/29098236229/job/86380143939
cargo-deny	COMPLETED	SUCCESS	https://github.com/rysweet/Simard/actions/runs/29098239003/job/86380153680
cargo-deny	COMPLETED	SUCCESS	https://github.com/rysweet/Simard/actions/runs/29098236229/job/86380143962
cargo-vet	COMPLETED	SUCCESS	https://github.com/rysweet/Simard/actions/runs/29098239003/job/86380153839
cargo-vet	COMPLETED	SUCCESS	https://github.com/rysweet/Simard/actions/runs/29098236229/job/86380143984
npm-audit	COMPLETED	SUCCESS	https://github.com/rysweet/Simard/actions/runs/29098239003/job/86380153720
npm-audit	COMPLETED	SUCCESS	https://github.com/rysweet/Simard/actions/runs/29098236229/job/86380143976
install-real	COMPLETED	SUCCESS	https://github.com/rysweet/Simard/actions/runs/29098239003/job/86384197818
install-real	COMPLETED	SUCCESS	https://github.com/rysweet/Simard/actions/runs/29098236229/job/86384499460
e2e-dashboard	COMPLETED	SUCCESS	https://github.com/rysweet/Simard/actions/runs/29098239003/job/86384197820
e2e-dashboard	COMPLETED	SUCCESS	https://github.com/rysweet/Simard/actions/runs/29098236229/job/86384499398
GitGuardian Security Checks	COMPLETED	SUCCESS	https://dashboard.gitguardian.com
```

## Merge verdict
READY TO MERGE after linked Crocutus PR #30 consumes this head. The PR is focused, CI-green, crusty-reviewed to HAPPY, live-canaried via Crocutus, and contains no unrelated source changes.

## G3 / parsing note
The preferred contract remains structured JSON. The added `ACTION: verdict` parser is a narrow compatibility adapter for actual direct Copilot reviewer output observed in the live canary; it is pinned by tests and does not replace the JSON-first path.
