### PR TITLE
fix(deps): honor lbug source-build override for storage compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=283e9a2f8f38b98343770f219c3f5d16bd1752dc#283e9a2f8f38b98343770f219c3f5d16bd1752dc"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=c266e15d1399967c04324370e77cf281990b8be1#c266e15d1399967c04324370e77cf281990b8be1"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -1218,7 +1218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2117,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "lbug"
 version = "0.17.1"
-source = "git+https://github.com/rysweet/ladybug-rust?rev=e3872c8f22562d55031726a304e99ef92d1e25ec#e3872c8f22562d55031726a304e99ef92d1e25ec"
+source = "git+https://github.com/rysweet/ladybug-rust?rev=5a2c107881879f4d1bb594b14967948870e65cdc#5a2c107881879f4d1bb594b14967948870e65cdc"
 dependencies = [
  "cmake",
  "cxx",
@@ -3113,7 +3113,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3445,7 +3445,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3458,7 +3458,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3517,7 +3517,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4221,7 +4221,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ path = "src/bin/supply_chain_steward.rs"
 # v40->v41+ no-data-loss gate now accepts v41-or-newer). Simard's direct `lbug` dep
 # below is repointed at the SAME fork rev in lockstep so the final binary links
 # exactly one engine. Still an upstream-`main` commit.
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "283e9a2f8f38b98343770f219c3f5d16bd1752dc", features = ["persistent"] }
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "c266e15d1399967c04324370e77cf281990b8be1", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream
@@ -155,7 +155,7 @@ amplihack-agent-eval = { git = "https://github.com/rysweet/amplihack-rs.git", re
 # so cargo unifies to exactly one `lbug` crate / one engine / one storage format.
 # The fork fixes the from-source duplicate-symbol link and the libstdc++
 # std::format ABI SIGSEGV; see amplihack-memory docs/lbug_libstdcxx_abi.md.
-lbug = { git = "https://github.com/rysweet/ladybug-rust", rev = "e3872c8f22562d55031726a304e99ef92d1e25ec" }
+lbug = { git = "https://github.com/rysweet/ladybug-rust", rev = "5a2c107881879f4d1bb594b14967948870e65cdc" }
 rusqlite = { version = "=0.31.0", features = ["bundled"] }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.149"

--- a/tests/issue_2626_amplihack_pin_bump.rs
+++ b/tests/issue_2626_amplihack_pin_bump.rs
@@ -50,7 +50,7 @@ const AGENT_EVAL_TARGET_REV: &str = "14dc30b10e87764120c6f2bae7f3630522c29e5d";
 /// to the rysweet/ladybug-rust fork commit whose crate version is `0.17.1`, so
 /// Simard does not accidentally link a v41-capable `0.17.0` fork engine against
 /// a live v42 cognitive store.
-const MEMORY_TARGET_REV: &str = "283e9a2f8f38b98343770f219c3f5d16bd1752dc";
+const MEMORY_TARGET_REV: &str = "c266e15d1399967c04324370e77cf281990b8be1";
 
 /// The stale revs the bump must move *off of* (anti-regression sentinels).
 const AGENT_EVAL_STALE_REV: &str = "59548a96049ab8d558110bcaf9c82a4316f1bbf0";
@@ -65,7 +65,7 @@ const MEMORY_REMOTE: &str = "https://github.com/rysweet/amplihack-memory-lib.git
 /// rysweet/ladybug-rust fork (issue #3119: fixes the from-source duplicate-symbol
 /// link + the libstdc++ std::format ABI SIGSEGV). It must pin the SAME fork rev
 /// amplihack-memory resolves to, so cargo unifies to exactly one lbug engine.
-const LBUG_FORK_TARGET_REV: &str = "e3872c8f22562d55031726a304e99ef92d1e25ec";
+const LBUG_FORK_TARGET_REV: &str = "5a2c107881879f4d1bb594b14967948870e65cdc";
 const LBUG_FORK_REMOTE: &str = "https://github.com/rysweet/ladybug-rust";
 
 // ── Path / IO helpers ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the remaining release-deploy storage regression. Simard release/precommit builds were still linking stale external lbug from `~/.cache/simard-lbug-precommit/lib`, whose engine reports storage version 41. This PR pins to amplihack-memory-lib `c266e15d1399967c04324370e77cf281990b8be1`, which pins lbug fork `5a2c107881879f4d1bb594b14967948870e65cdc`; that fork makes `LBUG_BUILD_FROM_SOURCE=1` override external `LBUG_LIBRARY_DIR` / `LBUG_INCLUDE_DIR` and tracks those env vars for rebuilds.

## Validation

- `cargo tree -i lbug@0.17.1 -e normal` shows one lbug engine.
- `cargo test --test issue_2626_amplihack_pin_bump -- --nocapture` passed 9/9.
- `cargo test --test install_real invalid_simard_home_fails_closed_before_any_systemctl_call -- --test-threads=1` passed.
- `cargo check --lib` passed.
- Clean release rebuild with `LBUG_BUILD_FROM_SOURCE=1 LBUG_RUST_BUILD_FROM_SOURCE=1` completed.
- Release binary opened a copied live v42 cognitive store and reported `total=27626`, `access_tier=direct-open`, with no quarantine/rebuild.
- Pre-commit and pre-push passed.
- GitHub checks on head `cbda1c1da0bc5596eae9e5c43144254d5f712fd9`: all required checks green.

## Merge readiness

- Platform: GitHub
- PR: #3797 https://github.com/rysweet/Simard/pull/3797
- Source -> target: `fix/lbug-storage-v42` -> `main`
- Current head revision: `cbda1c1da0bc5596eae9e5c43144254d5f712fd9`
- QA-team evidence: Rust CLI/native tests and copied-live-store release probe.
- Docs: not required; dependency/build behavior fix only.
- Quality-audit: targeted root-cause deploy investigation; scope limited to dependency pins/guard test.
- Checks/build validation: all GitHub checks green.
- Metadata: title/body complete, not draft.
- Merge conflicts: CLEAN/MERGEABLE.
- Scope: `Cargo.toml`, `Cargo.lock`, dependency guard test only.
- Final action: merge, deploy via `simard install`, restart OODA, verify dashboard + no v42/v41 quarantine + no command-not-found fallback flood.

No `--admin` merge. No `--no-verify`.
