### PR TITLE
fix(installer): render tool PATH in systemd units

### DIFF
--- a/docs/howto/run-ooda-daemon.md
+++ b/docs/howto/run-ooda-daemon.md
@@ -68,6 +68,11 @@ simard-ooda.service
 simard-signal.service
 ```
 
+The generated units include a deterministic tool `PATH`:
+`$HOME/.local/bin:$HOME/.cargo/bin:$SIMARD_HOME/bin:/usr/local/bin:/usr/bin:/bin`.
+That lets the daemon find user-installed tools such as `amplihack` without
+depending on interactive shell aliases or profile files.
+
 ## 2. Verify the services
 
 Check systemd first:
@@ -113,6 +118,7 @@ Both unit files should use the resolved `SIMARD_HOME`:
 WorkingDirectory=/home/you/.simard
 ExecStart=/home/you/.simard/bin/simard ooda run
 ExecStart=/home/you/.simard/bin/simard signal run
+Environment=PATH=/home/you/.local/bin:/home/you/.cargo/bin:/home/you/.simard/bin:/usr/local/bin:/usr/bin:/bin
 ```
 
 No unit should reference `target/`, the repository checkout, or `worktrees/main`.

--- a/docs/reference/simard-installer.md
+++ b/docs/reference/simard-installer.md
@@ -53,12 +53,35 @@ simard install [--simard-home PATH] [--dry-run] [--systemd-user-dir PATH] [--sys
 | --- | --- | --- |
 | `SIMARD_HOME` | `$HOME/.simard` | Install root when `--simard-home` is not supplied. |
 | `XDG_CONFIG_HOME` | `$HOME/.config` | Base directory for the default user systemd unit directory. |
+| `SIMARD_INSTALL_PROMPT_ASSETS_ROOT` | Auto-discovered | Preferred prompt asset source root for packaged installs. Must contain `simard/ooda_orient.md` and `simard/recipes/ooda-orient.yaml`. |
+| `SIMARD_PROMPT_ASSET_ROOT` | Auto-discovered | Compatibility prompt asset source root with the same expected directory shape as `SIMARD_INSTALL_PROMPT_ASSETS_ROOT`. |
+| `SIMARD_PROMPT_ASSETS_DIR` | Auto-discovered | Compatibility prompt asset source. May point either at a root containing `simard/` or directly at the `simard/` asset directory; direct `simard/` values are normalized to their parent root. |
 
 Precedence for the install root is:
 
 1. `--simard-home PATH`
 2. `SIMARD_HOME`
 3. `$HOME/.simard`
+
+Precedence for prompt asset source discovery is:
+
+1. `SIMARD_INSTALL_PROMPT_ASSETS_ROOT`
+2. `SIMARD_PROMPT_ASSET_ROOT`
+3. `SIMARD_PROMPT_ASSETS_DIR`
+4. `prompt_assets` under the current working directory
+5. `prompt_assets` under the compiled Cargo manifest directory
+
+The selected prompt asset source must contain both required files:
+
+```text
+<source-root>/
+`- simard/
+   |- ooda_orient.md
+   `- recipes/
+      `- ooda-orient.yaml
+```
+
+If no candidate has that shape, `simard install` exits non-zero before staging or service activation and reports the checked environment variables and fallback roots.
 
 All installer paths are validated before any live mutation. Empty paths, relative paths, control characters, newlines, carriage returns, and unsafe systemd percent escapes are rejected. Rejection is fail-closed: the installer exits non-zero and does not activate services.
 
@@ -73,6 +96,7 @@ For the default home, the installer owns this layout:
 |- prompt_assets/
 |- cognitive/
 |- config.toml
+|- .install.lock
 |- .install-staging/
 `- .install-backups/
 ```
@@ -81,6 +105,7 @@ For the default home, the installer owns this layout:
 | --- | --- | --- |
 | `$SIMARD_HOME/bin/simard` | Installer | Live Simard binary used by the systemd units. Replaced only by atomic rename. |
 | `$SIMARD_HOME/prompt_assets/` | Installer | Prompt assets that match the installed binary. Installed as a staged tree, then swapped into place through the directory strategy below. |
+| `$SIMARD_HOME/.install.lock` | Installer | Per-`SIMARD_HOME` install lock. A second installer for the same home fails instead of racing live replacements. |
 | `$SIMARD_HOME/.install-staging/` | Installer | Private staging area for the current install attempt. |
 | `$SIMARD_HOME/.install-backups/` | Installer/operator | Previous binary backups and operator-created memory snapshots. |
 | `$SIMARD_HOME/cognitive/` | Runtime | Cognitive memory store. The installer does not delete or rewrite it. |
@@ -143,13 +168,14 @@ services pointed at a half-written binary or partial prompt tree.
 2. Resolve the current executable: the binary running `simard install` is the binary being deployed.
 3. Render both systemd unit files in memory and validate their paths.
 4. Resolve the `systemctl` executable when activation is enabled.
-5. Stage the new binary and prompt assets under `.install-staging/`.
-6. Preserve the previous live binary under `.install-backups/` when one exists and differs from the new binary.
-7. Atomically rename the staged binary into `$SIMARD_HOME/bin/simard`.
-8. Replace `$SIMARD_HOME/prompt_assets/` with the staged asset tree using the prompt-assets swap strategy below.
-9. Atomically rename staged unit files into the user systemd directory.
-10. Print rollback guidance, including memory backup guidance, before any service restart.
-11. Reload, enable, and restart the user services unless `--dry-run` was supplied.
+5. Acquire the per-`SIMARD_HOME` install lock for the live transaction.
+6. Stage the new binary and prompt assets under `.install-staging/`.
+7. Preserve the previous live binary under `.install-backups/` when one exists and differs from the new binary.
+8. Atomically rename the staged binary into `$SIMARD_HOME/bin/simard`.
+9. Replace `$SIMARD_HOME/prompt_assets/` with the staged asset tree using the prompt-assets swap strategy below.
+10. Atomically rename staged unit files into the user systemd directory.
+11. Print rollback guidance, including memory backup guidance, before any service restart.
+12. Reload, enable, and restart the user services unless `--dry-run` was supplied.
 
 The live binary must never be overwritten by copying into the final path. The
 only live-binary replacement operation is a rename from a fully staged file.
@@ -203,8 +229,11 @@ services use the installed binary and assets.
 one:
 
 ```text
-$SIMARD_HOME/.install-backups/simard.<UTC>.bak
+$SIMARD_HOME/.install-backups/simard.<transaction-id>.bak
 ```
+
+The backup is first written to a sibling temporary file and then renamed into
+that final path, so operators never see a partially written final backup.
 
 The installer does not rewrite cognitive memory, but operators should snapshot
 memory before a service swap when they need a rollback point for state as well
@@ -286,6 +315,7 @@ activation when any required step fails, including:
 - invalid `SIMARD_HOME` or override paths
 - missing or non-executable `systemctl` when activation is enabled
 - failure to read the current executable
+- failure to acquire the per-`SIMARD_HOME` install lock
 - failure to stage the binary, prompt assets, or units
 - failure to preserve the previous binary
 - failure to atomically rename a staged live file into place

--- a/src/install/binary.rs
+++ b/src/install/binary.rs
@@ -41,13 +41,22 @@ pub fn preserve_prior_binary(layout: &InstallLayout) -> InstallResult<Option<Pat
     }
 
     let backup = backup_path(layout, "simard");
-    fs::copy(&layout.binary_path, &backup).map_err(|error| {
-        InstallError::new(format!(
-            "failed to preserve prior binary {} to {}: {error}",
-            layout.binary_path.display(),
+    if backup.exists() {
+        return err(format!(
+            "prior binary backup path already exists: {}",
             backup.display()
-        ))
-    })?;
+        ));
+    }
+    let temp_backup = temp_backup_path(&backup)?;
+
+    if let Err(error) = fs::copy(&layout.binary_path, &temp_backup) {
+        remove_failed_temp_backup(&temp_backup, "copy backup")?;
+        return Err(InstallError::new(format!(
+            "failed to stage prior binary backup {} to {}: {error}",
+            layout.binary_path.display(),
+            temp_backup.display()
+        )));
+    }
 
     let permissions = fs::metadata(&layout.binary_path)
         .map_err(|error| {
@@ -57,9 +66,26 @@ pub fn preserve_prior_binary(layout: &InstallLayout) -> InstallResult<Option<Pat
             ))
         })?
         .permissions();
-    fs::set_permissions(&backup, permissions).map_err(|error| {
-        InstallError::new(format!(
+    if let Err(error) = fs::set_permissions(&temp_backup, permissions) {
+        remove_failed_temp_backup(&temp_backup, "set permissions")?;
+        return Err(InstallError::new(format!(
             "failed to preserve prior binary permissions on {}: {error}",
+            temp_backup.display()
+        )));
+    }
+
+    if let Err(error) = fs::File::open(&temp_backup).and_then(|file| file.sync_all()) {
+        remove_failed_temp_backup(&temp_backup, "sync backup")?;
+        return Err(InstallError::new(format!(
+            "failed to sync staged prior binary backup {}: {error}",
+            temp_backup.display()
+        )));
+    }
+
+    fs::rename(&temp_backup, &backup).map_err(|error| {
+        InstallError::new(format!(
+            "failed atomic prior binary backup publish from {} to {}: {error}",
+            temp_backup.display(),
             backup.display()
         ))
     })?;
@@ -167,4 +193,86 @@ fn set_executable(path: &Path) -> InstallResult<()> {
         })?;
     }
     Ok(())
+}
+
+fn temp_backup_path(backup: &Path) -> InstallResult<PathBuf> {
+    let file_name = backup
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            InstallError::new(format!(
+                "prior binary backup path has no valid UTF-8 filename: {}",
+                backup.display()
+            ))
+        })?;
+    Ok(backup.with_file_name(format!(".{file_name}.tmp")))
+}
+
+fn remove_failed_temp_backup(path: &Path, failed_action: &str) -> InstallResult<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => err(format!(
+            "failed to remove staged prior binary backup {} after {failed_action} failed: {error}",
+            path.display()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn layout(root: &Path) -> InstallLayout {
+        InstallLayout {
+            simard_home: root.to_path_buf(),
+            bin_dir: root.join("bin"),
+            binary_path: root.join("bin/simard"),
+            prompt_assets_dir: root.join("prompt_assets"),
+            staging_root: root.join(".install-staging"),
+            backup_root: root.join(".install-backups"),
+            systemd_user_dir: root.join("systemd"),
+            ooda_unit_path: root.join("systemd/simard-ooda.service"),
+            signal_unit_path: root.join("systemd/simard-signal.service"),
+            transaction_id: "test-tx".to_string(),
+        }
+    }
+
+    fn collect_files(root: &Path) -> Vec<PathBuf> {
+        let mut files = Vec::new();
+        if !root.exists() {
+            return files;
+        }
+        for entry in fs::read_dir(root).expect("read backup root") {
+            files.push(entry.expect("backup entry").path());
+        }
+        files.sort();
+        files
+    }
+
+    #[test]
+    fn preserve_prior_binary_publishes_backup_without_leaving_temp_file() {
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let layout = layout(temp.path());
+        let prior_binary = b"old-simard-binary";
+        fs::create_dir_all(&layout.bin_dir).expect("bin dir");
+        fs::create_dir_all(&layout.backup_root).expect("backup dir");
+        fs::write(&layout.binary_path, prior_binary).expect("prior binary");
+
+        let backup = preserve_prior_binary(&layout)
+            .expect("preserve prior binary")
+            .expect("backup path");
+
+        assert_eq!(backup, backup_path(&layout, "simard"));
+        assert_eq!(fs::read(&backup).expect("backup bytes"), prior_binary);
+        let files = collect_files(&layout.backup_root);
+        assert!(
+            files.iter().all(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| !name.ends_with(".tmp"))
+            }),
+            "backup temp files should not remain: {files:?}"
+        );
+    }
 }

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -84,6 +84,7 @@ pub fn run(config: InstallConfig) -> InstallResult<InstallOutcome> {
     }
 
     let systemctl = systemd::resolve_systemctl(config.systemctl.as_deref())?;
+    let _install_lock = paths::acquire_install_lock(&layout)?;
     let staging = paths::prepare_staging(&layout)?;
     binary::stage_binary(&current_binary, &staging.binary)?;
     assets::stage_prompt_assets(&prompt_source, &staging.prompt_assets)?;

--- a/src/install/paths.rs
+++ b/src/install/paths.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsStr;
 use std::fs;
+use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -27,6 +28,11 @@ pub struct StagingLayout {
     pub root: PathBuf,
     pub binary: PathBuf,
     pub prompt_assets: PathBuf,
+}
+
+#[derive(Debug)]
+pub struct InstallLock {
+    _file: fs::File,
 }
 
 pub fn resolve(config: &InstallConfig) -> InstallResult<InstallLayout> {
@@ -99,6 +105,50 @@ pub fn remove_staging(path: &Path) -> InstallResult<()> {
             path.display()
         ))
     })
+}
+
+pub fn acquire_install_lock(layout: &InstallLayout) -> InstallResult<InstallLock> {
+    create_private_dir(&layout.simard_home)?;
+    let lock_path = layout.simard_home.join(".install.lock");
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|error| {
+            super::InstallError::new(format!(
+                "failed to open installer lock {}: {error}",
+                lock_path.display()
+            ))
+        })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::set_permissions(&lock_path, fs::Permissions::from_mode(0o600)).map_err(|error| {
+            super::InstallError::new(format!(
+                "failed to set owner-only permissions on installer lock {}: {error}",
+                lock_path.display()
+            ))
+        })?;
+
+        // SAFETY: flock only uses the open lock-file descriptor; the File stays
+        // alive in InstallLock until the installer transaction ends.
+        let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if result != 0 {
+            let error = std::io::Error::last_os_error();
+            return err(format!(
+                "another simard install appears to be running for {}; lock {} could not be acquired: {error}",
+                layout.simard_home.display(),
+                lock_path.display()
+            ));
+        }
+    }
+
+    Ok(InstallLock { _file: file })
 }
 
 pub fn backup_path(layout: &InstallLayout, name: &str) -> PathBuf {
@@ -194,4 +244,44 @@ fn create_private_dir(path: &Path) -> InstallResult<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn layout(root: &Path) -> InstallLayout {
+        InstallLayout {
+            simard_home: root.to_path_buf(),
+            bin_dir: root.join("bin"),
+            binary_path: root.join("bin/simard"),
+            prompt_assets_dir: root.join("prompt_assets"),
+            staging_root: root.join(".install-staging"),
+            backup_root: root.join(".install-backups"),
+            systemd_user_dir: root.join("systemd"),
+            ooda_unit_path: root.join("systemd/simard-ooda.service"),
+            signal_unit_path: root.join("systemd/simard-signal.service"),
+            transaction_id: "test-tx".to_string(),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_lock_is_exclusive_per_simard_home() {
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let layout = layout(&temp.path().join("simard-home"));
+
+        let first = acquire_install_lock(&layout).expect("first lock");
+        let error = acquire_install_lock(&layout)
+            .expect_err("second lock for same SIMARD_HOME should fail")
+            .to_string();
+
+        assert!(
+            error.contains("another simard install appears to be running"),
+            "{error}"
+        );
+
+        drop(first);
+        acquire_install_lock(&layout).expect("lock should be available after guard drop");
+    }
 }

--- a/src/install/systemd.rs
+++ b/src/install/systemd.rs
@@ -18,10 +18,23 @@ pub fn render_units(layout: &InstallLayout) -> InstallResult<RenderedUnits> {
     let binary = layout.binary_path.to_str().ok_or_else(|| {
         InstallError::new("installed binary path must be valid UTF-8 for systemd unit rendering")
     })?;
+    let service_path = render_service_path(home)?;
 
     Ok(RenderedUnits {
-        ooda: render_unit("Simard OODA daemon", home, binary, "ooda run"),
-        signal: render_unit("Simard Signal service", home, binary, "signal run"),
+        ooda: render_unit(
+            "Simard OODA daemon",
+            home,
+            binary,
+            "ooda run",
+            &service_path,
+        ),
+        signal: render_unit(
+            "Simard Signal service",
+            home,
+            binary,
+            "signal run",
+            &service_path,
+        ),
     })
 }
 
@@ -54,10 +67,46 @@ pub fn activate(systemctl: &Path) -> InstallResult<()> {
     Ok(())
 }
 
-fn render_unit(description: &str, working_directory: &str, binary: &str, args: &str) -> String {
+fn render_unit(
+    description: &str,
+    working_directory: &str,
+    binary: &str,
+    args: &str,
+    service_path: &str,
+) -> String {
     format!(
-        "[Unit]\nDescription={description}\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=simple\nWorkingDirectory={working_directory}\nExecStart={binary} {args}\nRestart=on-failure\nRestartSec=10\nEnvironment=SIMARD_HOME={working_directory}\nEnvironment=SIMARD_PROMPT_ASSETS_DIR={working_directory}/prompt_assets/simard\n\n[Install]\nWantedBy=default.target\n"
+        "[Unit]\nDescription={description}\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=simple\nWorkingDirectory={working_directory}\nExecStart={binary} {args}\nRestart=on-failure\nRestartSec=10\nEnvironment=SIMARD_HOME={working_directory}\nEnvironment=SIMARD_PROMPT_ASSETS_DIR={working_directory}/prompt_assets/simard\nEnvironment=PATH={service_path}\n\n[Install]\nWantedBy=default.target\n"
     )
+}
+
+fn render_service_path(simard_home: &str) -> InstallResult<String> {
+    let user_home = std::env::var_os("HOME")
+        .ok_or_else(|| InstallError::new("HOME is required to render systemd service PATH"))?;
+    let user_home = user_home
+        .to_str()
+        .ok_or_else(|| InstallError::new("HOME must be valid UTF-8 for systemd unit rendering"))?;
+    validate_unit_env_path("HOME", user_home)?;
+
+    Ok(format!(
+        "{user_home}/.local/bin:{user_home}/.cargo/bin:{simard_home}/bin:/usr/local/bin:/usr/bin:/bin"
+    ))
+}
+
+fn validate_unit_env_path(label: &str, value: &str) -> InstallResult<()> {
+    if value.is_empty() {
+        return err(format!(
+            "{label} must not be empty for systemd unit rendering"
+        ));
+    }
+    if let Some(ch) = value
+        .chars()
+        .find(|ch| matches!(ch, '\n' | '\r' | '%') || ch.is_ascii_whitespace())
+    {
+        return err(format!(
+            "{label} contains unsafe character '{ch}' for systemd unit rendering"
+        ));
+    }
+    Ok(())
 }
 
 fn write_unit_atomically(path: &Path, contents: &str, transaction_id: &str) -> InstallResult<()> {

--- a/src/install/systemd.rs
+++ b/src/install/systemd.rs
@@ -80,6 +80,8 @@ fn render_unit(
 }
 
 fn render_service_path(simard_home: &str) -> InstallResult<String> {
+    validate_unit_env_path("SIMARD_HOME", simard_home)?;
+
     let user_home = std::env::var_os("HOME")
         .ok_or_else(|| InstallError::new("HOME is required to render systemd service PATH"))?;
     let user_home = user_home
@@ -100,7 +102,7 @@ fn validate_unit_env_path(label: &str, value: &str) -> InstallResult<()> {
     }
     if let Some(ch) = value
         .chars()
-        .find(|ch| matches!(ch, '\n' | '\r' | '%') || ch.is_ascii_whitespace())
+        .find(|ch| matches!(ch, '\n' | '\r' | '%' | ':') || ch.is_ascii_whitespace())
     {
         return err(format!(
             "{label} contains unsafe character '{ch}' for systemd unit rendering"

--- a/tests/install_real.rs
+++ b/tests/install_real.rs
@@ -153,6 +153,20 @@ fn install_defaults_simard_home_under_home_and_uses_fake_systemctl() {
     );
     assert!(unit_dir.join("simard-ooda.service").is_file());
     assert!(unit_dir.join("simard-signal.service").is_file());
+    let expected_service_path = format!(
+        "Environment=PATH={}/.local/bin:{}/.cargo/bin:{}/bin:/usr/local/bin:/usr/bin:/bin",
+        fake_home.display(),
+        fake_home.display(),
+        simard_home.display()
+    );
+    assert_file_contains(
+        &unit_dir.join("simard-ooda.service"),
+        &expected_service_path,
+    );
+    assert_file_contains(
+        &unit_dir.join("simard-signal.service"),
+        &expected_service_path,
+    );
     assert_systemctl_logged(&systemctl_log, &["--user", "daemon-reload"]);
     assert_systemctl_logged(&systemctl_log, &["--user", "enable", "simard-ooda.service"]);
     assert_systemctl_logged(

--- a/tests/install_real.rs
+++ b/tests/install_real.rs
@@ -511,6 +511,36 @@ fn simard_home_with_spaces_fails_before_any_mutation_or_systemctl_call() {
 
 #[cfg(unix)]
 #[test]
+fn simard_home_with_path_separator_fails_before_any_mutation_or_systemctl_call() {
+    let temp = TempDir::new().expect("tempdir");
+    let simard_home = temp.path().join("simard:home");
+    let unit_dir = temp.path().join("systemd-user");
+    let (systemctl, systemctl_log) = fake_systemctl(temp.path());
+
+    let assert = simard()
+        .args(["install", "--simard-home"])
+        .arg(&simard_home)
+        .args(["--systemd-user-dir"])
+        .arg(&unit_dir)
+        .arg("--systemctl")
+        .arg(&systemctl)
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("SIMARD_HOME") && stderr.contains("unsafe character ':'"),
+        "PATH separator in SIMARD_HOME should fail with a precise validation error; stderr:\n{stderr}"
+    );
+    assert!(
+        !simard_home.exists(),
+        "invalid SIMARD_HOME must fail before creating install directories"
+    );
+    assert_no_systemctl_invocation(&systemctl_log);
+}
+
+#[cfg(unix)]
+#[test]
 fn unsafe_systemd_path_characters_fail_closed_before_any_live_swap() {
     let temp = TempDir::new().expect("tempdir");
     let simard_home = temp.path().join("bad%nhome");


### PR DESCRIPTION
## Summary

Fixes the live Simard OODA `amplihack: command not found` failure by making `simard install` render a deterministic tool PATH into both generated user systemd units. Also hardens the installer transaction after focused quality audit.

## Changes

- Render `Environment=PATH=$HOME/.local/bin:$HOME/.cargo/bin:$SIMARD_HOME/bin:/usr/local/bin:/usr/bin:/bin` in `simard-ooda.service` and `simard-signal.service`.
- Reject PATH-breaking install roots (`:` and existing unsafe systemd/path characters) before mutation.
- Document generated service PATH in the daemon runbook and installer reference.
- Add installer transaction hardening from focused quality-audit:
  - per-`SIMARD_HOME` install lock,
  - atomic prior-binary backup publish,
  - documented prompt asset source discovery and rollback artifact shape.

## Validation

- `cargo test --test install_real -- --test-threads=1` — 13/13 passed.
- `cargo check --lib` — passed.
- Commit/pre-push gates passed without `--no-verify`.
- Focused quality-audit-cycle on `src/install` completed with exit 0; follow-up fixes were committed in `b76f342e`.
- GitHub checks on head `b76f342e858e357ab5fdc6b621a3222f25baca72`: coverage, pre-commit, cargo-audit, cargo-deny, cargo-vet, npm-audit, install-real, e2e-dashboard, GitGuardian all passed.
- Crusty review after the PATH/colon fix: no blocking concerns.

## Merge readiness

- Platform: GitHub
- PR: #3750 https://github.com/rysweet/Simard/pull/3750
- Source -> target: `fix/installer-systemd-tool-path` -> `main`
- Current head revision: `b76f342e858e357ab5fdc6b621a3222f25baca72`
- QA-team evidence: Rust CLI repo; native installer outside-in tests substituted per qa-team guidance. `cargo test --test install_real -- --test-threads=1` passed 13/13, including generated systemd PATH and colon rejection coverage.
- Documentation: updated `docs/howto/run-ooda-daemon.md` and `docs/reference/simard-installer.md`.
- Quality-audit: focused `quality-audit-cycle -c target_path=src/install` completed; confirmed installer findings fixed in `b76f342e`.
- Checks/build validation: all GitHub checks green on head `b76f342e`.
- Metadata: title/body complete, not draft.
- Reviews/approvals: crusty review comment posted; no blocking requested changes.
- Merge conflicts: `mergeStateStatus=CLEAN`, `mergeable=MERGEABLE`.
- Linked issues/work items: not applicable; live operational fix surfaced by daemon logs.
- Comments/threads: no unresolved blocking review threads observed via `gh pr view`.
- Scope: changed installer implementation/tests and durable installer/runbook docs only.
- Final action plan: merge through normal gates, deploy via `simard install`, restart OODA, verify the command-not-found/fallback errors stop.

No `--admin` merge. No `--no-verify`.
