### PR TITLE
docs: decode recurring blocked-goal signature

### DIFF
--- a/docs/concepts/recurring-blocked-goal-signature.md
+++ b/docs/concepts/recurring-blocked-goal-signature.md
@@ -1,0 +1,105 @@
+---
+title: "Recurring blocked-goal signature investigation"
+description: >
+  Decodes the recurring cognitive-memory signature that combined kgpacks-rs
+  blocked-goal observations, quality:gym_skipped markers, and workstream-gap
+  markers. Identifies the recurrence as stale orchestration and memory state,
+  not a remaining kgpacks-rs implementation blockage.
+last_updated: 2026-07-11
+review_schedule: as-needed
+owner: simard
+doc_type: investigation
+status: current
+related:
+  - overseer-goal-board-health.md
+  - closed-loop-outcome-verification.md
+  - ooda-reinvestigate-blocked-goals.md
+  - progress-evidence-gating.md
+---
+
+# Recurring blocked-goal signature investigation
+
+## Finding
+
+The recurring cognitive-memory signature is a concatenated Overseer problem key,
+not one fresh failure. It repeats stale kgpacks-rs blocked-goal observations
+alongside `quality:gym_skipped` and `workstream-gap` markers every Overseer tick.
+
+The recurrence is caused by **orchestration/state reconciliation drift**:
+Simard's local goal board and Overseer memory still describe kgpacks-rs goals as
+blocked or uncovered after the corresponding GitHub issues have closed. The
+current evidence does not support a remaining kgpacks-rs implementation block.
+
+## Decoded signature
+
+The latest decoded signature in `~/.simard/overseer/activity.json` repeats the
+same marker family across recent Overseer ticks:
+
+| Marker | Count in latest key | Meaning |
+| --- | ---: | --- |
+| `overseer-obs:goal:blocked:fix-agent-kgpacks-rs-issue-17-ws2-int8-pq-embed-7f5afcca` | 50-51 | Recalled historical blocker for WS2/#17. |
+| `goal:blocked:fix-agent-kgpacks-rs-issue-17-ws2-int8-pq-embed-7f5afcca` | 9 | Local board still treats WS2/#17 as blocked. |
+| `goal:blocked:fix-agent-kgpacks-rs-issue-18-ws3-versioned-rel-67828479` | 9 | Local board still emits WS3/#18 as blocked/stale. |
+| `goal:blocked:fix-agent-kgpacks-rs-issue-21-ws6-resumable-pip-39ba30dc` | 8-9 | Local board still emits WS6/#21 as blocked/stale. |
+| `goal:blocked:fix-agent-kgpacks-rs-issue-22-ws7-sign-the-rele-b59dde3e` | 8-9 | Local board still emits WS7/#22 as blocked/stale. |
+| `goal:blocked:fix-agent-kgpacks-rs-issue-23-ws8-scalable-enti-982783ea` | 8 | Local board still emits WS8/#23 as blocked/stale. |
+| `overseer-obs:goal:blocked:advance-rysweet-agent-kgpacks-rs-to-full-parity-f29bb15c` | 9 | Parent parity goal is included in the stale blocked cluster. |
+| `quality:gym_skipped` | 7 | Gym quality work was skipped while the same blocked cluster dominated selection. |
+| `workstream-gap` | 7 | Overseer detected uncovered high-value workstreams, but the underlying goals were stale. |
+
+The affected workstreams are therefore:
+
+| Goal/workstream | GitHub issue | Current GitHub state | Local stale signal |
+| --- | ---: | --- | --- |
+| Parent parity goal | n/a | Covered by closed child issues | Local board still has failed worktree-allocation activity. |
+| WS2 int8/PQ embedding quantization | #17 | Closed | Marked blocked on an old dependency on WS1/#16. |
+| WS3 versioned release tags/provenance | #18 | Closed | Marked failed on `memory-ipc` transport. |
+| WS6 resumable/pipelined CVE build | #21 | Closed | Marked blocked on old dependency #25. |
+| WS7 signed release index | #22 | Closed | Marked as skipped/live-sentinel despite closure. |
+| WS8 scalable entity-relation load/traversal | #23 | Closed | Included in blocked/workstream-gap cluster. |
+
+Current GitHub issue state checked during the investigation: #12, #16, #17, #18,
+#19, #20, #21, #22, #23, and #25 are all closed in
+`rysweet/agent-kgpacks-rs`. One open PR remains, #45, with green checks, but its
+closing issue reference is #23, which is already closed; treat it as a separate
+PR hygiene item, not as proof that the blocked-goal cluster is still valid.
+
+## Root cause classification
+
+| Candidate cause | Verdict | Evidence |
+| --- | --- | --- |
+| Implementation blockage | Not current | The affected kgpacks-rs issues are closed upstream. |
+| Dependency blockage | Historical only | #17 depended on #16 and #21 depended on #25, but #16 and #25 are now closed. |
+| Validation blockage | Not primary | The `quality:gym_skipped` markers are symptoms of stale blocked selection, not evidence of a failing kgpacks validation gate. |
+| Orchestration/state blockage | Root cause | Local goal-board entries still carry `memory-ipc`, worktree-allocation, live-sentinel, and historical dependency messages after upstream completion. |
+
+The repeated signature is amplified by memory recall: the Overseer sees the same
+concatenated key, recalls prior occurrences, launches or reports workstream
+coverage again, and writes another occurrence without first reconciling the local
+goal board against the authoritative upstream issue/PR state.
+
+## Concrete next actions
+
+1. Reconcile the local goal board before spawning more kgpacks-rs work: for each
+   kgpacks-rs goal, check the upstream issue state and retire or unblock any goal
+   whose issue is already closed.
+2. Treat the remaining open PR #45 as PR hygiene: either merge it if it contains
+   still-needed WS8 work despite #23 being closed, or close it as superseded.
+3. Add an Overseer preflight for blocked external-repo goals: if the linked
+   GitHub issue is closed, suppress `goal:blocked:*`, `workstream-gap`, and
+   recipe-launch actions for that goal and emit a reconciliation action instead.
+4. Collapse repeated cognitive-memory keys before comparing recurrence: count
+   unique marker families and goal ids rather than comparing the full
+   pipe-delimited key, so one stale goal cannot dominate the process-health
+   signal 50 times in one tick.
+5. Keep `quality:gym_skipped` separate from root-cause classification: report it
+   as a downstream skipped-quality symptom unless a current gym run or gym
+   history record shows a concrete validation failure.
+
+## Prevention invariant
+
+Before the Overseer escalates a blocked external-repo goal, launches another
+workstream, or writes a recurring blocked-goal memory, it should verify the
+linked upstream issue/PR state. If the upstream work is already closed or merged,
+the valid action is reconciliation of local state, not another blocked-goal
+memory or implementation workstream.

--- a/docs/concepts/recurring-blocked-goal-signature.md
+++ b/docs/concepts/recurring-blocked-goal-signature.md
@@ -5,7 +5,7 @@ description: >
   blocked-goal observations, quality:gym_skipped markers, and workstream-gap
   markers. Identifies the recurrence as stale orchestration and memory state,
   not a remaining kgpacks-rs implementation blockage.
-last_updated: 2026-07-11
+last_updated: 2026-07-13
 review_schedule: as-needed
 owner: simard
 doc_type: investigation
@@ -32,16 +32,19 @@ current evidence does not support a remaining kgpacks-rs implementation block.
 
 ## Decoded signature
 
-The latest decoded signature in `~/.simard/overseer/activity.json` repeats the
-same marker family across recent Overseer ticks:
+The latest decoded signature in `~/.simard/overseer/activity.json` at
+`2026-07-13T02:00:18Z` repeats the same marker family across recent Overseer
+ticks. The key itself says the signature was seen `2x` in cognitive memory; the
+same 117-token key also appeared in the prior two ticks at `2026-07-13T01:40:40Z`
+and `2026-07-13T01:23:08Z`.
 
 | Marker | Count in latest key | Meaning |
 | --- | ---: | --- |
-| `overseer-obs:goal:blocked:fix-agent-kgpacks-rs-issue-17-ws2-int8-pq-embed-7f5afcca` | 50-51 | Recalled historical blocker for WS2/#17. |
+| `overseer-obs:goal:blocked:fix-agent-kgpacks-rs-issue-17-ws2-int8-pq-embed-7f5afcca` | 51 | Recalled historical blocker for WS2/#17. |
 | `goal:blocked:fix-agent-kgpacks-rs-issue-17-ws2-int8-pq-embed-7f5afcca` | 9 | Local board still treats WS2/#17 as blocked. |
 | `goal:blocked:fix-agent-kgpacks-rs-issue-18-ws3-versioned-rel-67828479` | 9 | Local board still emits WS3/#18 as blocked/stale. |
-| `goal:blocked:fix-agent-kgpacks-rs-issue-21-ws6-resumable-pip-39ba30dc` | 8-9 | Local board still emits WS6/#21 as blocked/stale. |
-| `goal:blocked:fix-agent-kgpacks-rs-issue-22-ws7-sign-the-rele-b59dde3e` | 8-9 | Local board still emits WS7/#22 as blocked/stale. |
+| `goal:blocked:fix-agent-kgpacks-rs-issue-21-ws6-resumable-pip-39ba30dc` | 8 | Local board still emits WS6/#21 as blocked/stale. |
+| `goal:blocked:fix-agent-kgpacks-rs-issue-22-ws7-sign-the-rele-b59dde3e` | 8 | Local board still emits WS7/#22 as blocked/stale. |
 | `goal:blocked:fix-agent-kgpacks-rs-issue-23-ws8-scalable-enti-982783ea` | 8 | Local board still emits WS8/#23 as blocked/stale. |
 | `overseer-obs:goal:blocked:advance-rysweet-agent-kgpacks-rs-to-full-parity-f29bb15c` | 9 | Parent parity goal is included in the stale blocked cluster. |
 | `quality:gym_skipped` | 7 | Gym quality work was skipped while the same blocked cluster dominated selection. |
@@ -60,9 +63,9 @@ The affected workstreams are therefore:
 
 Current GitHub issue state checked during the investigation: #12, #16, #17, #18,
 #19, #20, #21, #22, #23, and #25 are all closed in
-`rysweet/agent-kgpacks-rs`. One open PR remains, #45, with green checks, but its
-closing issue reference is #23, which is already closed; treat it as a separate
-PR hygiene item, not as proof that the blocked-goal cluster is still valid.
+`rysweet/agent-kgpacks-rs`. PR #45, which referenced #23, is also merged with
+green checks. There is no current upstream issue or PR state that justifies the
+blocked-goal cluster.
 
 ## Root cause classification
 
@@ -83,16 +86,14 @@ goal board against the authoritative upstream issue/PR state.
 1. Reconcile the local goal board before spawning more kgpacks-rs work: for each
    kgpacks-rs goal, check the upstream issue state and retire or unblock any goal
    whose issue is already closed.
-2. Treat the remaining open PR #45 as PR hygiene: either merge it if it contains
-   still-needed WS8 work despite #23 being closed, or close it as superseded.
-3. Add an Overseer preflight for blocked external-repo goals: if the linked
+2. Add an Overseer preflight for blocked external-repo goals: if the linked
    GitHub issue is closed, suppress `goal:blocked:*`, `workstream-gap`, and
    recipe-launch actions for that goal and emit a reconciliation action instead.
-4. Collapse repeated cognitive-memory keys before comparing recurrence: count
+3. Collapse repeated cognitive-memory keys before comparing recurrence: count
    unique marker families and goal ids rather than comparing the full
    pipe-delimited key, so one stale goal cannot dominate the process-health
-   signal 50 times in one tick.
-5. Keep `quality:gym_skipped` separate from root-cause classification: report it
+   signal 51 times in one tick.
+4. Keep `quality:gym_skipped` separate from root-cause classification: report it
    as a downstream skipped-quality symptom unless a current gym run or gym
    history record shows a concrete validation failure.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
     - No-Progress Breaker Explains WHY and Self-Resolves: concepts/no-progress-root-cause-resolution.md
     - Overseer Goal-Board Health: concepts/overseer-goal-board-health.md
     - Overseer Root-Cause (WHY) Principle: concepts/overseer-root-cause-why.md
+    - Recurring Blocked-Goal Signature Investigation: concepts/recurring-blocked-goal-signature.md
     - Re-Investigating Already-Blocked OODA Goals: concepts/ooda-reinvestigate-blocked-goals.md
     - Authoritative Goal-Board Store: concepts/authoritative-goal-board-store.md
     - Brain-Relative OODA Cycle Counter: concepts/brain-relative-ooda-cycle-counter.md


### PR DESCRIPTION
## Summary
- Decodes the recurring kgpacks-rs blocked-goal cognitive-memory signature into the affected workstreams and marker counts.
- Classifies the recurrence as stale orchestration/state reconciliation drift rather than a current implementation, dependency, or validation block.
- Documents concrete next actions: reconcile local goal-board state, handle stale PR #45 hygiene, add upstream-closed preflight suppression, collapse repeated memory keys, and keep gym skips as downstream symptoms unless current gym evidence exists.

## Validation
- python3 -m mkdocs build --strict --quiet
- pre-commit commit-stage gates, including cargo fmt and cargo clippy --release --no-deps -- -D warnings