### PR TITLE
fix(deps): keep lbug storage engine compatible with live store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=ae7a06ba6ce72b86fe223063a0212a574917b74f#ae7a06ba6ce72b86fe223063a0212a574917b74f"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=1f3ddcb5542d979579055c532d2fd3d5ce761a7e#1f3ddcb5542d979579055c532d2fd3d5ce761a7e"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=1f3ddcb5542d979579055c532d2fd3d5ce761a7e#1f3ddcb5542d979579055c532d2fd3d5ce761a7e"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=283e9a2f8f38b98343770f219c3f5d16bd1752dc#283e9a2f8f38b98343770f219c3f5d16bd1752dc"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -1084,7 +1084,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1218,7 +1218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2117,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "lbug"
 version = "0.17.1"
-source = "git+https://github.com/rysweet/ladybug-rust?rev=e3872c8#e3872c8f22562d55031726a304e99ef92d1e25ec"
+source = "git+https://github.com/rysweet/ladybug-rust?rev=e3872c8f22562d55031726a304e99ef92d1e25ec#e3872c8f22562d55031726a304e99ef92d1e25ec"
 dependencies = [
  "cmake",
  "cxx",
@@ -2453,7 +2453,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3113,7 +3113,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3445,7 +3445,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3458,7 +3458,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3517,7 +3517,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4221,7 +4221,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=5807d056112b8e6f73dae9c1fac05f214f9c6ece#5807d056112b8e6f73dae9c1fac05f214f9c6ece"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=ae7a06ba6ce72b86fe223063a0212a574917b74f#ae7a06ba6ce72b86fe223063a0212a574917b74f"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -1218,7 +1218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2116,8 +2116,8 @@ dependencies = [
 
 [[package]]
 name = "lbug"
-version = "0.17.0"
-source = "git+https://github.com/rysweet/ladybug-rust?rev=202352434642e683fdf008b68004d0645a57cd35#202352434642e683fdf008b68004d0645a57cd35"
+version = "0.17.1"
+source = "git+https://github.com/rysweet/ladybug-rust?rev=e3872c8#e3872c8f22562d55031726a304e99ef92d1e25ec"
 dependencies = [
  "cmake",
  "cxx",
@@ -3458,7 +3458,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3517,7 +3517,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4221,7 +4221,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5152,7 +5152,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ path = "src/bin/supply_chain_steward.rs"
 # v40->v41+ no-data-loss gate now accepts v41-or-newer). Simard's direct `lbug` dep
 # below is repointed at the SAME fork rev in lockstep so the final binary links
 # exactly one engine. Still an upstream-`main` commit.
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "ae7a06ba6ce72b86fe223063a0212a574917b74f", features = ["persistent"] }
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "1f3ddcb5542d979579055c532d2fd3d5ce761a7e", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ path = "src/bin/supply_chain_steward.rs"
 # v40->v41+ no-data-loss gate now accepts v41-or-newer). Simard's direct `lbug` dep
 # below is repointed at the SAME fork rev in lockstep so the final binary links
 # exactly one engine. Still an upstream-`main` commit.
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "1f3ddcb5542d979579055c532d2fd3d5ce761a7e", features = ["persistent"] }
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "283e9a2f8f38b98343770f219c3f5d16bd1752dc", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream
@@ -155,7 +155,7 @@ amplihack-agent-eval = { git = "https://github.com/rysweet/amplihack-rs.git", re
 # so cargo unifies to exactly one `lbug` crate / one engine / one storage format.
 # The fork fixes the from-source duplicate-symbol link and the libstdc++
 # std::format ABI SIGSEGV; see amplihack-memory docs/lbug_libstdcxx_abi.md.
-lbug = { git = "https://github.com/rysweet/ladybug-rust", rev = "e3872c8" }
+lbug = { git = "https://github.com/rysweet/ladybug-rust", rev = "e3872c8f22562d55031726a304e99ef92d1e25ec" }
 rusqlite = { version = "=0.31.0", features = ["bundled"] }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.149"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ path = "src/bin/supply_chain_steward.rs"
 # v40->v41+ no-data-loss gate now accepts v41-or-newer). Simard's direct `lbug` dep
 # below is repointed at the SAME fork rev in lockstep so the final binary links
 # exactly one engine. Still an upstream-`main` commit.
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "5807d056112b8e6f73dae9c1fac05f214f9c6ece", features = ["persistent"] }
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "ae7a06ba6ce72b86fe223063a0212a574917b74f", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream
@@ -155,7 +155,7 @@ amplihack-agent-eval = { git = "https://github.com/rysweet/amplihack-rs.git", re
 # so cargo unifies to exactly one `lbug` crate / one engine / one storage format.
 # The fork fixes the from-source duplicate-symbol link and the libstdc++
 # std::format ABI SIGSEGV; see amplihack-memory docs/lbug_libstdcxx_abi.md.
-lbug = { git = "https://github.com/rysweet/ladybug-rust", rev = "202352434642e683fdf008b68004d0645a57cd35" }
+lbug = { git = "https://github.com/rysweet/ladybug-rust", rev = "e3872c8" }
 rusqlite = { version = "=0.31.0", features = ["bundled"] }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.149"

--- a/tests/issue_2626_amplihack_pin_bump.rs
+++ b/tests/issue_2626_amplihack_pin_bump.rs
@@ -46,14 +46,11 @@ use std::path::PathBuf;
 /// amplihack-rs `main` HEAD carrying the `amplihack-agent-eval` crate to adopt.
 const AGENT_EVAL_TARGET_REV: &str = "14dc30b10e87764120c6f2bae7f3630522c29e5d";
 /// amplihack-memory-lib `main` commit carrying the `amplihack-memory` crate:
-/// PR #129's squash-merge — the lbug portability fix. It pins `lbug` to the
-/// rysweet/ladybug-rust fork (build.rs keeps `link_bundled_deps=false`, links
-/// only the self-contained liblbug.a), so building from source both cures the
-/// libstdc++ std::format ABI SIGSEGV on newer hosts (Ubuntu 26.04) and links
-/// cleanly with no unsafe `--allow-multiple-definition`. One commit ahead of the
-/// prior #126 pin, no regression. The fork engine writes on-disk store format
-/// v42 (forward-only from v41).
-const MEMORY_TARGET_REV: &str = "5807d056112b8e6f73dae9c1fac05f214f9c6ece";
+/// PR #131's squash-merge — the lbug storage-compatibility fix. It pins `lbug`
+/// to the rysweet/ladybug-rust fork commit whose crate version is `0.17.1`, so
+/// Simard does not accidentally link a v41-capable `0.17.0` fork engine against
+/// a live v42 cognitive store.
+const MEMORY_TARGET_REV: &str = "283e9a2f8f38b98343770f219c3f5d16bd1752dc";
 
 /// The stale revs the bump must move *off of* (anti-regression sentinels).
 const AGENT_EVAL_STALE_REV: &str = "59548a96049ab8d558110bcaf9c82a4316f1bbf0";
@@ -68,7 +65,7 @@ const MEMORY_REMOTE: &str = "https://github.com/rysweet/amplihack-memory-lib.git
 /// rysweet/ladybug-rust fork (issue #3119: fixes the from-source duplicate-symbol
 /// link + the libstdc++ std::format ABI SIGSEGV). It must pin the SAME fork rev
 /// amplihack-memory resolves to, so cargo unifies to exactly one lbug engine.
-const LBUG_FORK_TARGET_REV: &str = "202352434642e683fdf008b68004d0645a57cd35";
+const LBUG_FORK_TARGET_REV: &str = "e3872c8f22562d55031726a304e99ef92d1e25ec";
 const LBUG_FORK_REMOTE: &str = "https://github.com/rysweet/ladybug-rust";
 
 // ── Path / IO helpers ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the storage-version deployment regression found after the installer PATH deploy: current Simard main linked an lbug engine that reported storage version 41 while the live cognitive store is version 42. The failed deploy quarantined the real store and rebuilt empty; it was immediately rolled back.

This PR pins Simard to the merged amplihack-memory-lib full-SHA lbug source fix (`283e9a2f8f38b98343770f219c3f5d16bd1752dc`) and the full lbug fork SHA (`e3872c8f22562d55031726a304e99ef92d1e25ec`) so Cargo resolves exactly one `lbug v0.17.1` engine.

## Validation

- `cargo tree -i lbug@0.17.1 -e normal` shows exactly one lbug engine used by both Simard and amplihack-memory.
- `cargo test --test issue_2626_amplihack_pin_bump -- --nocapture` — 9/9 passed.
- `cargo test --test install_real invalid_simard_home_fails_closed_before_any_systemctl_call -- --test-threads=1` — passed.
- `cargo check --lib` — passed.
- `cargo run --quiet -- memory stats <copy-of-live-state-root> --json` opened a copied live v42 cognitive store and reported `total=27626`, `access_tier=direct-open`, without quarantine/rebuild.
- Pre-commit and pre-push gates passed.
- GitHub checks on head `f61d74707aa260d83f7686b567445b31c0c9d3fe`: all required checks green.

## Merge readiness

- Platform: GitHub
- PR: #3788 https://github.com/rysweet/Simard/pull/3788
- Source -> target: `fix/lbug-storage-v42` -> `main`
- Current head revision: `f61d74707aa260d83f7686b567445b31c0c9d3fe`
- QA-team evidence: Rust CLI/native tests used; copied-live-store probe proves user-visible deploy safety.
- Docs: not needed; dependency pin/lock guard only, existing installer docs unchanged.
- Quality-audit: targeted root-cause/deploy compatibility investigation; fix scoped to dependency pins and guard test.
- Checks/build validation: all GitHub checks green.
- Metadata: title/body complete, not draft.
- Merge conflicts: CLEAN/MERGEABLE.
- Scope: `Cargo.toml`, `Cargo.lock`, dependency guard test only.
- Final action plan: merge, deploy via `simard install`, restart OODA, verify dashboard and absence of storage-version quarantine / `amplihack command not found` fallback flood.

No `--admin` merge. No `--no-verify`.
